### PR TITLE
chore: release Nest 11 upgrade

### DIFF
--- a/.changeset/nest-11-upgrade.md
+++ b/.changeset/nest-11-upgrade.md
@@ -1,8 +1,0 @@
----
-'@getmunin/backend-core': minor
----
-
-Upgrade NestJS to v11 (was v10). Patches GHSA-36xv-jgw5-4q75 (SSE field
-injection). Consumers of `@getmunin/backend-core` must upgrade their own
-`@nestjs/*` deps to `^11.x` and `express` to `^5.x`. Wildcard route paths
-must use the new path-to-regexp v8 syntax (e.g. `*splat` instead of `:rest(.*)`).

--- a/packages/backend-core/CHANGELOG.md
+++ b/packages/backend-core/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @getmunin/backend-core
 
+## 0.4.0
+
+### Minor Changes
+
+- 9ef40a4: Upgrade NestJS to v11 (was v10). Patches GHSA-36xv-jgw5-4q75 (SSE field
+  injection). Consumers of `@getmunin/backend-core` must upgrade their own
+  `@nestjs/*` deps to `^11.x` and `express` to `^5.x`. Wildcard route paths
+  must use the new path-to-regexp v8 syntax (e.g. `*splat` instead of `:rest(.*)`).
+
+### Patch Changes
+
+- @getmunin/core@0.4.0
+- @getmunin/db@0.4.0
+- @getmunin/types@0.4.0
+- @getmunin/mcp-toolkit@0.4.0
+- @getmunin/bootstrap@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/backend-core",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Shared NestJS modules powering both OSS and cloud Munin backends.",
   "publishConfig": {

--- a/packages/bootstrap/CHANGELOG.md
+++ b/packages/bootstrap/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @getmunin/bootstrap
 
+## 0.4.0
+
+### Patch Changes
+
+- @getmunin/core@0.4.0
+- @getmunin/db@0.4.0
+- @getmunin/types@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/bootstrap",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Munin bootstrap engine: agent-driven app configuration via Q&A flows.",
   "publishConfig": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @getmunin/core
 
+## 0.4.0
+
+### Patch Changes
+
+- @getmunin/db@0.4.0
+- @getmunin/types@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/core",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Munin core: actor identity, request context, mailer, storage, crypto helpers.",
   "publishConfig": {

--- a/packages/dashboard-pages/CHANGELOG.md
+++ b/packages/dashboard-pages/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @getmunin/dashboard-pages
 
+## 0.4.0
+
+### Patch Changes
+
+- @getmunin/ui@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/dashboard-pages/package.json
+++ b/packages/dashboard-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/dashboard-pages",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Munin dashboard page components shared between OSS and cloud Next apps.",
   "publishConfig": {

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @getmunin/db
 
+## 0.4.0
+
+### Patch Changes
+
+- @getmunin/types@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/db",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Munin database: Drizzle schema, migrations, RLS policies.",
   "publishConfig": {

--- a/packages/mcp-toolkit/CHANGELOG.md
+++ b/packages/mcp-toolkit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @getmunin/mcp-toolkit
 
+## 0.4.0
+
+### Patch Changes
+
+- @getmunin/core@0.4.0
+- @getmunin/types@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/mcp-toolkit/package.json
+++ b/packages/mcp-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/mcp-toolkit",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Decorators + registry that turn NestJS providers into MCP tools.",
   "publishConfig": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @getmunin/sdk
 
+## 0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/sdk",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "TypeScript client for the Munin REST API (token minting, end-user lookup, webhooks).",
   "publishConfig": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @getmunin/types
 
+## 0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/types",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Shared Zod schemas + TypeScript types for the Munin platform.",
   "publishConfig": {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @getmunin/ui
 
+## 0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/ui",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Munin design-system primitives (shadcn-style) shared between OSS and cloud Next apps.",
   "publishConfig": {


### PR DESCRIPTION
Automated by changesets workflow. Releases @getmunin/backend-core@0.4.0 with the Nest 11 upgrade.