### PR TITLE
feat(i18n): localize OSS web + dashboard-pages with next-intl (en + nb)

### DIFF
--- a/.changeset/i18n-next-intl.md
+++ b/.changeset/i18n-next-intl.md
@@ -1,0 +1,15 @@
+---
+'@getmunin/dashboard-pages': minor
+'@getmunin/ui': minor
+---
+
+Localize all dashboard pages and UI components with [next-intl](https://next-intl.dev). Ships English (`en`) and Norwegian Bokmål (`nb`) message catalogs that consumers extend in their own `messages/{locale}.json`.
+
+**Breaking-ish (pre-1.0 minor):**
+
+- `next-intl` is now a required peer dependency of `@getmunin/dashboard-pages`. Consumers must wrap their app in `<NextIntlClientProvider>` and configure `next-intl/plugin` in `next.config.mjs`.
+- `GoogleButton.label` (in `@getmunin/ui`) is now required. Pass a translated label rather than relying on the previous English default.
+
+**What's translated:** all `dashboard-pages` exports (`AgentsPage`, `ApiKeysPage`, `TeamPage`, `AuditLogPage`, `UsagePage`, `EndUsersPage`, `ExportPage`, `DashboardPage`, `AcceptInvitePage`, `OrgSwitcher`) plus error messages mapped from stable backend codes (e.g. `SIGNUP_DOMAIN_NOT_ALLOWED`, `SIGNUP_INVITE_ONLY`).
+
+**Backend changes (`@getmunin/backend`):** `auth.config.ts` now emits two distinct codes (`SIGNUP_DOMAIN_NOT_ALLOWED` and `SIGNUP_INVITE_ONLY`) instead of a single `SIGNUP_NOT_ALLOWED`. Email templates (password reset, verification) move into `email-templates.ts` keyed by locale, with a default driven by `MUNIN_DEFAULT_LOCALE` (`en` | `nb`).

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -4,6 +4,7 @@ import { APIError } from 'better-auth/api';
 import { schema, type Db } from '@getmunin/db';
 import type { Mailer } from '@getmunin/core';
 import { and, asc, eq, isNull, sql } from 'drizzle-orm';
+import { resetPasswordEmail, verifyEmailEmail } from './email-templates.js';
 
 export type MuninAuth = ReturnType<typeof createMuninAuth>;
 
@@ -56,17 +57,11 @@ export function createMuninAuth({
       autoSignIn: true,
       sendResetPassword: mailer
         ? async ({ user, url }: { user: { email: string }; url: string }) => {
+            const tpl = resetPasswordEmail(url);
             await mailer.send({
               to: user.email,
-              subject: 'Reset your Munin password',
-              text: [
-                'You asked to reset your Munin password.',
-                '',
-                `Click the link below to set a new one (valid for 1 hour):`,
-                url,
-                '',
-                "If you didn't request this, you can ignore this email.",
-              ].join('\n'),
+              subject: tpl.subject,
+              text: tpl.text,
             });
           }
         : undefined,
@@ -74,17 +69,11 @@ export function createMuninAuth({
     emailVerification: mailer
       ? {
           sendVerificationEmail: async ({ user, url }: { user: { email: string }; url: string }) => {
+            const tpl = verifyEmailEmail(url);
             await mailer.send({
               to: user.email,
-              subject: 'Verify your Munin email',
-              text: [
-                `Welcome to Munin.`,
-                '',
-                'Confirm your email so we know we can reach you:',
-                url,
-                '',
-                `If you didn't sign up, ignore this email.`,
-              ].join('\n'),
+              subject: tpl.subject,
+              text: tpl.text,
             });
           },
           sendOnSignUp: true,
@@ -155,13 +144,17 @@ async function assertSignupAllowed(
     .limit(1);
   if (invite[0]) return;
 
-  const reason =
-    allowedEmailDomains.length > 0
-      ? `Signup is restricted. Your email domain (${domain || 'unknown'}) isn't on the allowlist, and there's no pending invitation for ${email}. Ask an admin to invite you.`
-      : `Signup is invite-only on this Munin instance. Ask an admin to send you an invitation for ${email}.`;
+  if (allowedEmailDomains.length > 0) {
+    throw new APIError('FORBIDDEN', {
+      code: 'SIGNUP_DOMAIN_NOT_ALLOWED',
+      message: `Signup is restricted. Your email domain (${domain || 'unknown'}) isn't on the allowlist, and there's no pending invitation for ${email}. Ask an admin to invite you.`,
+      details: { email, domain },
+    });
+  }
   throw new APIError('FORBIDDEN', {
-    code: 'SIGNUP_NOT_ALLOWED',
-    message: reason,
+    code: 'SIGNUP_INVITE_ONLY',
+    message: `Signup is invite-only on this Munin instance. Ask an admin to send you an invitation for ${email}.`,
+    details: { email },
   });
 }
 

--- a/apps/backend/src/auth/email-templates.ts
+++ b/apps/backend/src/auth/email-templates.ts
@@ -1,0 +1,75 @@
+export type EmailLocale = 'en' | 'nb';
+
+export const EMAIL_LOCALES: EmailLocale[] = ['en', 'nb'];
+
+export function defaultEmailLocale(): EmailLocale {
+  const env = (process.env.MUNIN_DEFAULT_LOCALE ?? 'en').toLowerCase();
+  return env === 'nb' ? 'nb' : 'en';
+}
+
+export function isEmailLocale(value: unknown): value is EmailLocale {
+  return value === 'en' || value === 'nb';
+}
+
+interface EmailContent {
+  subject: string;
+  text: string;
+}
+
+const RESET_PASSWORD: Record<EmailLocale, (url: string) => EmailContent> = {
+  en: (url) => ({
+    subject: 'Reset your Munin password',
+    text: [
+      'You asked to reset your Munin password.',
+      '',
+      'Click the link below to set a new one (valid for 1 hour):',
+      url,
+      '',
+      "If you didn't request this, you can ignore this email.",
+    ].join('\n'),
+  }),
+  nb: (url) => ({
+    subject: 'Tilbakestill Munin-passordet ditt',
+    text: [
+      'Du har bedt om å tilbakestille Munin-passordet ditt.',
+      '',
+      'Klikk på lenken nedenfor for å sette et nytt (gyldig i 1 time):',
+      url,
+      '',
+      'Hvis du ikke ba om dette, kan du ignorere denne e-posten.',
+    ].join('\n'),
+  }),
+};
+
+const VERIFY_EMAIL: Record<EmailLocale, (url: string) => EmailContent> = {
+  en: (url) => ({
+    subject: 'Verify your Munin email',
+    text: [
+      'Welcome to Munin.',
+      '',
+      'Confirm your email so we know we can reach you:',
+      url,
+      '',
+      "If you didn't sign up, ignore this email.",
+    ].join('\n'),
+  }),
+  nb: (url) => ({
+    subject: 'Bekreft Munin-e-postadressen din',
+    text: [
+      'Velkommen til Munin.',
+      '',
+      'Bekreft e-postadressen din slik at vi vet at vi kan nå deg:',
+      url,
+      '',
+      'Hvis du ikke registrerte deg, kan du ignorere denne e-posten.',
+    ].join('\n'),
+  }),
+};
+
+export function resetPasswordEmail(url: string, locale: EmailLocale = defaultEmailLocale()): EmailContent {
+  return RESET_PASSWORD[locale](url);
+}
+
+export function verifyEmailEmail(url: string, locale: EmailLocale = defaultEmailLocale()): EmailContent {
+  return VERIFY_EMAIL[locale](url);
+}

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { authClient } from '@getmunin/dashboard-pages';
 import { GoogleButton } from '@getmunin/ui';
 import { Button } from '@getmunin/ui';
@@ -10,6 +11,7 @@ import { Input } from '@getmunin/ui';
 import { Label } from '@getmunin/ui';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@getmunin/ui';
 import { Separator } from '@getmunin/ui';
+import { useTranslateError } from '@/lib/translate-error';
 
 function safeRedirect(raw: string | null): string {
   if (raw && raw.startsWith('/') && !raw.startsWith('//')) return raw;
@@ -17,6 +19,11 @@ function safeRedirect(raw: string | null): string {
 }
 
 function LoginForm() {
+  const t = useTranslations('auth.signIn');
+  const tFields = useTranslations('auth.fields');
+  const tCommon = useTranslations('common');
+  const tUi = useTranslations('ui.googleButton');
+  const translateError = useTranslateError();
   const router = useRouter();
   const params = useSearchParams();
   const redirectRaw = params.get('redirect');
@@ -37,13 +44,13 @@ function LoginForm() {
     try {
       const result = await authClient.signIn.email({ email, password });
       if (result.error) {
-        setError(result.error.message ?? 'Sign-in failed');
+        setError(translateError(result.error, 'unknownError') || t('failed'));
         return;
       }
       await refetch();
       router.push(redirectTo);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Network error — is the API reachable?');
+      setError(translateError(err) || tCommon('networkError'));
     } finally {
       setSubmitting(false);
     }
@@ -52,17 +59,18 @@ function LoginForm() {
   return (
     <Card className="border-0 shadow-none sm:border sm:shadow-sm">
       <CardHeader>
-        <CardTitle className="text-2xl">Sign in</CardTitle>
-        <CardDescription>Welcome back to Munin.</CardDescription>
+        <CardTitle className="text-2xl">{t('title')}</CardTitle>
+        <CardDescription>{t('subtitle')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <GoogleButton
+          label={tUi('signIn')}
           onSignIn={() => {
             void authClient.signIn.social({ provider: 'google', callbackURL: redirectTo });
           }}
         />
 
-        <DividerWithLabel label="or" />
+        <DividerWithLabel label={tCommon('or')} />
 
         <form
           onSubmit={(event) => {
@@ -71,7 +79,7 @@ function LoginForm() {
           className="space-y-4"
         >
           <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
+            <Label htmlFor="email">{tFields('email')}</Label>
             <Input
               id="email"
               type="email"
@@ -82,7 +90,7 @@ function LoginForm() {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="password">Password</Label>
+            <Label htmlFor="password">{tFields('password')}</Label>
             <Input
               id="password"
               type="password"
@@ -94,14 +102,14 @@ function LoginForm() {
           </div>
           {error && <p className="text-sm text-destructive">{error}</p>}
           <Button type="submit" className="w-full" disabled={submitting}>
-            {submitting ? 'Signing in…' : 'Sign in'}
+            {submitting ? t('submitting') : t('submit')}
           </Button>
         </form>
 
         <p className="pt-2 text-sm text-muted-foreground">
-          New here?{' '}
+          {t('noAccount')}{' '}
           <Link href={signupHref} className="font-medium text-foreground underline">
-            Create an account
+            {t('createAccount')}
           </Link>
         </p>
       </CardContent>

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { api, ApiError, authClient } from '@getmunin/dashboard-pages';
 import { GoogleButton } from '@getmunin/ui';
 import { Button } from '@getmunin/ui';
@@ -10,6 +11,7 @@ import { Input } from '@getmunin/ui';
 import { Label } from '@getmunin/ui';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@getmunin/ui';
 import { Separator } from '@getmunin/ui';
+import { useTranslateError } from '@/lib/translate-error';
 
 function safeRedirect(raw: string | null): string {
   if (raw && raw.startsWith('/') && !raw.startsWith('//')) return raw;
@@ -28,6 +30,11 @@ function extractInviteToken(redirectRaw: string | null): string | null {
 }
 
 function SignupForm() {
+  const t = useTranslations('auth.signUp');
+  const tFields = useTranslations('auth.fields');
+  const tCommon = useTranslations('common');
+  const tUi = useTranslations('ui.googleButton');
+  const translateError = useTranslateError();
   const router = useRouter();
   const params = useSearchParams();
   const redirectRaw = params.get('redirect');
@@ -53,13 +60,11 @@ function SignupForm() {
         setEmail(result.email);
       } catch (err) {
         setInviteError(
-          err instanceof ApiError
-            ? 'This invitation is no longer valid (revoked or expired).'
-            : 'Could not look up the invitation.',
+          err instanceof ApiError ? t('invitationInvalid') : t('invitationLookupFailed'),
         );
       }
     })();
-  }, [inviteToken]);
+  }, [inviteToken, t]);
 
   async function onSubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -68,13 +73,13 @@ function SignupForm() {
     try {
       const result = await authClient.signUp.email({ email, password, name });
       if (result.error) {
-        setError(result.error.message ?? 'Signup failed');
+        setError(translateError(result.error) || t('failed'));
         return;
       }
       await refetch();
       router.push(redirectTo);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Network error — is the API reachable?');
+      setError(translateError(err) || tCommon('networkError'));
     } finally {
       setSubmitting(false);
     }
@@ -83,25 +88,21 @@ function SignupForm() {
   return (
     <Card className="border-0 shadow-none sm:border sm:shadow-sm">
       <CardHeader>
-        <CardTitle className="text-2xl">Create your account</CardTitle>
+        <CardTitle className="text-2xl">{t('title')}</CardTitle>
         <CardDescription>
-          {inviteEmail
-            ? `You're accepting an invitation for ${inviteEmail}.`
-            : 'Munin — agent-native business apps.'}
+          {inviteEmail ? t('invitationSubtitle', { email: inviteEmail }) : t('subtitle')}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {inviteError && (
-          <p className="text-sm text-destructive">{inviteError}</p>
-        )}
+        {inviteError && <p className="text-sm text-destructive">{inviteError}</p>}
         <GoogleButton
-          label="Sign up with Google"
+          label={tUi('signUp')}
           onSignIn={() => {
             void authClient.signIn.social({ provider: 'google', callbackURL: redirectTo });
           }}
         />
 
-        <DividerWithLabel label="or" />
+        <DividerWithLabel label={tCommon('or')} />
 
         <form
           onSubmit={(event) => {
@@ -110,7 +111,7 @@ function SignupForm() {
           className="space-y-4"
         >
           <div className="space-y-2">
-            <Label htmlFor="name">Your name</Label>
+            <Label htmlFor="name">{tFields('name')}</Label>
             <Input
               id="name"
               type="text"
@@ -121,7 +122,7 @@ function SignupForm() {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
+            <Label htmlFor="email">{tFields('email')}</Label>
             <Input
               id="email"
               type="email"
@@ -133,7 +134,7 @@ function SignupForm() {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="password">Password</Label>
+            <Label htmlFor="password">{tFields('password')}</Label>
             <Input
               id="password"
               type="password"
@@ -145,17 +146,17 @@ function SignupForm() {
           </div>
           {error && <p className="text-sm text-destructive">{error}</p>}
           <Button type="submit" className="w-full" disabled={submitting}>
-            {submitting ? 'Creating account…' : 'Create account'}
+            {submitting ? t('submitting') : t('submit')}
           </Button>
         </form>
 
         <p className="pt-2 text-sm text-muted-foreground">
-          Already have an account?{' '}
+          {t('haveAccount')}{' '}
           <Link
             href={redirectRaw ? `/login?redirect=${encodeURIComponent(redirectRaw)}` : '/login'}
             className="font-medium text-foreground underline"
           >
-            Sign in
+            {t('signInLink')}
           </Link>
         </p>
       </CardContent>

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -15,6 +15,7 @@ import {
   Users,
   UsersRound,
 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { authClient } from '@getmunin/dashboard-pages';
 import { Button } from '@getmunin/ui';
 import {
@@ -32,23 +33,30 @@ import {
   DropdownMenuTrigger,
 } from '@getmunin/ui';
 import { cn } from '@getmunin/ui';
+import { LocaleSwitcher } from '@/components/locale-switcher';
 
-type NavItem = { href: Route; label: string; icon: React.ComponentType<{ className?: string }> };
+type NavItem = {
+  href: Route;
+  labelKey: 'overview' | 'team' | 'agents' | 'apiKeys' | 'endUsers' | 'usage' | 'auditLog' | 'dataExport';
+  icon: React.ComponentType<{ className?: string }>;
+};
 
 const NAV: NavItem[] = [
-  { href: '/dashboard', label: 'Overview', icon: LayoutDashboard },
-  { href: '/dashboard/team', label: 'Team', icon: UsersRound },
-  { href: '/dashboard/agents', label: 'Connected agents', icon: Bot },
-  { href: '/dashboard/api-keys', label: 'API keys', icon: KeyRound },
-  { href: '/dashboard/end-users', label: 'End-users', icon: Users },
-  { href: '/dashboard/usage', label: 'Usage', icon: Activity },
-  { href: '/dashboard/audit-log', label: 'Audit log', icon: ScrollText },
-  { href: '/dashboard/export', label: 'Data export', icon: Download },
+  { href: '/dashboard', labelKey: 'overview', icon: LayoutDashboard },
+  { href: '/dashboard/team', labelKey: 'team', icon: UsersRound },
+  { href: '/dashboard/agents', labelKey: 'agents', icon: Bot },
+  { href: '/dashboard/api-keys', labelKey: 'apiKeys', icon: KeyRound },
+  { href: '/dashboard/end-users', labelKey: 'endUsers', icon: Users },
+  { href: '/dashboard/usage', labelKey: 'usage', icon: Activity },
+  { href: '/dashboard/audit-log', labelKey: 'auditLog', icon: ScrollText },
+  { href: '/dashboard/export', labelKey: 'dataExport', icon: Download },
 ];
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
+  const tNav = useTranslations('nav');
+  const tCommon = useTranslations('common');
   const { data: session, isPending } = authClient.useSession();
 
   useEffect(() => {
@@ -56,7 +64,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   }, [isPending, session, router]);
 
   if (isPending || !session) {
-    return <p className="p-8 text-sm text-muted-foreground">Loading…</p>;
+    return <p className="p-8 text-sm text-muted-foreground">{tCommon('loading')}</p>;
   }
 
   return (
@@ -66,17 +74,21 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           <Link href="/dashboard" className="text-lg font-semibold tracking-tight">
             Munin
           </Link>
-          <UserMenu
-            email={session.user.email}
-            name={session.user.name ?? session.user.email}
-            image={session.user.image ?? null}
-            onSignOut={() => {
-              void (async () => {
-                await authClient.signOut();
-                router.push('/login');
-              })();
-            }}
-          />
+          <div className="flex items-center gap-3">
+            <LocaleSwitcher />
+            <UserMenu
+              email={session.user.email}
+              name={session.user.name ?? session.user.email}
+              image={session.user.image ?? null}
+              signOutLabel={tCommon('signOut')}
+              onSignOut={() => {
+                void (async () => {
+                  await authClient.signOut();
+                  router.push('/login');
+                })();
+              }}
+            />
+          </div>
         </div>
       </header>
 
@@ -100,7 +112,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                     )}
                   >
                     <item.icon className="size-4" />
-                    {item.label}
+                    {tNav(item.labelKey)}
                   </Link>
                 </li>
               );
@@ -117,10 +129,11 @@ interface UserMenuProps {
   email: string;
   name: string;
   image: string | null;
+  signOutLabel: string;
   onSignOut: () => void;
 }
 
-function UserMenu({ email, name, image, onSignOut }: UserMenuProps) {
+function UserMenu({ email, name, image, signOutLabel, onSignOut }: UserMenuProps) {
   const initials = name
     .split(' ')
     .map((part) => part[0]?.toUpperCase() ?? '')
@@ -147,7 +160,7 @@ function UserMenu({ email, name, image, onSignOut }: UserMenuProps) {
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={onSignOut}>
           <LogOut className="size-4" />
-          Sign out
+          {signOutLabel}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,20 +1,30 @@
 import type { Metadata } from 'next';
 import './globals.css';
-import { Geist } from "next/font/google";
+import { Geist } from 'next/font/google';
+import { NextIntlClientProvider } from 'next-intl';
+import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 import { cn } from '@getmunin/ui';
 
-const geist = Geist({subsets:['latin'],variable:'--font-sans'});
+const geist = Geist({ subsets: ['latin'], variable: '--font-sans' });
 
-export const metadata: Metadata = {
-  title: 'Munin — agent-native business apps',
-  description:
-    'Open-source headless business app suite (Knowledge Base, Conversations, CRM, CMS) where the AI agent is the UI.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('metadata');
+  return {
+    title: t('title'),
+    description: t('description'),
+  };
+}
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const locale = await getLocale();
+  const messages = await getMessages();
   return (
-    <html lang="en" className={cn("font-sans", geist.variable)}>
-      <body>{children}</body>
+    <html lang={locale} className={cn('font-sans', geist.variable)}>
+      <body>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          {children}
+        </NextIntlClientProvider>
+      </body>
     </html>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,23 +1,21 @@
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { Button } from '@getmunin/ui';
 
 export default function HomePage() {
+  const t = useTranslations('home');
   return (
     <main className="mx-auto flex min-h-screen max-w-4xl flex-col justify-center px-6">
       <div className="space-y-6">
-        <h1 className="text-5xl font-semibold tracking-tight">Munin</h1>
-        <p className="max-w-xl text-xl text-muted-foreground">
-          Agent-native business apps. The AI agent is the UI.
-        </p>
-        <p className="text-sm text-muted-foreground">
-          Knowledge Base · Conversations · CRM · CMS — open source, MCP-first.
-        </p>
+        <h1 className="text-5xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="max-w-xl text-xl text-muted-foreground">{t('tagline')}</p>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
         <div className="flex gap-3 pt-4">
           <Button size="lg" render={<Link href="/signup" />}>
-            Get started
+            {t('getStarted')}
           </Button>
           <Button size="lg" variant="outline" render={<Link href="/login" />}>
-            Sign in
+            {t('signIn')}
           </Button>
         </div>
       </div>

--- a/apps/web/components/locale-switcher.tsx
+++ b/apps/web/components/locale-switcher.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { setLocaleCookie } from '@/i18n/actions';
+import { SUPPORTED_LOCALES } from '@/i18n/locales';
+
+export function LocaleSwitcher({ className }: { className?: string }) {
+  const t = useTranslations('locale');
+  const locale = useLocale();
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  return (
+    <label className={className}>
+      <span className="sr-only">{t('label')}</span>
+      <select
+        aria-label={t('label')}
+        value={locale}
+        disabled={pending}
+        onChange={(e) => {
+          const next = e.target.value;
+          startTransition(async () => {
+            await setLocaleCookie(next);
+            router.refresh();
+          });
+        }}
+        className="rounded-md border bg-background px-2 py-1 text-sm"
+      >
+        {SUPPORTED_LOCALES.map((code) => (
+          <option key={code} value={code}>
+            {t(code)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/web/i18n/actions.ts
+++ b/apps/web/i18n/actions.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { LOCALE_COOKIE, isLocale } from './locales';
+
+export async function setLocaleCookie(value: string) {
+  if (!isLocale(value)) return;
+  const store = await cookies();
+  store.set(LOCALE_COOKIE, value, {
+    path: '/',
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: 'lax',
+  });
+}

--- a/apps/web/i18n/locales.ts
+++ b/apps/web/i18n/locales.ts
@@ -1,0 +1,8 @@
+export const SUPPORTED_LOCALES = ['en', 'nb'] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: Locale = 'en';
+export const LOCALE_COOKIE = 'munin_locale';
+
+export function isLocale(value: unknown): value is Locale {
+  return typeof value === 'string' && (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}

--- a/apps/web/i18n/request.ts
+++ b/apps/web/i18n/request.ts
@@ -1,0 +1,26 @@
+import { cookies, headers } from 'next/headers';
+import { getRequestConfig } from 'next-intl/server';
+import { DEFAULT_LOCALE, LOCALE_COOKIE, isLocale, type Locale } from './locales';
+
+function negotiateFromHeader(acceptLanguage: string | null): Locale {
+  if (!acceptLanguage) return DEFAULT_LOCALE;
+  const tags = acceptLanguage
+    .split(',')
+    .map((p) => (p.split(';')[0] ?? '').trim().toLowerCase())
+    .filter((s) => s.length > 0);
+  for (const tag of tags) {
+    const primary = tag.split('-')[0] ?? tag;
+    if (isLocale(primary)) return primary;
+    if (primary === 'no' || primary === 'nn') return 'nb';
+  }
+  return DEFAULT_LOCALE;
+}
+
+export default getRequestConfig(async () => {
+  const cookieStore = await cookies();
+  const cookieLocale = cookieStore.get(LOCALE_COOKIE)?.value;
+  const fromHeader = negotiateFromHeader((await headers()).get('accept-language'));
+  const locale: Locale = isLocale(cookieLocale) ? cookieLocale : fromHeader;
+  const messages = (await import(`../messages/${locale}.json`)).default;
+  return { locale, messages };
+});

--- a/apps/web/i18n/request.ts
+++ b/apps/web/i18n/request.ts
@@ -21,6 +21,6 @@ export default getRequestConfig(async () => {
   const cookieLocale = cookieStore.get(LOCALE_COOKIE)?.value;
   const fromHeader = negotiateFromHeader((await headers()).get('accept-language'));
   const locale: Locale = isLocale(cookieLocale) ? cookieLocale : fromHeader;
-  const messages = (await import(`../messages/${locale}.json`)).default;
-  return { locale, messages };
+  const mod = (await import(`../messages/${locale}.json`)) as { default: Record<string, unknown> };
+  return { locale, messages: mod.default };
 });

--- a/apps/web/lib/translate-error.ts
+++ b/apps/web/lib/translate-error.ts
@@ -1,0 +1,39 @@
+import { useMessages, useTranslations } from 'next-intl';
+
+interface ErrorLike {
+  code?: string | null;
+  message?: string | null;
+}
+
+export function getErrorCode(err: unknown): string | null {
+  if (err && typeof err === 'object') {
+    const e = err as { code?: unknown; body?: { code?: unknown }; cause?: { code?: unknown } };
+    if (typeof e.code === 'string') return e.code;
+    if (e.body && typeof e.body === 'object' && typeof e.body.code === 'string') return e.body.code;
+    if (e.cause && typeof e.cause === 'object' && typeof e.cause.code === 'string') return e.cause.code;
+  }
+  return null;
+}
+
+export function useTranslateError() {
+  const t = useTranslations('errors');
+  const common = useTranslations('common');
+  const messages = useMessages() as Record<string, unknown>;
+  const knownCodes = new Set(
+    messages.errors && typeof messages.errors === 'object'
+      ? Object.keys(messages.errors)
+      : [],
+  );
+  return (err: unknown, fallbackKey?: string): string => {
+    const code = getErrorCode(err);
+    if (code && knownCodes.has(code)) {
+      return t(code as never);
+    }
+    if (err && typeof err === 'object' && 'message' in err) {
+      const msg = (err as ErrorLike).message;
+      if (typeof msg === 'string' && msg.length > 0) return msg;
+    }
+    if (typeof err === 'string') return err;
+    return fallbackKey ? common(fallbackKey as never) : common('unknownError');
+  };
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1,0 +1,309 @@
+{
+  "metadata": {
+    "title": "Munin — agent-native business apps",
+    "description": "Open-source headless business app suite (Knowledge Base, Conversations, CRM, CMS) where the AI agent is the UI."
+  },
+  "common": {
+    "loading": "Loading…",
+    "or": "or",
+    "signOut": "Sign out",
+    "revoke": "Revoke",
+    "save": "Save",
+    "cancel": "Cancel",
+    "create": "Create",
+    "delete": "Delete",
+    "edit": "Edit",
+    "close": "Close",
+    "back": "Back",
+    "unknownError": "Unknown error.",
+    "networkError": "Network error — is the API reachable?"
+  },
+  "locale": {
+    "label": "Language",
+    "en": "English",
+    "nb": "Norsk"
+  },
+  "home": {
+    "title": "Munin",
+    "tagline": "Agent-native business apps. The AI agent is the UI.",
+    "subtitle": "Knowledge Base · Conversations · CRM · CMS — open source, MCP-first.",
+    "getStarted": "Get started",
+    "signIn": "Sign in"
+  },
+  "auth": {
+    "signIn": {
+      "title": "Sign in",
+      "subtitle": "Welcome back to Munin.",
+      "googleButton": "Sign in with Google",
+      "submit": "Sign in",
+      "submitting": "Signing in…",
+      "noAccount": "New here?",
+      "createAccount": "Create an account",
+      "failed": "Sign-in failed"
+    },
+    "signUp": {
+      "title": "Create your account",
+      "subtitle": "Munin — agent-native business apps.",
+      "invitationSubtitle": "You're accepting an invitation for {email}.",
+      "googleButton": "Sign up with Google",
+      "submit": "Create account",
+      "submitting": "Creating account…",
+      "haveAccount": "Already have an account?",
+      "signInLink": "Sign in",
+      "failed": "Signup failed",
+      "invitationInvalid": "This invitation is no longer valid (revoked or expired).",
+      "invitationLookupFailed": "Could not look up the invitation."
+    },
+    "fields": {
+      "name": "Your name",
+      "email": "Email",
+      "password": "Password"
+    }
+  },
+  "nav": {
+    "overview": "Overview",
+    "team": "Team",
+    "agents": "Connected agents",
+    "apiKeys": "API keys",
+    "endUsers": "End-users",
+    "usage": "Usage",
+    "auditLog": "Audit log",
+    "dataExport": "Data export",
+    "runbooks": "Runbooks",
+    "suggestions": "Suggestions",
+    "partnerAccess": "Partner access"
+  },
+  "dashboard": {
+    "overview": {
+      "title": "Welcome to Munin",
+      "subtitle": "Connect your AI agent or build a server-side integration.",
+      "connectCard": {
+        "title": "Connect your AI agent",
+        "description": "Add this URL to Claude Desktop, Cursor, or any MCP client.",
+        "consentNote": "You'll see a consent screen here when an agent connects."
+      },
+      "buildCard": {
+        "title": "Build a server integration",
+        "description": "Voice AI, web chatbot, or mobile app? Mint short-lived end-user tokens server-side.",
+        "cta": "Manage API keys"
+      }
+    },
+    "agents": {
+      "title": "Connected agents",
+      "subtitle": "Every OAuth-authorized agent and end-user token issued for this org. Revoke any active token to immediately invalidate further MCP calls.",
+      "emptyTitle": "No connected agents yet",
+      "emptyBody": "Add the MCP URL to Claude Desktop, Cursor, or your runtime, then complete consent — issued tokens will appear here.",
+      "noScopes": "no scopes",
+      "issued": "Issued {when}",
+      "lastUsed": "Last used {when}",
+      "expires": "Expires {when}",
+      "revoke": "Revoke",
+      "status": {
+        "active": "active",
+        "revoked": "revoked",
+        "expired": "expired"
+      },
+      "types": {
+        "oauth_access": "OAuth access token",
+        "oauth_refresh": "OAuth refresh token",
+        "delegated_end_user": "Delegated end-user token",
+        "guest": "Guest token"
+      },
+      "errors": {
+        "load": "Could not load connected agents.",
+        "revoke": "Could not revoke token."
+      }
+    },
+    "apiKeys": {
+      "title": "API keys",
+      "subtitle": "Long-lived admin keys for server-to-server integrations and programmatic admin agents. Self-hosters and CI use these too. Treat them like passwords.",
+      "createTitle": "Create a new key",
+      "createDescription": "The plaintext value is shown ONCE, immediately after creation. Copy it now and store it in your secret manager.",
+      "nameLabel": "Name",
+      "namePlaceholder": "e.g. production-backend",
+      "create": "Create key",
+      "creating": "Creating…",
+      "revoke": "Revoke",
+      "rowMeta": "<code>{prefix}…</code> · created {created}",
+      "rowMetaWithLast": "<code>{prefix}…</code> · created {created} · last used {lastUsed}",
+      "emptyTitle": "No API keys yet",
+      "emptyBody": "Create your first key above to get started.",
+      "createdTitle": "Key created — copy it now",
+      "createdDescription": "Munin only stores the hash. We can't show you this key again.",
+      "copy": "Copy",
+      "copied": "Copied",
+      "savedIt": "I've saved it",
+      "errors": {
+        "load": "Could not load API keys.",
+        "create": "Could not create API key.",
+        "revoke": "Could not revoke API key."
+      }
+    },
+    "team": {
+      "title": "Team",
+      "subtitle": "Members and pending invitations for this org. Owners can invite others, change roles, and remove members; members can use the apps but can't manage access.",
+      "inviteTitle": "Invite a teammate",
+      "inviteDescription": "They'll get an email with a link to accept. The link expires in 7 days.",
+      "emailLabel": "Email",
+      "emailPlaceholder": "teammate@example.com",
+      "roleLabel": "Role",
+      "roleMember": "Member",
+      "roleOwner": "Owner",
+      "roleMemberLower": "member",
+      "roleOwnerLower": "owner",
+      "sendInvite": "Send invite",
+      "sending": "Sending…",
+      "manualShareTitle": "Email isn't configured — share this link manually",
+      "manualShareBody": "No email provider is set up on this Munin instance, so we didn't send an email. Send the link below to <recipient>{email}</recipient> yourself, or set <code>MUNIN_MAIL_PROVIDER</code> (e.g. <code>resend</code>) and restart so future invites mail automatically.",
+      "manualShareValid": "Valid for 7 days.",
+      "copyLink": "Copy link",
+      "copied": "Copied",
+      "done": "Done",
+      "close": "Close",
+      "membersTitle": "Members",
+      "membersTitleCount": "Members ({count})",
+      "membersTableName": "Name",
+      "membersTableEmail": "Email",
+      "membersTableRole": "Role",
+      "membersTableJoined": "Joined",
+      "remove": "Remove",
+      "removeConfirm": "Remove this member? They lose access to the org immediately.",
+      "invitesTitle": "Pending invitations",
+      "invitesTitleCount": "Pending invitations ({count})",
+      "invitesEmptyTitle": "No pending invitations",
+      "invitesEmptyBody": "Use the form above to invite someone — they'll appear here until accepted.",
+      "inviteRow": "{role} · invited {created} · expires {expires}",
+      "revoke": "Revoke",
+      "errors": {
+        "load": "Could not load team.",
+        "invite": "Could not send invite.",
+        "revokeInvite": "Could not revoke invite.",
+        "remove": "Could not remove member.",
+        "changeRole": "Could not change role."
+      }
+    },
+    "endUsers": {
+      "title": "End-users",
+      "subtitle": "People your customer-facing agents act on behalf of. Created server-side via the SDK or <code>/api/end-users/lookup</code>; never trusted from agent input.",
+      "emptyTitle": "No end-users yet",
+      "emptyBody": "Mint your first delegated end-user token via <code>POST /api/delegated-token</code> with an admin key from your backend, and the corresponding EndUser will appear here.",
+      "tableName": "Name",
+      "tableExternalId": "External id",
+      "tableContact": "Contact",
+      "tableCreated": "Created",
+      "revokeActive": "Revoke active tokens",
+      "revoking": "Revoking…",
+      "noTokensRevoked": "No active tokens to revoke for this end-user.",
+      "errors": {
+        "load": "Could not load end-users.",
+        "revoke": "Could not revoke tokens."
+      }
+    },
+    "usage": {
+      "title": "Usage",
+      "subtitle": "MCP tool calls counted against your tier limits. Counters reset at the start of each window.",
+      "perMinute": "Per minute",
+      "perDay": "Per day",
+      "summary": "{used} of {limit} tool calls — resets {resetIn}.",
+      "percentUsed": "{pct}% used",
+      "resetNow": "now",
+      "resetMinutes": "in {minutes}m",
+      "resetHours": "in {hours}h",
+      "errors": {
+        "load": "Could not load usage."
+      }
+    },
+    "auditLog": {
+      "title": "Audit log",
+      "subtitle": "Every tool call and control-plane mutation, newest first. Filter by tool, actor type, or correlation id to isolate one request chain.",
+      "filterTitle": "Filter",
+      "filterDescription": "Leave blank to match all values.",
+      "filterTool": "Tool",
+      "filterActorType": "Actor type",
+      "filterCorrelationId": "Correlation id",
+      "apply": "Apply",
+      "loadMore": "Load more",
+      "emptyTitle": "No audit rows yet",
+      "emptyBody": "Tool calls and control-plane writes appear here. Connect an agent and try a tool.",
+      "tableTime": "Time",
+      "tableActor": "Actor",
+      "tableToolMethod": "Tool / method",
+      "tableResult": "Result",
+      "tableCorrelation": "Correlation",
+      "errors": {
+        "load": "Could not load audit log."
+      }
+    },
+    "export": {
+      "title": "Data export",
+      "subtitle": "Download a complete JSON dump of your org's domain data — knowledge base, end-users, and configuration. Use this to migrate to a self-hosted Munin or to keep an offline copy.",
+      "cardTitle": "Export now",
+      "cardDescription": "Includes: organization, end-users, agents, and KB spaces / documents / versions. Excludes: tokens, API keys, and the audit log (those are operational data you can't restore from an export).",
+      "download": "Download export",
+      "preparing": "Preparing…",
+      "errors": {
+        "export": "Could not generate export."
+      }
+    },
+    "orgSwitcher": {
+      "loading": "Loading orgs…",
+      "yourOrgs": "Your orgs",
+      "switching": " · switching…",
+      "errors": {
+        "load": "Could not load orgs.",
+        "switch": "Could not switch org."
+      }
+    }
+  },
+  "acceptInvite": {
+    "pendingTitle": "Accepting your invitation…",
+    "pendingBody": "One moment.",
+    "acceptedTitle": "Invitation accepted",
+    "acceptedBody": "You're now a member of the org.",
+    "goToDashboard": "Go to dashboard",
+    "errorTitle": "Couldn't accept the invitation",
+    "signOutAndRetry": "Sign out and try again",
+    "backToDashboard": "Back to dashboard",
+    "missingToken": "Missing invitation token.",
+    "errors": {
+      "lookup": "Could not look up the invitation.",
+      "accept": "Could not accept invitation.",
+      "expired": "This invitation is no longer valid (revoked or expired)."
+    }
+  },
+  "errors": {
+    "SIGNUP_NOT_ALLOWED": "Signup is restricted on this Munin instance. Ask an admin to invite you.",
+    "SIGNUP_DOMAIN_NOT_ALLOWED": "Your email domain isn't on the allowlist, and there's no pending invitation for this address. Ask an admin to invite you.",
+    "SIGNUP_INVITE_ONLY": "Signup is invite-only on this Munin instance. Ask an admin to send you an invitation.",
+    "INVITATION_NOT_FOUND": "Invitation not found.",
+    "INVITATION_EXPIRED": "This invitation has expired.",
+    "INVITATION_REVOKED": "This invitation has been revoked.",
+    "INVITATION_EMAIL_MISMATCH": "This invitation is for a different email address.",
+    "UNAUTHORIZED": "You need to sign in to do that.",
+    "INVALID_CREDENTIAL": "Invalid or expired credential.",
+    "FORBIDDEN": "You don't have permission to do that.",
+    "NOT_FOUND": "Not found.",
+    "BAD_REQUEST": "Invalid request.",
+    "RATE_LIMITED": "Too many requests. Please slow down and try again.",
+    "QUOTA_EXCEEDED": "You've hit a quota limit. Upgrade or wait for it to reset.",
+    "CONFLICT": "That conflicts with existing data.",
+    "VALIDATION_ERROR": "The data you submitted didn't validate.",
+    "WEBHOOK_DISABLED": "This webhook is disabled.",
+    "INVALID_SIGNED_URL": "Invalid or expired signed URL.",
+    "KB_INVALID": "Knowledge base entry is invalid.",
+    "KB_NOT_FOUND": "Knowledge base entry not found.",
+    "KB_CONFLICT": "Knowledge base conflict (version mismatch?).",
+    "CRM_INVALID": "CRM entry is invalid.",
+    "CMS_INVALID": "CMS entry is invalid.",
+    "CMS_CONFLICT": "CMS conflict (version mismatch?).",
+    "CONV_INVALID": "Conversation entry is invalid.",
+    "FEEDBACK_RATE_LIMIT": "Too many suggestions created in the last hour. Try again later.",
+    "FEEDBACK_NOT_FOUND": "Suggestion not found."
+  },
+  "ui": {
+    "googleButton": {
+      "signIn": "Sign in with Google",
+      "signUp": "Sign up with Google"
+    }
+  }
+}

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -1,0 +1,309 @@
+{
+  "metadata": {
+    "title": "Munin — agent-native forretningsapper",
+    "description": "Open source headless forretningsapp-suite (kunnskapsbase, samtaler, CRM, CMS) der AI-agenten er brukergrensesnittet."
+  },
+  "common": {
+    "loading": "Laster…",
+    "or": "eller",
+    "signOut": "Logg ut",
+    "revoke": "Tilbakekall",
+    "save": "Lagre",
+    "cancel": "Avbryt",
+    "create": "Opprett",
+    "delete": "Slett",
+    "edit": "Rediger",
+    "close": "Lukk",
+    "back": "Tilbake",
+    "unknownError": "Ukjent feil.",
+    "networkError": "Nettverksfeil — er API-et tilgjengelig?"
+  },
+  "locale": {
+    "label": "Språk",
+    "en": "English",
+    "nb": "Norsk"
+  },
+  "home": {
+    "title": "Munin",
+    "tagline": "Agent-native forretningsapper. AI-agenten er brukergrensesnittet.",
+    "subtitle": "Kunnskapsbase · Samtaler · CRM · CMS — open source, MCP-først.",
+    "getStarted": "Kom i gang",
+    "signIn": "Logg inn"
+  },
+  "auth": {
+    "signIn": {
+      "title": "Logg inn",
+      "subtitle": "Velkommen tilbake til Munin.",
+      "googleButton": "Logg inn med Google",
+      "submit": "Logg inn",
+      "submitting": "Logger inn…",
+      "noAccount": "Ny her?",
+      "createAccount": "Opprett konto",
+      "failed": "Innlogging mislyktes"
+    },
+    "signUp": {
+      "title": "Opprett konto",
+      "subtitle": "Munin — agent-native forretningsapper.",
+      "invitationSubtitle": "Du aksepterer en invitasjon for {email}.",
+      "googleButton": "Registrer deg med Google",
+      "submit": "Opprett konto",
+      "submitting": "Oppretter konto…",
+      "haveAccount": "Har du allerede konto?",
+      "signInLink": "Logg inn",
+      "failed": "Registrering mislyktes",
+      "invitationInvalid": "Denne invitasjonen er ikke lenger gyldig (tilbakekalt eller utløpt).",
+      "invitationLookupFailed": "Kunne ikke slå opp invitasjonen."
+    },
+    "fields": {
+      "name": "Navn",
+      "email": "E-post",
+      "password": "Passord"
+    }
+  },
+  "nav": {
+    "overview": "Oversikt",
+    "team": "Team",
+    "agents": "Tilkoblede agenter",
+    "apiKeys": "API-nøkler",
+    "endUsers": "Sluttbrukere",
+    "usage": "Bruk",
+    "auditLog": "Hendelseslogg",
+    "dataExport": "Dataeksport",
+    "runbooks": "Veiledninger",
+    "suggestions": "Forslag",
+    "partnerAccess": "Partnertilgang"
+  },
+  "dashboard": {
+    "overview": {
+      "title": "Velkommen til Munin",
+      "subtitle": "Koble til AI-agenten din eller bygg en serverside-integrasjon.",
+      "connectCard": {
+        "title": "Koble til AI-agenten din",
+        "description": "Legg denne URL-en inn i Claude Desktop, Cursor eller en annen MCP-klient.",
+        "consentNote": "Du ser et samtykkebilde her når en agent kobler seg til."
+      },
+      "buildCard": {
+        "title": "Bygg en serverside-integrasjon",
+        "description": "Tale-AI, web-chatbot eller mobilapp? Generer korte sluttbruker-tokens fra serveren.",
+        "cta": "Administrer API-nøkler"
+      }
+    },
+    "agents": {
+      "title": "Tilkoblede agenter",
+      "subtitle": "Alle OAuth-autoriserte agenter og sluttbruker-tokens utstedt for denne organisasjonen. Tilbakekall et aktivt token for å gjøre videre MCP-kall ugyldige umiddelbart.",
+      "emptyTitle": "Ingen tilkoblede agenter ennå",
+      "emptyBody": "Legg MCP-URL-en inn i Claude Desktop, Cursor eller kjøretiden din, og fullfør samtykket — utstedte tokens vises her.",
+      "noScopes": "ingen scopes",
+      "issued": "Utstedt {when}",
+      "lastUsed": "Sist brukt {when}",
+      "expires": "Utløper {when}",
+      "revoke": "Tilbakekall",
+      "status": {
+        "active": "aktiv",
+        "revoked": "tilbakekalt",
+        "expired": "utløpt"
+      },
+      "types": {
+        "oauth_access": "OAuth-tilgangstoken",
+        "oauth_refresh": "OAuth-fornyelsestoken",
+        "delegated_end_user": "Delegert sluttbruker-token",
+        "guest": "Gjeste-token"
+      },
+      "errors": {
+        "load": "Kunne ikke laste tilkoblede agenter.",
+        "revoke": "Kunne ikke tilbakekalle token."
+      }
+    },
+    "apiKeys": {
+      "title": "API-nøkler",
+      "subtitle": "Langlivede administratornøkler for integrasjoner fra server til server og programmatiske administratoragenter. Selvhostere og CI bruker disse også. Behandle dem som passord.",
+      "createTitle": "Opprett en ny nøkkel",
+      "createDescription": "Klartekstverdien vises ÉN GANG, umiddelbart etter opprettelse. Kopier den nå og oppbevar den i passordhåndtereren din.",
+      "nameLabel": "Navn",
+      "namePlaceholder": "f.eks. produksjon-backend",
+      "create": "Opprett nøkkel",
+      "creating": "Oppretter…",
+      "revoke": "Tilbakekall",
+      "rowMeta": "<code>{prefix}…</code> · opprettet {created}",
+      "rowMetaWithLast": "<code>{prefix}…</code> · opprettet {created} · sist brukt {lastUsed}",
+      "emptyTitle": "Ingen API-nøkler ennå",
+      "emptyBody": "Opprett din første nøkkel over for å komme i gang.",
+      "createdTitle": "Nøkkel opprettet — kopier den nå",
+      "createdDescription": "Munin lagrer bare hashen. Vi kan ikke vise deg denne nøkkelen igjen.",
+      "copy": "Kopier",
+      "copied": "Kopiert",
+      "savedIt": "Jeg har lagret den",
+      "errors": {
+        "load": "Kunne ikke laste API-nøkler.",
+        "create": "Kunne ikke opprette API-nøkkel.",
+        "revoke": "Kunne ikke tilbakekalle API-nøkkel."
+      }
+    },
+    "team": {
+      "title": "Team",
+      "subtitle": "Medlemmer og ventende invitasjoner for denne organisasjonen. Eiere kan invitere andre, endre roller og fjerne medlemmer; medlemmer kan bruke appene, men kan ikke administrere tilgang.",
+      "inviteTitle": "Inviter et teammedlem",
+      "inviteDescription": "De får en e-post med en lenke for å akseptere. Lenken utløper om 7 dager.",
+      "emailLabel": "E-post",
+      "emailPlaceholder": "kollega@eksempel.no",
+      "roleLabel": "Rolle",
+      "roleMember": "Medlem",
+      "roleOwner": "Eier",
+      "roleMemberLower": "medlem",
+      "roleOwnerLower": "eier",
+      "sendInvite": "Send invitasjon",
+      "sending": "Sender…",
+      "manualShareTitle": "E-post er ikke konfigurert — del denne lenken manuelt",
+      "manualShareBody": "Ingen e-postleverandør er satt opp på denne Munin-installasjonen, så vi sendte ikke e-post. Send lenken under til <recipient>{email}</recipient> selv, eller sett <code>MUNIN_MAIL_PROVIDER</code> (f.eks. <code>resend</code>) og start på nytt slik at fremtidige invitasjoner sendes automatisk.",
+      "manualShareValid": "Gyldig i 7 dager.",
+      "copyLink": "Kopier lenke",
+      "copied": "Kopiert",
+      "done": "Ferdig",
+      "close": "Lukk",
+      "membersTitle": "Medlemmer",
+      "membersTitleCount": "Medlemmer ({count})",
+      "membersTableName": "Navn",
+      "membersTableEmail": "E-post",
+      "membersTableRole": "Rolle",
+      "membersTableJoined": "Ble med",
+      "remove": "Fjern",
+      "removeConfirm": "Vil du fjerne dette medlemmet? De mister tilgang til organisasjonen umiddelbart.",
+      "invitesTitle": "Ventende invitasjoner",
+      "invitesTitleCount": "Ventende invitasjoner ({count})",
+      "invitesEmptyTitle": "Ingen ventende invitasjoner",
+      "invitesEmptyBody": "Bruk skjemaet over for å invitere noen — de vises her til de aksepterer.",
+      "inviteRow": "{role} · invitert {created} · utløper {expires}",
+      "revoke": "Tilbakekall",
+      "errors": {
+        "load": "Kunne ikke laste team.",
+        "invite": "Kunne ikke sende invitasjon.",
+        "revokeInvite": "Kunne ikke tilbakekalle invitasjon.",
+        "remove": "Kunne ikke fjerne medlem.",
+        "changeRole": "Kunne ikke endre rolle."
+      }
+    },
+    "endUsers": {
+      "title": "Sluttbrukere",
+      "subtitle": "Personer som de kundevendte agentene dine handler på vegne av. Opprettet på serversiden via SDK-en eller <code>/api/end-users/lookup</code>; aldri stol på agent-input.",
+      "emptyTitle": "Ingen sluttbrukere ennå",
+      "emptyBody": "Generer ditt første delegerte sluttbrukertoken via <code>POST /api/delegated-token</code> med en administratornøkkel fra backend-en din, og den tilsvarende EndUser vises her.",
+      "tableName": "Navn",
+      "tableExternalId": "Ekstern id",
+      "tableContact": "Kontakt",
+      "tableCreated": "Opprettet",
+      "revokeActive": "Tilbakekall aktive tokens",
+      "revoking": "Tilbakekaller…",
+      "noTokensRevoked": "Ingen aktive tokens å tilbakekalle for denne sluttbrukeren.",
+      "errors": {
+        "load": "Kunne ikke laste sluttbrukere.",
+        "revoke": "Kunne ikke tilbakekalle tokens."
+      }
+    },
+    "usage": {
+      "title": "Bruk",
+      "subtitle": "MCP-verktøykall som telles mot grensene i abonnementet ditt. Tellerne nullstilles ved starten av hvert vindu.",
+      "perMinute": "Per minutt",
+      "perDay": "Per dag",
+      "summary": "{used} av {limit} verktøykall — nullstilles {resetIn}.",
+      "percentUsed": "{pct}% brukt",
+      "resetNow": "nå",
+      "resetMinutes": "om {minutes}m",
+      "resetHours": "om {hours}t",
+      "errors": {
+        "load": "Kunne ikke laste bruksdata."
+      }
+    },
+    "auditLog": {
+      "title": "Hendelseslogg",
+      "subtitle": "Alle verktøykall og endringer i kontrollplanet, nyeste først. Filtrer etter verktøy, aktørtype eller korrelasjons-id for å isolere én forespørselskjede.",
+      "filterTitle": "Filter",
+      "filterDescription": "La feltene stå tomme for å matche alle verdier.",
+      "filterTool": "Verktøy",
+      "filterActorType": "Aktørtype",
+      "filterCorrelationId": "Korrelasjons-id",
+      "apply": "Bruk",
+      "loadMore": "Last flere",
+      "emptyTitle": "Ingen hendelser ennå",
+      "emptyBody": "Verktøykall og kontrollplanskriving vises her. Koble til en agent og prøv et verktøy.",
+      "tableTime": "Tid",
+      "tableActor": "Aktør",
+      "tableToolMethod": "Verktøy / metode",
+      "tableResult": "Resultat",
+      "tableCorrelation": "Korrelasjon",
+      "errors": {
+        "load": "Kunne ikke laste hendelseslogg."
+      }
+    },
+    "export": {
+      "title": "Dataeksport",
+      "subtitle": "Last ned en komplett JSON-dump av domenedataene til organisasjonen — kunnskapsbase, sluttbrukere og konfigurasjon. Bruk dette til å migrere til en selvhostet Munin eller for å beholde en frakoblet kopi.",
+      "cardTitle": "Eksporter nå",
+      "cardDescription": "Inkluderer: organisasjon, sluttbrukere, agenter og KB-områder / dokumenter / versjoner. Ekskluderer: tokens, API-nøkler og hendelsesloggen (dette er driftsdata som ikke kan gjenopprettes fra en eksport).",
+      "download": "Last ned eksport",
+      "preparing": "Forbereder…",
+      "errors": {
+        "export": "Kunne ikke generere eksport."
+      }
+    },
+    "orgSwitcher": {
+      "loading": "Laster organisasjoner…",
+      "yourOrgs": "Dine organisasjoner",
+      "switching": " · bytter…",
+      "errors": {
+        "load": "Kunne ikke laste organisasjoner.",
+        "switch": "Kunne ikke bytte organisasjon."
+      }
+    }
+  },
+  "acceptInvite": {
+    "pendingTitle": "Aksepterer invitasjonen…",
+    "pendingBody": "Et øyeblikk.",
+    "acceptedTitle": "Invitasjon akseptert",
+    "acceptedBody": "Du er nå medlem av organisasjonen.",
+    "goToDashboard": "Gå til dashbord",
+    "errorTitle": "Kunne ikke akseptere invitasjonen",
+    "signOutAndRetry": "Logg ut og prøv igjen",
+    "backToDashboard": "Tilbake til dashbord",
+    "missingToken": "Mangler invitasjonstoken.",
+    "errors": {
+      "lookup": "Kunne ikke slå opp invitasjonen.",
+      "accept": "Kunne ikke akseptere invitasjonen.",
+      "expired": "Denne invitasjonen er ikke lenger gyldig (tilbakekalt eller utløpt)."
+    }
+  },
+  "errors": {
+    "SIGNUP_NOT_ALLOWED": "Registrering er begrenset på denne Munin-installasjonen. Be en administrator om å invitere deg.",
+    "SIGNUP_DOMAIN_NOT_ALLOWED": "E-postdomenet ditt er ikke på listen, og det finnes ingen ventende invitasjon for denne adressen. Be en administrator om å invitere deg.",
+    "SIGNUP_INVITE_ONLY": "Registrering er kun ved invitasjon på denne Munin-installasjonen. Be en administrator om å sende en invitasjon.",
+    "INVITATION_NOT_FOUND": "Invitasjon ikke funnet.",
+    "INVITATION_EXPIRED": "Denne invitasjonen er utløpt.",
+    "INVITATION_REVOKED": "Denne invitasjonen er tilbakekalt.",
+    "INVITATION_EMAIL_MISMATCH": "Denne invitasjonen er for en annen e-postadresse.",
+    "UNAUTHORIZED": "Du må logge inn for å gjøre det.",
+    "INVALID_CREDENTIAL": "Ugyldig eller utløpt legitimasjon.",
+    "FORBIDDEN": "Du har ikke tilgang til å gjøre det.",
+    "NOT_FOUND": "Ikke funnet.",
+    "BAD_REQUEST": "Ugyldig forespørsel.",
+    "RATE_LIMITED": "For mange forespørsler. Vennligst senk farten og prøv igjen.",
+    "QUOTA_EXCEEDED": "Du har nådd en kvotegrense. Oppgrader eller vent til den nullstilles.",
+    "CONFLICT": "Det er i konflikt med eksisterende data.",
+    "VALIDATION_ERROR": "Dataene du sendte inn validerte ikke.",
+    "WEBHOOK_DISABLED": "Denne webhooken er deaktivert.",
+    "INVALID_SIGNED_URL": "Ugyldig eller utløpt signert URL.",
+    "KB_INVALID": "Kunnskapsbase-oppføringen er ugyldig.",
+    "KB_NOT_FOUND": "Kunnskapsbase-oppføringen finnes ikke.",
+    "KB_CONFLICT": "Kunnskapsbase-konflikt (versjonskollisjon?).",
+    "CRM_INVALID": "CRM-oppføringen er ugyldig.",
+    "CMS_INVALID": "CMS-oppføringen er ugyldig.",
+    "CMS_CONFLICT": "CMS-konflikt (versjonskollisjon?).",
+    "CONV_INVALID": "Samtaleoppføringen er ugyldig.",
+    "FEEDBACK_RATE_LIMIT": "For mange forslag opprettet siste time. Prøv igjen senere.",
+    "FEEDBACK_NOT_FOUND": "Forslaget ble ikke funnet."
+  },
+  "ui": {
+    "googleButton": {
+      "signIn": "Logg inn med Google",
+      "signUp": "Registrer deg med Google"
+    }
+  }
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,3 +1,7 @@
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
@@ -5,4 +9,4 @@ const nextConfig = {
   transpilePackages: ['@getmunin/dashboard-pages', '@getmunin/sdk', '@getmunin/types', '@getmunin/ui'],
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.11.0",
     "next": "^15.0.0",
+    "next-intl": "^4.11.0",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/dashboard-pages/package.json
+++ b/packages/dashboard-pages/package.json
@@ -32,6 +32,7 @@
   },
   "peerDependencies": {
     "next": "^15.0.0",
+    "next-intl": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/dashboard-pages/src/components/org-switcher.tsx
+++ b/packages/dashboard-pages/src/components/org-switcher.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { Building2, Check, ChevronDown } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import {
   Button,
   DropdownMenu,
@@ -11,7 +12,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@getmunin/ui';
-import { api, ApiError } from '../api';
+import { api } from '../api';
+import { useTranslateError } from '../i18n/translate-error';
 
 interface MembershipDto {
   orgId: string;
@@ -21,13 +23,9 @@ interface MembershipDto {
   isDefault: boolean;
 }
 
-/**
- * Cross-org switcher for the dashboard header. Lists every org the
- * caller is a member of via `GET /api/orgs/me/memberships`; selecting one
- * flips `is_default` server-side and reloads so the next request picks up
- * the new active org via the session-cookie credential resolver.
- */
 export function OrgSwitcher() {
+  const t = useTranslations('dashboard.orgSwitcher');
+  const translate = useTranslateError();
   const [memberships, setMemberships] = useState<MembershipDto[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [switching, setSwitching] = useState<string | null>(null);
@@ -35,16 +33,14 @@ export function OrgSwitcher() {
   useEffect(() => {
     void api<MembershipDto[]>('/api/orgs/me/memberships')
       .then(setMemberships)
-      .catch((err: unknown) =>
-        setError(err instanceof ApiError ? err.message : 'Could not load orgs.'),
-      );
-  }, []);
+      .catch((err: unknown) => setError(translate(err) || t('errors.load')));
+  }, [t, translate]);
 
   if (error) {
     return <span className="text-xs text-destructive">{error}</span>;
   }
   if (!memberships) {
-    return <span className="text-xs text-muted-foreground">Loading orgs…</span>;
+    return <span className="text-xs text-muted-foreground">{t('loading')}</span>;
   }
   if (memberships.length === 0) {
     return null;
@@ -60,10 +56,9 @@ export function OrgSwitcher() {
         method: 'PATCH',
         body: JSON.stringify({ orgId }),
       });
-      // Hard reload so server-side session resolution picks up the new active org.
       window.location.reload();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not switch org.');
+      setError(translate(err) || t('errors.switch'));
       setSwitching(null);
     }
   }
@@ -78,7 +73,7 @@ export function OrgSwitcher() {
         <ChevronDown className="size-3.5 text-muted-foreground" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-64">
-        <DropdownMenuLabel className="text-xs text-muted-foreground">Your orgs</DropdownMenuLabel>
+        <DropdownMenuLabel className="text-xs text-muted-foreground">{t('yourOrgs')}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {memberships.map((m) => (
           <DropdownMenuItem
@@ -90,7 +85,8 @@ export function OrgSwitcher() {
             <div className="flex flex-col">
               <span className="text-sm">{m.name}</span>
               <span className="text-xs text-muted-foreground">
-                {m.role}{switching === m.orgId ? ' · switching…' : ''}
+                {m.role}
+                {switching === m.orgId ? t('switching') : ''}
               </span>
             </div>
             {m.orgId === active.orgId && <Check className="size-4 text-muted-foreground" />}

--- a/packages/dashboard-pages/src/i18n/translate-error.ts
+++ b/packages/dashboard-pages/src/i18n/translate-error.ts
@@ -1,0 +1,68 @@
+import { useMessages, useTranslations } from 'next-intl';
+
+interface ErrorLike {
+  code?: string | null;
+  message?: string | null;
+}
+
+export function getErrorCode(err: unknown): string | null {
+  if (err && typeof err === 'object') {
+    const e = err as { code?: unknown; body?: { code?: unknown }; cause?: { code?: unknown } };
+    if (typeof e.code === 'string') return e.code;
+    if (e.body && typeof e.body === 'object' && typeof e.body.code === 'string') return e.body.code;
+    if (e.cause && typeof e.cause === 'object' && typeof e.cause.code === 'string') return e.cause.code;
+  }
+  return null;
+}
+
+type ErrorsTranslator = ReturnType<typeof useTranslations<'errors'>>;
+type RootTranslator = ReturnType<typeof useTranslations>;
+
+export function translateError(
+  err: unknown,
+  tErrors: ErrorsTranslator,
+  tRoot: RootTranslator,
+): string {
+  const code = getErrorCode(err);
+  if (code) {
+    try {
+      const tx = tErrors(code as never);
+      if (typeof tx === 'string' && tx.length > 0) return tx;
+    } catch {
+      // missing key — fall through
+    }
+  }
+  if (err && typeof err === 'object' && 'message' in err) {
+    const msg = (err as ErrorLike).message;
+    if (typeof msg === 'string' && msg.length > 0) return msg;
+  }
+  if (typeof err === 'string') return err;
+  try {
+    return tRoot('common.unknownError' as never);
+  } catch {
+    return 'Unknown error.';
+  }
+}
+
+export function useTranslateError() {
+  const tErrors = useTranslations('errors');
+  const tCommon = useTranslations('common');
+  const messages = useMessages() as Record<string, unknown>;
+  const knownCodes = new Set(
+    messages.errors && typeof messages.errors === 'object'
+      ? Object.keys(messages.errors)
+      : [],
+  );
+  return (err: unknown, fallbackKey?: string): string => {
+    const code = getErrorCode(err);
+    if (code && knownCodes.has(code)) {
+      return tErrors(code as never);
+    }
+    if (err && typeof err === 'object' && 'message' in err) {
+      const msg = (err as ErrorLike).message;
+      if (typeof msg === 'string' && msg.length > 0) return msg;
+    }
+    if (typeof err === 'string') return err;
+    return fallbackKey ? tCommon(fallbackKey as never) : tCommon('unknownError');
+  };
+}

--- a/packages/dashboard-pages/src/pages/accept-invite.tsx
+++ b/packages/dashboard-pages/src/pages/accept-invite.tsx
@@ -4,8 +4,10 @@ import { Suspense, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { CheckCircle2, MailQuestion } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { authClient } from '../auth-client';
-import { api, ApiError } from '../api';
+import { api } from '../api';
+import { useTranslateError } from '../i18n/translate-error';
 import { Button } from '@getmunin/ui';
 import {
   Card,
@@ -16,6 +18,9 @@ import {
 } from '@getmunin/ui';
 
 function AcceptInviteInner() {
+  const t = useTranslations('acceptInvite');
+  const tCommon = useTranslations('common');
+  const translate = useTranslateError();
   const router = useRouter();
   const params = useSearchParams();
   const token = params.get('token');
@@ -27,7 +32,7 @@ function AcceptInviteInner() {
     if (sessionLoading) return;
     if (!token) {
       setStatus('error');
-      setMessage('Missing invitation token.');
+      setMessage(t('missingToken'));
       return;
     }
     if (!session) {
@@ -46,10 +51,10 @@ function AcceptInviteInner() {
         setStatus('accepted');
       } catch (err) {
         setStatus('error');
-        setMessage(err instanceof ApiError ? err.message : 'Could not accept invitation.');
+        setMessage(translate(err) || t('errors.accept'));
       }
     })();
-  }, [sessionLoading, session, token, router, status]);
+  }, [sessionLoading, session, token, router, status, t, translate]);
 
   return (
     <main className="mx-auto flex min-h-screen max-w-md flex-col justify-center px-6">
@@ -58,13 +63,13 @@ function AcceptInviteInner() {
           <CardHeader>
             <div className="flex items-center gap-2">
               <CheckCircle2 className="size-5 text-emerald-700" />
-              <CardTitle>Invitation accepted</CardTitle>
+              <CardTitle>{t('acceptedTitle')}</CardTitle>
             </div>
-            <CardDescription>You&apos;re now a member of the org.</CardDescription>
+            <CardDescription>{t('acceptedBody')}</CardDescription>
           </CardHeader>
           <CardContent>
             <Button render={<Link href="/dashboard" />} className="w-full">
-              Go to dashboard
+              {t('goToDashboard')}
             </Button>
           </CardContent>
         </Card>
@@ -73,10 +78,10 @@ function AcceptInviteInner() {
           <CardHeader>
             <div className="flex items-center gap-2">
               <MailQuestion className="size-5 text-destructive" />
-              <CardTitle>Couldn&apos;t accept the invitation</CardTitle>
+              <CardTitle>{t('errorTitle')}</CardTitle>
             </div>
             <CardDescription className="whitespace-pre-wrap">
-              {message ?? 'Unknown error.'}
+              {message ?? tCommon('unknownError')}
             </CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col gap-2">
@@ -95,19 +100,19 @@ function AcceptInviteInner() {
                   })();
                 }}
               >
-                Sign out and try again
+                {t('signOutAndRetry')}
               </Button>
             )}
             <Button variant="outline" render={<Link href="/dashboard" />} className="w-full">
-              Back to dashboard
+              {t('backToDashboard')}
             </Button>
           </CardContent>
         </Card>
       ) : (
         <Card>
           <CardHeader>
-            <CardTitle>Accepting your invitation…</CardTitle>
-            <CardDescription>One moment.</CardDescription>
+            <CardTitle>{t('pendingTitle')}</CardTitle>
+            <CardDescription>{t('pendingBody')}</CardDescription>
           </CardHeader>
         </Card>
       )}

--- a/packages/dashboard-pages/src/pages/dashboard-agents.tsx
+++ b/packages/dashboard-pages/src/pages/dashboard-agents.tsx
@@ -128,7 +128,7 @@ function TokenCard({ token, onRevoke }: { token: TokenDto; onRevoke: () => void 
                 : 'rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground'
             }
           >
-            {t(`status.${status}` as 'status.active' | 'status.revoked' | 'status.expired')}
+            {t(`status.${status}`)}
           </span>
         </div>
       </CardHeader>

--- a/packages/dashboard-pages/src/pages/dashboard-agents.tsx
+++ b/packages/dashboard-pages/src/pages/dashboard-agents.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { Bot, Trash2 } from 'lucide-react';
-import { api, ApiError } from '../api';
+import { useFormatter, useLocale, useTranslations } from 'next-intl';
+import { api } from '../api';
+import { useTranslateError } from '../i18n/translate-error';
 import { Button } from '@getmunin/ui';
 import {
   Card,
@@ -25,6 +27,9 @@ interface TokenDto {
 }
 
 export function AgentsPage() {
+  const t = useTranslations('dashboard.agents');
+  const tCommon = useTranslations('common');
+  const translate = useTranslateError();
   const [tokens, setTokens] = useState<TokenDto[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -34,7 +39,7 @@ export function AgentsPage() {
       const list = await api<TokenDto[]>('/api/tokens');
       setTokens(list);
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not load connected agents.');
+      setError(translate(err) || t('errors.load'));
     }
   }
 
@@ -47,18 +52,15 @@ export function AgentsPage() {
       await api(`/api/tokens/${id}/revoke`, { method: 'POST' });
       await load();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not revoke token.');
+      setError(translate(err) || t('errors.revoke'));
     }
   }
 
   return (
     <>
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">Connected agents</h1>
-        <p className="text-sm text-muted-foreground">
-          Every OAuth-authorized agent and end-user token issued for this org. Revoke any active
-          token to immediately invalidate further MCP calls.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </header>
 
       {error && (
@@ -68,18 +70,15 @@ export function AgentsPage() {
       )}
 
       {tokens === null ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
       ) : tokens.length === 0 ? (
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
               <Bot className="size-5 text-muted-foreground" />
-              <CardTitle>No connected agents yet</CardTitle>
+              <CardTitle>{t('emptyTitle')}</CardTitle>
             </div>
-            <CardDescription>
-              Add the MCP URL to Claude Desktop, Cursor, or your runtime, then complete consent —
-              issued tokens will appear here.
-            </CardDescription>
+            <CardDescription>{t('emptyBody')}</CardDescription>
           </CardHeader>
         </Card>
       ) : (
@@ -100,17 +99,26 @@ export function AgentsPage() {
 }
 
 function TokenCard({ token, onRevoke }: { token: TokenDto; onRevoke: () => void }) {
+  const t = useTranslations('dashboard.agents');
+  const format = useFormatter();
+  const locale = useLocale();
   const isRevoked = token.revokedAt !== null;
   const isExpired = token.expiresAt !== null && new Date(token.expiresAt) < new Date();
-  const status = isRevoked ? 'revoked' : isExpired ? 'expired' : 'active';
+  const status: 'active' | 'revoked' | 'expired' = isRevoked
+    ? 'revoked'
+    : isExpired
+      ? 'expired'
+      : 'active';
+  const fmt = (iso: string) => format.dateTime(new Date(iso), { dateStyle: 'medium', timeStyle: 'short' });
+  const typeLabel = labelForType(token.type, t);
   return (
     <Card>
       <CardHeader>
         <div className="flex items-start justify-between gap-4">
           <div>
-            <CardTitle className="text-base">{labelForType(token.type)}</CardTitle>
+            <CardTitle className="text-base">{typeLabel}</CardTitle>
             <CardDescription>
-              {token.audiences.join(', ') || '—'} · {token.scopes.join(' ') || 'no scopes'}
+              {token.audiences.join(', ') || '—'} · {token.scopes.join(' ') || t('noScopes')}
             </CardDescription>
           </div>
           <span
@@ -120,20 +128,20 @@ function TokenCard({ token, onRevoke }: { token: TokenDto; onRevoke: () => void 
                 : 'rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground'
             }
           >
-            {status}
+            {t(`status.${status}` as 'status.active' | 'status.revoked' | 'status.expired')}
           </span>
         </div>
       </CardHeader>
       <CardContent className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
-        <div className="space-y-0.5">
-          <div>Issued {fmt(token.createdAt)}</div>
-          {token.lastUsedAt && <div>Last used {fmt(token.lastUsedAt)}</div>}
-          {token.expiresAt && <div>Expires {fmt(token.expiresAt)}</div>}
+        <div className="space-y-0.5" lang={locale}>
+          <div>{t('issued', { when: fmt(token.createdAt) })}</div>
+          {token.lastUsedAt && <div>{t('lastUsed', { when: fmt(token.lastUsedAt) })}</div>}
+          {token.expiresAt && <div>{t('expires', { when: fmt(token.expiresAt) })}</div>}
         </div>
         {!isRevoked && (
           <Button variant="outline" size="sm" onClick={() => onRevoke()}>
             <Trash2 className="size-4" />
-            Revoke
+            {t('revoke')}
           </Button>
         )}
       </CardContent>
@@ -141,14 +149,10 @@ function TokenCard({ token, onRevoke }: { token: TokenDto; onRevoke: () => void 
   );
 }
 
-function labelForType(type: string): string {
-  if (type === 'oauth_access') return 'OAuth access token';
-  if (type === 'oauth_refresh') return 'OAuth refresh token';
-  if (type === 'delegated_end_user') return 'Delegated end-user token';
-  if (type === 'guest') return 'Guest token';
+function labelForType(type: string, t: ReturnType<typeof useTranslations<'dashboard.agents'>>): string {
+  if (type === 'oauth_access') return t('types.oauth_access');
+  if (type === 'oauth_refresh') return t('types.oauth_refresh');
+  if (type === 'delegated_end_user') return t('types.delegated_end_user');
+  if (type === 'guest') return t('types.guest');
   return type;
-}
-
-function fmt(iso: string): string {
-  return new Date(iso).toLocaleString();
 }

--- a/packages/dashboard-pages/src/pages/dashboard-api-keys.tsx
+++ b/packages/dashboard-pages/src/pages/dashboard-api-keys.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { Copy, KeyRound, Plus, Trash2 } from 'lucide-react';
-import { api, ApiError } from '../api';
+import { useFormatter, useTranslations } from 'next-intl';
+import { api } from '../api';
+import { useTranslateError } from '../i18n/translate-error';
 import { Button } from '@getmunin/ui';
 import { Input } from '@getmunin/ui';
 import { Label } from '@getmunin/ui';
@@ -33,6 +35,10 @@ interface CreatedApiKey {
 }
 
 export function ApiKeysPage() {
+  const t = useTranslations('dashboard.apiKeys');
+  const tCommon = useTranslations('common');
+  const translate = useTranslateError();
+  const format = useFormatter();
   const [keys, setKeys] = useState<ApiKeySummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -45,7 +51,7 @@ export function ApiKeysPage() {
       const list = await api<ApiKeySummary[]>('/api/api-keys');
       setKeys(list);
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not load API keys.');
+      setError(translate(err) || t('errors.load'));
     }
   }
 
@@ -66,7 +72,7 @@ export function ApiKeysPage() {
       setName('');
       await load();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not create API key.');
+      setError(translate(err) || t('errors.create'));
     } finally {
       setCreating(false);
     }
@@ -77,27 +83,21 @@ export function ApiKeysPage() {
       await api(`/api/api-keys/${id}`, { method: 'DELETE' });
       await load();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not revoke API key.');
+      setError(translate(err) || t('errors.revoke'));
     }
   }
 
   return (
     <>
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">API keys</h1>
-        <p className="text-sm text-muted-foreground">
-          Long-lived admin keys for server-to-server integrations and programmatic admin agents.
-          Self-hosters and CI use these too. Treat them like passwords.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </header>
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Create a new key</CardTitle>
-          <CardDescription>
-            The plaintext value is shown ONCE, immediately after creation. Copy it now and store it
-            in your secret manager.
-          </CardDescription>
+          <CardTitle className="text-base">{t('createTitle')}</CardTitle>
+          <CardDescription>{t('createDescription')}</CardDescription>
         </CardHeader>
         <CardContent>
           <form
@@ -107,18 +107,18 @@ export function ApiKeysPage() {
             }}
           >
             <div className="flex-1 space-y-1">
-              <Label htmlFor="name">Name</Label>
+              <Label htmlFor="name">{t('nameLabel')}</Label>
               <Input
                 id="name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="e.g. production-backend"
+                placeholder={t('namePlaceholder')}
                 required
               />
             </div>
             <Button type="submit" disabled={creating}>
               <Plus className="size-4" />
-              {creating ? 'Creating…' : 'Create key'}
+              {creating ? t('creating') : t('create')}
             </Button>
           </form>
         </CardContent>
@@ -133,49 +133,59 @@ export function ApiKeysPage() {
       )}
 
       {keys === null ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
       ) : keys.length === 0 ? (
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
               <KeyRound className="size-5 text-muted-foreground" />
-              <CardTitle>No API keys yet</CardTitle>
+              <CardTitle>{t('emptyTitle')}</CardTitle>
             </div>
-            <CardDescription>Create your first key above to get started.</CardDescription>
+            <CardDescription>{t('emptyBody')}</CardDescription>
           </CardHeader>
         </Card>
       ) : (
         <ul className="space-y-2">
-          {keys.map((k) => (
-            <li
-              key={k.id}
-              className="flex items-center justify-between gap-4 rounded-lg border bg-background px-4 py-3"
-            >
-              <div className="min-w-0">
-                <p className="truncate text-sm font-medium">{k.name}</p>
-                <p className="text-xs text-muted-foreground">
-                  <span className="font-mono">{k.prefix}…</span> · created{' '}
-                  {new Date(k.createdAt).toLocaleDateString()}
-                  {k.lastUsedAt && (
-                    <>
-                      {' · last used '}
-                      {new Date(k.lastUsedAt).toLocaleString()}
-                    </>
-                  )}
-                </p>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  void revoke(k.id);
-                }}
+          {keys.map((k) => {
+            const createdLabel = format.dateTime(new Date(k.createdAt), { dateStyle: 'medium' });
+            const lastUsedLabel = k.lastUsedAt
+              ? format.dateTime(new Date(k.lastUsedAt), { dateStyle: 'medium', timeStyle: 'short' })
+              : null;
+            return (
+              <li
+                key={k.id}
+                className="flex items-center justify-between gap-4 rounded-lg border bg-background px-4 py-3"
               >
-                <Trash2 className="size-4" />
-                Revoke
-              </Button>
-            </li>
-          ))}
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{k.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {lastUsedLabel
+                      ? t.rich('rowMetaWithLast', {
+                          prefix: k.prefix,
+                          created: createdLabel,
+                          lastUsed: lastUsedLabel,
+                          code: (chunks) => <span className="font-mono">{chunks}</span>,
+                        })
+                      : t.rich('rowMeta', {
+                          prefix: k.prefix,
+                          created: createdLabel,
+                          code: (chunks) => <span className="font-mono">{chunks}</span>,
+                        })}
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    void revoke(k.id);
+                  }}
+                >
+                  <Trash2 className="size-4" />
+                  {t('revoke')}
+                </Button>
+              </li>
+            );
+          })}
         </ul>
       )}
     </>
@@ -189,6 +199,7 @@ function NewKeyCallout({
   created: CreatedApiKey;
   onDismiss: () => void;
 }) {
+  const t = useTranslations('dashboard.apiKeys');
   const [copied, setCopied] = useState(false);
   function copy() {
     void navigator.clipboard.writeText(created.key).then(() => {
@@ -199,10 +210,8 @@ function NewKeyCallout({
   return (
     <Card className="border-emerald-200 bg-emerald-50">
       <CardHeader>
-        <CardTitle className="text-base">Key created — copy it now</CardTitle>
-        <CardDescription>
-          Munin only stores the hash. We can&apos;t show you this key again.
-        </CardDescription>
+        <CardTitle className="text-base">{t('createdTitle')}</CardTitle>
+        <CardDescription>{t('createdDescription')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex items-center gap-2">
@@ -211,11 +220,11 @@ function NewKeyCallout({
           </code>
           <Button variant="outline" size="sm" onClick={copy}>
             <Copy className="size-4" />
-            {copied ? 'Copied' : 'Copy'}
+            {copied ? t('copied') : t('copy')}
           </Button>
         </div>
         <Button variant="ghost" size="sm" onClick={onDismiss}>
-          I&apos;ve saved it
+          {t('savedIt')}
         </Button>
       </CardContent>
     </Card>

--- a/packages/dashboard-pages/src/pages/dashboard-audit-log.tsx
+++ b/packages/dashboard-pages/src/pages/dashboard-audit-log.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { ScrollText } from 'lucide-react';
-import { api, ApiError } from '../api';
+import { useFormatter, useTranslations } from 'next-intl';
+import { api } from '../api';
+import { useTranslateError } from '../i18n/translate-error';
 import { Button } from '@getmunin/ui';
 import { Input } from '@getmunin/ui';
 import { Label } from '@getmunin/ui';
@@ -32,6 +34,9 @@ interface AuditPage {
 }
 
 export function AuditLogPage() {
+  const t = useTranslations('dashboard.auditLog');
+  const translate = useTranslateError();
+  const format = useFormatter();
   const [items, setItems] = useState<AuditDto[]>([]);
   const [cursor, setCursor] = useState<string | null>(null);
   const [exhausted, setExhausted] = useState(false);
@@ -55,29 +60,25 @@ export function AuditLogPage() {
       setCursor(page.nextCursor);
       setExhausted(page.nextCursor === null);
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not load audit log.');
+      setError(translate(err) || t('errors.load'));
     }
   }
 
   useEffect(() => {
     void load(true);
-
   }, []);
 
   return (
     <>
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">Audit log</h1>
-        <p className="text-sm text-muted-foreground">
-          Every tool call and control-plane mutation, newest first. Filter by tool, actor type, or
-          correlation id to isolate one request chain.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </header>
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Filter</CardTitle>
-          <CardDescription>Leave blank to match all values.</CardDescription>
+          <CardTitle className="text-base">{t('filterTitle')}</CardTitle>
+          <CardDescription>{t('filterDescription')}</CardDescription>
         </CardHeader>
         <CardContent>
           <form
@@ -90,7 +91,7 @@ export function AuditLogPage() {
             }}
           >
             <div className="space-y-1">
-              <Label htmlFor="tool">Tool</Label>
+              <Label htmlFor="tool">{t('filterTool')}</Label>
               <Input
                 id="tool"
                 value={filters.tool}
@@ -99,7 +100,7 @@ export function AuditLogPage() {
               />
             </div>
             <div className="space-y-1">
-              <Label htmlFor="actorType">Actor type</Label>
+              <Label htmlFor="actorType">{t('filterActorType')}</Label>
               <Input
                 id="actorType"
                 value={filters.actorType}
@@ -108,7 +109,7 @@ export function AuditLogPage() {
               />
             </div>
             <div className="space-y-1">
-              <Label htmlFor="correlationId">Correlation id</Label>
+              <Label htmlFor="correlationId">{t('filterCorrelationId')}</Label>
               <Input
                 id="correlationId"
                 value={filters.correlationId}
@@ -118,7 +119,7 @@ export function AuditLogPage() {
             </div>
             <div className="flex items-end">
               <Button type="submit" className="w-full">
-                Apply
+                {t('apply')}
               </Button>
             </div>
           </form>
@@ -136,11 +137,9 @@ export function AuditLogPage() {
           <CardHeader>
             <div className="flex items-center gap-2">
               <ScrollText className="size-5 text-muted-foreground" />
-              <CardTitle>No audit rows yet</CardTitle>
+              <CardTitle>{t('emptyTitle')}</CardTitle>
             </div>
-            <CardDescription>
-              Tool calls and control-plane writes appear here. Connect an agent and try a tool.
-            </CardDescription>
+            <CardDescription>{t('emptyBody')}</CardDescription>
           </CardHeader>
         </Card>
       ) : (
@@ -148,17 +147,22 @@ export function AuditLogPage() {
           <table className="w-full text-sm">
             <thead className="bg-muted/40">
               <tr className="text-left text-xs font-medium uppercase text-muted-foreground">
-                <th className="px-3 py-2">Time</th>
-                <th className="px-3 py-2">Actor</th>
-                <th className="px-3 py-2">Tool / method</th>
-                <th className="px-3 py-2">Result</th>
-                <th className="px-3 py-2">Correlation</th>
+                <th className="px-3 py-2">{t('tableTime')}</th>
+                <th className="px-3 py-2">{t('tableActor')}</th>
+                <th className="px-3 py-2">{t('tableToolMethod')}</th>
+                <th className="px-3 py-2">{t('tableResult')}</th>
+                <th className="px-3 py-2">{t('tableCorrelation')}</th>
               </tr>
             </thead>
             <tbody>
               {items.map((row) => (
                 <tr key={row.id} className="border-t">
-                  <td className="px-3 py-2 text-xs">{new Date(row.createdAt).toLocaleString()}</td>
+                  <td className="px-3 py-2 text-xs">
+                    {format.dateTime(new Date(row.createdAt), {
+                      dateStyle: 'medium',
+                      timeStyle: 'short',
+                    })}
+                  </td>
                   <td className="px-3 py-2 text-xs font-mono">{row.actorType}</td>
                   <td className="px-3 py-2 text-xs font-mono">{row.tool ?? row.method ?? '—'}</td>
                   <td className="px-3 py-2">
@@ -187,7 +191,7 @@ export function AuditLogPage() {
       {!exhausted && items.length > 0 && (
         <div className="flex justify-center">
           <Button variant="outline" onClick={() => void load(false)}>
-            Load more
+            {t('loadMore')}
           </Button>
         </div>
       )}

--- a/packages/dashboard-pages/src/pages/dashboard-end-users.tsx
+++ b/packages/dashboard-pages/src/pages/dashboard-end-users.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { Users } from 'lucide-react';
-import { api, ApiError } from '../api';
+import { useFormatter, useTranslations } from 'next-intl';
+import { api } from '../api';
+import { useTranslateError } from '../i18n/translate-error';
 import { Button } from '@getmunin/ui';
 import {
   Card,
@@ -24,6 +26,10 @@ interface EndUserDto {
 }
 
 export function EndUsersPage() {
+  const t = useTranslations('dashboard.endUsers');
+  const tCommon = useTranslations('common');
+  const translate = useTranslateError();
+  const format = useFormatter();
   const [items, setItems] = useState<EndUserDto[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [revokingId, setRevokingId] = useState<string | null>(null);
@@ -34,7 +40,7 @@ export function EndUsersPage() {
       const list = await api<EndUserDto[]>('/api/end-users');
       setItems(list);
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not load end-users.');
+      setError(translate(err) || t('errors.load'));
     }
   }
 
@@ -48,13 +54,9 @@ export function EndUsersPage() {
       const result = await api<{ revoked: number }>(`/api/end-users/${id}/revoke-tokens`, {
         method: 'POST',
       });
-      setError(
-        result.revoked > 0
-          ? null
-          : 'No active tokens to revoke for this end-user.',
-      );
+      setError(result.revoked > 0 ? null : t('noTokensRevoked'));
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not revoke tokens.');
+      setError(translate(err) || t('errors.revoke'));
     } finally {
       setRevokingId(null);
     }
@@ -63,10 +65,11 @@ export function EndUsersPage() {
   return (
     <>
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">End-users</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
         <p className="text-sm text-muted-foreground">
-          People your customer-facing agents act on behalf of. Created server-side via the SDK or
-          <code className="mx-1">/api/end-users/lookup</code>; never trusted from agent input.
+          {t.rich('subtitle', {
+            code: (chunks) => <code className="mx-1">{chunks}</code>,
+          })}
         </p>
       </header>
 
@@ -77,18 +80,18 @@ export function EndUsersPage() {
       )}
 
       {items === null ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
       ) : items.length === 0 ? (
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
               <Users className="size-5 text-muted-foreground" />
-              <CardTitle>No end-users yet</CardTitle>
+              <CardTitle>{t('emptyTitle')}</CardTitle>
             </div>
             <CardDescription>
-              Mint your first delegated end-user token via{' '}
-              <code>POST /api/delegated-token</code> with an admin key from your backend, and the
-              corresponding EndUser will appear here.
+              {t.rich('emptyBody', {
+                code: (chunks) => <code>{chunks}</code>,
+              })}
             </CardDescription>
           </CardHeader>
         </Card>
@@ -97,17 +100,19 @@ export function EndUsersPage() {
           <table className="w-full text-sm">
             <thead className="bg-muted/40">
               <tr className="text-left text-xs font-medium uppercase text-muted-foreground">
-                <th className="px-3 py-2">Name</th>
-                <th className="px-3 py-2">External id</th>
-                <th className="px-3 py-2">Contact</th>
-                <th className="px-3 py-2">Created</th>
+                <th className="px-3 py-2">{t('tableName')}</th>
+                <th className="px-3 py-2">{t('tableExternalId')}</th>
+                <th className="px-3 py-2">{t('tableContact')}</th>
+                <th className="px-3 py-2">{t('tableCreated')}</th>
                 <th className="px-3 py-2"></th>
               </tr>
             </thead>
             <tbody>
               {items.map((eu) => (
                 <tr key={eu.id} className="border-t">
-                  <td className="px-3 py-2">{eu.name ?? <span className="text-muted-foreground">—</span>}</td>
+                  <td className="px-3 py-2">
+                    {eu.name ?? <span className="text-muted-foreground">—</span>}
+                  </td>
                   <td className="px-3 py-2 font-mono text-xs text-muted-foreground">
                     {eu.externalId ?? '—'}
                   </td>
@@ -115,7 +120,7 @@ export function EndUsersPage() {
                     {eu.email ?? eu.phone ?? '—'}
                   </td>
                   <td className="px-3 py-2 text-xs text-muted-foreground">
-                    {new Date(eu.createdAt).toLocaleDateString()}
+                    {format.dateTime(new Date(eu.createdAt), { dateStyle: 'medium' })}
                   </td>
                   <td className="px-3 py-2 text-right">
                     <Button
@@ -126,7 +131,7 @@ export function EndUsersPage() {
                         void revokeTokens(eu.id);
                       }}
                     >
-                      {revokingId === eu.id ? 'Revoking…' : 'Revoke active tokens'}
+                      {revokingId === eu.id ? t('revoking') : t('revokeActive')}
                     </Button>
                   </td>
                 </tr>

--- a/packages/dashboard-pages/src/pages/dashboard-export.tsx
+++ b/packages/dashboard-pages/src/pages/dashboard-export.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from 'react';
 import { Download } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { ApiError } from '../api';
+import { useTranslateError } from '../i18n/translate-error';
 import { Button } from '@getmunin/ui';
 import {
   Card,
@@ -15,6 +17,8 @@ import {
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
 export function ExportPage() {
+  const t = useTranslations('dashboard.export');
+  const translate = useTranslateError();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -37,7 +41,7 @@ export function ExportPage() {
       a.remove();
       URL.revokeObjectURL(url);
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not generate export.');
+      setError(translate(err) || t('errors.export'));
     } finally {
       setLoading(false);
     }
@@ -46,12 +50,8 @@ export function ExportPage() {
   return (
     <>
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">Data export</h1>
-        <p className="text-sm text-muted-foreground">
-          Download a complete JSON dump of your org&apos;s domain data — knowledge base, end-users,
-          and configuration. Use this to migrate to a self-hosted Munin or to keep an
-          offline copy.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </header>
 
       {error && (
@@ -62,17 +62,13 @@ export function ExportPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Export now</CardTitle>
-          <CardDescription>
-            Includes: organization, end-users, agents, and KB spaces / documents / versions.
-            Excludes: tokens, API keys, and the audit log (those are operational data
-            you can&apos;t restore from an export).
-          </CardDescription>
+          <CardTitle>{t('cardTitle')}</CardTitle>
+          <CardDescription>{t('cardDescription')}</CardDescription>
         </CardHeader>
         <CardContent>
           <Button onClick={() => void download()} disabled={loading}>
             <Download className="size-4" />
-            {loading ? 'Preparing…' : 'Download export'}
+            {loading ? t('preparing') : t('download')}
           </Button>
         </CardContent>
       </Card>

--- a/packages/dashboard-pages/src/pages/dashboard-overview.tsx
+++ b/packages/dashboard-pages/src/pages/dashboard-overview.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { Bot, Code2, KeyRound } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { Button } from '@getmunin/ui';
 import {
   Card,
@@ -10,13 +11,12 @@ import {
 } from '@getmunin/ui';
 
 export function DashboardPage() {
+  const t = useTranslations('dashboard.overview');
   return (
     <>
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Welcome to Munin</h1>
-        <p className="text-sm text-muted-foreground">
-          Connect your AI agent or build a server-side integration.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
@@ -24,19 +24,15 @@ export function DashboardPage() {
           <CardHeader>
             <div className="flex items-center gap-2">
               <Bot className="size-5 text-muted-foreground" />
-              <CardTitle>Connect your AI agent</CardTitle>
+              <CardTitle>{t('connectCard.title')}</CardTitle>
             </div>
-            <CardDescription>
-              Add this URL to Claude Desktop, Cursor, or any MCP client.
-            </CardDescription>
+            <CardDescription>{t('connectCard.description')}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             <code className="block rounded-md border bg-muted px-3 py-2 font-mono text-sm">
               https://mcp.getmunin.com
             </code>
-            <p className="text-xs text-muted-foreground">
-              You&apos;ll see a consent screen here when an agent connects.
-            </p>
+            <p className="text-xs text-muted-foreground">{t('connectCard.consentNote')}</p>
           </CardContent>
         </Card>
 
@@ -44,16 +40,14 @@ export function DashboardPage() {
           <CardHeader>
             <div className="flex items-center gap-2">
               <Code2 className="size-5 text-muted-foreground" />
-              <CardTitle>Build a server integration</CardTitle>
+              <CardTitle>{t('buildCard.title')}</CardTitle>
             </div>
-            <CardDescription>
-              Voice AI, web chatbot, or mobile app? Mint short-lived end-user tokens server-side.
-            </CardDescription>
+            <CardDescription>{t('buildCard.description')}</CardDescription>
           </CardHeader>
           <CardContent>
             <Button className="w-full" render={<Link href="/dashboard/api-keys" />}>
               <KeyRound className="size-4" />
-              Manage API keys
+              {t('buildCard.cta')}
             </Button>
           </CardContent>
         </Card>

--- a/packages/dashboard-pages/src/pages/dashboard-team.tsx
+++ b/packages/dashboard-pages/src/pages/dashboard-team.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import { Copy, Mail, MailX, Trash2, UserPlus, Users, X } from 'lucide-react';
-import { api, ApiError } from '../api';
+import { useFormatter, useTranslations } from 'next-intl';
+import { api } from '../api';
+import { useTranslateError } from '../i18n/translate-error';
 import { Button } from '@getmunin/ui';
 import { Input } from '@getmunin/ui';
 import { Label } from '@getmunin/ui';
@@ -43,6 +45,10 @@ interface PendingShare {
 }
 
 export function TeamPage() {
+  const t = useTranslations('dashboard.team');
+  const tCommon = useTranslations('common');
+  const translate = useTranslateError();
+  const format = useFormatter();
   const [members, setMembers] = useState<MemberDto[] | null>(null);
   const [invites, setInvites] = useState<InvitationDto[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -62,7 +68,7 @@ export function TeamPage() {
       setMembers(m);
       setInvites(i);
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not load team.');
+      setError(translate(err) || t('errors.load'));
     }
   }
 
@@ -89,7 +95,7 @@ export function TeamPage() {
       }
       await load();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not send invite.');
+      setError(translate(err) || t('errors.invite'));
     } finally {
       setSubmitting(false);
     }
@@ -109,17 +115,17 @@ export function TeamPage() {
       await api(`/api/orgs/me/invitations/${id}`, { method: 'DELETE' });
       await load();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not revoke invite.');
+      setError(translate(err) || t('errors.revokeInvite'));
     }
   }
 
   async function removeMember(userId: string) {
-    if (!confirm('Remove this member? They lose access to the org immediately.')) return;
+    if (!confirm(t('removeConfirm'))) return;
     try {
       await api(`/api/orgs/me/members/${userId}`, { method: 'DELETE' });
       await load();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not remove member.');
+      setError(translate(err) || t('errors.remove'));
     }
   }
 
@@ -131,18 +137,15 @@ export function TeamPage() {
       });
       await load();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not change role.');
+      setError(translate(err) || t('errors.changeRole'));
     }
   }
 
   return (
     <>
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">Team</h1>
-        <p className="text-sm text-muted-foreground">
-          Members and pending invitations for this org. Owners can invite others, change roles,
-          and remove members; members can use the apps but can&apos;t manage access.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </header>
 
       {error && (
@@ -155,11 +158,9 @@ export function TeamPage() {
         <CardHeader>
           <div className="flex items-center gap-2">
             <UserPlus className="size-5 text-muted-foreground" />
-            <CardTitle className="text-base">Invite a teammate</CardTitle>
+            <CardTitle className="text-base">{t('inviteTitle')}</CardTitle>
           </div>
-          <CardDescription>
-            They&apos;ll get an email with a link to accept. The link expires in 7 days.
-          </CardDescription>
+          <CardDescription>{t('inviteDescription')}</CardDescription>
         </CardHeader>
         <CardContent>
           <form
@@ -169,31 +170,31 @@ export function TeamPage() {
             }}
           >
             <div className="flex-1 space-y-1">
-              <Label htmlFor="email">Email</Label>
+              <Label htmlFor="email">{t('emailLabel')}</Label>
               <Input
                 id="email"
                 type="email"
                 value={inviteEmail}
                 onChange={(e) => setInviteEmail(e.target.value)}
-                placeholder="teammate@example.com"
+                placeholder={t('emailPlaceholder')}
                 required
               />
             </div>
             <div className="space-y-1">
-              <Label htmlFor="role">Role</Label>
+              <Label htmlFor="role">{t('roleLabel')}</Label>
               <select
                 id="role"
                 className="h-9 rounded-md border bg-background px-3 text-sm"
                 value={inviteRole}
                 onChange={(e) => setInviteRole(e.target.value as 'owner' | 'member')}
               >
-                <option value="member">Member</option>
-                <option value="owner">Owner</option>
+                <option value="member">{t('roleMember')}</option>
+                <option value="owner">{t('roleOwner')}</option>
               </select>
             </div>
             <Button type="submit" disabled={submitting}>
               <Mail className="size-4" />
-              {submitting ? 'Sending…' : 'Send invite'}
+              {submitting ? t('sending') : t('sendInvite')}
             </Button>
           </form>
         </CardContent>
@@ -201,6 +202,7 @@ export function TeamPage() {
 
       <ManualShareDialog
         open={pendingShare !== null}
+        closeLabel={t('close')}
         onClose={() => {
           setPendingShare(null);
           setLinkCopied(false);
@@ -210,25 +212,22 @@ export function TeamPage() {
           <>
             <div className="flex items-center gap-2">
               <MailX className="size-5 text-amber-600" />
-              <h2 className="text-base font-semibold">
-                Email isn&apos;t configured — share this link manually
-              </h2>
+              <h2 className="text-base font-semibold">{t('manualShareTitle')}</h2>
             </div>
             <p className="text-sm text-muted-foreground">
-              No email provider is set up on this Munin instance, so we didn&apos;t send an
-              email. Send the link below to{' '}
-              <span className="font-medium text-foreground">{pendingShare.email}</span>{' '}
-              yourself, or set{' '}
-              <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">MUNIN_MAIL_PROVIDER</code>{' '}
-              (e.g.{' '}
-              <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">resend</code>)
-              and restart so future invites mail automatically.
+              {t.rich('manualShareBody', {
+                email: pendingShare.email,
+                recipient: (chunks) => <span className="font-medium text-foreground">{chunks}</span>,
+                code: (chunks) => (
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">{chunks}</code>
+                ),
+              })}
             </p>
             <code className="block break-all rounded-md border bg-muted/40 px-3 py-2 font-mono text-xs">
               {pendingShare.acceptUrl}
             </code>
             <div className="flex items-center justify-between">
-              <span className="text-xs text-muted-foreground">Valid for 7 days.</span>
+              <span className="text-xs text-muted-foreground">{t('manualShareValid')}</span>
               <div className="flex items-center gap-2">
                 <Button
                   size="sm"
@@ -238,7 +237,7 @@ export function TeamPage() {
                   }}
                 >
                   <Copy className="size-4" />
-                  {linkCopied ? 'Copied' : 'Copy link'}
+                  {linkCopied ? t('copied') : t('copyLink')}
                 </Button>
                 <Button
                   size="sm"
@@ -247,7 +246,7 @@ export function TeamPage() {
                     setLinkCopied(false);
                   }}
                 >
-                  Done
+                  {t('done')}
                 </Button>
               </div>
             </div>
@@ -257,19 +256,19 @@ export function TeamPage() {
 
       <section className="space-y-3">
         <h2 className="text-sm font-semibold text-muted-foreground">
-          Members {members && `(${members.length})`}
+          {members ? t('membersTitleCount', { count: members.length }) : t('membersTitle')}
         </h2>
         {members === null ? (
-          <p className="text-sm text-muted-foreground">Loading…</p>
+          <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
         ) : (
           <div className="overflow-hidden rounded-lg border bg-background">
             <table className="w-full text-sm">
               <thead className="bg-muted/40">
                 <tr className="text-left text-xs font-medium uppercase text-muted-foreground">
-                  <th className="px-3 py-2">Name</th>
-                  <th className="px-3 py-2">Email</th>
-                  <th className="px-3 py-2">Role</th>
-                  <th className="px-3 py-2">Joined</th>
+                  <th className="px-3 py-2">{t('membersTableName')}</th>
+                  <th className="px-3 py-2">{t('membersTableEmail')}</th>
+                  <th className="px-3 py-2">{t('membersTableRole')}</th>
+                  <th className="px-3 py-2">{t('membersTableJoined')}</th>
                   <th className="px-3 py-2"></th>
                 </tr>
               </thead>
@@ -286,12 +285,12 @@ export function TeamPage() {
                           void changeRole(m.userId, e.target.value as 'owner' | 'member');
                         }}
                       >
-                        <option value="member">member</option>
-                        <option value="owner">owner</option>
+                        <option value="member">{t('roleMemberLower')}</option>
+                        <option value="owner">{t('roleOwnerLower')}</option>
                       </select>
                     </td>
                     <td className="px-3 py-2 text-xs text-muted-foreground">
-                      {new Date(m.joinedAt).toLocaleDateString()}
+                      {format.dateTime(new Date(m.joinedAt), { dateStyle: 'medium' })}
                     </td>
                     <td className="px-3 py-2 text-right">
                       <Button
@@ -302,7 +301,7 @@ export function TeamPage() {
                         }}
                       >
                         <Trash2 className="size-4" />
-                        Remove
+                        {t('remove')}
                       </Button>
                     </td>
                   </tr>
@@ -315,20 +314,18 @@ export function TeamPage() {
 
       <section className="space-y-3">
         <h2 className="text-sm font-semibold text-muted-foreground">
-          Pending invitations {invites && `(${invites.length})`}
+          {invites ? t('invitesTitleCount', { count: invites.length }) : t('invitesTitle')}
         </h2>
         {invites === null ? (
-          <p className="text-sm text-muted-foreground">Loading…</p>
+          <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
         ) : invites.length === 0 ? (
           <Card>
             <CardHeader>
               <div className="flex items-center gap-2">
                 <Users className="size-5 text-muted-foreground" />
-                <CardTitle>No pending invitations</CardTitle>
+                <CardTitle>{t('invitesEmptyTitle')}</CardTitle>
               </div>
-              <CardDescription>
-                Use the form above to invite someone — they&apos;ll appear here until accepted.
-              </CardDescription>
+              <CardDescription>{t('invitesEmptyBody')}</CardDescription>
             </CardHeader>
           </Card>
         ) : (
@@ -341,8 +338,11 @@ export function TeamPage() {
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium">{inv.email}</p>
                   <p className="text-xs text-muted-foreground">
-                    {inv.role} · invited {new Date(inv.createdAt).toLocaleDateString()} · expires{' '}
-                    {new Date(inv.expiresAt).toLocaleDateString()}
+                    {t('inviteRow', {
+                      role: inv.role,
+                      created: format.dateTime(new Date(inv.createdAt), { dateStyle: 'medium' }),
+                      expires: format.dateTime(new Date(inv.expiresAt), { dateStyle: 'medium' }),
+                    })}
                   </p>
                 </div>
                 <Button
@@ -353,7 +353,7 @@ export function TeamPage() {
                   }}
                 >
                   <Trash2 className="size-4" />
-                  Revoke
+                  {t('revoke')}
                 </Button>
               </li>
             ))}
@@ -366,10 +366,12 @@ export function TeamPage() {
 
 function ManualShareDialog({
   open,
+  closeLabel,
   onClose,
   children,
 }: {
   open: boolean;
+  closeLabel: string;
   onClose: () => void;
   children: ReactNode;
 }) {
@@ -403,7 +405,7 @@ function ManualShareDialog({
           type="button"
           className="absolute right-3 top-3 rounded-md p-1 text-muted-foreground hover:bg-muted"
           onClick={onClose}
-          aria-label="Close"
+          aria-label={closeLabel}
         >
           <X className="size-4" />
         </button>

--- a/packages/dashboard-pages/src/pages/dashboard-usage.tsx
+++ b/packages/dashboard-pages/src/pages/dashboard-usage.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { Activity } from 'lucide-react';
-import { api, ApiError } from '../api';
+import { useTranslations } from 'next-intl';
+import { api } from '../api';
+import { useTranslateError } from '../i18n/translate-error';
 import {
   Card,
   CardContent,
@@ -18,6 +20,8 @@ interface UsageDto {
 }
 
 export function UsagePage() {
+  const t = useTranslations('dashboard.usage');
+  const translate = useTranslateError();
   const [usage, setUsage] = useState<UsageDto | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -31,7 +35,7 @@ export function UsagePage() {
           setError(null);
         }
       } catch (err) {
-        if (active) setError(err instanceof ApiError ? err.message : 'Could not load usage.');
+        if (active) setError(translate(err) || t('errors.load'));
       }
     }
     void load();
@@ -40,16 +44,13 @@ export function UsagePage() {
       active = false;
       clearInterval(id);
     };
-  }, []);
+  }, [t, translate]);
 
   return (
     <>
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">Usage</h1>
-        <p className="text-sm text-muted-foreground">
-          MCP tool calls counted against your tier limits. Counters reset at the start of each
-          window.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </header>
 
       {error && (
@@ -60,8 +61,8 @@ export function UsagePage() {
 
       {usage && (
         <div className="grid gap-4 md:grid-cols-2">
-          <UsageCard label="Per minute" data={usage.minute} />
-          <UsageCard label="Per day" data={usage.day} />
+          <UsageCard label={t('perMinute')} data={usage.minute} />
+          <UsageCard label={t('perDay')} data={usage.day} />
         </div>
       )}
     </>
@@ -75,6 +76,7 @@ function UsageCard({
   label: string;
   data: { used: number; limit: number; resetAt: string };
 }) {
+  const t = useTranslations('dashboard.usage');
   const pct = data.limit === 0 ? 0 : Math.min(100, Math.round((data.used / data.limit) * 100));
   const tone = pct >= 90 ? 'bg-destructive' : pct >= 70 ? 'bg-amber-500' : 'bg-emerald-500';
   return (
@@ -85,24 +87,28 @@ function UsageCard({
           <CardTitle className="text-base">{label}</CardTitle>
         </div>
         <CardDescription>
-          {data.used} of {data.limit} tool calls — resets {formatResetIn(data.resetAt)}.
+          {t('summary', {
+            used: data.used,
+            limit: data.limit,
+            resetIn: formatResetIn(data.resetAt, t),
+          })}
         </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="h-2 overflow-hidden rounded-full bg-muted">
           <div className={cn('h-full transition-all', tone)} style={{ width: `${pct}%` }} />
         </div>
-        <p className="mt-2 text-xs text-muted-foreground">{pct}% used</p>
+        <p className="mt-2 text-xs text-muted-foreground">{t('percentUsed', { pct })}</p>
       </CardContent>
     </Card>
   );
 }
 
-function formatResetIn(iso: string): string {
+function formatResetIn(iso: string, t: ReturnType<typeof useTranslations<'dashboard.usage'>>): string {
   const ms = new Date(iso).getTime() - Date.now();
-  if (ms < 0) return 'now';
+  if (ms < 0) return t('resetNow');
   const minutes = Math.round(ms / 60_000);
-  if (minutes < 60) return `in ${minutes}m`;
+  if (minutes < 60) return t('resetMinutes', { minutes });
   const hours = Math.round(minutes / 60);
-  return `in ${hours}h`;
+  return t('resetHours', { hours });
 }

--- a/packages/ui/src/components/google-button.tsx
+++ b/packages/ui/src/components/google-button.tsx
@@ -3,15 +3,11 @@
 import { Button } from './button';
 
 export interface GoogleButtonProps {
-  label?: string;
+  label: string;
   onSignIn: () => void;
 }
 
-/**
- * Presentational Google sign-in button. The auth client (BetterAuth, etc.)
- * is supplied by the consumer via `onSignIn` so this component stays UI-only.
- */
-export function GoogleButton({ label = 'Continue with Google', onSignIn }: GoogleButtonProps) {
+export function GoogleButton({ label, onSignIn }: GoogleButtonProps) {
   return (
     <Button type="button" variant="outline" className="w-full" onClick={onSignIn}>
       <GoogleLogo />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       next:
         specifier: ^15.0.0
         version: 15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next-intl:
+        specifier: ^4.11.0
+        version: 4.11.0(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -376,6 +379,9 @@ importers:
       lucide-react:
         specifier: ^1.11.0
         version: 1.14.0(react@19.2.5)
+      next-intl:
+        specifier: ^4.0.0
+        version: 4.11.0(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1153,6 +1159,18 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@formatjs/fast-memoize@3.1.3':
+    resolution: {integrity: sha512-Ocd1vPuD68rW6BJDuAOtnnc1GPeVepY5kZXML1psGVFQ+1Q8CfkftT3Tnam+Mxx97Pz08jIEDCotl/GV+Naccg==}
+
+  '@formatjs/icu-messageformat-parser@3.5.6':
+    resolution: {integrity: sha512-04ZjRIeQCnR/h32wBP9/S7rkyy1hLAs2fXJcNwc7hseJd//K9TMBqK0ukb4dXqnALKQ9m5ruZeOD2qqEkK9ixg==}
+
+  '@formatjs/icu-skeleton-parser@2.1.6':
+    resolution: {integrity: sha512-9f1VQ2kaaLHK0WPU1OrAmiNKCKJwyoDmwNzQXbUa6XtFBOgHZ4YZURE8sSedHmMr0kvpB75OtplB0hMYkfdwfg==}
+
+  '@formatjs/intl-localematcher@0.8.5':
+    resolution: {integrity: sha512-TEW/NR367c3PcQ2AXfkNig9jC740+qbkM0LgKl7UCE7Xtv7C5Uk1mvlu86MjQZBmscUai8HSWjcEETpwaVvJ6A==}
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -1720,6 +1738,88 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -1860,6 +1960,9 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
+
+  '@schummar/icu-type-parser@1.21.5':
+    resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -3362,6 +3465,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  icu-minify@4.11.0:
+    resolution: {integrity: sha512-XRvblCwLqWXio5ZLcmDqXvJv7alSACK6UjXuuMOdQWB//d25AQX6xlVlI1FEbc3Q6iPLXXo6HaVLn8LcAFhn1Q==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -3386,6 +3492,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  intl-messageformat@11.2.3:
+    resolution: {integrity: sha512-kZthTU+3WLcoWoRg5j6LOkN1TeUBtmkX0OIwSAbcHVIfQAEbGVdmANM8u6GL3eUDOqLwheYoXMUshAh1UdeXlQ==}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -3808,6 +3917,19 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
+  next-intl-swc-plugin-extractor@4.11.0:
+    resolution: {integrity: sha512-WUGBSxGNd8eQ0rAsJHFmRw2H7+SZAXQIY/HAnYM57JaUsj5D2vx4KOz4zFtXlyKDtsw9awHfgWVvBae2/RDF9A==}
+
+  next-intl@4.11.0:
+    resolution: {integrity: sha512-Chp8rgEVUYOX/bCtYy+PXH6lDX3X+GPT9sR9HScHroL283em/4urP9btfdHEMEHJJXdq2W/5wDaDDtWONPdNSA==}
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -3837,6 +3959,9 @@ packages:
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -4061,6 +4186,9 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  po-parser@2.1.1:
+    resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -4753,6 +4881,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-intl@4.11.0:
+    resolution: {integrity: sha512-7ILhTLuo3fnSKhoTGDk5X9591pjtWr6qB4inrlvGkN9OEyKhoiG73GZFoLSs68wz3BsSGtoWa62iWvrYEYU+iA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -5576,6 +5709,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@formatjs/fast-memoize@3.1.3': {}
+
+  '@formatjs/icu-messageformat-parser@3.5.6':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.6
+
+  '@formatjs/icu-skeleton-parser@2.1.6': {}
+
+  '@formatjs/intl-localematcher@0.8.5':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.3
+
   '@hono/node-server@1.19.14(hono@4.12.15)':
     dependencies:
       hono: 4.12.15
@@ -6123,6 +6268,66 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
+
   '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -6210,6 +6415,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@schummar/icu-type-parser@1.21.5': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -7053,8 +7260,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -7681,6 +7887,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  icu-minify@4.11.0:
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 3.5.6
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -7707,6 +7917,11 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
+
+  intl-messageformat@11.2.3:
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.3
+      '@formatjs/icu-messageformat-parser': 3.5.6
 
   ip-address@10.1.0: {}
 
@@ -8056,6 +8271,25 @@ snapshots:
 
   neo-async@2.6.2: {}
 
+  next-intl-swc-plugin-extractor@4.11.0: {}
+
+  next-intl@4.11.0(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.8.5
+      '@parcel/watcher': 2.5.6
+      '@swc/core': 1.15.32
+      icu-minify: 4.11.0
+      negotiator: 1.0.0
+      next: 15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next-intl-swc-plugin-extractor: 4.11.0
+      po-parser: 2.1.1
+      react: 19.2.5
+      use-intl: 4.11.0(react@19.2.5)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
   next-themes@0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -8085,6 +8319,8 @@ snapshots:
       - babel-plugin-macros
 
   node-abort-controller@3.1.1: {}
+
+  node-addon-api@7.1.1: {}
 
   node-domexception@1.0.0: {}
 
@@ -8297,6 +8533,8 @@ snapshots:
   pkce-challenge@5.0.1: {}
 
   pluralize@8.0.0: {}
+
+  po-parser@2.1.1: {}
 
   postcss-import@15.1.0(postcss@8.5.12):
     dependencies:
@@ -9075,6 +9313,14 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-intl@4.11.0(react@19.2.5):
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.3
+      '@schummar/icu-type-parser': 1.21.5
+      icu-minify: 4.11.0
+      intl-messageformat: 11.2.3
+      react: 19.2.5
 
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary

- Wires `next-intl` into `apps/web` and `packages/dashboard-pages` (cookie-based locale, no URL routing).
- Ships English (`en`) and Norwegian Bokmål (`nb`) message catalogs.
- Moves backend signup errors to stable codes (`SIGNUP_DOMAIN_NOT_ALLOWED`, `SIGNUP_INVITE_ONLY`) and extracts email templates to a locale-aware module.

## Breaking-ish (pre-1.0 minor)

- `@getmunin/dashboard-pages` now requires `next-intl` as a peer dep. Consumers must wrap their app in `<NextIntlClientProvider>` and configure `next-intl/plugin` in `next.config.mjs`. (`apps/web` and `apps/web-cloud` are already wired.)
- `@getmunin/ui` `GoogleButton.label` is now required — pass a translated label rather than relying on the previous English default.

## What's translated

All `dashboard-pages` exports (`AgentsPage`, `ApiKeysPage`, `TeamPage`, `AuditLogPage`, `UsagePage`, `EndUsersPage`, `ExportPage`, `DashboardPage`, `AcceptInvitePage`, `OrgSwitcher`), `apps/web` landing + auth pages + dashboard layout, plus an `errors.*` namespace mapping backend codes to translated messages.

## Backend

- `auth.config.ts` emits `SIGNUP_DOMAIN_NOT_ALLOWED` (with `details.domain`) or `SIGNUP_INVITE_ONLY` (with `details.email`) instead of the single `SIGNUP_NOT_ALLOWED`.
- New `email-templates.ts` keyed by locale (`en` | `nb`); default driven by `MUNIN_DEFAULT_LOCALE` env (falls back to `en`).

## Cloud follow-up

Once this is published as `@getmunin/dashboard-pages@0.9.0` (or whatever the changeset bumps it to), `munin-cloud` needs to bump its dep to pick up the localized strings. A separate PR there wires up `next-intl` in `apps/web-cloud` and localizes cloud-only pages.

## Test plan

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r test` passes (all real tests pass; integration tests skipped without DB)
- [x] `pnpm --filter @getmunin/web build` produces a clean production build
- [ ] Manual: set `munin_locale=nb` cookie and verify Norwegian renders across landing, auth, dashboard
- [ ] Manual: trigger a signup with email allowlist enabled, confirm `SIGNUP_DOMAIN_NOT_ALLOWED` translates correctly on the client
- [ ] Manual: trigger a password-reset email with `MUNIN_DEFAULT_LOCALE=nb`, confirm Norwegian copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)