### PR TITLE
feat: Anthropic directory readiness — tool annotations + legal pages

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist } from 'next/font/google';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 import { cn } from '@getmunin/ui';
+import { Footer } from '../components/Footer';
 
 const geist = Geist({ subsets: ['latin'], variable: '--font-sans' });
 
@@ -20,9 +21,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const messages = await getMessages();
   return (
     <html lang={locale} className={cn('font-sans', geist.variable)}>
-      <body>
+      <body className="flex min-h-screen flex-col">
         <NextIntlClientProvider locale={locale} messages={messages}>
-          {children}
+          <div className="flex-1">{children}</div>
+          <Footer />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { Metadata } from 'next';
+import ReactMarkdown from 'react-markdown';
+import { getTranslations } from 'next-intl/server';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('legal.privacy');
+  return { title: t('title'), description: t('description') };
+}
+
+export default function PrivacyPage() {
+  const md = readFileSync(
+    path.join(process.cwd(), 'public/legal/privacy.md'),
+    'utf-8',
+  );
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <article className="prose prose-neutral max-w-none dark:prose-invert">
+        <ReactMarkdown>{md}</ReactMarkdown>
+      </article>
+    </main>
+  );
+}

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { Metadata } from 'next';
+import ReactMarkdown from 'react-markdown';
+import { getTranslations } from 'next-intl/server';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('legal.terms');
+  return { title: t('title'), description: t('description') };
+}
+
+export default function TermsPage() {
+  const md = readFileSync(
+    path.join(process.cwd(), 'public/legal/terms.md'),
+    'utf-8',
+  );
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <article className="prose prose-neutral max-w-none dark:prose-invert">
+        <ReactMarkdown>{md}</ReactMarkdown>
+      </article>
+    </main>
+  );
+}

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
+
+export async function Footer() {
+  const t = await getTranslations('footer');
+  return (
+    <footer className="border-t border-border/60 px-4 py-6 text-xs text-muted-foreground">
+      <nav className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-4">
+        <span>© {new Date().getFullYear()} Munin</span>
+        <div className="flex items-center gap-4">
+          <Link href="/privacy" className="hover:underline">
+            {t('privacy')}
+          </Link>
+          <Link href="/terms" className="hover:underline">
+            {t('terms')}
+          </Link>
+          <a
+            href="https://github.com/getmunin/munin"
+            className="hover:underline"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            GitHub
+          </a>
+        </div>
+      </nav>
+    </footer>
+  );
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -305,5 +305,19 @@
       "signIn": "Sign in with Google",
       "signUp": "Sign up with Google"
     }
+  },
+  "footer": {
+    "privacy": "Privacy",
+    "terms": "Terms"
+  },
+  "legal": {
+    "privacy": {
+      "title": "Privacy Policy — Munin",
+      "description": "How getmunin.com handles personal data."
+    },
+    "terms": {
+      "title": "Terms of Use — Munin",
+      "description": "Terms governing use of getmunin.com and the Munin open-source project."
+    }
   }
 }

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -305,5 +305,19 @@
       "signIn": "Logg inn med Google",
       "signUp": "Registrer deg med Google"
     }
+  },
+  "footer": {
+    "privacy": "Personvern",
+    "terms": "Vilkår"
+  },
+  "legal": {
+    "privacy": {
+      "title": "Personvernerklæring — Munin",
+      "description": "Hvordan getmunin.com behandler personopplysninger."
+    },
+    "terms": {
+      "title": "Bruksvilkår — Munin",
+      "description": "Vilkår for bruk av getmunin.com og Munin-prosjektet."
+    }
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-markdown": "^9.1.0",
     "shadcn": "^4.5.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@getmunin/eslint-config": "workspace:*",
     "@getmunin/tsconfig": "workspace:*",
+    "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^22.7.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/apps/web/public/legal/privacy.md
+++ b/apps/web/public/legal/privacy.md
@@ -1,0 +1,77 @@
+# Privacy Policy — getmunin.com
+
+_Last updated: 2026-04-30_
+
+This policy covers **getmunin.com** — the public marketing site, the open-source documentation, and the GitHub Packages registry that serves the `@getmunin/*` libraries. It is published by Apps AS, registered at Vulkan 16, 0178 Oslo, Norway ("we", "us"). For the purposes of the EU GDPR we are the **data controller** for the personal data described below.
+
+If you run Munin as a **self-hosted** instance under your own control, this policy does **not** cover the data your instance processes. You are the data controller for that data; this policy only governs data that flows through getmunin.com itself.
+
+If you use **Munin Cloud** (https://app.getmunin.com), see the separate [Munin Cloud Privacy Policy](https://app.getmunin.com/privacy).
+
+## 1. What we collect on getmunin.com
+
+We collect the minimum needed to run the site and OSS distribution.
+
+| Category | Data | Source |
+| --- | --- | --- |
+| Server logs | IP address, user agent, request path, timestamp, response status | Automatic on every HTTP request |
+| Support contacts | Name, email, message body | When you email us at hello@getmunin.com or security@getmunin.com |
+| OSS package distribution | GitHub username and download metadata | Provided by GitHub when you install `@getmunin/*` from GitHub Packages |
+| Cookies | A locale preference cookie (`NEXT_LOCALE`) | Set when you switch language |
+
+We do **not** run third-party analytics, ad pixels, or session-replay tools on getmunin.com. The locale cookie is the only cookie we set; it is strictly necessary for the language switcher and is exempt from consent under the ePrivacy Directive.
+
+## 2. Why we process this data
+
+| Purpose | Legal basis (GDPR Art. 6) |
+| --- | --- |
+| Operating and securing the site (logs, abuse prevention) | Legitimate interest (Art. 6(1)(f)) |
+| Replying to support and security reports you send us | Legitimate interest, and performance of measures taken at your request (Art. 6(1)(b),(f)) |
+| Distributing the open-source code via GitHub Packages | Legitimate interest in maintaining the OSS project |
+| Remembering your language preference | Legitimate interest; strictly necessary functionality |
+
+We do not sell personal data and we do not use it to train AI models.
+
+## 3. Retention
+
+- **HTTP server logs:** up to 30 days, then deleted.
+- **Support emails:** for as long as is reasonably necessary to handle the conversation and any follow-up; typically 24 months.
+- **GitHub Packages downloads:** retained by GitHub under [GitHub's privacy policy](https://docs.github.com/site-policy/privacy-policies/github-general-privacy-statement); we receive aggregated counters only.
+- **Locale cookie:** 12 months from your last visit.
+
+## 4. Who we share it with
+
+We use a small number of processors to run getmunin.com:
+
+| Processor | What it processes | Where |
+| --- | --- | --- |
+| The hosting provider for getmunin.com | Server logs, request bodies | EU |
+| GitHub, Inc. | OSS source, releases, package downloads, issue tracker | US, with SCCs |
+| Our email provider (used for support correspondence) | Inbound and outbound mail | EU/US, with SCCs where applicable |
+
+We do not transfer personal data outside these processors. We do not share data with advertisers, brokers, or analytics partners.
+
+## 5. Your rights (EU/EEA, UK, California)
+
+You have the right to access, correct, delete, restrict, port, and object to our processing of your personal data. EU/EEA residents may also lodge a complaint with their supervisory authority. California residents have the rights under the CCPA/CPRA, including the right to know and delete; we do not sell or share personal information as those terms are defined under California law.
+
+To exercise these rights, email **privacy@getmunin.com**. We will respond within 30 days.
+
+## 6. Security
+
+- All getmunin.com traffic is served over TLS.
+- We follow the practices in our [Security Policy](https://github.com/getmunin/munin/blob/main/SECURITY.md). Vulnerabilities can be reported to **security@getmunin.com**; we acknowledge within 72 hours and provide a remediation timeline within 7 days for confirmed issues.
+
+## 7. Children
+
+getmunin.com is not directed at children under 16 and we do not knowingly collect their personal data. If you believe we have, contact privacy@getmunin.com and we will delete it.
+
+## 8. Changes
+
+We will post material changes on this page and update the "Last updated" date. For substantive changes we will, where feasible, also notify recent support contacts by email.
+
+## 9. Contact
+
+Apps AS
+Vulkan 16, 0178 Oslo, Norway
+privacy@getmunin.com

--- a/apps/web/public/legal/terms.md
+++ b/apps/web/public/legal/terms.md
@@ -1,0 +1,59 @@
+# Terms of Use — getmunin.com
+
+_Last updated: 2026-04-30_
+
+These terms govern your use of **getmunin.com** — the public marketing site, the open-source documentation, the public suggestions board, and the GitHub Packages registry that serves the `@getmunin/*` libraries. They are published by Apps AS, registered at Vulkan 16, 0178 Oslo, Norway ("we", "us").
+
+For the **Munin Cloud** hosted SaaS (https://app.getmunin.com), separate [Munin Cloud Terms](https://app.getmunin.com/terms) apply.
+
+## 1. The open-source software
+
+The Munin source code and the `@getmunin/*` libraries are licensed under the **MIT License** (see [LICENSE](https://github.com/getmunin/munin/blob/main/LICENSE)). The MIT License grants you broad rights and disclaims warranties and liability — read it; it governs your use of the code.
+
+When you use the code, including via `pnpm add` from GitHub Packages, you accept the MIT License's terms. These terms of use do **not** override the MIT License with respect to the code itself.
+
+## 2. The website
+
+You may browse getmunin.com, read the documentation, and link to it. You agree not to:
+
+- attempt to disrupt the site (denial of service, automated scraping at a scale that degrades the service for others, exploiting vulnerabilities outside the bounds of our [Security Policy](https://github.com/getmunin/munin/blob/main/SECURITY.md));
+- use the site to distribute malware, phishing content, or unlawful material;
+- impersonate us or misrepresent your relationship with the project.
+
+We may rate-limit or block traffic that violates these terms or threatens the service.
+
+## 3. Suggestions and other contributions
+
+The public suggestions board at https://getmunin.com/suggestions and the GitHub issue tracker accept user-generated content. By posting:
+
+- you grant us a non-exclusive, royalty-free, worldwide, perpetual licence to display, reproduce, and act upon your post within the project (including publishing aggregate vote counts, quoting it in changelogs, and shipping a feature in response);
+- you confirm the content is yours to share and does not violate anyone else's rights;
+- you accept that posts may be edited or removed if they are off-topic, abusive, infringing, or otherwise inappropriate.
+
+We don't use posted content to train AI models.
+
+## 4. Trademarks
+
+"Munin" and the Munin logo are our trademarks. The MIT License grants you rights to the code, not to our brand. Don't use the name or logo in a way that suggests endorsement or affiliation we haven't agreed to. Forks must use a different name and logo if distributed publicly.
+
+## 5. No warranty (the website)
+
+getmunin.com is provided **"as is"**, without warranty of any kind. We don't warrant that the site will be uninterrupted, error-free, or available in your region. The MIT License's warranty disclaimer governs the code itself.
+
+## 6. Limitation of liability
+
+To the maximum extent permitted by law, neither we nor our contributors will be liable for indirect, incidental, special, consequential, or punitive damages, or for lost profits, data, or goodwill, arising out of your use of getmunin.com or the open-source code. Our total liability arising out of these terms or your use of the site, in aggregate, will not exceed €100. Nothing in these terms limits liability that cannot be limited under applicable law (including liability for fraud, gross negligence, or death/personal injury caused by negligence).
+
+## 7. Changes
+
+We may update these terms. The current version is always at this URL with a "Last updated" date. Material changes will be announced in the changelog or repository. Continued use of the site after a change constitutes acceptance.
+
+## 8. Governing law
+
+These terms are governed by the laws of Norway, without regard to its conflict-of-laws rules. Disputes will be brought before the courts of Oslo, Norway, except where mandatory consumer-protection law of your country of residence requires otherwise.
+
+## 9. Contact
+
+Apps AS
+Vulkan 16, 0178 Oslo, Norway
+hello@getmunin.com

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import typography from '@tailwindcss/typography';
 
 const config: Config = {
   darkMode: 'class',
@@ -55,7 +56,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [typography],
 };
 
 export default config;

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -114,6 +114,19 @@ const skipReason = TEST_URL
       expect(names).toContain('ping');
       expect(names).not.toContain('suggestion_create');
 
+      for (const t of tools) {
+        expect(t.annotations, `tool ${t.name} missing annotations`).toBeDefined();
+        expect(t.annotations!.title, `tool ${t.name} missing title`).toBeTruthy();
+        expect(typeof t.annotations!.readOnlyHint).toBe('boolean');
+        expect(typeof t.annotations!.destructiveHint).toBe('boolean');
+      }
+      const kbDelete = tools.find((t) => t.name === 'kb_delete_document')!;
+      expect(kbDelete.annotations!.readOnlyHint).toBe(false);
+      expect(kbDelete.annotations!.destructiveHint).toBe(true);
+      const kbSearch = tools.find((t) => t.name === 'kb_search')!;
+      expect(kbSearch.annotations!.readOnlyHint).toBe(true);
+      expect(kbSearch.annotations!.destructiveHint).toBe(false);
+
       const ping = await c.callTool({ name: 'ping', arguments: { message: 'hi' } });
       expect(JSON.stringify(ping)).toContain('hi');
 

--- a/packages/backend-core/src/mcp/ping.tool.ts
+++ b/packages/backend-core/src/mcp/ping.tool.ts
@@ -19,10 +19,13 @@ const PingInput = z.object({
 export class PingMcpTool {
   @McpTool({
     name: 'ping',
+    title: 'Ping the MCP server',
     description: 'Verify the MCP pipe; echoes a message and returns the resolved org and actor type.',
     audiences: ['admin', 'self_service'],
     scopes: [],
     input: PingInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   ping(args: z.infer<typeof PingInput>) {
     const ctx = getCurrentContext();

--- a/packages/backend-core/src/modules/bootstrap/bootstrap.tools.ts
+++ b/packages/backend-core/src/modules/bootstrap/bootstrap.tools.ts
@@ -19,11 +19,14 @@ export class BootstrapTools {
 
   @McpTool({
     name: 'bootstrap_status',
+    title: 'Read bootstrap progress',
     description:
       'Read the conversational config progress for one Munin app (kb / conv / crm / ...). Returns the next step to ask the user about, or `completed: true` when all steps are done.',
     audiences: ['admin'],
     scopes: [],
     input: StatusInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   async status(args: z.infer<typeof StatusInput>) {
     const runner = this.registry.get(args.app);
@@ -37,11 +40,14 @@ export class BootstrapTools {
 
   @McpTool({
     name: 'bootstrap_answer',
+    title: 'Submit bootstrap answer',
     description:
       'Submit the user\'s answer to a bootstrap step. The runner validates `value`, applies side effects (e.g. creates a space), and returns the updated status.',
     audiences: ['admin'],
     scopes: [],
     input: AnswerInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   async answer(args: z.infer<typeof AnswerInput>) {
     const runner = this.registry.get(args.app);

--- a/packages/backend-core/src/modules/cms/cms.tools.ts
+++ b/packages/backend-core/src/modules/cms/cms.tools.ts
@@ -140,10 +140,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_collections',
+    title: 'List CMS collections',
     description: 'List CMS collections (content types) defined for your org.',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listCollections() {
     return this.cms.listCollections();
@@ -151,10 +154,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_get_collection',
+    title: 'Read CMS collection',
     description: 'Read one collection by id or slug, including its field definitions.',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: GetCollectionInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   getCollection(args: z.infer<typeof GetCollectionInput>) {
     return this.cms.getCollection(args.idOrSlug);
@@ -162,11 +168,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_create_collection',
+    title: 'Create CMS collection',
     description:
       'Define a new collection. Fields is an array of { name, type, required?, options? } — see field types: text, rich_text, markdown, number, integer, boolean, date, datetime, select, multi_select, asset, reference, array, json.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: CreateCollectionInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createCollection(args: z.infer<typeof CreateCollectionInput>) {
     return this.cms.createCollection(args);
@@ -174,11 +183,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_update_collection',
+    title: 'Update CMS collection',
     description:
-      'Patch a collection. Field migration is lossy: dropped/renamed fields stay in entries\' data jsonb but stop being read; a future cms_migrate_collection tool can rewrite.',
+      'Patch a collection. Field migration is lossy: dropped or renamed fields stay in entries\' `data` jsonb but stop being read by the projection layer.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: UpdateCollectionInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   updateCollection(args: z.infer<typeof UpdateCollectionInput>) {
     return this.cms.updateCollection(args.idOrSlug, args.patch);
@@ -186,10 +198,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_delete_collection',
+    title: 'Delete CMS collection',
     description: 'Delete a collection. Cascades to all entries, versions, and references.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: DeleteCollectionInput,
+    readOnlyHint: false,
+    destructiveHint: true,
   })
   deleteCollection(args: z.infer<typeof DeleteCollectionInput>) {
     return this.cms.deleteCollection(args.idOrSlug);
@@ -199,11 +214,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_entries',
+    title: 'List CMS entries',
     description:
       'List entries. Filters: collection (id or slug), status, locale. Drafts and scheduled entries are returned to admins; the public delivery API only ever returns published.',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: ListEntriesInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listEntries(args: z.infer<typeof ListEntriesInput>) {
     return this.cms.listEntries(args);
@@ -211,10 +229,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_get_entry',
+    title: 'Read CMS entry',
     description: 'Read one entry. Data is projected through the collection\'s current field schema.',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: GetEntryInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   getEntry(args: z.infer<typeof GetEntryInput>) {
     return this.cms.getEntry(args.id);
@@ -222,11 +243,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_create_entry',
+    title: 'Create CMS entry',
     description:
       'Create a new entry in a collection. `data` is keyed by field name; required fields must be present. Pass `status: "published"` to publish on creation; default is draft.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: CreateEntryInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createEntry(args: z.infer<typeof CreateEntryInput>) {
     return this.cms.createEntry(args);
@@ -234,11 +258,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_update_entry',
+    title: 'Update CMS entry',
     description:
       'Update an entry. Pass `ifVersion` (the current version you read) for optimistic concurrency. Updating `data` re-validates against the collection schema, regenerates search_text + embedding, and rewrites references.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: UpdateEntryInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   updateEntry(args: z.infer<typeof UpdateEntryInput>) {
     return this.cms.updateEntry(args);
@@ -246,10 +273,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_publish_entry',
+    title: 'Publish CMS entry',
     description: 'Flip an entry to status="published". Stamps publishedAt and fires cms.entry.published.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: PublishInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   publishEntry(args: z.infer<typeof PublishInput>) {
     return this.cms.publishEntry(args);
@@ -257,10 +287,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_unpublish_entry',
+    title: 'Unpublish CMS entry',
     description: 'Revert an entry to status="draft". Clears publishedAt; fires cms.entry.unpublished.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: PublishInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   unpublishEntry(args: z.infer<typeof PublishInput>) {
     return this.cms.unpublishEntry(args);
@@ -268,11 +301,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_schedule_publish',
+    title: 'Schedule CMS entry publish',
     description:
       'Schedule an entry to flip to published at a future ISO 8601 datetime. The schedule worker drains due rows every minute.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: ScheduleInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   scheduleEntry(args: z.infer<typeof ScheduleInput>) {
     return this.cms.scheduleEntry(args);
@@ -280,10 +316,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_delete_entry',
+    title: 'Delete CMS entry',
     description: 'Delete an entry. Cascades to its versions and references.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: DeleteEntryInput,
+    readOnlyHint: false,
+    destructiveHint: true,
   })
   deleteEntry(args: z.infer<typeof DeleteEntryInput>) {
     return this.cms.deleteEntry(args);
@@ -291,10 +330,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_versions',
+    title: 'List CMS entry versions',
     description: 'List all prior versions of an entry, newest first.',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: ListVersionsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listVersions(args: z.infer<typeof ListVersionsInput>) {
     return this.cms.listVersions(args.entryId);
@@ -302,11 +344,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_restore_version',
+    title: 'Restore CMS entry version',
     description:
       'Roll an entry back to an earlier version. Creates a new current version with that historical data.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: RestoreVersionInput,
+    readOnlyHint: false,
+    destructiveHint: true,
   })
   restoreVersion(args: z.infer<typeof RestoreVersionInput>) {
     return this.cms.restoreVersion(args);
@@ -316,10 +361,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_assets',
+    title: 'List CMS assets',
     description: 'List media-library assets in your org.',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: ListAssetsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listAssets(args: z.infer<typeof ListAssetsInput>) {
     return this.cms.listAssets(args);
@@ -327,11 +375,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_request_asset_upload',
+    title: 'Request CMS asset upload URL',
     description:
       'Mint a presigned upload URL for a new asset. The asset row is created in `uploaded:false` state; PUT the file body to `uploadUrl`, then call cms_complete_asset_upload to mark it live.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: RequestUploadInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   requestUpload(args: z.infer<typeof RequestUploadInput>) {
     return this.cms.requestAssetUpload(args);
@@ -339,10 +390,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_complete_asset_upload',
+    title: 'Complete CMS asset upload',
     description: 'Mark a previously-requested asset upload as complete.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: CompleteUploadInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   completeUpload(args: z.infer<typeof CompleteUploadInput>) {
     return this.cms.completeAssetUpload(args);
@@ -350,10 +404,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_delete_asset',
+    title: 'Delete CMS asset',
     description: 'Delete an asset and remove the underlying file from storage.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: DeleteAssetInput,
+    readOnlyHint: false,
+    destructiveHint: true,
   })
   deleteAsset(args: z.infer<typeof DeleteAssetInput>) {
     return this.cms.deleteAsset(args);
@@ -363,10 +420,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_locales',
+    title: 'List CMS locales',
     description: 'List configured locales for your org. The default locale is used when an entry omits one.',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listLocales() {
     return this.cms.listLocales();
@@ -374,10 +434,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_create_locale',
+    title: 'Create CMS locale',
     description: 'Add a locale. Code is ISO 639-1 (e.g. "en") or BCP-47 ("en-US"). The first locale is the default unless overridden.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: CreateLocaleInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createLocale(args: z.infer<typeof CreateLocaleInput>) {
     return this.cms.createLocale(args);
@@ -385,10 +448,13 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_set_default_locale',
+    title: 'Set default CMS locale',
     description: 'Set which locale is treated as the org\'s default for new entries.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: SetDefaultLocaleInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   setDefaultLocale(args: z.infer<typeof SetDefaultLocaleInput>) {
     return this.cms.setDefaultLocale(args);
@@ -398,11 +464,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_inbound_references',
+    title: 'List inbound CMS references',
     description:
       'List entries that link to the given entry. Useful before deleting — see "what would break".',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: ListInboundReferencesInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listInboundReferences(args: z.infer<typeof ListInboundReferencesInput>) {
     return this.cms.listInboundReferences(args.entryId);
@@ -412,11 +481,14 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_search',
+    title: 'Search CMS entries',
     description:
       'Hybrid full-text + semantic search across CMS entries. Returns drafts and published; the public delivery API runs the same engine but hard-filters to published-only.',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: SearchInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   searchEntries(args: z.infer<typeof SearchInput>) {
     return this.search.search(args);

--- a/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
@@ -28,11 +28,14 @@ export class ConvSelfServiceTools {
 
   @McpTool({
     name: 'conv_start_conversation',
+    title: 'Start conversation as end-user',
     description:
       'Start a new conversation as the end-user. The platform picks the best channel for you based on `channelHint` (defaults to "chat"). Returns the new conversation with the first message attached.',
     audiences: ['self_service'],
     scopes: ['conv:write'],
     input: StartConversationInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   async startConversation(args: z.infer<typeof StartConversationInput>) {
     const ctx = getCurrentContext();
@@ -60,11 +63,14 @@ export class ConvSelfServiceTools {
 
   @McpTool({
     name: 'conv_list_my_conversations',
+    title: 'List my conversations',
     description:
       'List the calling end-user\'s conversations. RLS enforces that only the caller\'s own conversations are returned, regardless of filters.',
     audiences: ['self_service'],
     scopes: ['conv:read'],
     input: ListMyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   async listMy(args: z.infer<typeof ListMyInput>) {
     const ctx = getCurrentContext();
@@ -78,11 +84,14 @@ export class ConvSelfServiceTools {
 
   @McpTool({
     name: 'conv_get_my_conversation',
+    title: 'Read my conversation',
     description:
       'Read one of the calling end-user\'s conversations. RLS hides internal staff messages — only public messages are returned.',
     audiences: ['self_service'],
     scopes: ['conv:read'],
     input: GetMyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   getMy(args: z.infer<typeof GetMyInput>) {
     return this.conv.getConversation(args.id);
@@ -90,11 +99,14 @@ export class ConvSelfServiceTools {
 
   @McpTool({
     name: 'conv_send_message_in_my_conversation',
+    title: 'Send message in my conversation',
     description:
       'Append a public message to one of the calling end-user\'s conversations. End-users cannot post internal notes.',
     audiences: ['self_service'],
     scopes: ['conv:write'],
     input: SendMyMessageInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   sendMyMessage(args: z.infer<typeof SendMyMessageInput>) {
     const ctx = getCurrentContext();

--- a/packages/backend-core/src/modules/conv/conv.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.tools.ts
@@ -59,11 +59,14 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_list_conversations',
+    title: 'List conversations',
     description:
       'List conversations for your org, newest activity first. Filter by status (open / snoozed / closed / spam), assignee, or topic.',
     audiences: ['admin'],
     scopes: ['conv:read'],
     input: ListConversationsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listConversations(args: z.infer<typeof ListConversationsInput>) {
     return this.conv.listConversations(args);
@@ -71,10 +74,13 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_get_conversation',
+    title: 'Read conversation',
     description: 'Read one conversation including every public + internal message.',
     audiences: ['admin'],
     scopes: ['conv:read'],
     input: GetConversationInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   getConversation(args: z.infer<typeof GetConversationInput>) {
     return this.conv.getConversation(args.id);
@@ -82,11 +88,14 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_send_message',
+    title: 'Send message in conversation',
     description:
       'Append a message to a conversation. Pass `internal: true` to leave a staff-only note (drafts, side comments) — end-user agents never see internal messages.',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: SendMessageInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   sendMessage(args: z.infer<typeof SendMessageInput>) {
     const ctx = getCurrentContext();
@@ -100,11 +109,14 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_assign_conversation',
+    title: 'Assign conversation',
     description:
       'Assign a conversation to a user (pass user id) or unassign (pass null). Useful for routing escalated conversations.',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: AssignInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   assign(args: z.infer<typeof AssignInput>) {
     return this.conv.assignConversation(args);
@@ -112,11 +124,14 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_change_status',
+    title: 'Change conversation status',
     description:
       'Change a conversation\'s status. `snoozeUntil` (ISO 8601) is required when status is "snoozed".',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: ChangeStatusInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   changeStatus(args: z.infer<typeof ChangeStatusInput>) {
     return this.conv.changeStatus(args);
@@ -124,11 +139,14 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_search_messages',
+    title: 'Search conversation messages',
     description:
       'Substring search over message bodies. Returns the matching messages newest first; use conv_get_conversation to load surrounding context.',
     audiences: ['admin'],
     scopes: ['conv:read'],
     input: SearchInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   search(args: z.infer<typeof SearchInput>) {
     return this.conv.searchMessages(args);
@@ -136,10 +154,13 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_list_channels',
-    description: 'List conversation channels (email, voice, chat, sms) configured for your org.',
+    title: 'List conversation channels',
+    description: 'List conversation channels configured for your org. Currently shipping adapters: email and chat (widget). The `voice` and `sms` channel types are reserved for upcoming adapters.',
     audiences: ['admin'],
     scopes: ['conv:read'],
     input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listChannels() {
     return this.conv.listChannels();
@@ -147,11 +168,14 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_create_channel',
+    title: 'Create conversation channel',
     description:
-      'Add a new conversation channel. Type is one of email / voice / chat / sms. Channel-specific configuration goes in `config`.',
+      'Add a new conversation channel. Currently shipping adapters: `email` and `chat` (widget). Channel-specific configuration goes in `config`. The `voice` and `sms` channel types are reserved and not yet wired to an adapter.',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: CreateChannelInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createChannel(args: z.infer<typeof CreateChannelInput>) {
     return this.conv.createChannel(args);
@@ -159,10 +183,13 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_list_topics',
+    title: 'List conversation topics',
     description: 'List conversation topics (Billing, Support, Refunds, …) for your org.',
     audiences: ['admin'],
     scopes: ['conv:read'],
     input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listTopics() {
     return this.conv.listTopics();
@@ -170,10 +197,13 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_create_topic',
+    title: 'Create conversation topic',
     description: 'Add a new conversation topic. Slug must be lowercase letters, digits, hyphens.',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: CreateTopicInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createTopic(args: z.infer<typeof CreateTopicInput>) {
     return this.conv.createTopic(args);

--- a/packages/backend-core/src/modules/conv/email/email.tools.ts
+++ b/packages/backend-core/src/modules/conv/email/email.tools.ts
@@ -34,11 +34,14 @@ export class EmailAdminTools {
 
   @McpTool({
     name: 'conv_email_setup_channel',
+    title: 'Set up email channel',
     description:
       "Create or update an email channel's transport configuration. Pass plaintext SMTP / IMAP passwords; the server encrypts them before storage and returns them redacted. Set `outbound.provider: 'mailer'` to send via Munin's configured Resend mailer instead of a custom SMTP host.",
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: SetupInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   async setupChannel(args: z.infer<typeof SetupInput>) {
     if (args.channelId) {
@@ -53,11 +56,14 @@ export class EmailAdminTools {
 
   @McpTool({
     name: 'conv_email_test_channel',
+    title: 'Test email channel credentials',
     description:
       'Test an email channel\'s stored credentials. Attempts an SMTP connect (and an IMAP connect if inbound is configured) without sending or fetching anything. Returns `{ smtp: "ok" | error, imap: "ok" | error | "not configured" }`.',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: TestInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   async testChannel(args: z.infer<typeof TestInput>): Promise<{
     smtp: string;

--- a/packages/backend-core/src/modules/conv/widget/widget.tools.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.tools.ts
@@ -38,11 +38,14 @@ interface CreateResult extends ChannelDto {
 export class WidgetAdminTools {
   @McpTool({
     name: 'conv_widget_create_channel',
+    title: 'Create chat-widget channel',
     description:
       'Create a chat-widget channel and mint a widget API key (`mn_widget_*`) bound to it. Returns the plaintext key once; store it server-side and pass it as `Authorization: Bearer` when calling POST /api/conv/widget/messages from the external agent.',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: CreateInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   async createChannel(args: z.infer<typeof CreateInput>): Promise<CreateResult> {
     const ctx = getCurrentContext();
@@ -89,11 +92,14 @@ export class WidgetAdminTools {
 
   @McpTool({
     name: 'conv_widget_update_channel',
+    title: 'Update chat-widget channel',
     description:
       'Update a chat-widget channel\'s displayName / originAllowlist / webhookOnEscalation. Pass null to clear webhookOnEscalation. The widget API key is unchanged.',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: UpdateInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   async updateChannel(args: z.infer<typeof UpdateInput>): Promise<ChannelDto> {
     const ctx = getCurrentContext();
@@ -140,11 +146,14 @@ export class WidgetAdminTools {
 
   @McpTool({
     name: 'conv_widget_rotate_key',
+    title: 'Rotate widget API key',
     description:
       'Revoke any active widget keys bound to this channel and mint a fresh `mn_widget_*` key. Returns the new plaintext key once. Existing inflight requests using the old key keep working until revocation lands.',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: RotateInput,
+    readOnlyHint: false,
+    destructiveHint: true,
   })
   async rotateKey(args: z.infer<typeof RotateInput>): Promise<{ widgetKey: string }> {
     const ctx = getCurrentContext();

--- a/packages/backend-core/src/modules/crm/crm.self-service.tools.ts
+++ b/packages/backend-core/src/modules/crm/crm.self-service.tools.ts
@@ -26,11 +26,14 @@ export class CrmSelfServiceTools {
 
   @McpTool({
     name: 'crm_get_my_contact',
+    title: 'Read my CRM contact',
     description:
       'Read the CRM contact linked to the calling end-user. RLS restricts visibility to that single row.',
     audiences: ['self_service'],
     scopes: ['crm:read'],
     input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   getMyContact() {
     return this.crm.getMyContact();
@@ -38,11 +41,14 @@ export class CrmSelfServiceTools {
 
   @McpTool({
     name: 'crm_update_my_contact',
+    title: 'Update my CRM contact',
     description:
       'Update the calling end-user\'s own contact record. Only basic personal fields (name, phone, address) are editable from this surface — tags, ownership, custom fields, and AI fields are admin-only.',
     audiences: ['self_service'],
     scopes: ['crm:write'],
     input: UpdateMyContactInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   async updateMyContact(args: z.infer<typeof UpdateMyContactInput>) {
     const own = await this.crm.getMyContact();
@@ -51,11 +57,14 @@ export class CrmSelfServiceTools {
 
   @McpTool({
     name: 'crm_log_activity_self',
+    title: 'Log activity as end-user',
     description:
       'Record an activity attributed to the calling end-user agent (e.g. a voice agent logging "spoke with customer for 4m, follow-up needed"). Auto-scoped to the end-user\'s own CRM contact when one exists.',
     audiences: ['self_service'],
     scopes: ['crm:write'],
     input: LogActivitySelfInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   async logActivitySelf(args: z.infer<typeof LogActivitySelfInput>) {
     const ctx = getCurrentContext();

--- a/packages/backend-core/src/modules/crm/crm.tools.ts
+++ b/packages/backend-core/src/modules/crm/crm.tools.ts
@@ -145,10 +145,13 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_contacts',
+    title: 'List contacts',
     description: 'List contacts in your org, newest-updated first. Filter by company or tag.',
     audiences: ['admin'],
     scopes: ['crm:read'],
     input: ListContactsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listContacts(args: z.infer<typeof ListContactsInput>) {
     return this.crm.listContacts(args);
@@ -156,10 +159,13 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_get_contact',
+    title: 'Read contact',
     description: 'Read one contact, including AI fields, tags, custom fields, and compliance flags.',
     audiences: ['admin'],
     scopes: ['crm:read'],
     input: GetContactInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   getContact(args: z.infer<typeof GetContactInput>) {
     return this.crm.getContact(args.id);
@@ -167,11 +173,14 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_find_contact',
+    title: 'Find contact by email or phone',
     description:
       'Find an existing contact by email and/or phone before creating a new one. Returns null if no match.',
     audiences: ['admin'],
     scopes: ['crm:read'],
     input: FindContactInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   findContact(args: z.infer<typeof FindContactInput>) {
     return this.crm.findContact(args);
@@ -179,10 +188,13 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_create_contact',
+    title: 'Create contact',
     description: 'Create a new contact. Search with crm_find_contact first to avoid duplicates.',
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: CreateContactInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createContact(args: z.infer<typeof CreateContactInput>) {
     return this.crm.createContact(args);
@@ -190,11 +202,14 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_update_contact',
+    title: 'Update contact',
     description:
       'Update fields on a contact. Setting `doNotContact: true` also stamps `unsubscribedAt`; setting it false clears it.',
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: UpdateContactInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   updateContact(args: z.infer<typeof UpdateContactInput>) {
     return this.crm.updateContact(args);
@@ -202,11 +217,14 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_bulk_create_contacts',
+    title: 'Bulk-create contacts',
     description:
       'Bulk-create contacts with dedupe + compliance checks: rows whose email or phone already match a do_not_contact contact are skipped, as are rows that would duplicate an existing contact.',
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: BulkCreateInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   bulkCreateContacts(args: z.infer<typeof BulkCreateInput>) {
     return this.crm.bulkCreateContacts(args.contacts);
@@ -214,11 +232,14 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_search_contacts',
+    title: 'Search contacts',
     description:
       'Substring search across name, email, phone, and title. Returns contacts ordered newest-updated first.',
     audiences: ['admin'],
     scopes: ['crm:read'],
     input: SearchContactsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   searchContacts(args: z.infer<typeof SearchContactsInput>) {
     return this.crm.searchContacts(args);
@@ -228,10 +249,13 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_companies',
+    title: 'List companies',
     description: 'List companies in your org.',
     audiences: ['admin'],
     scopes: ['crm:read'],
     input: ListCompaniesInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listCompanies(args: z.infer<typeof ListCompaniesInput>) {
     return this.crm.listCompanies(args);
@@ -239,10 +263,13 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_create_company',
+    title: 'Create company',
     description: 'Create a new company.',
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: CreateCompanyInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createCompany(args: z.infer<typeof CreateCompanyInput>) {
     return this.crm.createCompany(args);
@@ -252,10 +279,13 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_pipelines',
+    title: 'List sales pipelines',
     description: 'List sales pipelines for your org with their stages in position order.',
     audiences: ['admin'],
     scopes: ['crm:read'],
     input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listPipelines() {
     return this.crm.listPipelines();
@@ -263,11 +293,14 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_create_pipeline',
+    title: 'Create sales pipeline',
     description:
       'Create a new sales pipeline with at least one stage. Stages are inserted in array order; mark a stage `winLoss: "won"` or `"lost"` to record terminal outcomes.',
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: CreatePipelineInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createPipeline(args: z.infer<typeof CreatePipelineInput>) {
     return this.crm.createPipeline(args);
@@ -275,10 +308,13 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_deals',
+    title: 'List deals',
     description: 'List deals, optionally filtered by pipeline or stage.',
     audiences: ['admin'],
     scopes: ['crm:read'],
     input: ListDealsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listDeals(args: z.infer<typeof ListDealsInput>) {
     return this.crm.listDeals(args);
@@ -286,11 +322,14 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_create_deal',
+    title: 'Create deal',
     description:
       'Create a new deal in a pipeline. If `stageId` is omitted, the deal lands in the pipeline\'s first stage by position.',
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: CreateDealInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createDeal(args: z.infer<typeof CreateDealInput>) {
     return this.crm.createDeal(args);
@@ -298,11 +337,14 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_change_stage',
+    title: 'Change deal stage',
     description:
       'Move a deal to a new stage. If the destination stage is a won/lost terminal, `closedAt` is stamped automatically.',
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: ChangeStageInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   changeStage(args: z.infer<typeof ChangeStageInput>) {
     return this.crm.changeStage(args);
@@ -312,11 +354,14 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_log_activity',
+    title: 'Log CRM activity',
     description:
       'Record an activity (note / call / email / meeting / task) against a contact, company, or deal. If `contactId` is set, the contact\'s `lastContactedAt` is also bumped.',
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: LogActivityInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   logActivity(args: z.infer<typeof LogActivityInput>) {
     return this.crm.logActivity(args);
@@ -324,10 +369,13 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_activities',
+    title: 'List CRM activities',
     description: 'List CRM activities filtered by contact, deal, or company.',
     audiences: ['admin'],
     scopes: ['crm:read'],
     input: ListActivitiesInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listActivities(args: z.infer<typeof ListActivitiesInput>) {
     return this.crm.listActivities(args);
@@ -337,11 +385,14 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_set_ai_summary',
+    title: 'Set AI summary or next action',
     description:
       'Set the AI-generated summary and/or next-action for a contact, company, or deal. These live in dedicated columns so agents do not pollute the human-edited description.',
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: SetAiSummaryInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   setAiSummary(args: z.infer<typeof SetAiSummaryInput>) {
     return this.crm.setAiSummary(args);

--- a/packages/backend-core/src/modules/kb/kb.tools.ts
+++ b/packages/backend-core/src/modules/kb/kb.tools.ts
@@ -71,10 +71,13 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_list_spaces',
+    title: 'List KB spaces',
     description: 'List knowledge-base spaces in your org.',
     audiences: ['admin'],
     scopes: ['kb:read'],
     input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listSpaces() {
     return this.kb.listSpaces();
@@ -82,11 +85,14 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_create_space',
+    title: 'Create KB space',
     description:
       'Create a new knowledge-base space. Slug must be unique within your org and only contain lowercase letters, digits and hyphens.',
     audiences: ['admin'],
     scopes: ['kb:write'],
     input: CreateSpaceInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createSpace(args: z.infer<typeof CreateSpaceInput>) {
     return this.kb.createSpace(args);
@@ -94,11 +100,14 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_list_documents',
+    title: 'List KB documents',
     description:
       'List knowledge-base documents in your org, newest-updated first. Optionally filter by space or tag.',
     audiences: ['admin'],
     scopes: ['kb:read'],
     input: ListDocumentsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listDocuments(args: z.infer<typeof ListDocumentsInput>) {
     return this.kb.listDocuments(args);
@@ -106,11 +115,14 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_get_document',
+    title: 'Read KB document',
     description:
       'Read one knowledge-base document, including its full body, tags, and current version. End-user agents see only documents marked `public`.',
     audiences: ['admin', 'self_service'],
     scopes: ['kb:read'],
     input: GetDocumentInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   getDocument(args: z.infer<typeof GetDocumentInput>) {
     return this.kb.getDocument(args.id);
@@ -118,11 +130,14 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_search',
+    title: 'Search knowledge base',
     description:
       'Search the knowledge base by natural-language query. Combines full-text search and vector similarity for the best of both. End-user agents see only documents marked `public`.',
     audiences: ['admin', 'self_service'],
     scopes: ['kb:read'],
     input: SearchInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   search(args: z.infer<typeof SearchInput>) {
     return this.searchService.search(args);
@@ -130,11 +145,14 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_create_document',
+    title: 'Create KB document',
     description:
       'Create a knowledge-base document inside a space. Body should be markdown. Set `public: true` to expose it to end-user agents.',
     audiences: ['admin'],
     scopes: ['kb:write'],
     input: CreateDocumentInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   createDocument(args: z.infer<typeof CreateDocumentInput>) {
     return this.kb.createDocument(args);
@@ -142,11 +160,14 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_update_document',
+    title: 'Update KB document',
     description:
       'Update a knowledge-base document. Pass `ifVersion` (the current version you read) for optimistic concurrency; the call fails if it has changed.',
     audiences: ['admin'],
     scopes: ['kb:write'],
     input: UpdateDocumentInput,
+    readOnlyHint: false,
+    destructiveHint: false,
   })
   updateDocument(args: z.infer<typeof UpdateDocumentInput>) {
     return this.kb.updateDocument(args);
@@ -154,11 +175,14 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_delete_document',
+    title: 'Delete KB document',
     description:
       'Delete a knowledge-base document. Pass `ifVersion` for optimistic concurrency. Cascades to chunks and versions.',
     audiences: ['admin'],
     scopes: ['kb:write'],
     input: DeleteDocumentInput,
+    readOnlyHint: false,
+    destructiveHint: true,
   })
   deleteDocument(args: z.infer<typeof DeleteDocumentInput>) {
     return this.kb.deleteDocument(args);
@@ -166,10 +190,13 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_list_versions',
+    title: 'List KB document versions',
     description: 'List all prior versions of a knowledge-base document, newest first.',
     audiences: ['admin'],
     scopes: ['kb:read'],
     input: ListVersionsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
   })
   listVersions(args: z.infer<typeof ListVersionsInput>) {
     return this.kb.listVersions(args.documentId);
@@ -177,11 +204,14 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_restore_version',
+    title: 'Restore KB document version',
     description:
       'Roll a document back to an earlier version. Creates a new current version with that historical content.',
     audiences: ['admin'],
     scopes: ['kb:write'],
     input: RestoreVersionInput,
+    readOnlyHint: false,
+    destructiveHint: true,
   })
   restoreVersion(args: z.infer<typeof RestoreVersionInput>) {
     return this.kb.restoreVersion(args);

--- a/packages/mcp-toolkit/src/decorator.ts
+++ b/packages/mcp-toolkit/src/decorator.ts
@@ -17,6 +17,9 @@ export interface McpToolMeta<TInput extends z.ZodObject = z.ZodObject> {
   audiences: readonly Audience[];
   scopes: readonly string[];
   input: TInput;
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
 }
 
 export const MCP_TOOL_META = Symbol.for('munin.mcp.tool.meta');

--- a/packages/mcp-toolkit/src/registry.test.ts
+++ b/packages/mcp-toolkit/src/registry.test.ts
@@ -53,4 +53,25 @@ describe('McpToolRegistry', () => {
       required: ['msg'],
     });
   });
+
+  it('preserves directory annotations (title, readOnlyHint, destructiveHint)', () => {
+    const r = new McpToolRegistry();
+    r.register(
+      {
+        name: 'thing_delete',
+        title: 'Delete a thing',
+        description: 'Delete a thing.',
+        audiences: ['admin'],
+        scopes: [],
+        input: z.object({ id: z.string() }),
+        readOnlyHint: false,
+        destructiveHint: true,
+      },
+      () => 'ok',
+    );
+    const tool = r.get('thing_delete')!;
+    expect(tool.meta.title).toBe('Delete a thing');
+    expect(tool.meta.readOnlyHint).toBe(false);
+    expect(tool.meta.destructiveHint).toBe(true);
+  });
 });

--- a/packages/mcp-toolkit/src/server.ts
+++ b/packages/mcp-toolkit/src/server.ts
@@ -49,6 +49,11 @@ export function createMcpServer(opts: CreateMcpServerOptions): Server {
       name: t.meta.name,
       description: t.meta.description,
       inputSchema: t.inputJsonSchema as Record<string, unknown>,
+      annotations: {
+        title: t.meta.title ?? t.meta.name,
+        readOnlyHint: t.meta.readOnlyHint ?? false,
+        destructiveHint: t.meta.destructiveHint ?? false,
+      },
     })),
   }));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
       better-auth:
         specifier: ^1.1.0
-        version: 1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0))
+        version: 1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0))
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(kysely@0.28.16)(postgres@3.4.9)
@@ -128,7 +128,7 @@ importers:
         version: link:../../packages/ui
       better-auth:
         specifier: ^1.6.9
-        version: 1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0))
+        version: 1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -153,6 +153,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      react-markdown:
+        specifier: ^9.1.0
+        version: 9.1.0(@types/react@19.2.14)(react@19.2.5)
       shadcn:
         specifier: ^4.5.0
         version: 4.6.0(@types/node@22.19.17)(typescript@5.9.3)
@@ -175,6 +178,9 @@ importers:
       '@getmunin/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0))
       '@types/node':
         specifier: ^22.7.0
         version: 22.19.17
@@ -234,7 +240,7 @@ importers:
         version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
       better-auth:
         specifier: ^1.1.0
-        version: 1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0))
+        version: 1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0))
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(kysely@0.28.16)(postgres@3.4.9)
@@ -375,7 +381,7 @@ importers:
         version: link:../ui
       better-auth:
         specifier: ^1.6.9
-        version: 1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0))
+        version: 1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0))
       lucide-react:
         specifier: ^1.11.0
         version: 1.14.0(react@19.2.5)
@@ -2067,6 +2073,11 @@ packages:
   '@swc/types@0.1.26':
     resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -2113,11 +2124,17 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2128,6 +2145,9 @@ packages:
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
@@ -2136,6 +2156,12 @@ packages:
 
   '@types/mailparser@3.4.6':
     resolution: {integrity: sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -2171,6 +2197,12 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -2233,6 +2265,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.1':
     resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -2451,6 +2486,9 @@ packages:
     peerDependencies:
       postcss: ^8.5.10
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2611,6 +2649,9 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -2622,6 +2663,18 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -2693,6 +2746,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -2800,6 +2856,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -2845,6 +2904,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -2852,6 +2915,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -3135,6 +3201,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -3182,6 +3251,9 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -3419,6 +3491,12 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -3433,6 +3511,9 @@ packages:
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -3493,6 +3574,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   intl-messageformat@11.2.3:
     resolution: {integrity: sha512-kZthTU+3WLcoWoRg5j6LOkN1TeUBtmkX0OIwSAbcHVIfQAEbGVdmANM8u6GL3eUDOqLwheYoXMUshAh1UdeXlQ==}
 
@@ -3508,6 +3592,12 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -3518,6 +3608,9 @@ packages:
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -3535,6 +3628,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -3761,6 +3857,9 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -3788,6 +3887,30 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
@@ -3814,6 +3937,69 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -4093,6 +4279,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -4226,6 +4415,10 @@ packages:
     peerDependencies:
       postcss: ^8.5.10
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
@@ -4274,6 +4467,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -4312,6 +4508,12 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
+  react-markdown@9.1.0:
+    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -4345,6 +4547,12 @@ packages:
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4541,6 +4749,9 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -4587,6 +4798,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
     engines: {node: '>=14.16'}
@@ -4618,6 +4832,12 @@ packages:
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -4765,6 +4985,12 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -4849,6 +5075,24 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -4902,6 +5146,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -5084,6 +5334,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -6493,6 +6746,11 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(tsx@4.21.0))':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.19(tsx@4.21.0)
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -6535,6 +6793,10 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -6544,6 +6806,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
@@ -6560,6 +6826,10 @@ snapshots:
       '@types/express-serve-static-core': 5.1.1
       '@types/serve-static': 2.2.0
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
@@ -6568,6 +6838,12 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
       iconv-lite: 0.6.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@12.20.55': {}
 
@@ -6605,6 +6881,10 @@ snapshots:
       '@types/node': 22.19.17
 
   '@types/statuses@2.0.6': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -6698,6 +6978,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.59.1
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -6936,6 +7218,8 @@ snapshots:
       postcss: 8.5.12
       postcss-value-parser: 4.2.0
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -6944,7 +7228,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.24: {}
 
-  better-auth@1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)):
+  better-auth@1.6.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))
@@ -7069,6 +7353,8 @@ snapshots:
 
   caniuse-lite@1.0.30001791: {}
 
+  ccount@2.0.1: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -7083,6 +7369,14 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
 
@@ -7151,6 +7445,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
 
@@ -7231,6 +7527,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   dedent@1.7.2: {}
 
   deep-eql@5.0.2: {}
@@ -7258,9 +7558,15 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dezalgo@1.0.4:
     dependencies:
@@ -7491,6 +7797,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -7575,6 +7883,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
 
@@ -7834,6 +8144,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   he@1.2.0: {}
 
   headers-polyfill@5.0.1:
@@ -7850,6 +8184,8 @@ snapshots:
       dom-serializer: 2.0.0
       htmlparser2: 8.0.2
       selderee: 0.11.0
+
+  html-url-attributes@3.0.1: {}
 
   htmlparser2@8.0.2:
     dependencies:
@@ -7918,6 +8254,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   intl-messageformat@11.2.3:
     dependencies:
       '@formatjs/fast-memoize': 3.1.3
@@ -7929,6 +8267,13 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
@@ -7939,6 +8284,8 @@ snapshots:
     dependencies:
       hasown: 2.0.3
 
+  is-decimal@2.0.1: {}
+
   is-docker@3.0.0: {}
 
   is-extglob@2.1.1: {}
@@ -7948,6 +8295,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -8125,6 +8474,8 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  longest-streak@3.1.0: {}
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -8160,6 +8511,95 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
@@ -8175,6 +8615,139 @@ snapshots:
   merge2@1.4.1: {}
 
   methods@1.1.2: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -8457,6 +9030,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -8561,6 +9144,11 @@ snapshots:
       postcss: 8.5.12
       postcss-selector-parser: 6.1.2
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss-selector-parser@6.1.2:
     dependencies:
       cssesc: 3.0.0
@@ -8600,6 +9188,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  property-information@7.1.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -8632,6 +9222,24 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-markdown@9.1.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.5
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react@19.2.5: {}
 
@@ -8669,6 +9277,23 @@ snapshots:
       tslib: 2.8.1
 
   reflect-metadata@0.2.2: {}
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-directory@2.1.1: {}
 
@@ -8964,6 +9589,8 @@ snapshots:
 
   source-map@0.7.4: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -9007,6 +9634,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   stringify-object@5.0.0:
     dependencies:
       get-own-enumerable-keys: 1.0.0
@@ -9032,6 +9664,14 @@ snapshots:
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
     dependencies:
@@ -9190,6 +9830,10 @@ snapshots:
     dependencies:
       tldts: 7.0.29
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -9280,6 +9924,39 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
@@ -9331,6 +10008,16 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-node@2.1.9(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.2)(tsx@4.21.0):
     dependencies:
@@ -9531,3 +10218,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Adds `title` / `readOnlyHint` / `destructiveHint` to every `@McpTool` (76 tools across 10 files) and plumbs them through the `tools/list` response — required by Anthropic's Software Directory policy.
- Tightens three tool descriptions that referenced unimplemented features (`conv_list_channels`, `conv_create_channel`, `cms_update_collection`).
- Ships `/privacy` and `/terms` pages on getmunin.com with real first-draft copy (data controller for marketing only; self-hosters control their own data) plus a minimal site-wide footer.
- Adds `react-markdown` + `@tailwindcss/typography` to the OSS web for prose rendering.

## Test plan
- [ ] `pnpm test` passes in `mcp-toolkit` (annotation round-trip test added) and `backend-core` (integration test now asserts every tool returns annotations + spot-checks `kb_search` read-only and `kb_delete_document` destructive).
- [ ] `pnpm typecheck` clean across `mcp-toolkit`, `backend-core`, `apps/web`.
- [ ] `pnpm dev` in `apps/web`; visit `/privacy` and `/terms` — markdown renders, footer links navigate, locale switch to `/nb/privacy` works.
- [ ] Boot `apps/backend`; connect MCP Inspector at `http://localhost:3001/mcp`; confirm `tools/list` returns `annotations: { title, readOnlyHint, destructiveHint }` per tool.
- [ ] Have legal review the privacy + terms drafts before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)