### PR TITLE
refactor(kb): replace boolean public flag with audiences array

### DIFF
--- a/packages/backend-core/src/control/export.controller.ts
+++ b/packages/backend-core/src/control/export.controller.ts
@@ -45,7 +45,7 @@ export class ExportController {
             spaceId: schema.kbDocuments.spaceId,
             title: schema.kbDocuments.title,
             body: schema.kbDocuments.body,
-            public: schema.kbDocuments.public,
+            audiences: schema.kbDocuments.audiences,
             version: schema.kbDocuments.version,
             tags: schema.kbDocuments.tags,
             createdAt: schema.kbDocuments.createdAt,

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -406,7 +406,7 @@ const skipReason = TEST_URL
             spaceId,
             title: 'Public FAQ',
             body: 'Public answer about widgets.',
-            public: true,
+            audiences: ['admin', 'self_service'],
           },
         }),
       );
@@ -419,7 +419,7 @@ const skipReason = TEST_URL
             spaceId,
             title: 'Private widgets',
             body: 'Internal widget secrets.',
-            public: false,
+            audiences: ['admin'],
           },
         }),
       );

--- a/packages/backend-core/src/modules/kb/kb.bootstrap.ts
+++ b/packages/backend-core/src/modules/kb/kb.bootstrap.ts
@@ -71,7 +71,7 @@ const welcomeDoc = defineStep({
       spaceId: space.id,
       title,
       body,
-      public: false,
+      audiences: ['admin'],
       version: 1,
       contentHash: 'bootstrap',
       tags: [],

--- a/packages/backend-core/src/modules/kb/kb.search.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.search.test.ts
@@ -137,7 +137,7 @@ const skipReason = TEST_URL
         spaceId,
         title: 'Internal runbook',
         body: 'Do not share this with customers.',
-        public: false,
+        audiences: ['admin'],
       }),
     );
     await runAs(admin, () =>
@@ -145,7 +145,7 @@ const skipReason = TEST_URL
         spaceId,
         title: 'Public help article',
         body: 'How to reset your password.',
-        public: true,
+        audiences: ['admin', 'self_service'],
       }),
     );
     const hits = await runAs(endUser, () => search.search({ query: 'password reset' }));

--- a/packages/backend-core/src/modules/kb/kb.search.ts
+++ b/packages/backend-core/src/modules/kb/kb.search.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { sql } from 'drizzle-orm';
-import { getCurrentContext } from '@getmunin/core';
+import { getCurrentContext, type Audience } from '@getmunin/core';
 import { EmbeddingProviderHolder } from './embedding.provider.js';
 
 export interface SearchHit {
@@ -8,7 +8,7 @@ export interface SearchHit {
   spaceId: string;
   title: string;
   excerpt: string;
-  public: boolean;
+  audiences: Audience[];
   score: number;
   source: 'fts' | 'vector' | 'both';
 }
@@ -29,7 +29,7 @@ type FtsRow = {
   document_id: string;
   space_id: string;
   title: string;
-  public: boolean;
+  audiences: Audience[];
   excerpt: string;
   rank: number;
   rn: number;
@@ -39,7 +39,7 @@ type VectorRow = {
   document_id: string;
   space_id: string;
   title: string;
-  public: boolean;
+  audiences: Audience[];
   excerpt: string;
   similarity: number;
   rn: number;
@@ -56,7 +56,8 @@ export class KbSearchService {
    * chunk embeddings. Per-source ranks are combined via Reciprocal Rank Fusion
    * (RRF, k=60) so each source contributes monotonic, scale-free votes.
    *
-   * RLS enforces tenancy + the public-only filter for self-service callers.
+   * RLS enforces tenancy + the audiences filter for self-service callers
+   * (only docs whose audiences include 'self_service' surface to end-users).
    * Caller-passed filters (spaceId) are also AND'd in the SQL.
    */
   async search(input: SearchInput): Promise<SearchHit[]> {
@@ -72,7 +73,7 @@ export class KbSearchService {
           d.id            AS document_id,
           d.space_id      AS space_id,
           d.title         AS title,
-          d.public        AS public,
+          d.audiences     AS audiences,
           ts_headline('english', left(d.body, 600), q.tsq,
             'StartSel=,StopSel=,MaxWords=40,MinWords=15,ShortWord=3') AS excerpt,
           ts_rank_cd(d.fts, q.tsq) AS rank,
@@ -95,7 +96,7 @@ export class KbSearchService {
               d.id            AS document_id,
               d.space_id      AS space_id,
               d.title         AS title,
-              d.public        AS public,
+              d.audiences     AS audiences,
               left(c.content, 400) AS excerpt,
               1 - (c.embedding <=> ${formatVector(queryVec)}::vector) AS similarity,
               ROW_NUMBER() OVER (
@@ -108,7 +109,7 @@ export class KbSearchService {
               ${input.spaceId ? sql`AND d.space_id = ${input.spaceId}` : sql``}
           )
           SELECT
-            document_id, space_id, title, public, excerpt, similarity,
+            document_id, space_id, title, audiences, excerpt, similarity,
             ROW_NUMBER() OVER (ORDER BY similarity DESC) AS rn
           FROM ranked
           WHERE chunk_rn = 1
@@ -143,7 +144,7 @@ function reciprocalRankFuse(
         spaceId: row.space_id,
         title: row.title,
         excerpt: row.excerpt,
-        public: row.public,
+        audiences: row.audiences,
       },
       ftsScore: score,
       vectorScore: 0,
@@ -164,7 +165,7 @@ function reciprocalRankFuse(
           spaceId: row.space_id,
           title: row.title,
           excerpt: row.excerpt,
-          public: row.public,
+          audiences: row.audiences,
         },
         ftsScore: 0,
         vectorScore: score,

--- a/packages/backend-core/src/modules/kb/kb.service.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.test.ts
@@ -99,7 +99,7 @@ const skipReason = TEST_URL
       }),
     );
     expect(doc.version).toBe(1);
-    expect(doc.public).toBe(false);
+    expect(doc.audiences).toEqual(['admin']);
 
     const versions = await run(() => svc.listVersions(doc.id));
     expect(versions).toHaveLength(1);
@@ -136,7 +136,7 @@ const skipReason = TEST_URL
       sql`SELECT id FROM kb_document_chunks WHERE document_id = ${doc.id} ORDER BY chunk_index LIMIT 1`,
     );
     const firstChunkId = firstRows[0]!.id;
-    await run(() => svc.updateDocument({ id: doc.id, ifVersion: 1, public: true }));
+    await run(() => svc.updateDocument({ id: doc.id, ifVersion: 1, audiences: ['admin', 'self_service'] }));
     const secondRows = await db.execute<{ id: string }>(
       sql`SELECT id FROM kb_document_chunks WHERE document_id = ${doc.id} ORDER BY chunk_index LIMIT 1`,
     );

--- a/packages/backend-core/src/modules/kb/kb.service.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.ts
@@ -2,9 +2,23 @@ import { Injectable, Inject } from '@nestjs/common';
 import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import { schema } from '@getmunin/db';
 import { chunkDocument, contentHash, getCurrentContext } from '@getmunin/core';
-import type { ActorIdentity } from '@getmunin/core';
+import type { ActorIdentity, Audience } from '@getmunin/core';
 import { EmbeddingProviderHolder } from './embedding.provider.js';
 import { QuotasService } from '../../common/quotas/quotas.service.js';
+
+const AUDIENCES: readonly Audience[] = ['admin', 'self_service'];
+
+function normaliseAudiences(input: readonly string[] | undefined, fallback: readonly Audience[] = ['admin']): Audience[] {
+  if (!input) return [...fallback];
+  const dedup = new Set<Audience>();
+  for (const v of input) {
+    if ((AUDIENCES as readonly string[]).includes(v)) dedup.add(v as Audience);
+  }
+  if (dedup.size === 0) {
+    throw new KbInvalidError(`audiences must be a non-empty subset of ${AUDIENCES.join(', ')}`);
+  }
+  return Array.from(dedup);
+}
 
 export class KbConflictError extends Error {
   readonly code = 'kb_version_conflict';
@@ -43,7 +57,7 @@ export interface DocumentDto {
   spaceId: string;
   title: string;
   body: string;
-  public: boolean;
+  audiences: Audience[];
   version: number;
   tags: string[];
   createdAt: string;
@@ -54,7 +68,7 @@ export interface DocumentSummary {
   id: string;
   spaceId: string;
   title: string;
-  public: boolean;
+  audiences: Audience[];
   version: number;
   tags: string[];
   updatedAt: string;
@@ -66,7 +80,7 @@ export interface VersionDto {
   version: number;
   title: string;
   body: string;
-  public: boolean;
+  audiences: Audience[];
   tags: string[];
   createdAt: string;
 }
@@ -139,7 +153,7 @@ export class KbService {
         id: schema.kbDocuments.id,
         spaceId: schema.kbDocuments.spaceId,
         title: schema.kbDocuments.title,
-        public: schema.kbDocuments.public,
+        audiences: schema.kbDocuments.audiences,
         version: schema.kbDocuments.version,
         tags: schema.kbDocuments.tags,
         updatedAt: schema.kbDocuments.updatedAt,
@@ -152,7 +166,7 @@ export class KbService {
       id: r.id,
       spaceId: r.spaceId,
       title: r.title,
-      public: r.public,
+      audiences: r.audiences,
       version: r.version,
       tags: r.tags,
       updatedAt: r.updatedAt.toISOString(),
@@ -175,13 +189,14 @@ export class KbService {
     spaceId: string;
     title: string;
     body: string;
-    public?: boolean;
+    audiences?: readonly string[];
     tags?: string[];
   }): Promise<DocumentDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     await this.assertSpaceExists(input.spaceId);
     await this.quotas.assertCanAdd('kb_documents');
+    const audiences = normaliseAudiences(input.audiences);
     const hash = contentHash(input.title, input.body);
     const [doc] = await ctx.db
       .insert(schema.kbDocuments)
@@ -190,7 +205,7 @@ export class KbService {
         spaceId: input.spaceId,
         title: input.title,
         body: input.body,
-        public: input.public ?? false,
+        audiences,
         version: 1,
         contentHash: hash,
         tags: input.tags ?? [],
@@ -207,7 +222,7 @@ export class KbService {
     ifVersion: number;
     title?: string;
     body?: string;
-    public?: boolean;
+    audiences?: readonly string[];
     tags?: string[];
   }): Promise<DocumentDto> {
     const ctx = getCurrentContext();
@@ -218,7 +233,9 @@ export class KbService {
     }
     const newTitle = input.title ?? existing.title;
     const newBody = input.body ?? existing.body;
-    const newPublic = input.public ?? existing.public;
+    const newAudiences = input.audiences === undefined
+      ? existing.audiences
+      : normaliseAudiences(input.audiences);
     const newTags = input.tags ?? existing.tags;
     const newHash = contentHash(newTitle, newBody);
     const contentChanged = newHash !== existing.contentHash;
@@ -228,7 +245,7 @@ export class KbService {
       .set({
         title: newTitle,
         body: newBody,
-        public: newPublic,
+        audiences: newAudiences,
         tags: newTags,
         contentHash: newHash,
         version: existing.version + 1,
@@ -298,7 +315,7 @@ export class KbService {
       .set({
         title: snap.title,
         body: snap.body,
-        public: snap.public,
+        audiences: snap.audiences,
         tags: snap.tags,
         contentHash: newHash,
         version: existing.version + 1,
@@ -357,7 +374,7 @@ export class KbService {
       version: doc.version,
       title: doc.title,
       body: doc.body,
-      public: doc.public,
+      audiences: doc.audiences,
       tags: doc.tags,
       createdByType: actorTypeToCreatorTag(actor),
       createdById: actor.id,
@@ -411,7 +428,7 @@ function toDocumentDto(row: typeof schema.kbDocuments.$inferSelect): DocumentDto
     spaceId: row.spaceId,
     title: row.title,
     body: row.body,
-    public: row.public,
+    audiences: row.audiences,
     version: row.version,
     tags: row.tags,
     createdAt: row.createdAt.toISOString(),
@@ -426,7 +443,7 @@ function toVersionDto(row: typeof schema.kbDocumentVersions.$inferSelect): Versi
     version: row.version,
     title: row.title,
     body: row.body,
-    public: row.public,
+    audiences: row.audiences,
     tags: row.tags,
     createdAt: row.createdAt.toISOString(),
   };

--- a/packages/backend-core/src/modules/kb/kb.tools.ts
+++ b/packages/backend-core/src/modules/kb/kb.tools.ts
@@ -22,11 +22,14 @@ const GetDocumentInput = z.object({
   id: z.string(),
 });
 
+const AudienceSchema = z.enum(['admin', 'self_service']);
+const AudiencesSchema = z.array(AudienceSchema).min(1);
+
 const CreateDocumentInput = z.object({
   spaceId: z.string(),
   title: z.string().min(1).max(300),
   body: z.string().min(1),
-  public: z.boolean().optional(),
+  audiences: AudiencesSchema.optional(),
   tags: TagsSchema.optional(),
 });
 
@@ -35,7 +38,7 @@ const UpdateDocumentInput = z.object({
   ifVersion: z.number().int().nonnegative(),
   title: z.string().min(1).max(300).optional(),
   body: z.string().min(1).optional(),
-  public: z.boolean().optional(),
+  audiences: AudiencesSchema.optional(),
   tags: TagsSchema.optional(),
 });
 
@@ -117,7 +120,7 @@ export class KbAdminTools {
     name: 'kb_get_document',
     title: 'Read KB document',
     description:
-      'Read one knowledge-base document, including its full body, tags, and current version. End-user agents see only documents marked `public`.',
+      "Read one knowledge-base document, including its full body, tags, and current version. End-user agents see only documents whose `audiences` includes `'self_service'`.",
     audiences: ['admin', 'self_service'],
     scopes: ['kb:read'],
     input: GetDocumentInput,
@@ -132,7 +135,7 @@ export class KbAdminTools {
     name: 'kb_search',
     title: 'Search knowledge base',
     description:
-      'Search the knowledge base by natural-language query. Combines full-text search and vector similarity for the best of both. End-user agents see only documents marked `public`.',
+      "Search the knowledge base by natural-language query. Combines full-text search and vector similarity for the best of both. End-user agents see only documents whose `audiences` includes `'self_service'`.",
     audiences: ['admin', 'self_service'],
     scopes: ['kb:read'],
     input: SearchInput,
@@ -147,7 +150,7 @@ export class KbAdminTools {
     name: 'kb_create_document',
     title: 'Create KB document',
     description:
-      'Create a knowledge-base document inside a space. Body should be markdown. Set `public: true` to expose it to end-user agents.',
+      "Create a knowledge-base document inside a space. Body should be markdown. Set `audiences: ['admin', 'self_service']` to expose it to end-user agents; defaults to `['admin']` (admin-only).",
     audiences: ['admin'],
     scopes: ['kb:write'],
     input: CreateDocumentInput,

--- a/packages/backend-core/src/modules/kb/skills/article-bulk-import.md
+++ b/packages/backend-core/src/modules/kb/skills/article-bulk-import.md
@@ -77,7 +77,7 @@ For each chunk:
 }
 ```
 
-Default `public: false` unless the source is explicitly a public help center. Embeddings are generated server-side asynchronously — you don't wait, but search results for new docs become accurate within ~5 seconds.
+Default `audiences: ['admin']` unless the source is explicitly customer-facing material. End-user agents only see docs whose `audiences` includes `'self_service'`. Embeddings are generated server-side asynchronously — you don't wait, but search results for new docs become accurate within ~5 seconds.
 
 Pace: a few documents per second is fine. If you're importing thousands of rows, throttle to leave room for other traffic.
 
@@ -94,7 +94,7 @@ Then count: search by the import-tag prefix and confirm the count matches your s
 ## What NOT to do
 
 - **Don't ignore `kb_create_document` errors.** Title-too-long and empty-body errors are common in CSV exports; logging them per-row lets you fix the source data and re-run.
-- **Don't import as `public: true` by default.** It exposes content via the self-service search audience. Only flip on for explicitly public knowledge.
+- **Don't import with `audiences: ['admin', 'self_service']` by default.** That exposes content to end-user agents via `kb_search`. Only include `'self_service'` for explicitly customer-facing knowledge.
 - **Don't import the same source twice without the import-tag idempotency key.** Duplicate articles dilute search quality and confuse end-users.
 - **Don't set hundreds of identical tags across the import.** Tags are filterable; that means each tag is part of someone's mental model. Use tags as facets, not as labels.
 

--- a/packages/backend-core/src/modules/kb/skills/import-from-google-docs.md
+++ b/packages/backend-core/src/modules/kb/skills/import-from-google-docs.md
@@ -51,7 +51,7 @@ When in doubt, fewer larger articles beat many tiny ones. A retrieval that retur
 
 - `body` is markdown. Headings, lists, code blocks all preserved for the rendered view.
 - `tags` are a flat string array. Don't overuse — 3–5 high-signal tags > 20 weak ones.
-- `public: true` exposes the article via the public delivery API; default false keeps it admin/agent-only.
+- `audiences` is an array of `'admin'` and / or `'self_service'`. Default `['admin']` keeps the doc admin-only; include `'self_service'` to surface it via `kb_search` for end-user agents.
 
 ## Step 4 — embeddings
 

--- a/packages/backend-core/src/modules/kb/skills/kb-onboarding.md
+++ b/packages/backend-core/src/modules/kb/skills/kb-onboarding.md
@@ -74,7 +74,7 @@ Or skip:
 }
 ```
 
-If you create one, the doc will be in the first space, default `public: false`. The body is markdown; chunking and tagging guidance lives in `skill://kb/import-from-google-docs`.
+If you create one, the doc will be in the first space, default `audiences: ['admin']` (admin-only). The body is markdown; chunking and tagging guidance lives in `skill://kb/import-from-google-docs`.
 
 ## Step 4 — confirm
 

--- a/packages/db/drizzle/0003_kb_audiences.sql
+++ b/packages/db/drizzle/0003_kb_audiences.sql
@@ -1,0 +1,47 @@
+-- Replace kb_documents.public (boolean) with kb_documents.audiences (jsonb
+-- array), matching the audience model used by skills + the rest of MCP. The
+-- old `public` flag was a half-baked toggle: there's no anonymous KB
+-- delivery endpoint, so what it actually controlled was whether a
+-- self-service-audience caller could see the doc. Renaming makes that
+-- explicit and lets us hold both audiences (or only one) per doc.
+--
+-- Mapping:
+--   public = false  →  audiences = ['admin']
+--   public = true   →  audiences = ['admin', 'self_service']
+--
+-- Same column added to kb_document_versions so historical snapshots keep
+-- the right visibility on restore.
+
+ALTER TABLE "kb_documents"
+  ADD COLUMN "audiences" jsonb NOT NULL DEFAULT '["admin"]'::jsonb;
+--> statement-breakpoint
+
+UPDATE "kb_documents"
+SET "audiences" = CASE
+  WHEN "public" = true THEN '["admin","self_service"]'::jsonb
+  ELSE '["admin"]'::jsonb
+END;
+--> statement-breakpoint
+
+DROP INDEX IF EXISTS "kb_documents_public_idx";
+--> statement-breakpoint
+
+CREATE INDEX "kb_documents_audiences_idx"
+  ON "kb_documents" USING gin ("audiences");
+--> statement-breakpoint
+
+ALTER TABLE "kb_documents" DROP COLUMN "public";
+--> statement-breakpoint
+
+ALTER TABLE "kb_document_versions"
+  ADD COLUMN "audiences" jsonb NOT NULL DEFAULT '["admin"]'::jsonb;
+--> statement-breakpoint
+
+UPDATE "kb_document_versions"
+SET "audiences" = CASE
+  WHEN "public" = true THEN '["admin","self_service"]'::jsonb
+  ELSE '["admin"]'::jsonb
+END;
+--> statement-breakpoint
+
+ALTER TABLE "kb_document_versions" DROP COLUMN "public";

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777534883413,
       "tag": "0002_drop_suggestions",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777680000000,
+      "tag": "0003_kb_audiences",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -494,7 +494,10 @@ export const kbDocuments = pgTable(
       .references(() => kbSpaces.id, { onDelete: 'cascade' }),
     title: text('title').notNull(),
     body: text('body').notNull(),
-    public: boolean('public').notNull().default(false),
+    audiences: jsonb('audiences')
+      .$type<('admin' | 'self_service')[]>()
+      .notNull()
+      .default(['admin']),
     version: integer('version').notNull().default(1),
     contentHash: varchar('content_hash', { length: 64 }).notNull(),
     tags: jsonb('tags').$type<string[]>().notNull().default([]),
@@ -509,7 +512,7 @@ export const kbDocuments = pgTable(
   (t) => ({
     orgIdx: index('kb_documents_org_idx').on(t.orgId),
     spaceIdx: index('kb_documents_space_idx').on(t.spaceId),
-    publicIdx: index('kb_documents_public_idx').on(t.orgId, t.public),
+    audiencesIdx: index('kb_documents_audiences_idx').using('gin', t.audiences),
   }),
 );
 
@@ -554,7 +557,10 @@ export const kbDocumentVersions = pgTable(
     version: integer('version').notNull(),
     title: text('title').notNull(),
     body: text('body').notNull(),
-    public: boolean('public').notNull(),
+    audiences: jsonb('audiences')
+      .$type<('admin' | 'self_service')[]>()
+      .notNull()
+      .default(['admin']),
     tags: jsonb('tags').$type<string[]>().notNull().default([]),
     createdByType: varchar('created_by_type', { length: 16 }).notNull(),
     createdById: text('created_by_id').notNull(),

--- a/packages/db/src/sql/kb.sql
+++ b/packages/db/src/sql/kb.sql
@@ -36,11 +36,11 @@ CREATE INDEX IF NOT EXISTS kb_chunks_embedding_hnsw_idx
   ON kb_document_chunks USING hnsw (embedding vector_cosine_ops);
 
 -- ───────────────────────── KB RLS policies ─────────────────────────────────
--- All KB tables are org-scoped. Documents have an additional `public` flag
+-- All KB tables are org-scoped. Documents have an `audiences` jsonb array
 -- consulted by self-service callers (when app.end_user_id is set, only
--- public docs are visible). Chunks/versions inherit visibility from their
--- parent document — a tighter sub-policy avoids leaking embedding text via
--- direct chunk reads.
+-- docs whose audiences include 'self_service' are visible). Chunks/versions
+-- inherit visibility from their parent document — a tighter sub-policy
+-- avoids leaking embedding text via direct chunk reads.
 
 ALTER TABLE kb_spaces ENABLE ROW LEVEL SECURITY;
 ALTER TABLE kb_spaces FORCE ROW LEVEL SECURITY;
@@ -57,7 +57,7 @@ CREATE POLICY tenant_isolation ON kb_documents
     app_bypass_rls()
     OR (
       org_id = app_org_id()
-      AND (app_end_user_id() = '' OR public = true)
+      AND (app_end_user_id() = '' OR audiences @> '["self_service"]'::jsonb)
     )
   )
   WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
@@ -75,7 +75,7 @@ CREATE POLICY tenant_isolation ON kb_document_chunks
         OR EXISTS (
           SELECT 1 FROM kb_documents d
           WHERE d.id = kb_document_chunks.document_id
-            AND d.public = true
+            AND d.audiences @> '["self_service"]'::jsonb
         )
       )
     )


### PR DESCRIPTION
## Why

The \`public\` flag on \`kb_documents\` was misleading: there's no anonymous KB delivery endpoint, so what \`public=true\` actually controlled was whether a self-service-audience caller could see the doc via \`kb_search\`. Renaming makes that explicit and lets a doc carry both audiences (or only one), matching the \`audiences\` shape skills already use.

## Behaviour mapping

| Before | After |
|---|---|
| \`public = false\` | \`audiences = ['admin']\` |
| \`public = true\` | \`audiences = ['admin', 'self_service']\` |

\`audiences = ['self_service']\` (no admin) is allowed but rare — typically you want both, since admin agents should see everything end-user agents see.

## What changed

**Schema (\`packages/db\`):**
- \`drizzle/0003_kb_audiences.sql\` — adds \`audiences jsonb\` to \`kb_documents\` + \`kb_document_versions\`, backfills from \`public\`, drops \`public\` + the public index, adds a GIN index on \`audiences\`.
- \`src/sql/kb.sql\` — RLS policies on \`kb_documents\` and \`kb_document_chunks\` filter by \`audiences @> '["self_service"]'::jsonb\` for end-user callers (was \`public = true\`).
- \`schema.ts\` — \`kbDocuments\` + \`kbDocumentVersions\` get \`audiences jsonb\` (typed \`Audience[]\`).

**Service / search / tools (\`packages/backend-core\`):**
- \`KbService.{createDocument, updateDocument, restoreVersion}\` accept \`audiences?: readonly string[]\` (defaults to existing on update; \`['admin']\` on create). New \`normaliseAudiences\` helper validates input.
- \`DocumentDto\` / \`DocumentSummary\` / \`VersionDto\` carry \`audiences: Audience[]\`.
- \`kb.search.ts\` raw SQL projects \`audiences\` instead of \`public\`; \`SearchHit\` shape updated.
- \`kb.tools.ts\` MCP input schemas use \`AudiencesSchema (z.array(z.enum))\`.
- \`kb.bootstrap\` default doc creates with \`['admin']\`.
- \`export.controller.ts\` projection updated.

**Skill docs:**
- \`article-bulk-import.md\`, \`import-from-google-docs.md\`, \`kb-onboarding.md\` rephrased to talk about audiences instead of public.

**Tests:**
- \`kb.service.test.ts\`, \`kb.search.test.ts\`, \`mcp.integration.test.ts\` updated to pass audiences arrays.

## Test plan

- [x] Migration applies cleanly on a fresh DB
- [x] \`pnpm --filter @getmunin/db typecheck\` is green
- [x] \`pnpm --filter @getmunin/backend-core typecheck\` is green
- [x] All 68 backend-core tests pass against the migrated database
- [ ] Production deploy: migration is safe — backfill preserves existing behaviour exactly. The new GIN index on \`audiences\` is small and fast to create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)