### PR TITLE
refactor(backend-core): split self-service into MCP decisions + REST lifecycle

### DIFF
--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -20,6 +20,7 @@ import { MembersController } from './members.controller.js';
 import { MembershipsController } from './memberships.controller.js';
 import { ConversationsController } from './conversations.controller.js';
 import { ActivityController } from './activity.controller.js';
+import { EndUserConversationsController } from './end-user-conversations.controller.js';
 
 /**
  * Control plane: server-to-server REST endpoints used by an org's backend
@@ -49,6 +50,7 @@ import { ActivityController } from './activity.controller.js';
     PublicSkillsController,
     ConversationsController,
     ActivityController,
+    EndUserConversationsController,
   ],
   providers: [InvitationsService],
 })

--- a/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
@@ -1,0 +1,229 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { buildApiKey, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { AppModule } from '../app.module.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run end-user conversations REST integration tests.';
+
+(skipReason ? describe.skip : describe)('End-user conversations REST controller', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let adminKey: string;
+  let aliceToken: string;
+  let bobToken: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod-it-must-be-32-chars';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const ts = Date.now();
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'EndUser Conv Org', slug: `eu-conv-${ts}` })
+      .returning();
+    orgId = org!.id;
+
+    adminKey = buildApiKey('admin');
+    await db.insert(schema.apiKeys).values({
+      orgId,
+      type: 'admin',
+      name: 'eu-conv-admin',
+      keyHash: hashSecret(adminKey),
+      keyPrefix: keyPrefix(adminKey),
+      scopes: ['*'],
+    });
+
+    const [alice] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: 'eu-alice', name: 'Alice' })
+      .returning();
+    const [bob] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: 'eu-bob', name: 'Bob' })
+      .returning();
+
+    aliceToken = randomToken(32);
+    await db.insert(schema.tokens).values({
+      orgId,
+      type: 'delegated_end_user',
+      tokenHash: hashSecret(aliceToken),
+      scopes: ['conv:read', 'conv:write'],
+      audiences: ['self_service'],
+      endUserId: alice!.id,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    bobToken = randomToken(32);
+    await db.insert(schema.tokens).values({
+      orgId,
+      type: 'delegated_end_user',
+      tokenHash: hashSecret(bobToken),
+      scopes: ['conv:read', 'conv:write'],
+      audiences: ['self_service'],
+      endUserId: bob!.id,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    await db.insert(schema.convChannels).values({
+      orgId,
+      type: 'chat',
+      name: 'Web chat',
+    });
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  async function rest<T>(
+    token: string,
+    method: 'GET' | 'POST',
+    path: string,
+    body?: unknown,
+  ): Promise<{ status: number; body: T }> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method,
+      headers: { Authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const text = await res.text();
+    const parsed = text ? (JSON.parse(text) as T) : (undefined as unknown as T);
+    return { status: res.status, body: parsed };
+  }
+
+  it('happy path: end-user starts, lists, gets, replies', async () => {
+    const start = await rest<{ id: string; messages: { body: string; authorType: string }[] }>(
+      aliceToken,
+      'POST',
+      '/api/end-user/conversations',
+      { body: 'I need help with my plan.' },
+    );
+    expect(start.status).toBe(201);
+    expect(start.body.messages).toHaveLength(1);
+    expect(start.body.messages[0]!.authorType).toBe('end_user');
+
+    const list = await rest<{ items: Array<{ id: string }> }>(
+      aliceToken,
+      'GET',
+      '/api/end-user/conversations',
+    );
+    expect(list.status).toBe(200);
+    expect(list.body.items.find((c) => c.id === start.body.id)).toBeTruthy();
+
+    const detail = await rest<{ id: string; messages: Array<{ body: string }> }>(
+      aliceToken,
+      'GET',
+      `/api/end-user/conversations/${start.body.id}`,
+    );
+    expect(detail.status).toBe(200);
+    expect(detail.body.id).toBe(start.body.id);
+
+    const reply = await rest<{ authorType: string }>(
+      aliceToken,
+      'POST',
+      `/api/end-user/conversations/${start.body.id}/messages`,
+      { body: 'Actually, my account is also locked.' },
+    );
+    expect(reply.status).toBe(201);
+    expect(reply.body.authorType).toBe('end_user');
+  }, 30_000);
+
+  it('admin token is rejected with 403 on every endpoint', async () => {
+    const start = await rest(adminKey, 'POST', '/api/end-user/conversations', { body: 'hi' });
+    expect(start.status).toBe(403);
+
+    const list = await rest(adminKey, 'GET', '/api/end-user/conversations');
+    expect(list.status).toBe(403);
+
+    const get = await rest(adminKey, 'GET', '/api/end-user/conversations/some-id');
+    expect(get.status).toBe(403);
+
+    const reply = await rest(
+      adminKey,
+      'POST',
+      '/api/end-user/conversations/some-id/messages',
+      { body: 'hi' },
+    );
+    expect(reply.status).toBe(403);
+  });
+
+  it('cross-end-user isolation: bob cannot see or write to alice\'s thread', async () => {
+    const aliceStart = await rest<{ id: string }>(
+      aliceToken,
+      'POST',
+      '/api/end-user/conversations',
+      { body: 'private message from Alice' },
+    );
+    expect(aliceStart.status).toBe(201);
+
+    const bobList = await rest<{ items: Array<{ id: string }> }>(
+      bobToken,
+      'GET',
+      '/api/end-user/conversations',
+    );
+    expect(bobList.body.items.find((c) => c.id === aliceStart.body.id)).toBeFalsy();
+
+    const bobGet = await rest(
+      bobToken,
+      'GET',
+      `/api/end-user/conversations/${aliceStart.body.id}`,
+    );
+    expect(bobGet.status).toBe(404);
+
+    const bobReply = await rest(
+      bobToken,
+      'POST',
+      `/api/end-user/conversations/${aliceStart.body.id}/messages`,
+      { body: 'sneak attempt' },
+    );
+    expect(bobReply.status).toBe(404);
+  }, 30_000);
+
+  it('POST /messages always stores authorType=end_user, ignoring any client field', async () => {
+    const start = await rest<{ id: string }>(
+      aliceToken,
+      'POST',
+      '/api/end-user/conversations',
+      { body: 'starting' },
+    );
+    const reply = await rest<{ authorType: string }>(
+      aliceToken,
+      'POST',
+      `/api/end-user/conversations/${start.body.id}/messages`,
+      // Even if the client tries to spoof the author type, the server forces 'end_user'.
+      { body: 'second message', authorType: 'agent' },
+    );
+    expect(reply.status).toBe(201);
+    expect(reply.body.authorType).toBe('end_user');
+  }, 30_000);
+});

--- a/packages/backend-core/src/control/end-user-conversations.controller.ts
+++ b/packages/backend-core/src/control/end-user-conversations.controller.ts
@@ -1,0 +1,166 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { z } from 'zod';
+import { getCurrentContext } from '@getmunin/core';
+import { AuthGuard } from '../common/auth/auth.guard.js';
+import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.js';
+import { AuditInterceptor } from '../common/audit/audit.interceptor.js';
+import {
+  ConvInvalidError,
+  ConvService,
+  STATUSES,
+  type ConversationDetail,
+  type ConversationSummary,
+  type MessageDto,
+} from '../modules/conv/conv.service.js';
+
+const StatusSchema = z.enum(STATUSES);
+
+const StartBody = z.object({
+  body: z.string().min(1).max(50_000),
+  subject: z.string().max(300).optional(),
+  channelHint: z.enum(['email', 'voice', 'chat', 'sms']).optional(),
+});
+
+const ReplyBody = z.object({
+  body: z.string().min(1).max(50_000),
+});
+
+interface ConversationListResponse {
+  items: ConversationSummary[];
+  nextCursor: string | null;
+}
+
+@Controller('api/end-user/conversations')
+@UseGuards(AuthGuard)
+@UseInterceptors(TenancyInterceptor, AuditInterceptor)
+export class EndUserConversationsController {
+  constructor(private readonly conv: ConvService) {}
+
+  @Post()
+  @HttpCode(201)
+  async start(@Body() body: unknown): Promise<ConversationDetail> {
+    const parsed = StartBody.safeParse(body);
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    const actor = this.requireEndUserActor();
+    const channel =
+      (await this.conv.firstActiveChannel(parsed.data.channelHint ?? 'chat')) ??
+      (await this.conv.firstActiveChannel());
+    if (!channel) {
+      throw new BadRequestException(
+        'no active channel configured for this org; ask an admin to create one (e.g. type=chat)',
+      );
+    }
+    return translate(() =>
+      this.conv.createConversation({
+        channelId: channel.id,
+        body: parsed.data.body,
+        subject: parsed.data.subject,
+        endUserId: actor.endUserId,
+        authorType: 'end_user',
+        authorId: actor.endUserId,
+      }),
+    );
+  }
+
+  @Get()
+  async list(
+    @Query('status') status?: string,
+    @Query('cursor') cursor?: string,
+    @Query('limit') limit?: string,
+  ): Promise<ConversationListResponse> {
+    this.requireEndUserActor();
+    const parsedStatus = status ? StatusSchema.safeParse(status) : null;
+    if (parsedStatus && !parsedStatus.success) {
+      throw new BadRequestException(`invalid status: ${status}`);
+    }
+    const decodedCursor = cursor ? decodeListCursor(cursor) : undefined;
+    const page = await translate(() =>
+      this.conv.listConversationsPage({
+        status: parsedStatus?.success ? parsedStatus.data : undefined,
+        limit: parseLimit(limit),
+        cursor: decodedCursor,
+      }),
+    );
+    return {
+      items: page.items,
+      nextCursor: page.nextCursor ? encodeListCursor(page.nextCursor) : null,
+    };
+  }
+
+  @Get(':id')
+  async get(@Param('id') id: string): Promise<ConversationDetail> {
+    this.requireEndUserActor();
+    return translate(() => this.conv.getConversation(id));
+  }
+
+  @Post(':id/messages')
+  @HttpCode(201)
+  async reply(@Param('id') id: string, @Body() body: unknown): Promise<MessageDto> {
+    const parsed = ReplyBody.safeParse(body);
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    const actor = this.requireEndUserActor();
+    return translate(() =>
+      this.conv.sendMessage({
+        conversationId: id,
+        body: parsed.data.body,
+        internal: false,
+        authorType: 'end_user',
+        authorId: actor.endUserId,
+      }),
+    );
+  }
+
+  private requireEndUserActor(): { endUserId: string; orgId: string } {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    if (actor.type !== 'end_user_agent' || !actor.endUserId) {
+      throw new ForbiddenException('end-user delegated token required for this endpoint');
+    }
+    return { endUserId: actor.endUserId, orgId: actor.orgId };
+  }
+}
+
+async function translate<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof ConvInvalidError) throw new BadRequestException(err.message);
+    throw err;
+  }
+}
+
+function parseLimit(value: string | undefined): number | undefined {
+  const n = value ? Number.parseInt(value, 10) : NaN;
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.min(n, 50);
+}
+
+function encodeListCursor(c: { lastMessageAt: string | null; id: string }): string {
+  return Buffer.from(JSON.stringify(c)).toString('base64url');
+}
+
+function decodeListCursor(raw: string): { lastMessageAt: string | null; id: string } | undefined {
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(raw, 'base64url').toString());
+    if (!parsed || typeof parsed !== 'object') return undefined;
+    const candidate = parsed as { id?: unknown; lastMessageAt?: unknown };
+    if (typeof candidate.id !== 'string') return undefined;
+    if (candidate.lastMessageAt !== null && typeof candidate.lastMessageAt !== 'string')
+      return undefined;
+    return { lastMessageAt: candidate.lastMessageAt, id: candidate.id };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/backend-core/src/modules/conv/conv.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.integration.test.ts
@@ -115,7 +115,23 @@ const skipReason = TEST_URL
     }
   }
 
-  it('admin sets up channel; end-user starts a conversation; admin replies; end-user sees the reply', async () => {
+  async function rest<T>(
+    token: string,
+    method: 'GET' | 'POST',
+    path: string,
+    body?: unknown,
+  ): Promise<{ status: number; body: T }> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method,
+      headers: { Authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const text = await res.text();
+    const parsed = text ? (JSON.parse(text) as T) : (undefined as unknown as T);
+    return { status: res.status, body: parsed };
+  }
+
+  it('admin sets up channel; end-user starts a conversation via REST; admin replies; end-user sees the reply', async () => {
     const channel = await withClient(adminKey, async (c) => {
       return parseToolResult<{ id: string }>(
         await c.callTool({
@@ -125,21 +141,26 @@ const skipReason = TEST_URL
       );
     });
 
-    const startedConv = await withClient(endUserToken, async (c) => {
+    await withClient(endUserToken, async (c) => {
       const { tools } = await c.listTools();
       const names = tools.map((t) => t.name);
-      expect(names).toContain('conv_start_conversation');
-      expect(names).toContain('conv_list_my_conversations');
+      expect(names).toContain('conv_request_handover_in_my_conversation');
+      expect(names).not.toContain('conv_start_conversation');
+      expect(names).not.toContain('conv_list_my_conversations');
+      expect(names).not.toContain('conv_get_my_conversation');
+      expect(names).not.toContain('conv_send_message_in_my_conversation');
       expect(names).not.toContain('conv_create_channel');
       expect(names).not.toContain('conv_change_status');
-
-      return parseToolResult<{ id: string; displayId: number; messages: { body: string }[] }>(
-        await c.callTool({
-          name: 'conv_start_conversation',
-          arguments: { body: 'Hi — my account is locked, can you help?' },
-        }),
-      );
     });
+
+    const startResp = await rest<{ id: string; displayId: number; messages: { body: string }[] }>(
+      endUserToken,
+      'POST',
+      '/api/end-user/conversations',
+      { body: 'Hi — my account is locked, can you help?' },
+    );
+    expect(startResp.status).toBe(201);
+    const startedConv = startResp.body;
 
     expect(startedConv.displayId).toBeGreaterThan(0);
     expect(startedConv.messages).toHaveLength(1);
@@ -173,37 +194,40 @@ const skipReason = TEST_URL
     });
     expect(adminReply.internal).toBe(false);
 
-    await withClient(endUserToken, async (c) => {
-      const detail = parseToolResult<{ messages: { body: string; internal: boolean }[] }>(
-        await c.callTool({
-          name: 'conv_get_my_conversation',
-          arguments: { id: startedConv.id },
-        }),
-      );
-      const bodies = detail.messages.map((m) => m.body);
-      expect(bodies).toContain('Hi Alice, I\'ve unlocked your account.');
-      // Internal note is filtered by RLS — never visible to end-users.
-      expect(bodies.find((b) => /2FA/.test(b))).toBeUndefined();
-      expect(detail.messages.every((m) => m.internal === false)).toBe(true);
-    });
+    const detailResp = await rest<{ messages: { body: string; internal: boolean }[] }>(
+      endUserToken,
+      'GET',
+      `/api/end-user/conversations/${startedConv.id}`,
+    );
+    expect(detailResp.status).toBe(200);
+    const detail = detailResp.body;
+    const bodies = detail.messages.map((m) => m.body);
+    expect(bodies).toContain('Hi Alice, I\'ve unlocked your account.');
+    // Internal note is filtered by RLS — never visible to end-users.
+    expect(bodies.find((b) => /2FA/.test(b))).toBeUndefined();
+    expect(detail.messages.every((m) => m.internal === false)).toBe(true);
 
     // Cross-end-user isolation: Bob can't see Alice's conversation.
-    await withClient(otherEndUserToken, async (c) => {
-      const list = parseToolResult<Array<{ id: string }>>(
-        await c.callTool({ name: 'conv_list_my_conversations', arguments: {} }),
-      );
-      expect(list.find((row) => row.id === startedConv.id)).toBeFalsy();
-    });
+    const otherList = await rest<{ items: Array<{ id: string }> }>(
+      otherEndUserToken,
+      'GET',
+      '/api/end-user/conversations',
+    );
+    expect(otherList.body.items.find((row) => row.id === startedConv.id)).toBeFalsy();
+
+    const otherGet = await rest<{ message?: string }>(
+      otherEndUserToken,
+      'GET',
+      `/api/end-user/conversations/${startedConv.id}`,
+    );
+    expect(otherGet.status).toBe(404);
 
     void channel;
   }, 30_000);
 
   it('admin can change status to closed; subsequent listings respect the filter', async () => {
-    await withClient(endUserToken, async (c) => {
-      await c.callTool({
-        name: 'conv_start_conversation',
-        arguments: { body: 'How do I export my data?' },
-      });
+    await rest(endUserToken, 'POST', '/api/end-user/conversations', {
+      body: 'How do I export my data?',
     });
 
     await withClient(adminKey, async (c) => {
@@ -239,14 +263,10 @@ const skipReason = TEST_URL
   }, 30_000);
 
   it('admin agent requests handover; flag is set, internal note appears, idempotent, then user reply clears it', async () => {
-    const conv = await withClient(endUserToken, async (c) =>
-      parseToolResult<{ id: string }>(
-        await c.callTool({
-          name: 'conv_start_conversation',
-          arguments: { body: 'Can I get a partial refund for last month?' },
-        }),
-      ),
-    );
+    const startResp = await rest<{ id: string }>(endUserToken, 'POST', '/api/end-user/conversations', {
+      body: 'Can I get a partial refund for last month?',
+    });
+    const conv = startResp.body;
 
     type Summary = {
       id: string;
@@ -286,16 +306,13 @@ const skipReason = TEST_URL
       return result;
     });
 
-    await withClient(endUserToken, async (c) => {
-      const detail = parseToolResult<Detail>(
-        await c.callTool({
-          name: 'conv_get_my_conversation',
-          arguments: { id: conv.id },
-        }),
-      );
-      const systemNotes = detail.messages.filter((m) => m.authorType === 'system');
-      expect(systemNotes).toHaveLength(0);
-    });
+    const endUserDetail = await rest<Detail>(
+      endUserToken,
+      'GET',
+      `/api/end-user/conversations/${conv.id}`,
+    );
+    const systemNotes = endUserDetail.body.messages.filter((m) => m.authorType === 'system');
+    expect(systemNotes).toHaveLength(0);
 
     await withClient(adminKey, async (c) => {
       const list = parseToolResult<Summary[]>(
@@ -322,14 +339,10 @@ const skipReason = TEST_URL
   }, 30_000);
 
   it('end-user agent can flag its own conversation via conv_request_handover_in_my_conversation (self-service)', async () => {
-    const conv = await withClient(endUserToken, async (c) =>
-      parseToolResult<{ id: string }>(
-        await c.callTool({
-          name: 'conv_start_conversation',
-          arguments: { body: 'I need to talk to a human about my contract.' },
-        }),
-      ),
-    );
+    const startResp = await rest<{ id: string }>(endUserToken, 'POST', '/api/end-user/conversations', {
+      body: 'I need to talk to a human about my contract.',
+    });
+    const conv = startResp.body;
 
     await withClient(endUserToken, async (c) => {
       const { tools } = await c.listTools();
@@ -355,14 +368,10 @@ const skipReason = TEST_URL
   }, 30_000);
 
   it('changeStatus to closed clears needsHumanAttention', async () => {
-    const conv = await withClient(endUserToken, async (c) =>
-      parseToolResult<{ id: string }>(
-        await c.callTool({
-          name: 'conv_start_conversation',
-          arguments: { body: 'My invoice has the wrong VAT.' },
-        }),
-      ),
-    );
+    const startResp = await rest<{ id: string }>(endUserToken, 'POST', '/api/end-user/conversations', {
+      body: 'My invoice has the wrong VAT.',
+    });
+    const conv = startResp.body;
 
     await withClient(adminKey, async (c) => {
       await c.callTool({

--- a/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
@@ -1,26 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
-import { getCurrentContext } from '@getmunin/core';
-import { ConvInvalidError, ConvService } from './conv.service.js';
-
-const StartConversationInput = z.object({
-  body: z.string().min(1).max(50_000),
-  subject: z.string().max(300).optional(),
-  channelHint: z.enum(['email', 'voice', 'chat', 'sms']).optional(),
-});
-
-const ListMyInput = z.object({
-  status: z.enum(['open', 'snoozed', 'closed', 'spam']).optional(),
-  limit: z.number().int().positive().max(50).optional(),
-});
-
-const GetMyInput = z.object({ id: z.string() });
-
-const SendMyMessageInput = z.object({
-  conversationId: z.string(),
-  body: z.string().min(1).max(50_000),
-});
+import { ConvService } from './conv.service.js';
 
 const RequestMyHandoverInput = z.object({
   conversationId: z.string(),
@@ -30,100 +11,6 @@ const RequestMyHandoverInput = z.object({
 @Injectable()
 export class ConvSelfServiceTools {
   constructor(@Inject(ConvService) private readonly conv: ConvService) {}
-
-  @McpTool({
-    name: 'conv_start_conversation',
-    title: 'Start conversation as end-user',
-    description:
-      'Start a new conversation as the end-user. The platform picks the best channel for you based on `channelHint` (defaults to "chat"). Returns the new conversation with the first message attached.',
-    audiences: ['self_service'],
-    scopes: ['conv:write'],
-    input: StartConversationInput,
-    readOnlyHint: false,
-    destructiveHint: false,
-  })
-  async startConversation(args: z.infer<typeof StartConversationInput>) {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    if (!actor.endUserId) {
-      throw new ConvInvalidError('end-user identity required to start a conversation');
-    }
-    const channel =
-      (await this.conv.firstActiveChannel(args.channelHint ?? 'chat')) ??
-      (await this.conv.firstActiveChannel());
-    if (!channel) {
-      throw new ConvInvalidError(
-        'no active channel configured for this org; ask an admin to create one (e.g. conv_create_channel type=chat)',
-      );
-    }
-    return this.conv.createConversation({
-      channelId: channel.id,
-      body: args.body,
-      subject: args.subject,
-      endUserId: actor.endUserId,
-      authorType: 'end_user',
-      authorId: actor.endUserId,
-    });
-  }
-
-  @McpTool({
-    name: 'conv_list_my_conversations',
-    title: 'List my conversations',
-    description:
-      'List the calling end-user\'s conversations. RLS enforces that only the caller\'s own conversations are returned, regardless of filters.',
-    audiences: ['self_service'],
-    scopes: ['conv:read'],
-    input: ListMyInput,
-    readOnlyHint: true,
-    destructiveHint: false,
-  })
-  async listMy(args: z.infer<typeof ListMyInput>) {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    return this.conv.listConversations({
-      status: args.status,
-      endUserId: actor.endUserId,
-      limit: args.limit,
-    });
-  }
-
-  @McpTool({
-    name: 'conv_get_my_conversation',
-    title: 'Read my conversation',
-    description:
-      'Read one of the calling end-user\'s conversations. RLS hides internal staff messages — only public messages are returned.',
-    audiences: ['self_service'],
-    scopes: ['conv:read'],
-    input: GetMyInput,
-    readOnlyHint: true,
-    destructiveHint: false,
-  })
-  getMy(args: z.infer<typeof GetMyInput>) {
-    return this.conv.getConversation(args.id);
-  }
-
-  @McpTool({
-    name: 'conv_send_message_in_my_conversation',
-    title: 'Send message in my conversation',
-    description:
-      'Append a public message to one of the calling end-user\'s conversations. End-users cannot post internal notes.',
-    audiences: ['self_service'],
-    scopes: ['conv:write'],
-    input: SendMyMessageInput,
-    readOnlyHint: false,
-    destructiveHint: false,
-  })
-  sendMyMessage(args: z.infer<typeof SendMyMessageInput>) {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    return this.conv.sendMessage({
-      conversationId: args.conversationId,
-      body: args.body,
-      internal: false,
-      authorType: 'end_user',
-      authorId: actor.endUserId ?? actor.id,
-    });
-  }
 
   @McpTool({
     name: 'conv_request_handover_in_my_conversation',


### PR DESCRIPTION
## Summary

The self-service MCP catalog previously had five conversation tools — four of them widget-shaped (start, list, get, send) plus the just-shipped handover. For an LLM agent, MCP is the right transport for tools the model **chooses between**. Posting a reply isn't a choice (text generation is the default action). The widget posting user-typed text isn't a choice either (it's a UI primitive). Forcing both through MCP clutters the agent's tool catalog and forces the browser to ship the MCP SDK to do trivial HTTP.

This PR splits the surface cleanly:

- **MCP self-service** keeps only \`conv_request_handover_in_my_conversation\` — genuinely an agent decision (escalate vs. keep replying).
- **REST \`/api/end-user/*\`** carries everything widget-shaped: thread lifecycle and user-typed message posting.

## Changes

**Dropped from MCP:**
| Tool | Replacement |
| --- | --- |
| \`conv_start_conversation\` | \`POST /api/end-user/conversations\` |
| \`conv_list_my_conversations\` | \`GET /api/end-user/conversations\` |
| \`conv_get_my_conversation\` | \`GET /api/end-user/conversations/:id\` |
| \`conv_send_message_in_my_conversation\` | \`POST /api/end-user/conversations/:id/messages\` |

**New \`EndUserConversationsController\`:**
- Each handler asserts \`actor.type === 'end_user_agent'\` (admin tokens get 403), mirroring \`DelegatedTokenController\`'s gate.
- RLS auto-scopes \`conv_conversations\` and \`conv_messages\` by \`app.end_user_id\` — no explicit \`WHERE end_user_id = …\` filtering. Verified via the \`tenant_isolation\` policies already in \`conv.sql\`.
- \`POST /messages\` always stamps \`authorType: 'end_user'\` regardless of body content. AI-generated replies don't go through this path; they go through the existing admin \`POST /api/conversations/:id/messages\` (admin actor → \`authorType: 'agent'\` automatically).

**MCP self-service catalog after this PR (six tools, all decisions):**
\`kb_search\`, \`kb_get_document\`, \`crm_get_my_contact\`, \`crm_update_my_contact\`, \`crm_log_activity_self\`, \`conv_request_handover_in_my_conversation\`.

## Why no \`conv_reply\` tool

When you call an LLM with tool use, the model returns either a tool call or plain text. Plain text **is** the agent's reply — your orchestrator takes it and POSTs to the admin messages endpoint. There's nothing for the model to choose; replying isn't a tool, it's the default.

## Test plan

- [ ] \`pnpm --filter @getmunin/backend-core typecheck\` — clean.
- [ ] \`pnpm --filter @getmunin/backend-core lint\` — clean.
- [ ] \`TEST_DATABASE_URL=… pnpm --filter @getmunin/backend-core test\`:
  - [ ] \`end-user-conversations.controller.integration.test.ts\` (new): happy path, admin → 403 on every endpoint, cross-end-user isolation (Bob can't see Alice's thread; \`GET /:id\` returns 404, \`POST /:id/messages\` returns 404), authorType spoofing rejected (server forces \`end_user\`).
  - [ ] \`conv.integration.test.ts\` (migrated): five existing scenarios now use REST for start/list/get/reply; handover scenarios stay on MCP.
- [ ] Manual: \`tools/list\` from a delegated end-user MCP session shows exactly the six tools above; no \`conv_start_conversation\` etc.
- [ ] Manual: \`curl\` happy path against a delegated token confirms start/list/get/reply work end-to-end.

## Follow-up (separate PR)

Update \`chat-widget-vanilla\` in the \`munin-examples\` repo to drop \`@modelcontextprotocol/sdk\` and use \`fetch()\` against these REST endpoints. The widget bundle gets significantly lighter and the integration is one round-trip per message.

> **Stacked on** #22. Will retarget to \`main\` once #22 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)