### PR TITLE
feat(web): editable user-menu + dashboard spinner

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import type { Route } from 'next';
@@ -10,6 +10,7 @@ import {
   Download,
   KeyRound,
   LayoutDashboard,
+  Loader2,
   LogOut,
   MessageCircle,
   Newspaper,
@@ -26,14 +27,23 @@ import {
   AvatarImage,
 } from '@getmunin/ui';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@getmunin/ui';
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@getmunin/ui';
+import { Input } from '@getmunin/ui';
+import { Label } from '@getmunin/ui';
 import { cn } from '@getmunin/ui';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 
@@ -78,7 +88,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   }, [isPending, session, router]);
 
   if (isPending || !session) {
-    return <p className="p-8 text-sm text-muted-foreground">{tCommon('loading')}</p>;
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" aria-label={tCommon('loading')} />
+      </div>
+    );
   }
 
   return (
@@ -148,35 +162,129 @@ interface UserMenuProps {
 }
 
 function UserMenu({ email, name, image, signOutLabel, onSignOut }: UserMenuProps) {
+  const tProfile = useTranslations('dashboard.profile');
+  const [editOpen, setEditOpen] = useState(false);
   const initials = name
     .split(' ')
     .map((part) => part[0]?.toUpperCase() ?? '')
     .slice(0, 2)
     .join('');
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger render={<Button variant="ghost" className="h-9 gap-2 px-2" />}>
-        <Avatar className="size-7">
-          {image && <AvatarImage src={image} alt={name} />}
-          <AvatarFallback>{initials || '?'}</AvatarFallback>
-        </Avatar>
-        <span className="hidden text-sm font-medium sm:inline">{name}</span>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
-        <DropdownMenuGroup>
-          <DropdownMenuLabel className="font-normal">
-            <div className="flex flex-col space-y-1">
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger render={<Button variant="ghost" className="h-9 gap-2 px-2" />}>
+          <Avatar className="size-7">
+            {image && <AvatarImage src={image} alt={name} />}
+            <AvatarFallback>{initials || '?'}</AvatarFallback>
+          </Avatar>
+          <span className="hidden text-sm font-medium sm:inline">{name}</span>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              onClick={() => setEditOpen(true)}
+              className="flex-col items-start gap-0.5 py-1.5"
+              aria-label={tProfile('editAria')}
+            >
               <span className="text-sm font-medium">{name}</span>
               <span className="text-xs text-muted-foreground">{email}</span>
-            </div>
-          </DropdownMenuLabel>
-        </DropdownMenuGroup>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={onSignOut}>
-          <LogOut className="size-4" />
-          {signOutLabel}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={onSignOut}>
+            <LogOut className="size-4" />
+            {signOutLabel}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <EditProfileDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        initialName={name}
+        email={email}
+      />
+    </>
+  );
+}
+
+interface EditProfileDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialName: string;
+  email: string;
+}
+
+function EditProfileDialog({ open, onOpenChange, initialName, email }: EditProfileDialogProps) {
+  const t = useTranslations('dashboard.profile');
+  const tCommon = useTranslations('common');
+  const [name, setName] = useState(initialName);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setName(initialName);
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [open, initialName]);
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === initialName) {
+      onOpenChange(false);
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    void (async () => {
+      try {
+        const result = await authClient.updateUser({ name: trimmed });
+        if (result?.error) throw new Error(result.error.message ?? tCommon('unknownError'));
+        onOpenChange(false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : tCommon('unknownError'));
+      } finally {
+        setSubmitting(false);
+      }
+    })();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+          <DialogDescription>{t('subtitle')}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="profile-name">{t('nameLabel')}</Label>
+            <Input
+              id="profile-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+              required
+              disabled={submitting}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="profile-email">{t('emailLabel')}</Label>
+            <Input id="profile-email" value={email} readOnly disabled />
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+              {tCommon('cancel')}
+            </Button>
+            <Button type="submit" disabled={submitting || !name.trim()}>
+              {submitting ? t('saving') : tCommon('save')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -255,6 +255,14 @@
         "load": "Could not load orgs.",
         "switch": "Could not switch org."
       }
+    },
+    "profile": {
+      "title": "Edit your details",
+      "subtitle": "Update the name shown on your account.",
+      "nameLabel": "Name",
+      "emailLabel": "Email",
+      "saving": "Saving…",
+      "editAria": "Edit your account details"
     }
   },
   "acceptInvite": {

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -255,6 +255,14 @@
         "load": "Kunne ikke laste organisasjoner.",
         "switch": "Kunne ikke bytte organisasjon."
       }
+    },
+    "profile": {
+      "title": "Rediger detaljene dine",
+      "subtitle": "Oppdater navnet som vises på kontoen din.",
+      "nameLabel": "Navn",
+      "emailLabel": "E-post",
+      "saving": "Lagrer…",
+      "editAria": "Rediger kontodetaljer"
     }
   },
   "acceptInvite": {


### PR DESCRIPTION
## Summary
- The name/email row in the dashboard user dropdown is now a clickable menu item that opens an edit-details dialog. Saving updates the account name via better-auth's `authClient.updateUser`. Email is shown read-only since changing it needs a separate verification flow.
- Replace the dashboard's initial \`Loading…\` text with a centered animated Loader2 spinner.
- Adds \`dashboard.profile\` translation keys to \`en.json\` and \`nb.json\`.

## Test plan
- [ ] \`pnpm --filter @getmunin/web typecheck\` passes
- [ ] \`pnpm --filter @getmunin/web lint\` passes
- [ ] In the browser: open \`/dashboard\`, confirm spinner shows during initial load (no "Loading…" text)
- [ ] Open user dropdown, click name row, edit name in dialog, save — name updates everywhere it's shown
- [ ] Cancel and Escape both close the dialog without saving
- [ ] Verify \`nb\` locale renders translated copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)