### PR TITLE
feat(self-service-ai): MCP-driven sidecar for self-hosted munin

### DIFF
--- a/apps/self-service-ai/.env.example
+++ b/apps/self-service-ai/.env.example
@@ -1,0 +1,27 @@
+# Munin instance the sidecar talks to.
+MUNIN_BASE_URL=http://localhost:3001
+
+# Admin API key (mn_admin_…) used to subscribe to the realtime gateway,
+# fetch conversation history, mint delegated end-user tokens, and post
+# the agent's final reply.
+MUNIN_ADMIN_API_KEY=
+
+# OpenAI-compatible LLM provider. Defaults to OpenRouter; point at OpenAI,
+# a self-hosted Ollama, vLLM, etc. by overriding the base URL.
+SELF_SERVICE_AI_PROVIDER_BASE_URL=https://openrouter.ai/api/v1
+SELF_SERVICE_AI_PROVIDER_API_KEY=
+
+# Model to use. For OpenRouter, this is the slug they document
+# (https://openrouter.ai/models).
+SELF_SERVICE_AI_MODEL=anthropic/claude-haiku-4.5
+
+# Top-level system prompt. Override per deployment to set tone, scope,
+# brand voice, and explicit instructions about when to hand off.
+SELF_SERVICE_AI_SYSTEM_PROMPT="You are a helpful self-service assistant. Use the available tools to look up accurate information from the knowledge base and the caller's CRM record before answering. If you cannot answer confidently, request a human handover."
+
+# Wait this many ms after the last user message before generating, so
+# multi-message bursts collapse into one reply.
+SELF_SERVICE_AI_DEBOUNCE_MS=500
+
+# Hard cap on the LLM ↔ tool-call loop iterations per turn.
+SELF_SERVICE_AI_MAX_TOOL_ITERATIONS=8

--- a/apps/self-service-ai/Dockerfile
+++ b/apps/self-service-ai/Dockerfile
@@ -1,0 +1,33 @@
+# Multistage build for the self-service-ai sidecar.
+# Build context expected to be the monorepo root.
+
+FROM node:24-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+WORKDIR /repo
+
+# ─── deps ──────────────────────────────────────────────────────────────
+FROM base AS deps
+COPY pnpm-workspace.yaml pnpm-lock.yaml* package.json ./
+COPY apps/self-service-ai/package.json apps/self-service-ai/
+COPY packages/agent-runtime/package.json packages/agent-runtime/
+COPY packages/sdk/package.json packages/sdk/
+COPY packages/tsconfig/package.json packages/tsconfig/
+COPY packages/eslint-config/package.json packages/eslint-config/
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --filter @getmunin/self-service-ai...
+
+# ─── build ─────────────────────────────────────────────────────────────
+FROM deps AS build
+COPY tsconfig.base.json turbo.json ./
+COPY packages/ packages/
+COPY apps/self-service-ai apps/self-service-ai
+RUN pnpm --filter @getmunin/self-service-ai... build
+
+# ─── runtime ───────────────────────────────────────────────────────────
+FROM base AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=build /repo/apps/self-service-ai/dist ./dist
+COPY --from=build /repo/apps/self-service-ai/package.json ./
+COPY --from=build /repo/node_modules ./node_modules
+CMD ["node", "dist/main.js"]

--- a/apps/self-service-ai/README.md
+++ b/apps/self-service-ai/README.md
@@ -1,0 +1,83 @@
+# self-service-ai
+
+Optional sidecar service that turns end-user messages on a self-hosted Munin into AI-driven agent replies, using Munin's self-service MCP surface as the agent's tool layer.
+
+```
+            ┌────────────────────────────────────────────┐
+            │           munin backend                    │
+            │  /api/realtime  /api/conversations  /mcp   │
+            └────────────────────────────────────────────┘
+                 ▲           ▲              ▲
+   admin Bearer  │           │POST reply    │delegated end-user token
+                 │           │              │(audience='self_service')
+                 │           │              │
+            ┌────┴───────────┴──────────────┴────────────┐
+            │             self-service-ai                │
+            │                                            │
+            │  on conversation.message.received:         │
+            │   1. mint delegated token                  │
+            │   2. open /mcp client as end-user          │
+            │   3. fetch conversation history (REST)     │
+            │   4. runAgent() — tool-using LLM loop      │
+            │   5. POST reply via admin REST             │
+            └────────────────────────────────────────────┘
+```
+
+The sidecar holds two credentials by design:
+- **Admin API key** — subscribes to the realtime gateway, fetches conversation history, posts the agent's reply (so it lands as `authorType: 'agent'`).
+- **Per-conversation delegated end-user token** — used to authenticate the MCP connection, so the LLM only sees what *that end-user* is allowed to see (audience-filtered KB, their own CRM record, only their own conversation handover).
+
+## When you'd run this
+
+You're self-hosting munin and you want a working self-service chat without writing your own runner. If you already have your own agent (Claude Desktop connected via MCP, your own server-side agent, a human staff workflow), you don't need this — leave it off.
+
+## Running
+
+Drop the variables in your `.env` (see `.env.example`) and start the docker compose profile:
+
+```bash
+docker compose --profile ai up
+```
+
+Local dev outside docker:
+
+```bash
+pnpm --filter @getmunin/self-service-ai dev
+```
+
+## Config
+
+| Var | Required | Default |
+|---|---|---|
+| `MUNIN_BASE_URL` | yes | `http://localhost:3001` |
+| `MUNIN_ADMIN_API_KEY` | yes | — |
+| `SELF_SERVICE_AI_PROVIDER_BASE_URL` | no | `https://openrouter.ai/api/v1` |
+| `SELF_SERVICE_AI_PROVIDER_API_KEY` | yes | — |
+| `SELF_SERVICE_AI_MODEL` | no | `anthropic/claude-haiku-4.5` |
+| `SELF_SERVICE_AI_SYSTEM_PROMPT` | no | sensible default; override per deployment |
+| `SELF_SERVICE_AI_DEBOUNCE_MS` | no | `500` |
+| `SELF_SERVICE_AI_MAX_TOOL_ITERATIONS` | no | `8` |
+
+## Behavior
+
+The sidecar reacts only to `conversation.message.received` events (i.e. messages from end-users) and skips when:
+- The conversation is closed / snoozed / spam.
+- A staff member has claimed the conversation (`assigneeUserId` is set).
+- The triggering message wasn't from a `user` / `end_user` actor.
+
+A 500ms debounce after the last triggering event collapses multi-message bursts into one reply. A new triggering event for the same conversation aborts any in-flight run and starts a fresh one with the now-current history.
+
+On provider errors the sidecar retries with exponential backoff (3 attempts). If all attempts fail, it calls `conv_request_handover_in_my_conversation` via MCP — the dashboard's `needsHumanAttention` flag surfaces the conversation to staff, and no agent message is posted.
+
+## Architecture
+
+This sidecar consumes the shared `@getmunin/agent-runtime` kernel (`packages/agent-runtime/`), which holds the LLM ↔ tool-call loop and provider abstraction. The kernel is pure: given a config, conversation history, and an MCP tool handle, it returns a reply. The sidecar wires up the I/O — realtime subscription, REST calls, MCP client lifecycle, retries.
+
+The same kernel will back the multi-tenant cloud addon when that lands; per-org config storage and inference billing are the only things layered on top.
+
+## Out of scope (today)
+
+- Multi-tenant deployments — this is the single-tenant OSS sidecar. Cloud has its own runner.
+- Streaming partial replies. Final text only; the widget already polls.
+- Per-conversation prompt overrides. One global system prompt per deployment.
+- Inference rate-limiting. The provider's own limits apply.

--- a/apps/self-service-ai/eslint.config.mjs
+++ b/apps/self-service-ai/eslint.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@getmunin/eslint-config';

--- a/apps/self-service-ai/package.json
+++ b/apps/self-service-ai/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@getmunin/self-service-ai",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "description": "Optional sidecar that turns end-user messages on a self-hosted Munin into AI-driven agent replies via the self-service MCP surface.",
+  "type": "module",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx --watch src/main.ts",
+    "start": "node dist/main.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@getmunin/agent-runtime": "workspace:*",
+    "@getmunin/sdk": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "ws": "^8.18.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@getmunin/eslint-config": "workspace:*",
+    "@getmunin/tsconfig": "workspace:*",
+    "@types/node": "^22.7.0",
+    "@types/ws": "^8.5.13",
+    "eslint": "^9.10.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/apps/self-service-ai/src/config.ts
+++ b/apps/self-service-ai/src/config.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+const ConfigSchema = z.object({
+  muninBaseUrl: z.string().url(),
+  muninAdminApiKey: z.string().min(1),
+  providerBaseUrl: z.string().url(),
+  providerApiKey: z.string().min(1),
+  model: z.string().min(1),
+  systemPrompt: z.string().min(1),
+  debounceMs: z.number().int().nonnegative(),
+  maxToolIterations: z.number().int().positive(),
+});
+
+export type SidecarConfig = z.infer<typeof ConfigSchema>;
+
+export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): SidecarConfig {
+  const parsed = ConfigSchema.safeParse({
+    muninBaseUrl: env.MUNIN_BASE_URL ?? 'http://localhost:3001',
+    muninAdminApiKey: env.MUNIN_ADMIN_API_KEY ?? '',
+    providerBaseUrl:
+      env.SELF_SERVICE_AI_PROVIDER_BASE_URL ?? 'https://openrouter.ai/api/v1',
+    providerApiKey: env.SELF_SERVICE_AI_PROVIDER_API_KEY ?? '',
+    model: env.SELF_SERVICE_AI_MODEL ?? 'anthropic/claude-haiku-4.5',
+    systemPrompt:
+      env.SELF_SERVICE_AI_SYSTEM_PROMPT ??
+      'You are a helpful self-service assistant. Use the available tools to look up accurate information from the knowledge base and the caller\'s CRM record before answering. If you cannot answer confidently, request a human handover.',
+    debounceMs: parseIntOr(env.SELF_SERVICE_AI_DEBOUNCE_MS, 500),
+    maxToolIterations: parseIntOr(env.SELF_SERVICE_AI_MAX_TOOL_ITERATIONS, 8),
+  });
+
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
+      .join('\n');
+    throw new Error(`invalid configuration:\n${issues}`);
+  }
+  return parsed.data;
+}
+
+function parseIntOr(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
+}

--- a/apps/self-service-ai/src/conversation-handler.test.ts
+++ b/apps/self-service-ai/src/conversation-handler.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createConversationHandler, type OpenedMcp } from './conversation-handler.js';
+import type { SidecarConfig } from './config.js';
+import type { ConversationDetail, MuninRestClient } from './munin-rest.js';
+import type { McpToolResult, Provider, ProviderResponse } from '@getmunin/agent-runtime';
+
+const baseConfig: SidecarConfig = {
+  muninBaseUrl: 'http://munin',
+  muninAdminApiKey: 'mn_admin_test',
+  providerBaseUrl: 'http://provider',
+  providerApiKey: 'sk-test',
+  model: 'test-model',
+  systemPrompt: 'sys',
+  debounceMs: 0,
+  maxToolIterations: 4,
+};
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+const noDelayScheduler = {
+  delay: (_ms: number, signal: AbortSignal) =>
+    new Promise<void>((resolve, reject) => {
+      if (signal.aborted) {
+        reject(new DOMException('aborted', 'AbortError'));
+        return;
+      }
+      queueMicrotask(() => {
+        if (signal.aborted) reject(new DOMException('aborted', 'AbortError'));
+        else resolve();
+      });
+    }),
+};
+
+function buildConversation(overrides: Partial<ConversationDetail> = {}): ConversationDetail {
+  return {
+    id: 'conv_1',
+    status: 'open',
+    endUserId: 'eu_1',
+    assigneeUserId: null,
+    messages: [
+      {
+        id: 'msg_1',
+        authorType: 'end_user',
+        body: 'when do you open?',
+        createdAt: new Date().toISOString(),
+        internal: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function buildRest(overrides: Partial<MuninRestClient> = {}): MuninRestClient {
+  return {
+    getConversation: vi.fn(() => Promise.resolve(buildConversation())),
+    postAgentMessage: vi.fn(() => Promise.resolve()),
+    mintDelegatedToken: vi.fn(() =>
+      Promise.resolve({
+        accessToken: 'mn_eu_test',
+        endUserId: 'eu_1',
+        expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      }),
+    ),
+    toRuntimeHistory: (detail) =>
+      detail.messages
+        .filter((m) => !m.internal)
+        .map((m) => ({ authorType: m.authorType, body: m.body, createdAt: m.createdAt })),
+    ...overrides,
+  };
+}
+
+function buildMcp(opts: {
+  reply?: string;
+  callToolError?: Error;
+} = {}): OpenedMcp {
+  return {
+    listTools: vi.fn(() => Promise.resolve([])),
+    callTool: vi.fn((): Promise<McpToolResult> =>
+      opts.callToolError
+        ? Promise.reject(opts.callToolError)
+        : Promise.resolve({ content: [{ type: 'text', text: 'ok' }] }),
+    ),
+    close: vi.fn(() => Promise.resolve()),
+  };
+}
+
+describe('createConversationHandler', () => {
+  it('skips when authorType is agent (no self-replies)', async () => {
+    const rest = buildRest();
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+    });
+    handler.handle({ conversationId: 'conv_1', authorType: 'agent' });
+    await handler.flush();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(rest.getConversation).not.toHaveBeenCalled();
+  });
+
+  it('skips when conversation is closed', async () => {
+    const rest = buildRest({
+      getConversation: vi.fn(() => Promise.resolve(buildConversation({ status: 'closed' }))),
+    });
+    const postSpy = vi.fn(() => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+    });
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips when conversation has been claimed by staff', async () => {
+    const rest = buildRest({
+      getConversation: vi.fn(() => Promise.resolve(buildConversation({ assigneeUserId: 'user_42' }))),
+    });
+    const postSpy = vi.fn(() => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+    });
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls handover tool after MAX_RETRIES provider failures', async () => {
+    const handoverCalls: string[] = [];
+    const buildFailingMcp = (): OpenedMcp => ({
+      listTools: vi.fn(() =>
+        Promise.resolve([
+          {
+            name: 'kb_search',
+            description: 'kb',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ]),
+      ),
+      callTool: vi.fn((name: string) => {
+        handoverCalls.push(name);
+        return Promise.resolve<McpToolResult>({ content: [] });
+      }),
+      close: vi.fn(() => Promise.resolve()),
+    });
+    const rest = buildRest();
+    const postSpy = vi.fn(() => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+
+    // Provider always errors → runAgent rethrows from listTools→provider call.
+    // We simulate this by making the first call to listTools succeed but the
+    // openai provider call fail. Easiest: make openMcp return a handle whose
+    // listTools throws on the first three runs, then succeeds for handover.
+    let runCount = 0;
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      openMcp: () => {
+        runCount += 1;
+        if (runCount <= 3) {
+          return Promise.resolve({
+            listTools: vi.fn(() => Promise.reject(new Error('provider boom'))),
+            callTool: vi.fn(() => Promise.resolve<McpToolResult>({ content: [] })),
+            close: vi.fn(() => Promise.resolve()),
+          });
+        }
+        return Promise.resolve(buildFailingMcp());
+      },
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+    });
+
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(handoverCalls).toEqual(['conv_request_handover_in_my_conversation']);
+  });
+
+  it('aborts the in-flight debounce when a new triggering event arrives for the same conversation', async () => {
+    const pending: Array<{ resolve: () => void; reject: (e: unknown) => void; signal: AbortSignal }> = [];
+    const collectingScheduler = {
+      delay: (_ms: number, signal: AbortSignal) =>
+        new Promise<void>((resolve, reject) => {
+          if (signal.aborted) {
+            reject(new DOMException('aborted', 'AbortError'));
+            return;
+          }
+          const entry = { resolve, reject, signal };
+          pending.push(entry);
+          signal.addEventListener('abort', () => {
+            entry.reject(new DOMException('aborted', 'AbortError'));
+          });
+        }),
+    };
+
+    const getConvMock = vi.fn(() => Promise.resolve(buildConversation()));
+    const rest = buildRest();
+    rest.getConversation = getConvMock;
+
+    const happyResponse: ProviderResponse = {
+      message: { role: 'assistant', content: 'hi' },
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      finishReason: 'stop',
+    };
+    const stubProvider: Provider = () => Promise.resolve(happyResponse);
+
+    const handlerWithProvider = createConversationHandler({
+      config: baseConfig,
+      rest,
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: collectingScheduler,
+      provider: stubProvider,
+    });
+
+    handlerWithProvider.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    handlerWithProvider.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+
+    await new Promise((r) => setTimeout(r, 0));
+    const live = pending.find((p) => !p.signal.aborted);
+    live?.resolve();
+    await handlerWithProvider.flush();
+
+    expect(getConvMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/self-service-ai/src/conversation-handler.test.ts
+++ b/apps/self-service-ai/src/conversation-handler.test.ts
@@ -188,6 +188,83 @@ describe('createConversationHandler', () => {
     expect(handoverCalls).toEqual(['conv_request_handover_in_my_conversation']);
   });
 
+  it('caches the delegated token per end-user across triggering events', async () => {
+    const rest = buildRest();
+    const mintSpy = vi.fn(() =>
+      Promise.resolve({
+        accessToken: 'mn_eu_cached',
+        endUserId: 'eu_1',
+        expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      }),
+    );
+    rest.mintDelegatedToken = mintSpy;
+
+    const happyResponse: ProviderResponse = {
+      message: { role: 'assistant', content: 'hi' },
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      finishReason: 'stop',
+    };
+    const stubProvider: Provider = () => Promise.resolve(happyResponse);
+
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+      provider: stubProvider,
+    });
+
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+
+    expect(mintSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-mints when the cached token is within the refresh margin', async () => {
+    const rest = buildRest();
+    let call = 0;
+    const mintSpy = vi.fn(() => {
+      call += 1;
+      // First mint returns a token expiring in 30s (inside the 60s margin).
+      // Second mint returns a fresh long-lived token.
+      const ttlMs = call === 1 ? 30_000 : 600_000;
+      return Promise.resolve({
+        accessToken: `mn_eu_${call}`,
+        endUserId: 'eu_1',
+        expiresAt: new Date(Date.now() + ttlMs).toISOString(),
+      });
+    });
+    rest.mintDelegatedToken = mintSpy;
+
+    const happyResponse: ProviderResponse = {
+      message: { role: 'assistant', content: 'hi' },
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      finishReason: 'stop',
+    };
+    const stubProvider: Provider = () => Promise.resolve(happyResponse);
+
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+      provider: stubProvider,
+    });
+
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+
+    expect(mintSpy).toHaveBeenCalledTimes(2);
+  });
+
   it('aborts the in-flight debounce when a new triggering event arrives for the same conversation', async () => {
     const pending: Array<{ resolve: () => void; reject: (e: unknown) => void; signal: AbortSignal }> = [];
     const collectingScheduler = {

--- a/apps/self-service-ai/src/conversation-handler.ts
+++ b/apps/self-service-ai/src/conversation-handler.ts
@@ -1,0 +1,218 @@
+import { runAgent, type ConversationMessage, type McpToolHandle, type Provider } from '@getmunin/agent-runtime';
+import type { SidecarConfig } from './config.js';
+import type { ConversationDetail, MuninRestClient } from './munin-rest.js';
+
+const MAX_RETRIES = 3;
+const RETRY_BASE_MS = 1000;
+const HANDOVER_TOOL_NAME = 'conv_request_handover_in_my_conversation';
+
+export interface OpenedMcp extends McpToolHandle {
+  close(): Promise<void>;
+}
+
+export interface ConversationHandlerDeps {
+  config: SidecarConfig;
+  rest: MuninRestClient;
+  openMcp: (opts: { delegatedToken: string }) => Promise<OpenedMcp>;
+  logger?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+  /** Test seam — defaults to setTimeout-based scheduler. */
+  scheduler?: {
+    delay: (ms: number, signal: AbortSignal) => Promise<void>;
+  };
+  /** Test seam — defaults to OpenAI-compatible provider. */
+  provider?: Provider;
+}
+
+export interface IncomingMessage {
+  conversationId: string;
+  authorType: 'user' | 'agent' | 'end_user' | 'system';
+}
+
+interface InFlight {
+  controller: AbortController;
+  promise: Promise<void>;
+}
+
+export interface ConversationHandler {
+  handle(event: IncomingMessage): void;
+  /** Wait for all in-flight runs to finish (used by tests). */
+  flush(): Promise<void>;
+}
+
+export function createConversationHandler(deps: ConversationHandlerDeps): ConversationHandler {
+  const log = deps.logger ?? {
+    info: (m) => console.log(`[handler] ${m}`),
+    warn: (m) => console.warn(`[handler] ${m}`),
+    error: (m) => console.error(`[handler] ${m}`),
+  };
+  const scheduler = deps.scheduler ?? defaultScheduler;
+  const inFlight = new Map<string, InFlight>();
+
+  function shouldRespond(detail: ConversationDetail): boolean {
+    if (detail.status !== 'open') {
+      log.info(`skip ${detail.id}: status=${detail.status}`);
+      return false;
+    }
+    if (detail.assigneeUserId) {
+      log.info(`skip ${detail.id}: assigned to staff ${detail.assigneeUserId}`);
+      return false;
+    }
+    if (!detail.endUserId) {
+      log.info(`skip ${detail.id}: no end-user bound`);
+      return false;
+    }
+    const last = lastInbound(detail);
+    if (!last) {
+      log.info(`skip ${detail.id}: no inbound message yet`);
+      return false;
+    }
+    return true;
+  }
+
+  async function run(conversationId: string, signal: AbortSignal): Promise<void> {
+    try {
+      await scheduler.delay(deps.config.debounceMs, signal);
+    } catch {
+      return;
+    }
+    if (signal.aborted) return;
+
+    const detail = await deps.rest.getConversation(conversationId);
+    if (!shouldRespond(detail)) return;
+    if (signal.aborted) return;
+
+    const history = deps.rest.toRuntimeHistory(detail);
+    const endUserId = detail.endUserId!;
+
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
+      if (signal.aborted) return;
+      const token = await deps.rest.mintDelegatedToken(endUserId);
+      const mcp = await deps.openMcp({ delegatedToken: token.accessToken });
+      try {
+        const reply = await runAgent({
+          config: {
+            provider: {
+              baseUrl: deps.config.providerBaseUrl,
+              apiKey: deps.config.providerApiKey,
+            },
+            model: deps.config.model,
+            systemPrompt: deps.config.systemPrompt,
+            maxToolIterations: deps.config.maxToolIterations,
+          },
+          history,
+          mcp,
+          abortSignal: signal,
+          provider: deps.provider,
+        });
+
+        if (reply.body.trim().length > 0) {
+          await deps.rest.postAgentMessage(conversationId, reply.body);
+          log.info(
+            `${conversationId} replied (model=${reply.model}, tools=${reply.toolCalls.length}, tokens=${reply.usage.totalTokens})`,
+          );
+          return;
+        }
+        log.warn(`${conversationId} produced empty body (finishReason=${reply.finishReason})`);
+        // Empty body is treated like an error → retry.
+        lastError = new Error(`empty reply (finishReason=${reply.finishReason})`);
+      } catch (err) {
+        if (signal.aborted) return;
+        lastError = err instanceof Error ? err : new Error(String(err));
+        log.warn(`${conversationId} attempt ${attempt + 1} failed: ${lastError.message}`);
+      } finally {
+        await mcp.close().catch(() => undefined);
+      }
+
+      if (attempt + 1 < MAX_RETRIES) {
+        const backoff = RETRY_BASE_MS * 2 ** attempt;
+        try {
+          await scheduler.delay(backoff, signal);
+        } catch {
+          return;
+        }
+      }
+    }
+
+    log.error(
+      `${conversationId} exhausted retries (${lastError?.message ?? 'unknown'}); requesting human handover`,
+    );
+    await requestHandover(conversationId, endUserId).catch((err) => {
+      log.error(
+        `${conversationId} handover request failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
+
+  async function requestHandover(conversationId: string, endUserId: string): Promise<void> {
+    const token = await deps.rest.mintDelegatedToken(endUserId);
+    const mcp = await deps.openMcp({ delegatedToken: token.accessToken });
+    try {
+      await mcp.callTool(HANDOVER_TOOL_NAME, { conversationId });
+    } finally {
+      await mcp.close().catch(() => undefined);
+    }
+  }
+
+  return {
+    handle(event: IncomingMessage): void {
+      if (event.authorType !== 'user' && event.authorType !== 'end_user') return;
+
+      const existing = inFlight.get(event.conversationId);
+      if (existing) {
+        existing.controller.abort();
+      }
+      const controller = new AbortController();
+      const promise = run(event.conversationId, controller.signal)
+        .catch((err) => {
+          log.error(
+            `${event.conversationId} unhandled: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        })
+        .finally(() => {
+          if (inFlight.get(event.conversationId)?.controller === controller) {
+            inFlight.delete(event.conversationId);
+          }
+        });
+      inFlight.set(event.conversationId, { controller, promise });
+    },
+    async flush(): Promise<void> {
+      await Promise.all([...inFlight.values()].map((f) => f.promise));
+    },
+  };
+}
+
+function lastInbound(detail: ConversationDetail): ConversationMessage | null {
+  for (let i = detail.messages.length - 1; i >= 0; i -= 1) {
+    const m = detail.messages[i];
+    if (!m) continue;
+    if (m.authorType === 'user' || m.authorType === 'end_user') {
+      return { authorType: m.authorType, body: m.body, createdAt: m.createdAt };
+    }
+  }
+  return null;
+}
+
+const defaultScheduler = {
+  delay(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (signal.aborted) {
+        reject(new DOMException('aborted', 'AbortError'));
+        return;
+      }
+      const timer = setTimeout(() => {
+        signal.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      const onAbort = (): void => {
+        clearTimeout(timer);
+        reject(new DOMException('aborted', 'AbortError'));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    });
+  },
+};

--- a/apps/self-service-ai/src/conversation-handler.ts
+++ b/apps/self-service-ai/src/conversation-handler.ts
@@ -5,6 +5,8 @@ import type { ConversationDetail, MuninRestClient } from './munin-rest.js';
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
 const HANDOVER_TOOL_NAME = 'conv_request_handover_in_my_conversation';
+/** Re-mint when the cached token has less than this much TTL remaining. */
+const TOKEN_REFRESH_MARGIN_MS = 60_000;
 
 export interface OpenedMcp extends McpToolHandle {
   close(): Promise<void>;
@@ -51,6 +53,21 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
   };
   const scheduler = deps.scheduler ?? defaultScheduler;
   const inFlight = new Map<string, InFlight>();
+  const tokenCache = new Map<string, { accessToken: string; expiresAtMs: number }>();
+
+  async function getDelegatedToken(endUserId: string): Promise<string> {
+    const now = Date.now();
+    const cached = tokenCache.get(endUserId);
+    if (cached && cached.expiresAtMs - now > TOKEN_REFRESH_MARGIN_MS) {
+      return cached.accessToken;
+    }
+    const minted = await deps.rest.mintDelegatedToken(endUserId);
+    tokenCache.set(endUserId, {
+      accessToken: minted.accessToken,
+      expiresAtMs: Date.parse(minted.expiresAt),
+    });
+    return minted.accessToken;
+  }
 
   function shouldRespond(detail: ConversationDetail): boolean {
     if (detail.status !== 'open') {
@@ -91,8 +108,8 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     let lastError: Error | null = null;
     for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
       if (signal.aborted) return;
-      const token = await deps.rest.mintDelegatedToken(endUserId);
-      const mcp = await deps.openMcp({ delegatedToken: token.accessToken });
+      const accessToken = await getDelegatedToken(endUserId);
+      const mcp = await deps.openMcp({ delegatedToken: accessToken });
       try {
         const reply = await runAgent({
           config: {
@@ -149,8 +166,8 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
   }
 
   async function requestHandover(conversationId: string, endUserId: string): Promise<void> {
-    const token = await deps.rest.mintDelegatedToken(endUserId);
-    const mcp = await deps.openMcp({ delegatedToken: token.accessToken });
+    const accessToken = await getDelegatedToken(endUserId);
+    const mcp = await deps.openMcp({ delegatedToken: accessToken });
     try {
       await mcp.callTool(HANDOVER_TOOL_NAME, { conversationId });
     } finally {

--- a/apps/self-service-ai/src/main.ts
+++ b/apps/self-service-ai/src/main.ts
@@ -1,0 +1,44 @@
+import { loadConfigFromEnv } from './config.js';
+import { createConversationHandler } from './conversation-handler.js';
+import { createMuninRestClient } from './munin-rest.js';
+import { openMcpClient } from './mcp-client.js';
+import { createRealtimeClient } from './realtime.js';
+
+function main(): void {
+  const config = loadConfigFromEnv();
+  const rest = createMuninRestClient({
+    baseUrl: config.muninBaseUrl,
+    adminApiKey: config.muninAdminApiKey,
+  });
+  const handler = createConversationHandler({
+    config,
+    rest,
+    openMcp: ({ delegatedToken }) =>
+      openMcpClient({ baseUrl: config.muninBaseUrl, delegatedToken }),
+  });
+  const realtime = createRealtimeClient({
+    baseUrl: config.muninBaseUrl,
+    adminApiKey: config.muninAdminApiKey,
+    onMessageReceived: (event) => handler.handle(event),
+  });
+  realtime.start();
+  console.log(
+    `[self-service-ai] connected to ${config.muninBaseUrl}, model=${config.model}, debounce=${config.debounceMs}ms`,
+  );
+
+  const shutdown = async (): Promise<void> => {
+    console.log('[self-service-ai] shutting down…');
+    await realtime.stop();
+    await handler.flush();
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => void shutdown());
+  process.on('SIGINT', () => void shutdown());
+}
+
+try {
+  main();
+} catch (err) {
+  console.error('[self-service-ai] fatal:', err);
+  process.exit(1);
+}

--- a/apps/self-service-ai/src/mcp-client.ts
+++ b/apps/self-service-ai/src/mcp-client.ts
@@ -1,0 +1,49 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { McpTool, McpToolHandle, McpToolResult } from '@getmunin/agent-runtime';
+
+export interface OpenMcpClientOptions {
+  baseUrl: string;
+  delegatedToken: string;
+}
+
+export interface OpenedMcpClient extends McpToolHandle {
+  close(): Promise<void>;
+}
+
+export async function openMcpClient(opts: OpenMcpClientOptions): Promise<OpenedMcpClient> {
+  const url = new URL(`${opts.baseUrl.replace(/\/+$/, '')}/mcp`);
+  const transport = new StreamableHTTPClientTransport(url, {
+    requestInit: {
+      headers: {
+        authorization: `Bearer ${opts.delegatedToken}`,
+      },
+    },
+  });
+  const client = new Client(
+    { name: 'munin-self-service-ai', version: '0.0.1' },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+
+  return {
+    async listTools(): Promise<McpTool[]> {
+      const result = await client.listTools();
+      return result.tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema ?? { type: 'object', properties: {} },
+      }));
+    },
+    async callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
+      const result = await client.callTool({ name, arguments: args });
+      return {
+        content: (result.content ?? []) as McpToolResult['content'],
+        isError: typeof result.isError === 'boolean' ? result.isError : undefined,
+      };
+    },
+    async close(): Promise<void> {
+      await client.close();
+    },
+  };
+}

--- a/apps/self-service-ai/src/munin-rest.ts
+++ b/apps/self-service-ai/src/munin-rest.ts
@@ -1,0 +1,87 @@
+import type { ConversationMessage } from '@getmunin/agent-runtime';
+
+export interface ConversationDetail {
+  id: string;
+  status: 'open' | 'snoozed' | 'closed' | 'spam';
+  endUserId: string | null;
+  assigneeUserId: string | null;
+  messages: Array<{
+    id: string;
+    authorType: 'user' | 'agent' | 'end_user' | 'system';
+    body: string;
+    createdAt: string;
+    internal?: boolean;
+  }>;
+}
+
+export interface DelegatedToken {
+  accessToken: string;
+  endUserId: string;
+  expiresAt: string;
+}
+
+export interface MuninRestClient {
+  getConversation(id: string): Promise<ConversationDetail>;
+  postAgentMessage(conversationId: string, body: string): Promise<void>;
+  mintDelegatedToken(endUserId: string, ttlSeconds?: number): Promise<DelegatedToken>;
+  toRuntimeHistory(detail: ConversationDetail): ConversationMessage[];
+}
+
+export interface CreateMuninRestClientOptions {
+  baseUrl: string;
+  adminApiKey: string;
+  fetch?: typeof fetch;
+}
+
+export function createMuninRestClient(opts: CreateMuninRestClientOptions): MuninRestClient {
+  const baseUrl = opts.baseUrl.replace(/\/+$/, '');
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
+
+  async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const headers: Record<string, string> = {
+      ...(init.headers as Record<string, string> | undefined),
+      authorization: `Bearer ${opts.adminApiKey}`,
+    };
+    if (init.body && !headers['content-type']) {
+      headers['content-type'] = 'application/json';
+    }
+    const res = await fetchImpl(`${baseUrl}${path}`, { ...init, headers });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`munin ${init.method ?? 'GET'} ${path} → ${res.status}: ${text.slice(0, 300)}`);
+    }
+    if (res.status === 204) return undefined as T;
+    return (await res.json()) as T;
+  }
+
+  return {
+    async getConversation(id: string): Promise<ConversationDetail> {
+      return call<ConversationDetail>(`/api/conversations/${encodeURIComponent(id)}`);
+    },
+    async postAgentMessage(conversationId: string, body: string): Promise<void> {
+      await call<unknown>(`/api/conversations/${encodeURIComponent(conversationId)}/messages`, {
+        method: 'POST',
+        body: JSON.stringify({ body }),
+      });
+    },
+    async mintDelegatedToken(endUserId: string, ttlSeconds = 600): Promise<DelegatedToken> {
+      return call<DelegatedToken>('/api/delegated-token', {
+        method: 'POST',
+        body: JSON.stringify({
+          endUserId,
+          audiences: ['self_service'],
+          ttlSeconds,
+        }),
+      });
+    },
+    toRuntimeHistory(detail: ConversationDetail): ConversationMessage[] {
+      return detail.messages
+        .filter((m) => !m.internal)
+        .map((m) => ({
+          authorType: m.authorType,
+          body: m.body,
+          createdAt: m.createdAt,
+        }));
+    },
+  };
+}

--- a/apps/self-service-ai/src/realtime.ts
+++ b/apps/self-service-ai/src/realtime.ts
@@ -1,0 +1,137 @@
+import { WebSocket } from 'ws';
+
+export interface MessageReceivedEvent {
+  conversationId: string;
+  messageId: string;
+  authorType: 'user' | 'agent' | 'end_user' | 'system';
+  endUserId?: string;
+}
+
+export interface RealtimeClientOptions {
+  baseUrl: string;
+  adminApiKey: string;
+  onMessageReceived: (event: MessageReceivedEvent) => void;
+  /** Optional logger; defaults to console. */
+  logger?: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
+}
+
+interface RealtimeClient {
+  start(): void;
+  stop(): Promise<void>;
+}
+
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30_000;
+const PING_INTERVAL_MS = 30_000;
+
+export function createRealtimeClient(opts: RealtimeClientOptions): RealtimeClient {
+  const log = opts.logger ?? {
+    info: (m) => console.log(`[realtime] ${m}`),
+    warn: (m) => console.warn(`[realtime] ${m}`),
+    error: (m) => console.error(`[realtime] ${m}`),
+  };
+
+  let ws: WebSocket | null = null;
+  let pingTimer: NodeJS.Timeout | null = null;
+  let reconnectTimer: NodeJS.Timeout | null = null;
+  let attempt = 0;
+  let stopped = false;
+
+  function clearTimers(): void {
+    if (pingTimer) {
+      clearInterval(pingTimer);
+      pingTimer = null;
+    }
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+  }
+
+  function scheduleReconnect(): void {
+    if (stopped) return;
+    const delay = Math.min(RECONNECT_BASE_MS * 2 ** attempt, RECONNECT_MAX_MS);
+    attempt += 1;
+    log.info(`reconnecting in ${delay}ms (attempt ${attempt})`);
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, delay);
+  }
+
+  function connect(): void {
+    if (stopped) return;
+    const url = `${opts.baseUrl.replace(/^http/, 'ws').replace(/\/+$/, '')}/api/realtime`;
+    const socket = new WebSocket(url, {
+      headers: { authorization: `Bearer ${opts.adminApiKey}` },
+    });
+    ws = socket;
+
+    socket.on('open', () => {
+      log.info('connected');
+      attempt = 0;
+      socket.send(JSON.stringify({ type: 'subscribe', channel: 'org' }));
+      pingTimer = setInterval(() => {
+        if (socket.readyState === WebSocket.OPEN) {
+          socket.send(JSON.stringify({ type: 'ping' }));
+        }
+      }, PING_INTERVAL_MS);
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const text = Buffer.isBuffer(raw)
+          ? raw.toString('utf8')
+          : Array.isArray(raw)
+            ? Buffer.concat(raw).toString('utf8')
+            : Buffer.from(raw).toString('utf8');
+        const msg = JSON.parse(text) as {
+          type: string;
+          event?: { type?: string; payload?: Record<string, unknown> };
+        };
+        if (msg.type !== 'event' || !msg.event) return;
+        if (msg.event.type !== 'conversation.message.received') return;
+        const payload = msg.event.payload ?? {};
+        const conversationId = payload['conversationId'];
+        const messageId = payload['messageId'];
+        const authorType = payload['authorType'];
+        if (typeof conversationId !== 'string' || typeof messageId !== 'string') return;
+        opts.onMessageReceived({
+          conversationId,
+          messageId,
+          authorType: typeof authorType === 'string' ? (authorType as MessageReceivedEvent['authorType']) : 'end_user',
+          endUserId: typeof payload['endUserId'] === 'string' ? payload['endUserId'] : undefined,
+        });
+      } catch (err) {
+        log.warn(`failed to parse event: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+    socket.on('close', (code) => {
+      log.info(`closed (${code})`);
+      clearTimers();
+      ws = null;
+      scheduleReconnect();
+    });
+
+    socket.on('error', (err) => {
+      log.error(`socket error: ${err.message}`);
+    });
+  }
+
+  return {
+    start(): void {
+      stopped = false;
+      connect();
+    },
+    async stop(): Promise<void> {
+      stopped = true;
+      clearTimers();
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.close(1000, 'shutdown');
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      ws = null;
+    },
+  };
+}

--- a/apps/self-service-ai/tsconfig.json
+++ b/apps/self-service-ai/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@getmunin/tsconfig/base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "incremental": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -56,5 +56,29 @@ services:
     ports:
       - "${WEB_PORT:-3000}:3000"
 
+  # Optional self-service AI sidecar.
+  # Subscribes to conversation events on the local munin instance and posts
+  # AI-driven agent replies. Off by default — start with:
+  #   docker compose --profile ai up
+  # See apps/self-service-ai/.env.example for required variables.
+  self-service-ai:
+    profiles: ["ai"]
+    build:
+      context: ..
+      dockerfile: apps/self-service-ai/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      - backend
+    environment:
+      NODE_ENV: production
+      MUNIN_BASE_URL: ${MUNIN_BASE_URL:-http://backend:3001}
+      MUNIN_ADMIN_API_KEY: ${MUNIN_ADMIN_API_KEY:?set MUNIN_ADMIN_API_KEY in .env}
+      SELF_SERVICE_AI_PROVIDER_BASE_URL: ${SELF_SERVICE_AI_PROVIDER_BASE_URL:-https://openrouter.ai/api/v1}
+      SELF_SERVICE_AI_PROVIDER_API_KEY: ${SELF_SERVICE_AI_PROVIDER_API_KEY:?set SELF_SERVICE_AI_PROVIDER_API_KEY in .env}
+      SELF_SERVICE_AI_MODEL: ${SELF_SERVICE_AI_MODEL:-anthropic/claude-haiku-4.5}
+      SELF_SERVICE_AI_SYSTEM_PROMPT: ${SELF_SERVICE_AI_SYSTEM_PROMPT:-You are a helpful self-service assistant. Use the available tools to look up accurate information from the knowledge base and the caller's CRM record before answering. If you cannot answer confidently, request a human handover.}
+      SELF_SERVICE_AI_DEBOUNCE_MS: ${SELF_SERVICE_AI_DEBOUNCE_MS:-500}
+      SELF_SERVICE_AI_MAX_TOOL_ITERATIONS: ${SELF_SERVICE_AI_MAX_TOOL_ITERATIONS:-8}
+
 volumes:
   munin-pg:

--- a/packages/agent-runtime/eslint.config.mjs
+++ b/packages/agent-runtime/eslint.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@getmunin/eslint-config';

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@getmunin/agent-runtime",
+  "version": "0.0.1",
+  "license": "MIT",
+  "description": "LLM agent loop — given a config, conversation history, and an MCP tool handle, produce a reply.",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getmunin/munin.git",
+    "directory": "packages/agent-runtime"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@getmunin/eslint-config": "workspace:*",
+    "@getmunin/tsconfig": "workspace:*",
+    "@types/node": "^22.7.0",
+    "eslint": "^9.10.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,0 +1,22 @@
+export { runAgent } from './runtime.js';
+export { openAiCompatibleProvider, ProviderError } from './providers/openai-compatible.js';
+export { createStubProvider, type StubProviderHandle, type StubScript } from './providers/stub.js';
+export { mcpToolsToChatTools, flattenToolResult } from './mcp-tool-translation.js';
+export type {
+  AgentConfig,
+  AgentReply,
+  AuthorType,
+  ChatMessage,
+  ChatToolCall,
+  ChatToolDefinition,
+  ConversationMessage,
+  McpTool,
+  McpToolHandle,
+  McpToolResult,
+  Provider,
+  ProviderCallArgs,
+  ProviderConfig,
+  ProviderResponse,
+  ProviderUsage,
+  ToolCallTrace,
+} from './types.js';

--- a/packages/agent-runtime/src/mcp-tool-translation.ts
+++ b/packages/agent-runtime/src/mcp-tool-translation.ts
@@ -1,0 +1,26 @@
+import type { ChatToolDefinition, McpTool } from './types.js';
+
+export function mcpToolsToChatTools(tools: McpTool[]): ChatToolDefinition[] {
+  return tools.map((tool) => ({
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: normalizeSchema(tool.inputSchema),
+    },
+  }));
+}
+
+function normalizeSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  if (schema && typeof schema === 'object' && 'type' in schema) return schema;
+  return { type: 'object', properties: {}, additionalProperties: true };
+}
+
+export function flattenToolResult(result: { content: Array<{ type: string; text?: string; [k: string]: unknown }> }): string {
+  const parts: string[] = [];
+  for (const item of result.content) {
+    if (item.type === 'text' && typeof item.text === 'string') parts.push(item.text);
+    else parts.push(JSON.stringify(item));
+  }
+  return parts.join('\n');
+}

--- a/packages/agent-runtime/src/providers/openai-compatible.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.ts
@@ -1,0 +1,82 @@
+import type { ChatMessage, Provider, ProviderResponse } from '../types.js';
+
+interface OpenAIChoice {
+  message: ChatMessage;
+  finish_reason: string;
+}
+
+interface OpenAIResponse {
+  choices: OpenAIChoice[];
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+}
+
+export const openAiCompatibleProvider: Provider = async ({
+  config,
+  messages,
+  tools,
+  abortSignal,
+}) => {
+  const url = `${config.provider.baseUrl.replace(/\/+$/, '')}/chat/completions`;
+  const body: Record<string, unknown> = {
+    model: config.model,
+    messages,
+  };
+  if (tools.length > 0) {
+    body.tools = tools;
+    body.tool_choice = 'auto';
+  }
+  if (typeof config.maxTokens === 'number') body.max_tokens = config.maxTokens;
+  if (typeof config.temperature === 'number') body.temperature = config.temperature;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${config.provider.apiKey}`,
+    },
+    body: JSON.stringify(body),
+    signal: abortSignal,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ProviderError(
+      `provider returned ${res.status}: ${text.slice(0, 500)}`,
+      res.status,
+    );
+  }
+
+  const json = (await res.json()) as OpenAIResponse;
+  const choice = json.choices[0];
+  if (!choice) {
+    throw new ProviderError('provider returned no choices', 0);
+  }
+
+  const finishReason: ProviderResponse['finishReason'] =
+    choice.finish_reason === 'tool_calls'
+      ? 'tool_calls'
+      : choice.finish_reason === 'length'
+        ? 'length'
+        : choice.finish_reason === 'stop'
+          ? 'stop'
+          : 'error';
+
+  return {
+    message: choice.message,
+    usage: json.usage,
+    finishReason,
+  };
+};
+
+export class ProviderError extends Error {
+  override readonly name = 'ProviderError';
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+  }
+}

--- a/packages/agent-runtime/src/providers/stub.ts
+++ b/packages/agent-runtime/src/providers/stub.ts
@@ -1,0 +1,33 @@
+import type { ChatMessage, Provider, ProviderResponse } from '../types.js';
+
+export interface StubScript {
+  responses: ProviderResponse[];
+}
+
+export interface StubProviderHandle {
+  provider: Provider;
+  /** Captured calls in order. */
+  calls: Array<{ messages: ChatMessage[]; toolNames: string[] }>;
+}
+
+export function createStubProvider(script: StubScript): StubProviderHandle {
+  const queue = [...script.responses];
+  const calls: StubProviderHandle['calls'] = [];
+
+  const provider: Provider = ({ messages, tools, abortSignal }) => {
+    if (abortSignal?.aborted) {
+      return Promise.reject(new DOMException('aborted', 'AbortError'));
+    }
+    calls.push({
+      messages: messages.map((m) => ({ ...m })),
+      toolNames: tools.map((t) => t.function.name),
+    });
+    const next = queue.shift();
+    if (!next) {
+      return Promise.reject(new Error('stub provider exhausted: no scripted responses left'));
+    }
+    return Promise.resolve(next);
+  };
+
+  return { provider, calls };
+}

--- a/packages/agent-runtime/src/runtime.test.ts
+++ b/packages/agent-runtime/src/runtime.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runAgent } from './runtime.js';
+import { createStubProvider } from './providers/stub.js';
+import type {
+  AgentConfig,
+  ConversationMessage,
+  McpToolHandle,
+  ProviderResponse,
+} from './types.js';
+
+const baseConfig: AgentConfig = {
+  provider: { baseUrl: 'http://stub', apiKey: 'stub' },
+  model: 'stub-model',
+  systemPrompt: 'You are a helpful self-service assistant.',
+};
+
+function makeMcp(overrides: Partial<McpToolHandle> = {}): McpToolHandle {
+  return {
+    listTools: vi.fn(() =>
+      Promise.resolve([
+        {
+          name: 'kb_search',
+          description: 'Search the knowledge base.',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+        },
+      ]),
+    ),
+    callTool: vi.fn(() =>
+      Promise.resolve({
+        content: [{ type: 'text' as const, text: 'kb result: hours 9-5' }],
+      }),
+    ),
+    ...overrides,
+  };
+}
+
+function plainTextResponse(content: string): ProviderResponse {
+  return {
+    message: { role: 'assistant', content },
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    finishReason: 'stop',
+  };
+}
+
+function toolCallResponse(callId: string, toolName: string, args: Record<string, unknown>): ProviderResponse {
+  return {
+    message: {
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: callId,
+          type: 'function',
+          function: { name: toolName, arguments: JSON.stringify(args) },
+        },
+      ],
+    },
+    usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+    finishReason: 'tool_calls',
+  };
+}
+
+describe('runAgent', () => {
+  it('returns assistant content directly when no tool calls are made', async () => {
+    const { provider, calls } = createStubProvider({
+      responses: [plainTextResponse('Hello there!')],
+    });
+
+    const reply = await runAgent({
+      config: baseConfig,
+      history: [{ authorType: 'end_user', body: 'hi' }],
+      mcp: makeMcp(),
+      provider,
+    });
+
+    expect(reply.body).toBe('Hello there!');
+    expect(reply.finishReason).toBe('stop');
+    expect(reply.toolCalls).toHaveLength(0);
+    expect(reply.usage).toEqual({ promptTokens: 10, completionTokens: 5, totalTokens: 15 });
+    expect(calls[0]?.messages[0]).toEqual({
+      role: 'system',
+      content: baseConfig.systemPrompt,
+    });
+    expect(calls[0]?.toolNames).toEqual(['kb_search']);
+  });
+
+  it('runs the tool-call loop and stitches tool results back into the conversation', async () => {
+    const { provider, calls } = createStubProvider({
+      responses: [
+        toolCallResponse('call_1', 'kb_search', { query: 'opening hours' }),
+        plainTextResponse('We are open 9 to 5.'),
+      ],
+    });
+    const mcp = makeMcp();
+
+    const reply = await runAgent({
+      config: baseConfig,
+      history: [{ authorType: 'end_user', body: 'when are you open?' }],
+      mcp,
+      provider,
+    });
+
+    expect(reply.body).toBe('We are open 9 to 5.');
+    expect(reply.toolCalls).toHaveLength(1);
+    expect(reply.toolCalls[0]?.name).toBe('kb_search');
+    expect(reply.toolCalls[0]?.args).toEqual({ query: 'opening hours' });
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mcp.callTool).toHaveBeenCalledWith('kb_search', { query: 'opening hours' });
+
+    expect(reply.usage.totalTokens).toBe(27);
+
+    const secondCallMessages = calls[1]?.messages ?? [];
+    const toolMessage = secondCallMessages.find((m) => m.role === 'tool');
+    expect(toolMessage?.content).toContain('kb result: hours 9-5');
+    expect(toolMessage?.tool_call_id).toBe('call_1');
+  });
+
+  it('caps the tool-call loop with tool_iteration_limit', async () => {
+    const responses: ProviderResponse[] = Array.from({ length: 3 }, (_, i) =>
+      toolCallResponse(`call_${i}`, 'kb_search', { query: `q${i}` }),
+    );
+    const { provider } = createStubProvider({ responses });
+
+    const reply = await runAgent({
+      config: { ...baseConfig, maxToolIterations: 3 },
+      history: [{ authorType: 'end_user', body: 'loop forever' }],
+      mcp: makeMcp(),
+      provider,
+    });
+
+    expect(reply.finishReason).toBe('tool_iteration_limit');
+    expect(reply.body).toBe('');
+    expect(reply.toolCalls).toHaveLength(3);
+  });
+
+  it('aborts mid-loop when abortSignal fires', async () => {
+    const { provider } = createStubProvider({
+      responses: [
+        toolCallResponse('call_1', 'kb_search', { query: 'x' }),
+        plainTextResponse('Final answer.'),
+      ],
+    });
+    const controller = new AbortController();
+    const mcp = makeMcp({
+      callTool: vi.fn(() => {
+        controller.abort();
+        return Promise.resolve({ content: [{ type: 'text' as const, text: 'done' }] });
+      }),
+    });
+
+    await expect(
+      runAgent({
+        config: baseConfig,
+        history: [{ authorType: 'end_user', body: 'go' }],
+        mcp,
+        provider,
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow(/abort/i);
+  });
+
+  it('maps history author types to chat roles correctly', async () => {
+    const { provider, calls } = createStubProvider({
+      responses: [plainTextResponse('ack')],
+    });
+    const history: ConversationMessage[] = [
+      { authorType: 'end_user', body: 'first user msg' },
+      { authorType: 'agent', body: 'agent reply' },
+      { authorType: 'staff', body: 'staff note' },
+      { authorType: 'end_user', body: 'second user msg' },
+    ];
+
+    await runAgent({
+      config: baseConfig,
+      history,
+      mcp: makeMcp(),
+      provider,
+    });
+
+    const sent = calls[0]?.messages ?? [];
+    expect(sent[0]?.role).toBe('system');
+    expect(sent[1]).toMatchObject({ role: 'user', content: 'first user msg' });
+    expect(sent[2]).toMatchObject({ role: 'assistant', content: 'agent reply' });
+    expect(sent[3]?.role).toBe('user');
+    expect(sent[3]?.name).toBe('staff');
+    expect(sent[4]).toMatchObject({ role: 'user', content: 'second user msg' });
+  });
+});

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -1,0 +1,131 @@
+import { flattenToolResult, mcpToolsToChatTools } from './mcp-tool-translation.js';
+import { openAiCompatibleProvider } from './providers/openai-compatible.js';
+import type {
+  AgentConfig,
+  AgentReply,
+  ChatMessage,
+  ConversationMessage,
+  McpToolHandle,
+  Provider,
+  ProviderUsage,
+  ToolCallTrace,
+} from './types.js';
+
+const DEFAULT_MAX_TOOL_ITERATIONS = 8;
+
+export interface RunAgentArgs {
+  config: AgentConfig;
+  history: ConversationMessage[];
+  mcp: McpToolHandle;
+  abortSignal?: AbortSignal;
+  /** Override provider — used by tests. Defaults to OpenAI-compatible. */
+  provider?: Provider;
+}
+
+export async function runAgent({
+  config,
+  history,
+  mcp,
+  abortSignal,
+  provider = openAiCompatibleProvider,
+}: RunAgentArgs): Promise<AgentReply> {
+  const tools = mcpToolsToChatTools(await mcp.listTools());
+  const messages: ChatMessage[] = [
+    { role: 'system', content: config.systemPrompt },
+    ...history.map(historyToChatMessage),
+  ];
+
+  const toolCalls: ToolCallTrace[] = [];
+  const usageTotal = { prompt: 0, completion: 0, total: 0 };
+  const maxIterations = config.maxToolIterations ?? DEFAULT_MAX_TOOL_ITERATIONS;
+
+  for (let iteration = 0; iteration < maxIterations; iteration += 1) {
+    if (abortSignal?.aborted) {
+      throw new DOMException('aborted', 'AbortError');
+    }
+
+    const response = await provider({ config, messages, tools, abortSignal });
+    accumulateUsage(usageTotal, response.usage);
+
+    if (response.finishReason === 'tool_calls' && response.message.tool_calls?.length) {
+      messages.push(response.message);
+      for (const call of response.message.tool_calls) {
+        if (abortSignal?.aborted) {
+          throw new DOMException('aborted', 'AbortError');
+        }
+        const args = parseArgs(call.function.arguments);
+        const result = await mcp.callTool(call.function.name, args);
+        toolCalls.push({ name: call.function.name, args, result });
+        messages.push({
+          role: 'tool',
+          tool_call_id: call.id,
+          content: flattenToolResult(result),
+        });
+      }
+      continue;
+    }
+
+    return {
+      body: response.message.content ?? '',
+      usage: {
+        promptTokens: usageTotal.prompt,
+        completionTokens: usageTotal.completion,
+        totalTokens: usageTotal.total,
+      },
+      model: config.model,
+      finishReason: response.finishReason === 'stop' ? 'stop' : response.finishReason === 'length' ? 'length' : 'error',
+      toolCalls,
+    };
+  }
+
+  return {
+    body: '',
+    usage: {
+      promptTokens: usageTotal.prompt,
+      completionTokens: usageTotal.completion,
+      totalTokens: usageTotal.total,
+    },
+    model: config.model,
+    finishReason: 'tool_iteration_limit',
+    toolCalls,
+  };
+}
+
+function historyToChatMessage(msg: ConversationMessage): ChatMessage {
+  switch (msg.authorType) {
+    case 'user':
+    case 'end_user':
+      return { role: 'user', content: msg.body };
+    case 'agent':
+      return { role: 'assistant', content: msg.body };
+    case 'staff':
+      return { role: 'user', name: 'staff', content: `[staff message] ${msg.body}` };
+    case 'system':
+      return { role: 'system', content: msg.body };
+    default:
+      return { role: 'user', content: msg.body };
+  }
+}
+
+function parseArgs(raw: string): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function accumulateUsage(
+  totals: { prompt: number; completion: number; total: number },
+  usage?: ProviderUsage,
+): void {
+  if (!usage) return;
+  totals.prompt += usage.prompt_tokens ?? 0;
+  totals.completion += usage.completion_tokens ?? 0;
+  totals.total += usage.total_tokens ?? 0;
+}

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -1,0 +1,102 @@
+export type AuthorType = 'user' | 'agent' | 'end_user' | 'system' | 'staff';
+
+export interface ConversationMessage {
+  authorType: AuthorType;
+  body: string;
+  createdAt?: string;
+}
+
+export interface ProviderConfig {
+  baseUrl: string;
+  apiKey: string;
+}
+
+export interface AgentConfig {
+  provider: ProviderConfig;
+  model: string;
+  systemPrompt: string;
+  maxToolIterations?: number;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface McpToolResult {
+  content: Array<{ type: 'text'; text: string } | { type: string; [key: string]: unknown }>;
+  isError?: boolean;
+}
+
+export interface McpToolHandle {
+  listTools(): Promise<McpTool[]>;
+  callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult>;
+}
+
+export interface ToolCallTrace {
+  name: string;
+  args: Record<string, unknown>;
+  result: McpToolResult;
+}
+
+export interface AgentReply {
+  body: string;
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  model: string;
+  finishReason: 'stop' | 'length' | 'tool_iteration_limit' | 'error';
+  toolCalls: ToolCallTrace[];
+}
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: ChatToolCall[];
+}
+
+export interface ChatToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+export interface ChatToolDefinition {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+export interface ProviderUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+export interface ProviderResponse {
+  message: ChatMessage;
+  usage?: ProviderUsage;
+  finishReason: 'stop' | 'tool_calls' | 'length' | 'error';
+}
+
+export interface ProviderCallArgs {
+  config: AgentConfig;
+  messages: ChatMessage[];
+  tools: ChatToolDefinition[];
+  abortSignal?: AbortSignal;
+}
+
+export type Provider = (args: ProviderCallArgs) => Promise<ProviderResponse>;

--- a/packages/agent-runtime/tsconfig.json
+++ b/packages/agent-runtime/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@getmunin/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,49 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)
 
+  apps/self-service-ai:
+    dependencies:
+      '@getmunin/agent-runtime':
+        specifier: workspace:*
+        version: link:../../packages/agent-runtime
+      '@getmunin/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+      ws:
+        specifier: ^8.18.0
+        version: 8.20.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@getmunin/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@getmunin/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: ^22.7.0
+        version: 22.19.17
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
+      eslint:
+        specifier: ^9.10.0
+        version: 9.39.4(jiti@1.21.7)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)
+
   apps/web:
     dependencies:
       '@base-ui/react':
@@ -214,6 +257,31 @@ importers:
       tailwindcss:
         specifier: ^3.4.13
         version: 3.4.19(tsx@4.21.0)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)
+
+  packages/agent-runtime:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@getmunin/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@getmunin/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^22.7.0
+        version: 22.19.17
+      eslint:
+        specifier: ^9.10.0
+        version: 9.39.4(jiti@1.21.7)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3


### PR DESCRIPTION
## What this is

An optional service that turns the existing \`chat-widget-vanilla\` example into a working AI chat without compromising munin's positioning. The sidecar:

1. Subscribes to \`conversation.message.received\` events via the realtime gateway (admin Bearer).
2. For each end-user message, mints a delegated end-user token and connects to munin's \`/mcp\` *as that end-user*, so the LLM's tool surface is **the self-service MCP** — KB search, the caller's own CRM contact, handover request — with the same audience filtering any third-party agent has.
3. Calls an LLM via the shared \`@getmunin/agent-runtime\` kernel (OpenAI-compatible — defaults to OpenRouter so any model is reachable through one key).
4. Posts the final reply via admin REST as \`authorType: 'agent'\`.

Two credentials by design: admin for the realtime subscription + reply post; delegated end-user for the MCP session. Mixing them would either over-permission the LLM or post replies as the end-user.

## Why it's structured this way

This isn't a parallel data path. The sidecar consumes the *same* MCP audience the chat-widget example demonstrates for delegated tokens, so anything the agent can see is something a third-party agent could also see if it connected directly. KB additions, new CRM tools, and any future self-service tool surface flow through automatically — no kernel updates needed.

The kernel package (\`@getmunin/agent-runtime\`) is pure: \`(config, history, mcp) → reply\`. The same kernel will back the multi-tenant cloud addon — per-org config storage and inference billing layer on top, runtime is unchanged.

## Architecture

\`\`\`
                  ┌───────────────────────────────────────────┐
                  │ munin backend                              │
                  │ /api/realtime  /api/conversations  /mcp    │
                  └───────────────────────────────────────────┘
                       ▲           ▲              ▲
   admin Bearer        │           │POST reply    │delegated end-user token
                       │           │authorType=   │(audience='self_service')
                       │           │'agent'       │
                       │           │              │
                  ┌────┴───────────┴──────────────┴────────────┐
                  │ apps/self-service-ai (sidecar)             │
                  │   on conversation.message.received:        │
                  │    1. mint delegated token                 │
                  │    2. open /mcp client as end-user         │
                  │    3. fetch conversation history (REST)    │
                  │    4. runAgent() — tool-using LLM loop     │
                  │    5. POST reply via admin REST            │
                  └────────────────────────────────────────────┘
\`\`\`

## Behavior

- Reacts only to \`conversation.message.received\` events with \`authorType: 'user' | 'end_user'\`.
- Skips closed / snoozed conversations and conversations claimed by staff (\`assigneeUserId\` set).
- 500ms debounce so multi-message bursts collapse into one reply.
- Per-conversation \`AbortController\`: a new triggering event aborts the in-flight run and starts a fresh one with current history.
- Provider errors retry with exponential backoff (3 attempts). After exhaustion, calls \`conv_request_handover_in_my_conversation\` via MCP — \`needsHumanAttention\` surfaces it to staff, no agent message posted.

## Test plan

- [x] \`pnpm --filter @getmunin/agent-runtime test\` (5 passed)
- [x] \`pnpm --filter @getmunin/self-service-ai test\` (5 passed)
- [x] typecheck + lint clean across both packages and \`@getmunin/backend-core\`
- [ ] **Manual end-to-end**: \`docker compose --profile ai up\` with \`MUNIN_ADMIN_API_KEY\` + \`SELF_SERVICE_AI_PROVIDER_API_KEY\`, type into the chat-widget-vanilla example, see a reply within ~5s with \`authorType: 'agent'\`. Audit log shows MCP tool calls (e.g. \`kb_search\`) attributed to the delegated end-user token.
- [ ] **Hand-off path**: kill the OpenRouter API key. Send a message. After 3 failed attempts, conversation appears with \`needsHumanAttention=true\` and no agent reply.
- [ ] **Staff takeover**: assign a conversation to a staff user. Send another end-user message — sidecar does NOT reply.

## Out of scope (deliberately deferred)

- Multi-tenant cloud addon — separate PR once this is validated. Reuses \`@getmunin/agent-runtime\` directly; only adds per-org config + inference billing.
- Native Anthropic SDK provider (OpenRouter routes Anthropic adequately for v1).
- Streaming partial replies (final text only; widget already polls).
- Per-conversation prompt overrides / skill routing.
- Inference rate-limiting (provider's own limits apply in single-tenant OSS).

A follow-up PR in \`munin-examples\` adds a "Make the agent reply" section to the \`chat-widget-vanilla\` README pointing at this sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)