### PR TITLE
feat(realtime): accept bearer token via Sec-WebSocket-Protocol

### DIFF
--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
+import { WebSocket } from 'ws';
 import { buildApiKey, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { eq, sql } from 'drizzle-orm';
@@ -583,6 +584,59 @@ interface OrgFixture {
         headers: authHeaders(orgA.adminKey),
       });
       expect(res.status).toBe(403);
+    });
+  });
+
+  // ─── realtime gateway (websocket auth) ──────────────────────────────
+
+  describe('GET /api/realtime (websocket)', () => {
+    function wsUrl(): string {
+      return baseUrl.replace(/^http/, 'ws') + '/api/realtime';
+    }
+
+    function awaitOpen(ws: WebSocket): Promise<{ subprotocol: string }> {
+      return new Promise((resolve, reject) => {
+        const onError = (err: Error): void => {
+          ws.removeAllListeners();
+          reject(err);
+        };
+        ws.once('open', () => {
+          ws.removeListener('error', onError);
+          resolve({ subprotocol: ws.protocol });
+        });
+        ws.once('error', onError);
+        ws.once('unexpected-response', (_req, res) => {
+          ws.removeAllListeners();
+          reject(new Error(`unexpected ${res.statusCode}`));
+        });
+      });
+    }
+
+    it('accepts the admin API key via Authorization header (existing path)', async () => {
+      const ws = new WebSocket(wsUrl(), {
+        headers: { authorization: `Bearer ${orgA.adminKey}` },
+      });
+      const result = await awaitOpen(ws);
+      expect(result.subprotocol).toBe('');
+      ws.close();
+    });
+
+    it('accepts the admin API key via Sec-WebSocket-Protocol (browser path)', async () => {
+      const ws = new WebSocket(wsUrl(), ['bearer', orgA.adminKey]);
+      const result = await awaitOpen(ws);
+      // Server must echo `bearer` for browsers to consider the handshake valid.
+      expect(result.subprotocol).toBe('bearer');
+      ws.close();
+    });
+
+    it('rejects bogus subprotocol token with 401', async () => {
+      const ws = new WebSocket(wsUrl(), ['bearer', 'mn_admin_obviouslyfake']);
+      await expect(awaitOpen(ws)).rejects.toThrow(/401/);
+    });
+
+    it('rejects upgrade with no credentials (401)', async () => {
+      const ws = new WebSocket(wsUrl());
+      await expect(awaitOpen(ws)).rejects.toThrow(/401/);
     });
   });
 

--- a/packages/backend-core/src/realtime/realtime.gateway.test.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { readBearerSubprotocol } from './realtime.gateway.js';
+
+describe('readBearerSubprotocol', () => {
+  it('returns null for undefined', () => {
+    expect(readBearerSubprotocol(undefined)).toBeNull();
+  });
+
+  it('returns null when only one value is offered', () => {
+    expect(readBearerSubprotocol('bearer')).toBeNull();
+  });
+
+  it('returns null when bearer marker is absent', () => {
+    expect(readBearerSubprotocol('json, foo')).toBeNull();
+  });
+
+  it('parses the standard browser form', () => {
+    expect(readBearerSubprotocol('bearer, mn_admin_abc')).toBe('mn_admin_abc');
+  });
+
+  it('is case-insensitive on the marker', () => {
+    expect(readBearerSubprotocol('Bearer, mn_admin_abc')).toBe('mn_admin_abc');
+  });
+
+  it('honors the first bearer + token pair when more follow', () => {
+    expect(readBearerSubprotocol('bearer, first, bearer, second')).toBe('first');
+  });
+
+  it('handles trailing commas and whitespace', () => {
+    expect(readBearerSubprotocol('  bearer ,  mn_eu_xyz  , ')).toBe('mn_eu_xyz');
+  });
+});

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -59,7 +59,18 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       return;
     }
 
-    this.wss = new WebSocketServer({ noServer: true });
+    this.wss = new WebSocketServer({
+      noServer: true,
+      // Browsers can't set arbitrary HTTP headers on a WebSocket upgrade, so
+      // browser callers pass the bearer token via Sec-WebSocket-Protocol:
+      //   ['bearer', '<token>']  →  send 'bearer' back so the handshake
+      // completes. Native (Node ws) callers set the Authorization header and
+      // don't offer any subprotocol, so we just decline negotiation.
+      handleProtocols: (protocols) => {
+        if (protocols.has('bearer')) return 'bearer';
+        return false;
+      },
+    });
     const listener = (req: IncomingMessage, socket: Duplex, head: Buffer) => {
       if (!req.url || !req.url.startsWith(PATH)) return;
       void this.handleUpgrade(req, socket, head);
@@ -162,20 +173,13 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   }
 
   private async authenticate(req: IncomingMessage): Promise<ResolvedCredential | null> {
-    const value = readHeader(req, 'authorization');
-    if (value && value.toLowerCase().startsWith('bearer ')) {
-      const raw = value.slice('Bearer '.length).trim();
-      if (looksLikeApiKey(raw)) {
-        let credential = await this.resolver.resolveApiKey(raw);
-        if (!credential) {
-          for (const extra of this.additionalResolvers) {
-            credential = await extra.resolve(raw);
-            if (credential) break;
-          }
-        }
-        return credential;
-      }
-      return this.resolver.resolveBearerToken(raw);
+    const headerToken = readBearerToken(readHeader(req, 'authorization'));
+    if (headerToken) {
+      return this.resolveToken(headerToken);
+    }
+    const subprotocolToken = readBearerSubprotocol(readHeader(req, 'sec-websocket-protocol'));
+    if (subprotocolToken) {
+      return this.resolveToken(subprotocolToken);
     }
     const cookieValue = readHeader(req, 'cookie');
     const sessionToken = readSessionCookie(cookieValue);
@@ -183,6 +187,20 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       return this.resolver.resolveSessionToken(sessionToken);
     }
     return null;
+  }
+
+  private async resolveToken(raw: string): Promise<ResolvedCredential | null> {
+    if (looksLikeApiKey(raw)) {
+      let credential = await this.resolver.resolveApiKey(raw);
+      if (!credential) {
+        for (const extra of this.additionalResolvers) {
+          credential = await extra.resolve(raw);
+          if (credential) break;
+        }
+      }
+      return credential;
+    }
+    return this.resolver.resolveBearerToken(raw);
   }
 }
 
@@ -196,6 +214,32 @@ function readHeader(req: IncomingMessage, name: string): string | undefined {
   const raw = headers[name];
   if (Array.isArray(raw)) return raw[0];
   return raw;
+}
+
+function readBearerToken(value: string | undefined): string | null {
+  if (!value || !value.toLowerCase().startsWith('bearer ')) return null;
+  const raw = value.slice('Bearer '.length).trim();
+  return raw.length > 0 ? raw : null;
+}
+
+/**
+ * Browser WebSocket clients pass the bearer token as the second value in
+ * `Sec-WebSocket-Protocol: bearer, <token>`. The header may concatenate
+ * multiple `Sec-WebSocket-Protocol` lines into a single comma-separated
+ * value; we only honor the first `bearer + token` pair we find.
+ */
+export function readBearerSubprotocol(value: string | undefined): string | null {
+  if (!value) return null;
+  const parts = value
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    if (parts[i]?.toLowerCase() === 'bearer') {
+      return parts[i + 1] ?? null;
+    }
+  }
+  return null;
 }
 
 function readSessionCookie(cookieHeader: string | undefined): string | null {


### PR DESCRIPTION
## Why
Browsers can't set arbitrary HTTP headers on a WebSocket upgrade, so today they can't authenticate against \`/api/realtime\` at all — only Node clients (sidecar, tests) work. Blocks the chat-widget switching from polling to realtime.

## What
The gateway now reads the bearer token from either:

- \`Authorization: Bearer <token>\` (Node ws clients, sidecar) — unchanged
- \`Sec-WebSocket-Protocol: bearer, <token>\` (browsers) — new

…and echoes \`bearer\` as the negotiated subprotocol so the browser handshake completes. This is the standard pattern (used by, e.g., the Kubernetes API server). Native callers that don't offer a subprotocol see no behavior change.

\`\`\`ts
// Browser:
new WebSocket(\`\${apiUrl}/api/realtime\`, ['bearer', delegatedToken]);

// Node (existing path, unchanged):
new WebSocket(\`\${apiUrl}/api/realtime\`, {
  headers: { authorization: \`Bearer \${delegatedToken}\` },
});
\`\`\`

## Tests
- Unit (\`realtime.gateway.test.ts\`): the subprotocol parser is case-insensitive, rejects bare marker without token, picks the first \`bearer + token\` pair, tolerates whitespace + trailing commas.
- Integration (\`control-plane.integration.test.ts\`, real WS handshake against booted app):
  - header path works (regression check)
  - subprotocol path works and the negotiated protocol is \`bearer\`
  - bogus subprotocol token → 401
  - no credentials → 401

All 231 backend-core tests pass against a fresh local Postgres.

Pairs with the upcoming widget PR in [getmunin/munin-examples](https://github.com/getmunin/munin-examples) that switches the widget from polling to WebSocket using this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)