### PR TITLE
chore(agent-runtime): make publishable to GitHub Packages

### DIFF
--- a/.changeset/agent-runtime-publish.md
+++ b/.changeset/agent-runtime-publish.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/agent-runtime': patch
+---
+
+First publishable release of `@getmunin/agent-runtime` — the LLM agent loop kernel shared by the OSS self-service-ai sidecar and (forthcoming) cloud multi-tenant runner. Public API:
+
+- `runAgent({ config, history, mcp, abortSignal?, provider? })` — tool-using LLM loop
+- `compactHistory(history, maxChars)` — drops oldest turns to fit a budget; emits a system notice on truncation
+- `openAiCompatibleProvider`, `createStubProvider` — provider implementations
+- `mcpToolsToChatTools`, `flattenToolResult` — MCP ↔ OpenAI tool translation
+- All public types (`AgentConfig`, `AgentReply`, `ConversationMessage`, `McpToolHandle`, etc.)
+
+The package was added in #29 (sidecar) and extended in #31 (channel-aware prompt + history compaction); this changeset just makes it publishable to the GitHub Packages registry so cloud and other downstream consumers can install it.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,11 +2,11 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/bootstrap", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core"]],
+  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/bootstrap", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core", "@getmunin/agent-runtime"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@getmunin/backend", "@getmunin/web", "@getmunin/eslint-config", "@getmunin/tsconfig"]
+  "ignore": ["@getmunin/backend", "@getmunin/web", "@getmunin/self-service-ai", "@getmunin/eslint-config", "@getmunin/tsconfig"]
 }
 

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.1",
   "license": "MIT",
   "description": "LLM agent loop — given a config, conversation history, and an MCP tool handle, produce a reply.",
-  "private": true,
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/getmunin/munin.git",


### PR DESCRIPTION
## Why
The package was added in #29 and extended in #31 but stayed \`private: true\` because the OSS sidecar consumes it via workspace link. The cloud multi-tenant runner (forthcoming) installs it from the npm registry, so it needs to be a real published package.

## What
- Drop \`private: true\` from \`packages/agent-runtime/package.json\` and add the standard \`publishConfig\` block (mirrors \`@getmunin/sdk\`).
- Add \`@getmunin/agent-runtime\` to the changeset \`fixed\` group so it versions in lockstep with the rest of the OSS library suite (\`@getmunin/core\`, \`@getmunin/sdk\`, etc.).
- Add \`@getmunin/self-service-ai\` (the OSS sidecar app) to the changeset \`ignore\` list — apps are not published.
- Changeset entry bumping the suite at patch.

\`pnpm changeset status\` confirms the suite (including \`agent-runtime\`) is queued at patch on the next release run.

Once this lands and the resulting release PR merges, the cloud runner PR (forthcoming) will be unblocked and can \`pnpm install\` the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)