### PR TITLE
feat(kb): document slug + slug lookup + change events

### DIFF
--- a/packages/backend-core/src/modules/kb/kb.search.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.search.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import {
   ActorIdentity,
   StubEmbeddingProvider,
+  WebhookDispatcher,
   withContext,
   type RequestContext,
 } from '@getmunin/core';
@@ -63,7 +64,7 @@ const skipReason = TEST_URL
         return new StubEmbeddingProvider();
       }
     })();
-    kb = new KbService(holder, new QuotasService());
+    kb = new KbService(holder, new QuotasService(), new WebhookDispatcher());
     search = new KbSearchService(holder);
   });
 

--- a/packages/backend-core/src/modules/kb/kb.service.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import {
   ActorIdentity,
   StubEmbeddingProvider,
+  WebhookDispatcher,
   withContext,
   type RequestContext,
 } from '@getmunin/core';
@@ -43,7 +44,7 @@ const skipReason = TEST_URL
         return new StubEmbeddingProvider();
       }
     })();
-    svc = new KbService(holder, new QuotasService());
+    svc = new KbService(holder, new QuotasService(), new WebhookDispatcher());
   });
 
   afterAll(async () => {
@@ -187,5 +188,76 @@ const skipReason = TEST_URL
     ).rejects.toThrow(KbConflictError);
     await run(() => svc.deleteDocument({ id: doc.id, ifVersion: 1 }));
     await expect(run(() => svc.getDocument(doc.id))).rejects.toThrow(KbNotFoundError);
+  });
+
+  it('round-trips a slug through createDocument and getDocumentBySlug', async () => {
+    const space = await run(() =>
+      svc.createSpace({ name: 'Agent runtime', slug: 'agent-runtime' }),
+    );
+    const doc = await run(() =>
+      svc.createDocument({
+        spaceId: space.id,
+        slug: 'system-prompt',
+        title: 'System prompt',
+        body: 'You are a helpful assistant.',
+      }),
+    );
+    expect(doc.slug).toBe('system-prompt');
+
+    const found = await run(() => svc.getDocumentBySlug('agent-runtime', 'system-prompt'));
+    expect(found?.id).toBe(doc.id);
+    expect(found?.body).toBe('You are a helpful assistant.');
+
+    const missing = await run(() => svc.getDocumentBySlug('agent-runtime', 'nope'));
+    expect(missing).toBeNull();
+  });
+
+  it('rejects a duplicate (space, slug) pair', async () => {
+    const space = await run(() => svc.createSpace({ name: 'A', slug: 'agent-runtime' }));
+    await run(() =>
+      svc.createDocument({
+        spaceId: space.id,
+        slug: 'system-prompt',
+        title: 'First',
+        body: 'B',
+      }),
+    );
+    await expect(
+      run(() =>
+        svc.createDocument({
+          spaceId: space.id,
+          slug: 'system-prompt',
+          title: 'Second',
+          body: 'B',
+        }),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('rejects an invalid slug shape', async () => {
+    const space = await run(() => svc.createSpace({ name: 'A', slug: 'agent-runtime' }));
+    await expect(
+      run(() =>
+        svc.createDocument({
+          spaceId: space.id,
+          slug: 'BAD slug!',
+          title: 'T',
+          body: 'B',
+        }),
+      ),
+    ).rejects.toThrow(KbInvalidError);
+  });
+
+  it('allows multiple un-slugged docs in the same space (partial unique index)', async () => {
+    const space = await run(() => svc.createSpace({ name: 'A', slug: 'docs' }));
+    const a = await run(() =>
+      svc.createDocument({ spaceId: space.id, title: 'A', body: 'a' }),
+    );
+    const b = await run(() =>
+      svc.createDocument({ spaceId: space.id, title: 'B', body: 'b' }),
+    );
+    expect(a.slug).toBeNull();
+    expect(b.slug).toBeNull();
+    expect(a.id).not.toBe(b.id);
   });
 });

--- a/packages/backend-core/src/modules/kb/kb.service.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import { schema } from '@getmunin/db';
-import { chunkDocument, contentHash, getCurrentContext } from '@getmunin/core';
+import { chunkDocument, contentHash, getCurrentContext, WebhookDispatcher } from '@getmunin/core';
 import type { ActorIdentity, Audience } from '@getmunin/core';
 import { EmbeddingProviderHolder } from './embedding.provider.js';
 import { QuotasService } from '../../common/quotas/quotas.service.js';
@@ -55,6 +55,7 @@ export interface SpaceDto {
 export interface DocumentDto {
   id: string;
   spaceId: string;
+  slug: string | null;
   title: string;
   body: string;
   audiences: Audience[];
@@ -90,6 +91,7 @@ export class KbService {
   constructor(
     @Inject(EmbeddingProviderHolder) private readonly embeddings: EmbeddingProviderHolder,
     @Inject(QuotasService) private readonly quotas: QuotasService,
+    @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
   ) {}
 
   // ─── Spaces ─────────────────────────────────────────────────────────────
@@ -191,11 +193,15 @@ export class KbService {
     body: string;
     audiences?: readonly string[];
     tags?: string[];
+    slug?: string;
   }): Promise<DocumentDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     await this.assertSpaceExists(input.spaceId);
     await this.quotas.assertCanAdd('kb_documents');
+    if (input.slug !== undefined && !isValidSlug(input.slug)) {
+      throw new KbInvalidError(`slug must match [a-z0-9][a-z0-9-]{0,63}`);
+    }
     const audiences = normaliseAudiences(input.audiences);
     const hash = contentHash(input.title, input.body);
     const [doc] = await ctx.db
@@ -203,6 +209,7 @@ export class KbService {
       .values({
         orgId: actor.orgId,
         spaceId: input.spaceId,
+        slug: input.slug ?? null,
         title: input.title,
         body: input.body,
         audiences,
@@ -214,7 +221,31 @@ export class KbService {
       .returning();
     await this.snapshotVersion(doc!, actor);
     await this.regenerateChunks(doc!);
+    await this.webhooks.emit({
+      type: 'kb.document.created',
+      payload: {
+        spaceId: doc!.spaceId,
+        documentId: doc!.id,
+        slug: doc!.slug,
+        version: doc!.version,
+      },
+    });
     return toDocumentDto(doc!);
+  }
+
+  async getDocumentBySlug(
+    spaceSlug: string,
+    docSlug: string,
+  ): Promise<DocumentDto | null> {
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select({ doc: schema.kbDocuments })
+      .from(schema.kbDocuments)
+      .innerJoin(schema.kbSpaces, eq(schema.kbSpaces.id, schema.kbDocuments.spaceId))
+      .where(and(eq(schema.kbSpaces.slug, spaceSlug), eq(schema.kbDocuments.slug, docSlug)))
+      .limit(1);
+    const row = rows[0];
+    return row ? toDocumentDto(row.doc) : null;
   }
 
   async updateDocument(input: {
@@ -259,6 +290,15 @@ export class KbService {
     if (contentChanged) {
       await this.regenerateChunks(updated!);
     }
+    await this.webhooks.emit({
+      type: 'kb.document.updated',
+      payload: {
+        spaceId: updated!.spaceId,
+        documentId: updated!.id,
+        slug: updated!.slug,
+        version: updated!.version,
+      },
+    });
     return toDocumentDto(updated!);
   }
 
@@ -269,6 +309,14 @@ export class KbService {
       throw new KbConflictError(existing.version, input.ifVersion);
     }
     await ctx.db.delete(schema.kbDocuments).where(eq(schema.kbDocuments.id, input.id));
+    await this.webhooks.emit({
+      type: 'kb.document.deleted',
+      payload: {
+        spaceId: existing.spaceId,
+        documentId: existing.id,
+        slug: existing.slug,
+      },
+    });
     return { deleted: true };
   }
 
@@ -326,6 +374,15 @@ export class KbService {
       .returning();
     await this.snapshotVersion(updated!, actor);
     await this.regenerateChunks(updated!);
+    await this.webhooks.emit({
+      type: 'kb.document.updated',
+      payload: {
+        spaceId: updated!.spaceId,
+        documentId: updated!.id,
+        slug: updated!.slug,
+        version: updated!.version,
+      },
+    });
     return toDocumentDto(updated!);
   }
 
@@ -426,6 +483,7 @@ function toDocumentDto(row: typeof schema.kbDocuments.$inferSelect): DocumentDto
   return {
     id: row.id,
     spaceId: row.spaceId,
+    slug: row.slug,
     title: row.title,
     body: row.body,
     audiences: row.audiences,

--- a/packages/backend-core/src/modules/kb/kb.tools.ts
+++ b/packages/backend-core/src/modules/kb/kb.tools.ts
@@ -22,6 +22,11 @@ const GetDocumentInput = z.object({
   id: z.string(),
 });
 
+const GetDocumentBySlugInput = z.object({
+  spaceSlug: z.string().min(1).max(64),
+  slug: z.string().min(1).max(64),
+});
+
 const AudienceSchema = z.enum(['admin', 'self_service']);
 const AudiencesSchema = z.array(AudienceSchema).min(1);
 
@@ -31,6 +36,7 @@ const CreateDocumentInput = z.object({
   body: z.string().min(1),
   audiences: AudiencesSchema.optional(),
   tags: TagsSchema.optional(),
+  slug: z.string().min(1).max(64).optional(),
 });
 
 const UpdateDocumentInput = z.object({
@@ -129,6 +135,21 @@ export class KbAdminTools {
   })
   getDocument(args: z.infer<typeof GetDocumentInput>) {
     return this.kb.getDocument(args.id);
+  }
+
+  @McpTool({
+    name: 'kb_get_document_by_slug',
+    title: 'Read KB document by slug',
+    description:
+      "Read a knowledge-base document by its space slug and document slug — used when a stable identifier (e.g. 'agent-runtime/system-prompt') is needed instead of the document UUID. Returns null when the document does not exist.",
+    audiences: ['admin'],
+    scopes: ['kb:read'],
+    input: GetDocumentBySlugInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  getDocumentBySlug(args: z.infer<typeof GetDocumentBySlugInput>) {
+    return this.kb.getDocumentBySlug(args.spaceSlug, args.slug);
   }
 
   @McpTool({

--- a/packages/db/drizzle/0006_kb_document_slug.sql
+++ b/packages/db/drizzle/0006_kb_document_slug.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "kb_documents"
+  ADD COLUMN "slug" varchar(64);
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "kb_documents_space_slug_uq"
+  ON "kb_documents" ("space_id", "slug")
+  WHERE "slug" IS NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777681100000,
       "tag": "0005_events_notify_trigger",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777681200000,
+      "tag": "0006_kb_document_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -492,6 +492,7 @@ export const kbDocuments = pgTable(
     spaceId: text('space_id')
       .notNull()
       .references(() => kbSpaces.id, { onDelete: 'cascade' }),
+    slug: varchar('slug', { length: 64 }),
     title: text('title').notNull(),
     body: text('body').notNull(),
     audiences: jsonb('audiences')
@@ -513,6 +514,9 @@ export const kbDocuments = pgTable(
     orgIdx: index('kb_documents_org_idx').on(t.orgId),
     spaceIdx: index('kb_documents_space_idx').on(t.spaceId),
     audiencesIdx: index('kb_documents_audiences_idx').using('gin', t.audiences),
+    spaceSlugUq: uniqueIndex('kb_documents_space_slug_uq')
+      .on(t.spaceId, t.slug)
+      .where(sql`slug IS NOT NULL`),
   }),
 );
 


### PR DESCRIPTION
Three foundations the self-service-ai sidecar's PromptResolver (in PR2) needs from the KB:

## What this PR adds

1. **Per-space slug on \`kb_documents\`.** Optional \`varchar(64)\` with a partial unique index \`(space_id, slug) WHERE slug IS NOT NULL\`. Lets callers reference docs by stable identifier — \`agent-runtime/system-prompt\` instead of a UUID — without forcing existing rows to backfill. Format is the existing \`[a-z0-9][a-z0-9-]{0,63}\` slug regex used elsewhere.
2. **\`kb_get_document_by_slug\` MCP tool + \`KbService.getDocumentBySlug\` helper.** Admin audience (the prompt seed/read flow is admin-only). Returns null on miss rather than throwing — the calling pattern is "is this seeded yet?" not "this must exist." \`kb_create_document\` now accepts an optional \`slug\` field.
3. **\`kb.document.{created,updated,deleted}\` events.** \`KbService\` now injects \`WebhookDispatcher\` and emits on create / update / restoreVersion / delete. Payload carries \`spaceId\`, \`documentId\`, \`slug\` (when set), and \`version\` (where applicable). Lets the sidecar invalidate its prompt cache via the realtime gateway instead of polling.

## Migration

Purely additive — \`0006_kb_document_slug.sql\` adds the column + partial unique index. Existing rows keep null slugs. Existing \`kb_documents\` queries are unaffected.

## What this enables (PR2)

The sidecar can now:
- \`kb_get_document_by_slug({ spaceSlug: 'agent-runtime', slug: 'system-prompt' })\` → null on first boot
- \`kb_create_document({ spaceId, slug: 'system-prompt', body: <markdown from disk>, audiences: ['admin'] })\` → seeds the prompt
- Subscribe to \`kb.document.updated\` events on the realtime gateway and refresh cache when an operator edits the prompt via the dashboard

## Tests

- Round-trip a slug through \`createDocument\` → \`getDocumentBySlug\`.
- Reject duplicate \`(space, slug)\` at the DB layer.
- Reject malformed slug at the service layer.
- Multiple un-slugged docs in one space remain valid (partial index).
- 255/255 backend-core tests pass against fresh Postgres.

## Test plan
- [x] \`pnpm --filter @getmunin/db typecheck\`
- [x] \`pnpm --filter @getmunin/backend-core typecheck && lint\`
- [x] \`pnpm --filter @getmunin/backend-core test\` (255/255)
- [ ] manual via MCP: connect with admin token, call \`kb_create_space({ slug: 'agent-runtime', ... })\`, then \`kb_create_document({ spaceId, slug: 'system-prompt', ... })\`, then \`kb_get_document_by_slug({ spaceSlug: 'agent-runtime', slug: 'system-prompt' })\` — confirm round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)