### PR TITLE
feat(agent-runtime): include the four shared runtime helpers

### DIFF
--- a/.changeset/runtime-shared-bits-into-agent-runtime.md
+++ b/.changeset/runtime-shared-bits-into-agent-runtime.md
@@ -1,0 +1,27 @@
+---
+'@getmunin/agent-runtime': minor
+---
+
+Move the four shared runtime helpers — `createConversationHandler`,
+`createMuninRestClient`, `createRealtimeClient`, `openMcpClient` —
+from the OSS sidecar app into the agent-runtime package, so the cloud
+multi-tenant runner and any future runner can reuse them instead of
+maintaining their own copies.
+
+The handler now takes a minimal `HandlerConfig` (the 6 inference-loop
+fields: provider URL/key, model, max tool iterations, max history
+chars, debounce ms) instead of a deployment-specific config type.
+Existing consumers can pass any config object that has those fields.
+
+`@modelcontextprotocol/sdk` and `ws` move from the sidecar's
+dependencies into agent-runtime's, since they're needed by the
+extracted clients. Consumers shouldn't need to add them themselves
+anymore.
+
+New exports: `createConversationHandler`, `createMuninRestClient`,
+`createRealtimeClient`, `openMcpClient`, plus their option/result/handle
+types: `HandlerConfig`, `ConversationHandler`, `ConversationHandlerDeps`,
+`IncomingMessage`, `OpenedMcp`, `ConversationDetail`,
+`CreateMuninRestClientOptions`, `DelegatedToken`, `MuninRestClient`,
+`OpenMcpClientOptions`, `OpenedMcpClient`, `KbDocumentChangedEvent`,
+`MessageReceivedEvent`, `RealtimeClient`, `RealtimeClientOptions`.

--- a/apps/self-service-ai/README.md
+++ b/apps/self-service-ai/README.md
@@ -96,7 +96,7 @@ On provider errors the sidecar retries with exponential backoff (3 attempts). If
 
 ## Architecture
 
-This sidecar consumes the shared `@getmunin/agent-runtime` kernel (`packages/agent-runtime/`), which holds the LLM ↔ tool-call loop, provider abstraction, and the KB-backed prompt resolver (with built-in default prompts). The kernel is pure: given a config, conversation history, and an MCP tool handle, it returns a reply. The sidecar wires up the I/O — realtime subscription, REST calls, MCP client lifecycle, and retries.
+This sidecar consumes the shared `@getmunin/agent-runtime` package, which holds everything the runner needs: the LLM ↔ tool-call loop, the provider abstraction, the KB-backed prompt resolver (with built-in default prompts), the conversation handler (debounce + retry + handover), and the I/O clients (`createMuninRestClient`, `createRealtimeClient`, `openMcpClient`). The sidecar itself is just env-loading + wiring + lifecycle.
 
 The same kernel will back the multi-tenant cloud addon when that lands; per-org config storage and inference billing are the only things layered on top.
 

--- a/apps/self-service-ai/package.json
+++ b/apps/self-service-ai/package.json
@@ -17,15 +17,12 @@
   "dependencies": {
     "@getmunin/agent-runtime": "workspace:*",
     "@getmunin/sdk": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "ws": "^8.18.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@getmunin/eslint-config": "workspace:*",
     "@getmunin/tsconfig": "workspace:*",
     "@types/node": "^22.7.0",
-    "@types/ws": "^8.5.13",
     "eslint": "^9.10.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",

--- a/apps/self-service-ai/src/main.ts
+++ b/apps/self-service-ai/src/main.ts
@@ -1,9 +1,11 @@
+import {
+  createConversationHandler,
+  createMuninRestClient,
+  createPromptResolver,
+  createRealtimeClient,
+  openMcpClient,
+} from '@getmunin/agent-runtime';
 import { loadConfigFromEnv } from './config.js';
-import { createConversationHandler } from './conversation-handler.js';
-import { createMuninRestClient } from './munin-rest.js';
-import { openMcpClient } from './mcp-client.js';
-import { createPromptResolver } from '@getmunin/agent-runtime';
-import { createRealtimeClient } from './realtime.js';
 
 async function main(): Promise<void> {
   const config = loadConfigFromEnv();

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -34,12 +34,15 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "ws": "^8.18.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@getmunin/eslint-config": "workspace:*",
     "@getmunin/tsconfig": "workspace:*",
     "@types/node": "^22.7.0",
+    "@types/ws": "^8.5.13",
     "eslint": "^9.10.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -1,24 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createConversationHandler, type OpenedMcp } from './conversation-handler.js';
-import type { SidecarConfig } from './config.js';
+import {
+  createConversationHandler,
+  type HandlerConfig,
+  type OpenedMcp,
+} from './conversation-handler.js';
 import type { ConversationDetail, MuninRestClient } from './munin-rest.js';
-import type {
-  McpToolResult,
-  PromptResolver,
-  Provider,
-  ProviderResponse,
-} from '@getmunin/agent-runtime';
+import type { PromptResolver } from './prompt-resolver.js';
+import type { McpToolResult, Provider, ProviderResponse } from './types.js';
 
-const baseConfig: SidecarConfig = {
-  muninBaseUrl: 'http://munin',
-  muninAdminApiKey: 'mn_admin_test',
+const baseConfig: HandlerConfig = {
   providerBaseUrl: 'http://provider',
   providerApiKey: 'sk-test',
   model: 'test-model',
   debounceMs: 0,
   maxToolIterations: 4,
   maxHistoryChars: 32_000,
-  promptsDir: '/tmp/prompts',
 };
 
 function buildPrompts(overrides: Partial<{ system: string; channels: Record<string, string> }> = {}): PromptResolver {

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -1,12 +1,20 @@
-import {
-  runAgent,
-  type ConversationMessage,
-  type McpToolHandle,
-  type PromptResolver,
-  type Provider,
-} from '@getmunin/agent-runtime';
-import type { SidecarConfig } from './config.js';
+import { runAgent } from './runtime.js';
+import type {
+  ConversationMessage,
+  McpToolHandle,
+  Provider,
+} from './types.js';
+import type { PromptResolver } from './prompt-resolver.js';
 import type { ConversationDetail, MuninRestClient } from './munin-rest.js';
+
+export interface HandlerConfig {
+  providerBaseUrl: string;
+  providerApiKey: string;
+  model: string;
+  maxToolIterations: number;
+  maxHistoryChars: number;
+  debounceMs: number;
+}
 
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
@@ -18,7 +26,7 @@ export interface OpenedMcp extends McpToolHandle {
 }
 
 export interface ConversationHandlerDeps {
-  config: SidecarConfig;
+  config: HandlerConfig;
   rest: MuninRestClient;
   prompts: PromptResolver;
   openMcp: (opts: { delegatedToken: string }) => Promise<OpenedMcp>;

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -11,6 +11,33 @@ export {
   type CreatePromptResolverOptions,
   type PromptResolver,
 } from './prompt-resolver.js';
+export {
+  createConversationHandler,
+  type ConversationHandler,
+  type ConversationHandlerDeps,
+  type HandlerConfig,
+  type IncomingMessage,
+  type OpenedMcp,
+} from './conversation-handler.js';
+export {
+  createMuninRestClient,
+  type ConversationDetail,
+  type CreateMuninRestClientOptions,
+  type DelegatedToken,
+  type MuninRestClient,
+} from './munin-rest.js';
+export {
+  openMcpClient,
+  type OpenMcpClientOptions,
+  type OpenedMcpClient,
+} from './mcp-client.js';
+export {
+  createRealtimeClient,
+  type KbDocumentChangedEvent,
+  type MessageReceivedEvent,
+  type RealtimeClient,
+  type RealtimeClientOptions,
+} from './realtime.js';
 export type {
   AgentConfig,
   AgentReply,

--- a/packages/agent-runtime/src/mcp-client.ts
+++ b/packages/agent-runtime/src/mcp-client.ts
@@ -1,6 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import type { McpTool, McpToolHandle, McpToolResult } from '@getmunin/agent-runtime';
+import type { McpTool, McpToolHandle, McpToolResult } from './types.js';
 
 export interface OpenMcpClientOptions {
   baseUrl: string;

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -1,4 +1,4 @@
-import type { ConversationMessage } from '@getmunin/agent-runtime';
+import type { ConversationMessage } from './types.js';
 
 export interface ConversationDetail {
   id: string;

--- a/packages/agent-runtime/src/realtime.ts
+++ b/packages/agent-runtime/src/realtime.ts
@@ -23,7 +23,7 @@ export interface RealtimeClientOptions {
   logger?: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
 }
 
-interface RealtimeClient {
+export interface RealtimeClient {
   start(): void;
   stop(): Promise<void>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,12 +123,6 @@ importers:
       '@getmunin/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
-      ws:
-        specifier: ^8.18.0
-        version: 8.20.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -142,9 +136,6 @@ importers:
       '@types/node':
         specifier: ^22.7.0
         version: 22.19.17
-      '@types/ws':
-        specifier: ^8.5.13
-        version: 8.18.1
       eslint:
         specifier: ^9.10.0
         version: 9.39.4(jiti@1.21.7)
@@ -266,6 +257,12 @@ importers:
 
   packages/agent-runtime:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+      ws:
+        specifier: ^8.18.0
+        version: 8.20.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -279,6 +276,9 @@ importers:
       '@types/node':
         specifier: ^22.7.0
         version: 22.19.17
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
       eslint:
         specifier: ^9.10.0
         version: 9.39.4(jiti@1.21.7)


### PR DESCRIPTION
## Summary

Move the OSS sidecar's four shared runtime helpers — \`createConversationHandler\`, \`createMuninRestClient\`, \`createRealtimeClient\`, \`openMcpClient\` — into \`@getmunin/agent-runtime\` so the cloud multi-tenant runner (which currently keeps its own near-identical copies) consumes the package instead of maintaining a parallel ~600 lines.

- The handler's config type tightens from \`SidecarConfig\` (full env-loaded shape) to a minimal \`HandlerConfig\` — just the 6 fields the inference loop actually uses (provider URL/key, model, max tool iterations, max history chars, debounce ms). Existing deployment-specific config types still satisfy it structurally.
- \`@modelcontextprotocol/sdk\` and \`ws\` move into the package's dependencies. The OSS sidecar drops them from its own package.json since they come transitively now.
- \`conversation-handler.test.ts\` moves with the handler (9 tests, all pass against the new \`HandlerConfig\`).
- New exports: \`createConversationHandler\`, \`createMuninRestClient\`, \`createRealtimeClient\`, \`openMcpClient\`, plus their type companions.

Once this merges + publishes, a tiny munin-cloud PR will delete cloud's local copies of the four files.

## Test plan

- [x] \`pnpm --filter @getmunin/agent-runtime typecheck && lint && test\` — 26/26 pass.
- [x] \`pnpm --filter @getmunin/self-service-ai typecheck && lint && test\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)