### PR TITLE
fix(auth): route mn_dlg_* tokens to resolveBearerToken, not resolveApiKey

### DIFF
--- a/.changeset/fix-auth-guard-delegated-token-routing.md
+++ b/.changeset/fix-auth-guard-delegated-token-routing.md
@@ -1,0 +1,18 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Fix the AuthGuard and RealtimeGateway routing delegated end-user tokens
+(`mn_dlg_*`) to `resolveApiKey` because they match the generic
+`mn_<kind>_*` shape. `resolveApiKey` only queries the `api_keys` table,
+so delegated tokens never resolved and every protected endpoint
+(including `/mcp` and `/api/realtime`) returned 401 when called with a
+freshly minted delegated token.
+
+Tokens with the `mn_dlg_` prefix now route to `resolveBearerToken`
+directly, which queries the `tokens` table where they actually live.
+
+The integration test fixtures were using bare 32-byte random tokens
+(no `mn_dlg_` prefix) for delegated-token cases, which masked the bug.
+Updated those fixtures to use `buildApiKey('dlg')` so they exercise the
+real prefix routing path.

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -66,7 +66,9 @@ export class AuthGuard implements CanActivate {
 
     if (value && value.toLowerCase().startsWith('bearer ')) {
       const raw = value.slice('Bearer '.length).trim();
-      if (looksLikeApiKey(raw)) {
+      if (raw.startsWith('mn_dlg_')) {
+        credential = await this.resolver.resolveBearerToken(raw);
+      } else if (looksLikeApiKey(raw)) {
         credential = await this.resolver.resolveApiKey(raw);
         if (!credential) {
           for (const extra of this.additionalResolvers) {

--- a/packages/backend-core/src/control/conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/conversations.controller.integration.test.ts
@@ -5,7 +5,7 @@ import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { buildApiKey, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.js';
@@ -87,7 +87,7 @@ const skipReason = TEST_URL
       .insert(schema.endUsers)
       .values({ orgId: orgAId, externalId: 'eu-1', name: 'Caller' })
       .returning();
-    endUserToken = randomToken(32);
+    endUserToken = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId: orgAId,
       type: 'delegated_end_user',

--- a/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { NestFactory } from '@nestjs/core';
 import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
-import { buildApiKey, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.js';
@@ -62,7 +62,7 @@ const skipReason = TEST_URL
       .values({ orgId, externalId: 'eu-bob', name: 'Bob' })
       .returning();
 
-    aliceToken = randomToken(32);
+    aliceToken = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',
@@ -72,7 +72,7 @@ const skipReason = TEST_URL
       endUserId: alice!.id,
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
     });
-    bobToken = randomToken(32);
+    bobToken = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -5,7 +5,7 @@ import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { buildApiKey, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.js';
@@ -60,7 +60,7 @@ const skipReason = TEST_URL
       .insert(schema.endUsers)
       .values({ orgId, externalId: 'eu-1', name: 'EU One' })
       .returning();
-    endUserToken = randomToken(32);
+    endUserToken = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',
@@ -348,7 +348,7 @@ const skipReason = TEST_URL
   }, 30_000);
 
   it('expired bearer token is rejected at connect (401)', async () => {
-    const expired = randomToken(32);
+    const expired = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',
@@ -366,7 +366,7 @@ const skipReason = TEST_URL
   }, 30_000);
 
   it('revoked bearer token is rejected at connect (401)', async () => {
-    const revoked = randomToken(32);
+    const revoked = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',

--- a/packages/backend-core/src/modules/cms/cms.integration.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.integration.test.ts
@@ -4,7 +4,7 @@ import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { buildApiKey, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { mkdtemp, rm } from 'node:fs/promises';
@@ -71,7 +71,7 @@ const skipReason = TEST_URL
       .insert(schema.endUsers)
       .values({ orgId, externalId: 'eu-1', name: 'Alice' })
       .returning();
-    endUserToken = randomToken(32);
+    endUserToken = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',

--- a/packages/backend-core/src/modules/conv/conv.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.integration.test.ts
@@ -5,7 +5,7 @@ import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { buildApiKey, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.js';
@@ -64,7 +64,7 @@ const skipReason = TEST_URL
       .values({ orgId, externalId: 'eu-2', name: 'Bob' })
       .returning();
 
-    endUserToken = randomToken(32);
+    endUserToken = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',
@@ -74,7 +74,7 @@ const skipReason = TEST_URL
       endUserId: eu1!.id,
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
     });
-    otherEndUserToken = randomToken(32);
+    otherEndUserToken = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',

--- a/packages/backend-core/src/modules/crm/crm.integration.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.integration.test.ts
@@ -5,7 +5,7 @@ import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { buildApiKey, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.js';
@@ -63,7 +63,7 @@ const skipReason = TEST_URL
       .returning();
     endUserId = eu!.id;
 
-    endUserToken = randomToken(32);
+    endUserToken = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',
@@ -80,7 +80,7 @@ const skipReason = TEST_URL
       .insert(schema.endUsers)
       .values({ orgId, externalId: 'eu-2', name: 'Bob', email: 'bob@example.com' })
       .returning();
-    otherEndUserToken = randomToken(32);
+    otherEndUserToken = buildApiKey('dlg');
     await db.insert(schema.tokens).values({
       orgId,
       type: 'delegated_end_user',

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -190,6 +190,9 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   }
 
   private async resolveToken(raw: string): Promise<ResolvedCredential | null> {
+    if (raw.startsWith('mn_dlg_')) {
+      return this.resolver.resolveBearerToken(raw);
+    }
     if (looksLikeApiKey(raw)) {
       let credential = await this.resolver.resolveApiKey(raw);
       if (!credential) {


### PR DESCRIPTION
## The bug

\`AuthGuard\` and \`RealtimeGateway\` both routed delegated end-user tokens (\`mn_dlg_*\`) to \`resolveApiKey\` because they match the generic \`mn_<kind>_*\` shape \`looksLikeApiKey()\` recognizes. \`resolveApiKey\` only queries the \`api_keys\` table — but delegated tokens live in the \`tokens\` table and need \`resolveBearerToken\`.

So every protected endpoint returned **401** when called with a freshly minted delegated token: \`/mcp\`, \`/api/realtime\`, \`/api/end-user/*\`, etc.

Concretely, this blocked the self-service-ai sidecar's per-conversation MCP flow end-to-end (mint delegated token → open MCP client → 401). Any non-Munin consumer doing the same dance via \`/api/delegated-token\` had the same problem.

## How it slipped through CI

The integration test fixtures (mcp / crm / conv / cms / conversations.controller / end-user-conversations.controller) all used bare \`randomToken(32)\` strings to seed \`tokens\` rows. Without the \`mn_dlg_\` prefix those don't match \`looksLikeApiKey\` and fall through to \`resolveBearerToken\` directly — masking the routing bug. Production uses \`buildApiKey('dlg')\` (which **does** have the prefix), so prod 401'd while CI stayed green.

## The fix

Detect the \`mn_dlg_\` prefix explicitly **before** the \`looksLikeApiKey\` branch in both \`AuthGuard\` and \`RealtimeGateway\`, and route directly to \`resolveBearerToken\`. Updated all integration test fixtures to use \`buildApiKey('dlg')\` so the real prefix path is exercised.

## Test plan

- [x] \`pnpm --filter @getmunin/backend-core typecheck && lint && build\` — clean.
- [x] \`pnpm --filter @getmunin/backend build\` — clean.
- [x] Manual: minted a delegated token via \`POST /api/delegated-token\`, used it against \`/mcp\` → \`200 initialize\` (was \`401\` before the fix). The self-service-ai sidecar's full reply loop now completes (LLM call + tool call + agent message posted).
- [ ] CI integration tests pass against the updated fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)