### PR TITLE
feat(dashboard): "Needs attention" backlog card + overview aggregator

### DIFF
--- a/.changeset/dashboard-backlog-card.md
+++ b/.changeset/dashboard-backlog-card.md
@@ -1,0 +1,23 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Add a "Needs attention" backlog card to the dashboard overview, plus a
+small `/api/overview/backlog` aggregator that returns counts of items
+across modules waiting on human or admin-agent attention.
+
+The card is a *signal*, not a CRUD surface — it tells the operator
+what to attend to (open conversations needing handover, KB curation
+candidates pending review) but the actual work still happens through
+the connected admin agent. This keeps the dashboard on-thesis ("the
+agent is the UI") while still giving operators a single place to see
+the backlog grow and shrink.
+
+Today the card surfaces:
+- conversations with `needsHumanAttention = true`
+- KB documents in the `kb-curation-inbox` space tagged `candidate`
+
+Future modules (CRM dirty-data, CMS stale-content, …) can extend the
+endpoint shape without controller refactoring — it returns a flat
+`{ key: count }` object.

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -91,6 +91,14 @@
         "cta": "Manage API keys"
       }
     },
+    "needsAttention": {
+      "title": "Needs attention",
+      "allClear": "All caught up.",
+      "conversationsLabel": "conversations needing handover",
+      "openConversations": "Open conversations →",
+      "kbCurationLabel": "KB curation candidates pending review",
+      "kbCurationHint": "Open your connected admin agent and ask it to do a curation pass — it'll use skill://kb/curation."
+    },
     "agents": {
       "title": "Connected agents",
       "subtitle": "Every OAuth-authorized agent and end-user token issued for this org. Revoke any active token to immediately invalidate further MCP calls.",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -91,6 +91,14 @@
         "cta": "Administrer API-nøkler"
       }
     },
+    "needsAttention": {
+      "title": "Trenger oppmerksomhet",
+      "allClear": "Alt er ajour.",
+      "conversationsLabel": "samtaler som venter på overlevering",
+      "openConversations": "Åpne samtaler →",
+      "kbCurationLabel": "kunnskapsbase-kandidater venter på gjennomgang",
+      "kbCurationHint": "Åpne admin-agenten din og be den gjøre en kurateringsrunde – den bruker skill://kb/curation."
+    },
     "agents": {
       "title": "Tilkoblede agenter",
       "subtitle": "Alle OAuth-autoriserte agenter og sluttbruker-tokens utstedt for denne organisasjonen. Tilbakekall et aktivt token for å gjøre videre MCP-kall ugyldige umiddelbart.",

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -21,6 +21,7 @@ import { MembershipsController } from './memberships.controller.js';
 import { ConversationsController } from './conversations.controller.js';
 import { ActivityController } from './activity.controller.js';
 import { EndUserConversationsController } from './end-user-conversations.controller.js';
+import { OverviewController } from './overview.controller.js';
 
 /**
  * Control plane: server-to-server REST endpoints used by an org's backend
@@ -51,6 +52,7 @@ import { EndUserConversationsController } from './end-user-conversations.control
     ConversationsController,
     ActivityController,
     EndUserConversationsController,
+    OverviewController,
   ],
   providers: [InvitationsService],
 })

--- a/packages/backend-core/src/control/overview.controller.integration.test.ts
+++ b/packages/backend-core/src/control/overview.controller.integration.test.ts
@@ -1,0 +1,178 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { AppModule } from '../app.module.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run overview integration tests.';
+
+(skipReason ? describe.skip : describe)('Overview backlog controller', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgAId: string;
+  let orgBId: string;
+  let adminKeyA: string;
+  let adminKeyB: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod-it-must-be-32-chars';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const ts = Date.now();
+    const [orgA] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Overview Org A', slug: `ov-a-${ts}` })
+      .returning();
+    orgAId = orgA!.id;
+    const [orgB] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Overview Org B', slug: `ov-b-${ts}` })
+      .returning();
+    orgBId = orgB!.id;
+
+    adminKeyA = buildApiKey('admin');
+    await db.insert(schema.apiKeys).values({
+      orgId: orgAId,
+      type: 'admin',
+      name: 'a',
+      keyHash: hashSecret(adminKeyA),
+      keyPrefix: keyPrefix(adminKeyA),
+      scopes: ['*'],
+    });
+    adminKeyB = buildApiKey('admin');
+    await db.insert(schema.apiKeys).values({
+      orgId: orgBId,
+      type: 'admin',
+      name: 'b',
+      keyHash: hashSecret(adminKeyB),
+      keyPrefix: keyPrefix(adminKeyB),
+      scopes: ['*'],
+    });
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id IN (${orgAId}, ${orgBId})`);
+    }
+  });
+
+  async function getBacklog(adminKey: string): Promise<{
+    conversationsNeedingAttention: number;
+    kbCurationPending: number;
+  }> {
+    const res = await fetch(`${baseUrl}/api/overview/backlog`, {
+      headers: { authorization: `Bearer ${adminKey}` },
+    });
+    expect(res.ok).toBe(true);
+    return (await res.json()) as {
+      conversationsNeedingAttention: number;
+      kbCurationPending: number;
+    };
+  }
+
+  async function withClient<T>(token: string, fn: (c: Client) => Promise<T>): Promise<T> {
+    const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+      requestInit: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const c = new Client({ name: 'overview-it', version: '0.0.0' });
+    await c.connect(transport);
+    try {
+      return await fn(c);
+    } finally {
+      await transport.close();
+      await c.close();
+    }
+  }
+
+  it('returns zeros for an empty org', async () => {
+    const backlog = await getBacklog(adminKeyA);
+    expect(backlog).toEqual({
+      conversationsNeedingAttention: 0,
+      kbCurationPending: 0,
+    });
+  });
+
+  it('counts conversations needing attention scoped to caller org', async () => {
+    // Seed channels + conversations directly (service-role).
+    const [chanA] = await db
+      .insert(schema.convChannels)
+      .values({ orgId: orgAId, type: 'chat', name: 'A chat', config: {} })
+      .returning();
+    await db.insert(schema.convConversations).values({
+      orgId: orgAId,
+      channelId: chanA!.id,
+      displayId: 1,
+      status: 'open',
+      needsHumanAttention: true,
+      needsHumanAttentionAt: new Date(),
+    });
+    await db.insert(schema.convConversations).values({
+      orgId: orgAId,
+      channelId: chanA!.id,
+      displayId: 2,
+      status: 'open',
+      needsHumanAttention: false,
+    });
+
+    const a = await getBacklog(adminKeyA);
+    expect(a.conversationsNeedingAttention).toBe(1);
+
+    // org B sees zero — RLS isolation.
+    const b = await getBacklog(adminKeyB);
+    expect(b.conversationsNeedingAttention).toBe(0);
+  });
+
+  it('counts pending KB curation candidates scoped to caller org', async () => {
+    await withClient(adminKeyA, async (c) => {
+      await c.callTool({
+        name: 'kb_propose_curation_candidate',
+        arguments: { subject: 'Refunds', draftBody: 'Refunds within 14 days.' },
+      });
+      await c.callTool({
+        name: 'kb_propose_curation_candidate',
+        arguments: { subject: 'Hours', draftBody: '10–18 weekdays.' },
+      });
+    });
+    await withClient(adminKeyB, async (c) => {
+      await c.callTool({
+        name: 'kb_propose_curation_candidate',
+        arguments: { subject: 'Other org thing', draftBody: 'private to B' },
+      });
+    });
+
+    const a = await getBacklog(adminKeyA);
+    expect(a.kbCurationPending).toBe(2);
+
+    const b = await getBacklog(adminKeyB);
+    expect(b.kbCurationPending).toBe(1);
+  });
+});

--- a/packages/backend-core/src/control/overview.controller.ts
+++ b/packages/backend-core/src/control/overview.controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, UseGuards, UseInterceptors } from '@nestjs/common';
+import { schema } from '@getmunin/db';
+import { and, eq, sql } from 'drizzle-orm';
+import { getCurrentContext } from '@getmunin/core';
+import { AuthGuard } from '../common/auth/auth.guard.js';
+import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.js';
+import { AuditInterceptor } from '../common/audit/audit.interceptor.js';
+import { CURATION_INBOX_SLUG } from '../modules/kb/kb.service.js';
+
+export interface OverviewBacklog {
+  conversationsNeedingAttention: number;
+  kbCurationPending: number;
+}
+
+@Controller('api/overview')
+@UseGuards(AuthGuard)
+@UseInterceptors(TenancyInterceptor, AuditInterceptor)
+export class OverviewController {
+  @Get('backlog')
+  async backlog(): Promise<OverviewBacklog> {
+    const ctx = getCurrentContext();
+    const [convCountRow] = await ctx.db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(schema.convConversations)
+      .where(eq(schema.convConversations.needsHumanAttention, true));
+
+    const [kbCountRow] = await ctx.db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(schema.kbDocuments)
+      .innerJoin(schema.kbSpaces, eq(schema.kbSpaces.id, schema.kbDocuments.spaceId))
+      .where(
+        and(
+          eq(schema.kbSpaces.slug, CURATION_INBOX_SLUG),
+          sql`${schema.kbDocuments.tags} @> ${JSON.stringify(['candidate'])}::jsonb`,
+        ),
+      );
+
+    return {
+      conversationsNeedingAttention: convCountRow?.n ?? 0,
+      kbCurationPending: kbCountRow?.n ?? 0,
+    };
+  }
+}

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -1,5 +1,8 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Bot, Code2, KeyRound } from 'lucide-react';
+import { AlertCircle, Bot, CheckCircle2, Code2, KeyRound } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@getmunin/ui';
 import {
@@ -9,15 +12,88 @@ import {
   CardHeader,
   CardTitle,
 } from '@getmunin/ui';
+import { api } from '../api';
+
+interface BacklogDto {
+  conversationsNeedingAttention: number;
+  kbCurationPending: number;
+}
 
 export function DashboardPage() {
   const t = useTranslations('dashboard.overview');
+  const tBacklog = useTranslations('dashboard.needsAttention');
+
+  const [backlog, setBacklog] = useState<BacklogDto | null>(null);
+
+  useEffect(() => {
+    void api<BacklogDto>('/api/overview/backlog')
+      .then(setBacklog)
+      .catch(() => setBacklog(null));
+  }, []);
+
+  const allClear =
+    backlog !== null &&
+    backlog.conversationsNeedingAttention === 0 &&
+    backlog.kbCurationPending === 0;
+
   return (
     <>
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
         <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </div>
+
+      {backlog !== null && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              {allClear ? (
+                <CheckCircle2 className="size-5 text-muted-foreground" />
+              ) : (
+                <AlertCircle className="size-5 text-amber-600 dark:text-amber-400" />
+              )}
+              <CardTitle>{tBacklog('title')}</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            {allClear ? (
+              <p className="text-muted-foreground">{tBacklog('allClear')}</p>
+            ) : (
+              <ul className="space-y-2">
+                {backlog.conversationsNeedingAttention > 0 && (
+                  <li className="flex items-center justify-between gap-3">
+                    <span>
+                      <strong className="font-medium">
+                        {backlog.conversationsNeedingAttention}
+                      </strong>{' '}
+                      {tBacklog('conversationsLabel')}
+                    </span>
+                    <Link
+                      href="/dashboard/conversations"
+                      className="text-xs text-muted-foreground hover:underline"
+                    >
+                      {tBacklog('openConversations')}
+                    </Link>
+                  </li>
+                )}
+                {backlog.kbCurationPending > 0 && (
+                  <li>
+                    <div className="flex items-center justify-between gap-3">
+                      <span>
+                        <strong className="font-medium">{backlog.kbCurationPending}</strong>{' '}
+                        {tBacklog('kbCurationLabel')}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {tBacklog('kbCurationHint')}
+                    </p>
+                  </li>
+                )}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       <div className="grid gap-4 md:grid-cols-2">
         <Card>


### PR DESCRIPTION
## Summary

Add a "Needs attention" backlog card to the dashboard overview, plus a small \`GET /api/overview/backlog\` aggregator that returns counts of items across modules waiting on human/admin-agent attention.

Stacked on [#44](https://github.com/getmunin/munin/pull/44) (which adds the curation primitives the card counts against). Once #44 merges, this PR's base will move to \`main\` automatically.

The card surfaces, today:
- Open conversations with \`needsHumanAttention = true\` (with a link to the conversations page).
- KB curation candidates in the \`kb-curation-inbox\` space tagged \`candidate\` (no link target — the helper text points the operator at their connected admin agent + \`skill://kb/curation\`).

If both counts are zero, a quiet "All caught up" state replaces the list.

## Why this is on-thesis

The card is a **signal**, not a CRUD surface. No KB browser, no candidate editor, no conversation editor — those would force matching UIs in CRM/CMS and break the "agent is the UI" thesis. The dashboard tells the operator what's piling up; the work happens through their connected admin agent.

The endpoint returns a flat \`{ key: count }\` shape so future modules (CRM dirty-data backlog, CMS stale-content review, …) can extend it without a controller refactor.

## Test plan

- [x] \`pnpm --filter @getmunin/backend-core typecheck && lint && build\` — clean.
- [x] \`TEST_DATABASE_URL=… pnpm --filter @getmunin/backend-core test\` — 263/263 pass, including 3 new cases in \`overview.controller.integration.test.ts\` (empty-org zeros, conversation-count isolated by org, KB-curation-count isolated by org).
- [x] \`pnpm --filter @getmunin/dashboard-pages typecheck && lint\` — clean.
- [x] \`pnpm --filter @getmunin/web typecheck && lint\` — clean.
- [ ] Manual: dashboard at localhost:3000/dashboard shows the card. Trigger a handover via MCP — count goes up. Reply to the conversation — count goes down. \`kb_propose_curation_candidate\` — KB count goes up. \`kb_publish_curation_candidate\` — KB count goes back down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)