### PR TITLE
feat(agent-runtime): generalize audit to multi-action verdict

### DIFF
--- a/.changeset/agent-runtime-audit-multi-action.md
+++ b/.changeset/agent-runtime-audit-multi-action.md
@@ -1,0 +1,55 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/agent-runtime': minor
+---
+
+Add a post-turn audit pass that reads (last user message, agent reply, tool
+names called this turn, the org's topic catalog) and returns a structured
+list of follow-up actions for the runtime to dispatch. Catches the common
+LLM failure mode where the agent's text says "let me flag this for a
+teammate" but no handover tool was actually called, plus generalizes to
+other automatic moves the runtime should make on the conversation.
+
+Action types supported today:
+
+- `request_handover` — reply implies handover but no handover tool was
+  called. Force-calls `conv_request_handover_in_my_conversation` via the
+  per-conversation delegated MCP.
+- `close_conversation` — end-user clearly said "thanks, that's all".
+  Calls `POST /api/conversations/:id/status` with `status: closed`.
+- `snooze_conversation` — user asked to be followed up later. Same
+  endpoint with `status: snoozed` + `snoozeUntil = now + untilHours`.
+- `mark_spam` — user message is automated / promotional / off-topic.
+  Same endpoint with `status: spam`.
+- `set_topic` — picks one of the org's existing topic slugs. Calls a new
+  endpoint `POST /api/conversations/:id/topic`.
+
+Audit dispatch routes via the existing admin REST client the handler
+already holds (it's how the handler fetches history and posts replies).
+No new MCP factory needed — the runner doesn't have to wire anything up.
+The only new dep on the handler side is three more methods on
+`MuninRestClient` (`changeStatus`, `setTopic`, `listTopics`) which the
+package's `createMuninRestClient` factory implements against the new
+backend endpoints.
+
+OSS backend-core adds:
+
+- New admin tool `conv_set_topic({ conversationId, topicId | null })` for
+  any admin agent (Claude Desktop, the cloud curator) that wants to apply
+  topics from MCP.
+- New REST endpoints `POST /api/conversations/:id/topic` and
+  `GET /api/conversations/topics` (admin) — both wrap existing service
+  methods.
+
+The audit only ever picks topic slugs from the catalog the runtime fetched
+via `rest.listTopics()`; the LLM cannot invent slugs (parser drops
+anything not in the catalog).
+
+Failure mode is fail-open: provider errors or unparseable JSON return
+`{ actions: [] }` so a misbehaving audit cannot silence real replies.
+
+New `@getmunin/agent-runtime` exports: `auditConversation`, types
+`AuditAction`, `AuditConversationArgs`, `AuditTopic`, `AuditVerdict`,
+`ConversationStatus`, `ConversationTopic`. New `HandlerConfig` fields:
+`auditEnabled?: boolean` (default true), `auditModel?: string`. New
+`AgentConfig` field: `responseFormat?: 'json_object'`.

--- a/packages/agent-runtime/src/audit.test.ts
+++ b/packages/agent-runtime/src/audit.test.ts
@@ -1,55 +1,214 @@
 import { describe, expect, it } from 'vitest';
-import { auditReply } from './audit.js';
+import { auditConversation } from './audit.js';
 import { createStubProvider } from './providers/stub.js';
 
-describe('auditReply', () => {
-  it('returns handover=true when the model says deferral is implied', async () => {
+describe('auditConversation', () => {
+  it('returns a request_handover action when the model says deferral is implied', async () => {
     const stub = createStubProvider({
       responses: [
         {
           message: {
             role: 'assistant',
-            content: '{"handover": true, "reason": "agent told the user a teammate would follow up"}',
+            content: '{"actions":[{"type":"request_handover","reason":"agent told user a teammate would follow up"}]}',
           },
           finishReason: 'stop',
           usage: {},
         },
       ],
     });
-    const verdict = await auditReply({
+    const verdict = await auditConversation({
       provider: { baseUrl: 'http://stub', apiKey: 'k' },
-      model: 'audit-model',
+      model: 'audit',
       question: 'When are you open Saturday?',
-      reply: 'Let me flag this for a teammate who can answer.',
+      reply: 'Let me flag this for a teammate.',
       toolNames: ['kb_search'],
       providerImpl: stub.provider,
     });
-    expect(verdict.handover).toBe(true);
-    expect(verdict.reason).toContain('teammate');
+    expect(verdict.actions).toEqual([
+      { type: 'request_handover', reason: 'agent told user a teammate would follow up' },
+    ]);
   });
 
-  it('returns handover=false when the reply is a real answer', async () => {
+  it('returns close_conversation for explicit goodbyes', async () => {
     const stub = createStubProvider({
       responses: [
         {
           message: {
             role: 'assistant',
-            content: '{"handover": false, "reason": "complete answer drawn from kb"}',
+            content: '{"actions":[{"type":"close_conversation","reason":"user said thanks that is all"}]}',
           },
           finishReason: 'stop',
           usage: {},
         },
       ],
     });
-    const verdict = await auditReply({
+    const verdict = await auditConversation({
       provider: { baseUrl: 'http://stub', apiKey: 'k' },
-      model: 'audit-model',
-      question: 'When are you open Saturday?',
-      reply: 'We are open 10–16 on Saturdays.',
-      toolNames: ['kb_search'],
+      model: 'audit',
+      question: "Thanks, that's all I needed!",
+      reply: "Glad I could help.",
+      toolNames: [],
       providerImpl: stub.provider,
     });
-    expect(verdict.handover).toBe(false);
+    expect(verdict.actions).toEqual([
+      { type: 'close_conversation', reason: 'user said thanks that is all' },
+    ]);
+  });
+
+  it('returns snooze_conversation with untilHours', async () => {
+    const stub = createStubProvider({
+      responses: [
+        {
+          message: {
+            role: 'assistant',
+            content: '{"actions":[{"type":"snooze_conversation","untilHours":24,"reason":"user will check tomorrow"}]}',
+          },
+          finishReason: 'stop',
+          usage: {},
+        },
+      ],
+    });
+    const verdict = await auditConversation({
+      provider: { baseUrl: 'http://stub', apiKey: 'k' },
+      model: 'audit',
+      question: "I'll check back tomorrow once I have the invoice number.",
+      reply: 'Sure, take your time.',
+      toolNames: [],
+      providerImpl: stub.provider,
+    });
+    expect(verdict.actions).toEqual([
+      { type: 'snooze_conversation', untilHours: 24, reason: 'user will check tomorrow' },
+    ]);
+  });
+
+  it('drops snooze_conversation if untilHours is missing or non-positive', async () => {
+    const stub = createStubProvider({
+      responses: [
+        {
+          message: {
+            role: 'assistant',
+            content: '{"actions":[{"type":"snooze_conversation","reason":"forgot the hours"},{"type":"snooze_conversation","untilHours":-1,"reason":"bad"}]}',
+          },
+          finishReason: 'stop',
+          usage: {},
+        },
+      ],
+    });
+    const verdict = await auditConversation({
+      provider: { baseUrl: 'http://stub', apiKey: 'k' },
+      model: 'audit',
+      question: 'q',
+      reply: 'r',
+      toolNames: [],
+      providerImpl: stub.provider,
+    });
+    expect(verdict.actions).toEqual([]);
+  });
+
+  it('returns mark_spam', async () => {
+    const stub = createStubProvider({
+      responses: [
+        {
+          message: {
+            role: 'assistant',
+            content: '{"actions":[{"type":"mark_spam","reason":"automated promotional message"}]}',
+          },
+          finishReason: 'stop',
+          usage: {},
+        },
+      ],
+    });
+    const verdict = await auditConversation({
+      provider: { baseUrl: 'http://stub', apiKey: 'k' },
+      model: 'audit',
+      question: 'BUY CRYPTO NOW visit example.example',
+      reply: "I can't help with that.",
+      toolNames: [],
+      providerImpl: stub.provider,
+    });
+    expect(verdict.actions).toEqual([{ type: 'mark_spam', reason: 'automated promotional message' }]);
+  });
+
+  it('accepts set_topic when slug is in the catalog', async () => {
+    const stub = createStubProvider({
+      responses: [
+        {
+          message: {
+            role: 'assistant',
+            content: '{"actions":[{"type":"set_topic","topicSlug":"billing","reason":"question is about an invoice"}]}',
+          },
+          finishReason: 'stop',
+          usage: {},
+        },
+      ],
+    });
+    const verdict = await auditConversation({
+      provider: { baseUrl: 'http://stub', apiKey: 'k' },
+      model: 'audit',
+      question: 'I have a question about my invoice.',
+      reply: '…',
+      toolNames: [],
+      topicCatalog: [
+        { slug: 'billing', name: 'Billing' },
+        { slug: 'support', name: 'Support' },
+      ],
+      providerImpl: stub.provider,
+    });
+    expect(verdict.actions).toEqual([
+      { type: 'set_topic', topicSlug: 'billing', reason: 'question is about an invoice' },
+    ]);
+  });
+
+  it('drops set_topic when slug is not in the catalog', async () => {
+    const stub = createStubProvider({
+      responses: [
+        {
+          message: {
+            role: 'assistant',
+            content: '{"actions":[{"type":"set_topic","topicSlug":"made-up-slug","reason":"hallucinated"}]}',
+          },
+          finishReason: 'stop',
+          usage: {},
+        },
+      ],
+    });
+    const verdict = await auditConversation({
+      provider: { baseUrl: 'http://stub', apiKey: 'k' },
+      model: 'audit',
+      question: 'q',
+      reply: 'r',
+      toolNames: [],
+      topicCatalog: [{ slug: 'billing', name: 'Billing' }],
+      providerImpl: stub.provider,
+    });
+    expect(verdict.actions).toEqual([]);
+  });
+
+  it('returns multiple actions in a single verdict', async () => {
+    const stub = createStubProvider({
+      responses: [
+        {
+          message: {
+            role: 'assistant',
+            content: '{"actions":[{"type":"set_topic","topicSlug":"billing","reason":"invoice question"},{"type":"close_conversation","reason":"user thanked us"}]}',
+          },
+          finishReason: 'stop',
+          usage: {},
+        },
+      ],
+    });
+    const verdict = await auditConversation({
+      provider: { baseUrl: 'http://stub', apiKey: 'k' },
+      model: 'audit',
+      question: 'q',
+      reply: 'r',
+      toolNames: [],
+      topicCatalog: [{ slug: 'billing', name: 'Billing' }],
+      providerImpl: stub.provider,
+    });
+    expect(verdict.actions).toHaveLength(2);
+    expect(verdict.actions[0]?.type).toBe('set_topic');
+    expect(verdict.actions[1]?.type).toBe('close_conversation');
   });
 
   it('extracts JSON from prose that wraps it', async () => {
@@ -58,36 +217,34 @@ describe('auditReply', () => {
         {
           message: {
             role: 'assistant',
-            content:
-              'Sure — here is my judgment:\n\n{"handover": true, "reason": "deferred to staff"}\n\nHope that helps.',
+            content: 'Here is my judgment:\n\n{"actions":[{"type":"request_handover","reason":"deferred"}]}\n\nDone.',
           },
           finishReason: 'stop',
           usage: {},
         },
       ],
     });
-    const verdict = await auditReply({
+    const verdict = await auditConversation({
       provider: { baseUrl: 'http://stub', apiKey: 'k' },
-      model: 'audit-model',
+      model: 'audit',
       question: 'q',
       reply: 'r',
       toolNames: [],
       providerImpl: stub.provider,
     });
-    expect(verdict.handover).toBe(true);
-    expect(verdict.reason).toBe('deferred to staff');
+    expect(verdict.actions).toEqual([{ type: 'request_handover', reason: 'deferred' }]);
   });
 
   it('fails open when the provider errors', async () => {
-    const verdict = await auditReply({
+    const verdict = await auditConversation({
       provider: { baseUrl: 'http://stub', apiKey: 'k' },
-      model: 'audit-model',
+      model: 'audit',
       question: 'q',
       reply: 'r',
       toolNames: [],
       providerImpl: () => Promise.reject(new Error('upstream broken')),
     });
-    expect(verdict).toEqual({ handover: false, reason: '' });
+    expect(verdict).toEqual({ actions: [] });
   });
 
   it('fails open when the model returns unparseable text', async () => {
@@ -100,14 +257,14 @@ describe('auditReply', () => {
         },
       ],
     });
-    const verdict = await auditReply({
+    const verdict = await auditConversation({
       provider: { baseUrl: 'http://stub', apiKey: 'k' },
-      model: 'audit-model',
+      model: 'audit',
       question: 'q',
       reply: 'r',
       toolNames: [],
       providerImpl: stub.provider,
     });
-    expect(verdict).toEqual({ handover: false, reason: '' });
+    expect(verdict).toEqual({ actions: [] });
   });
 });

--- a/packages/agent-runtime/src/audit.ts
+++ b/packages/agent-runtime/src/audit.ts
@@ -1,44 +1,82 @@
 import { openAiCompatibleProvider } from './providers/openai-compatible.js';
 import type { ChatMessage, Provider, ProviderConfig } from './types.js';
 
-export interface AuditReplyArgs {
+export type AuditAction =
+  | { type: 'request_handover'; reason: string }
+  | { type: 'close_conversation'; reason: string }
+  | { type: 'snooze_conversation'; untilHours: number; reason: string }
+  | { type: 'mark_spam'; reason: string }
+  | { type: 'set_topic'; topicSlug: string; reason: string };
+
+export interface AuditTopic {
+  slug: string;
+  name: string;
+  description?: string;
+}
+
+export interface AuditConversationArgs {
   provider: ProviderConfig;
   model: string;
   question: string;
   reply: string;
   toolNames: string[];
+  topicCatalog?: AuditTopic[];
   providerImpl?: Provider;
   abortSignal?: AbortSignal;
 }
 
 export interface AuditVerdict {
-  handover: boolean;
-  reason: string;
+  actions: AuditAction[];
 }
 
-const SYSTEM_PROMPT = `You audit a self-service AI agent's reply to an end-user. The agent has a tool called \`conv_request_handover_in_my_conversation\` that flags the conversation for human staff review.
+const ACTION_GUIDE = `Possible actions you can recommend (zero or more):
 
-Decide whether the agent's reply IMPLIES it can't fully handle the question and a human teammate should follow up.
+- {"type": "request_handover", "reason": "<why>"}
+  When the agent's reply implies a human teammate should follow up
+  (defers, escalates, says "let me flag this", or admits it can't answer).
+  Use when the reply text and the tools called don't already include a
+  handover.
 
-Counts as handover-needed:
-- The reply tells the user that someone else (a teammate, colleague, human, staff) will follow up, look into it, get back to them.
-- The reply defers, escalates, punts, or admits "I don't have that information" without giving a useful answer.
-- The reply asks the user to wait while a person takes over.
+- {"type": "close_conversation", "reason": "<why>"}
+  When the end-user clearly signals the conversation is done — "thanks,
+  that's all", "perfect, problem solved", explicit goodbye. Don't use
+  for ambiguous replies.
 
-Does NOT count as handover-needed:
-- A complete answer (even brief) drawn from the knowledge base or tools.
-- A clarifying question to narrow down what the user is asking.
-- A polite refusal grounded in a stated policy ("we can't process refunds older than 60 days").
-- An acknowledgement of an action the agent itself performed via tools.
+- {"type": "snooze_conversation", "untilHours": <number>, "reason": "<why>"}
+  When the user asks to be followed up later, or said "I'll get back to
+  you tomorrow" / "next week". Pick a reasonable wait in hours
+  (24 = next day, 168 = next week). Don't use for typical questions
+  with no waiting cue.
 
-Return JSON only, no prose:
-{"handover": true|false, "reason": "<one-sentence justification>"}`;
+- {"type": "mark_spam", "reason": "<why>"}
+  When the user message is clearly automated, promotional, off-topic
+  scraping, or junk. Be conservative — only obvious cases. Real
+  questions in broken English are NOT spam.
 
-export async function auditReply(args: AuditReplyArgs): Promise<AuditVerdict> {
+- {"type": "set_topic", "topicSlug": "<slug>", "reason": "<why>"}
+  Tag the conversation with one of the org's existing topics, when one
+  fits the user's question. Only use slugs from the supplied catalog.
+  If no topic fits, skip this action — do not invent slugs.`;
+
+const SYSTEM_PROMPT_HEAD = `You audit a self-service AI agent's turn in a customer-support conversation. Decide which (if any) follow-up actions the runtime should take. Return JSON only:
+
+{"actions": [...]}
+
+Each entry in \`actions\` is one of the action shapes below. Multiple actions can apply (e.g. "set_topic" + "close_conversation"). If no action is needed, return {"actions": []}.
+
+`;
+
+export async function auditConversation(args: AuditConversationArgs): Promise<AuditVerdict> {
   const provider = args.providerImpl ?? openAiCompatibleProvider;
-  const userPrompt = buildUserPrompt(args.question, args.reply, args.toolNames);
+  const systemPrompt = buildSystemPrompt(args.topicCatalog);
+  const userPrompt = buildUserPrompt(
+    args.question,
+    args.reply,
+    args.toolNames,
+    args.topicCatalog,
+  );
   const messages: ChatMessage[] = [
-    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'system', content: systemPrompt },
     { role: 'user', content: userPrompt },
   ];
 
@@ -48,7 +86,7 @@ export async function auditReply(args: AuditReplyArgs): Promise<AuditVerdict> {
       config: {
         provider: args.provider,
         model: args.model,
-        systemPrompt: SYSTEM_PROMPT,
+        systemPrompt,
         responseFormat: 'json_object',
       },
       messages,
@@ -56,25 +94,45 @@ export async function auditReply(args: AuditReplyArgs): Promise<AuditVerdict> {
       abortSignal: args.abortSignal,
     });
   } catch {
-    return { handover: false, reason: '' };
+    return { actions: [] };
   }
 
-  const raw = response.message.content ?? '';
-  return parseVerdict(raw);
+  return parseVerdict(response.message.content ?? '', args.topicCatalog);
 }
 
-function buildUserPrompt(question: string, reply: string, toolNames: string[]): string {
-  const tools = toolNames.length > 0 ? toolNames.join(', ') : '(none)';
-  return [
-    `[End-user question]`,
+function buildSystemPrompt(topicCatalog: AuditTopic[] | undefined): string {
+  const parts = [SYSTEM_PROMPT_HEAD, ACTION_GUIDE];
+  if (!topicCatalog || topicCatalog.length === 0) {
+    parts.push(
+      '\nThe org has no topics defined yet — skip the `set_topic` action entirely.',
+    );
+  }
+  return parts.join('\n');
+}
+
+function buildUserPrompt(
+  question: string,
+  reply: string,
+  toolNames: string[],
+  topicCatalog: AuditTopic[] | undefined,
+): string {
+  const lines: string[] = [
+    '[End-user question]',
     truncate(question, 4000),
-    ``,
-    `[Agent reply]`,
+    '',
+    '[Agent reply]',
     truncate(reply, 4000),
-    ``,
-    `[Tools the agent already called this turn]`,
-    tools,
-  ].join('\n');
+    '',
+    '[Tools the agent already called this turn]',
+    toolNames.length > 0 ? toolNames.join(', ') : '(none)',
+  ];
+  if (topicCatalog && topicCatalog.length > 0) {
+    lines.push('', '[Available topic slugs (pick at most one if it fits)]');
+    for (const t of topicCatalog) {
+      lines.push(`- ${t.slug}: ${t.name}${t.description ? ` — ${t.description}` : ''}`);
+    }
+  }
+  return lines.join('\n');
 }
 
 function truncate(s: string, max: number): string {
@@ -82,26 +140,55 @@ function truncate(s: string, max: number): string {
   return `${s.slice(0, max)}…`;
 }
 
-function parseVerdict(raw: string): AuditVerdict {
+function parseVerdict(raw: string, topicCatalog: AuditTopic[] | undefined): AuditVerdict {
   const trimmed = raw.trim();
-  if (!trimmed) return { handover: false, reason: '' };
+  if (!trimmed) return { actions: [] };
   const candidates = [trimmed, extractFirstJsonObject(trimmed)].filter(
     (s): s is string => typeof s === 'string',
   );
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(candidate) as Partial<AuditVerdict>;
-      if (typeof parsed.handover === 'boolean') {
-        return {
-          handover: parsed.handover,
-          reason: typeof parsed.reason === 'string' ? parsed.reason : '',
-        };
+      const parsed = JSON.parse(candidate) as { actions?: unknown };
+      if (!Array.isArray(parsed.actions)) continue;
+      const known = new Set(topicCatalog?.map((t) => t.slug) ?? []);
+      const actions: AuditAction[] = [];
+      for (const raw of parsed.actions) {
+        const action = normaliseAction(raw, known);
+        if (action) actions.push(action);
       }
+      return { actions };
     } catch {
       continue;
     }
   }
-  return { handover: false, reason: '' };
+  return { actions: [] };
+}
+
+function normaliseAction(raw: unknown, knownTopicSlugs: Set<string>): AuditAction | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const type = typeof r['type'] === 'string' ? r['type'] : '';
+  const reason = typeof r['reason'] === 'string' ? r['reason'] : '';
+  switch (type) {
+    case 'request_handover':
+      return { type: 'request_handover', reason };
+    case 'close_conversation':
+      return { type: 'close_conversation', reason };
+    case 'snooze_conversation': {
+      const hours = Number(r['untilHours']);
+      if (!Number.isFinite(hours) || hours <= 0) return null;
+      return { type: 'snooze_conversation', untilHours: hours, reason };
+    }
+    case 'mark_spam':
+      return { type: 'mark_spam', reason };
+    case 'set_topic': {
+      const slug = typeof r['topicSlug'] === 'string' ? r['topicSlug'] : '';
+      if (!slug || !knownTopicSlugs.has(slug)) return null;
+      return { type: 'set_topic', topicSlug: slug, reason };
+    }
+    default:
+      return null;
+  }
 }
 
 function extractFirstJsonObject(s: string): string | null {

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -79,6 +79,9 @@ function buildRest(overrides: Partial<MuninRestClient> = {}): MuninRestClient {
       detail.messages
         .filter((m) => !m.internal)
         .map((m) => ({ authorType: m.authorType, body: m.body, createdAt: m.createdAt })),
+    changeStatus: vi.fn(() => Promise.resolve()),
+    setTopic: vi.fn(() => Promise.resolve()),
+    listTopics: vi.fn(() => Promise.resolve([])),
     ...overrides,
   };
 }

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -1,4 +1,4 @@
-import { auditReply } from './audit.js';
+import { auditConversation, type AuditAction, type AuditTopic } from './audit.js';
 import { runAgent } from './runtime.js';
 import type {
   ConversationMessage,
@@ -151,7 +151,7 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
         });
 
         if (reply.body.trim().length > 0) {
-          await maybeForceHandover({
+          await runAuditPass({
             conversationId,
             reply,
             history,
@@ -195,7 +195,7 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     });
   }
 
-  async function maybeForceHandover(args: {
+  async function runAuditPass(args: {
     conversationId: string;
     reply: { body: string; toolCalls: { name: string }[] };
     history: ConversationMessage[];
@@ -203,16 +203,17 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     log: { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void };
   }): Promise<void> {
     if (deps.config.auditEnabled === false) return;
-    if (
-      args.reply.toolCalls.some((t) => t.name === HANDOVER_TOOL_NAME)
-    ) {
-      return;
-    }
     const lastUser = [...args.history].reverse().find(
       (m) => m.authorType === 'user' || m.authorType === 'end_user',
     );
     if (!lastUser) return;
-    const verdict = await auditReply({
+
+    const topics = await deps.rest
+      .listTopics()
+      .catch(() => [] as { id: string; slug: string; name: string }[]);
+    const topicCatalog: AuditTopic[] = topics.map((t) => ({ slug: t.slug, name: t.name }));
+
+    const verdict = await auditConversation({
       provider: {
         baseUrl: deps.config.providerBaseUrl,
         apiKey: deps.config.providerApiKey,
@@ -221,20 +222,65 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
       question: lastUser.body,
       reply: args.reply.body,
       toolNames: args.reply.toolCalls.map((t) => t.name),
+      topicCatalog,
       providerImpl: deps.provider,
     });
-    if (!verdict.handover) return;
-    args.log.warn(
-      `${args.conversationId} audit force-handover (${verdict.reason || 'no reason'})`,
+
+    const agentCalledHandover = args.reply.toolCalls.some(
+      (t) => t.name === HANDOVER_TOOL_NAME,
     );
+    for (const action of verdict.actions) {
+      if (action.type === 'request_handover' && agentCalledHandover) continue;
+      await dispatchAuditAction(args.conversationId, action, args.mcp, topics, args.log);
+    }
+  }
+
+  async function dispatchAuditAction(
+    conversationId: string,
+    action: AuditAction,
+    delegatedMcp: McpToolHandle,
+    topics: { id: string; slug: string }[],
+    log: { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void },
+  ): Promise<void> {
     try {
-      await args.mcp.callTool(HANDOVER_TOOL_NAME, {
-        conversationId: args.conversationId,
-        reason: verdict.reason || 'audit detected deferral without handover call',
-      });
+      switch (action.type) {
+        case 'request_handover':
+          log.warn(`${conversationId} audit → request_handover (${action.reason})`);
+          await delegatedMcp.callTool(HANDOVER_TOOL_NAME, {
+            conversationId,
+            reason: action.reason || 'audit pass',
+          });
+          break;
+        case 'close_conversation':
+          log.info(`${conversationId} audit → close (${action.reason})`);
+          await deps.rest.changeStatus(conversationId, 'closed');
+          break;
+        case 'snooze_conversation': {
+          const until = new Date(Date.now() + action.untilHours * 3600_000).toISOString();
+          log.info(`${conversationId} audit → snooze ${action.untilHours}h (${action.reason})`);
+          await deps.rest.changeStatus(conversationId, 'snoozed', until);
+          break;
+        }
+        case 'mark_spam':
+          log.warn(`${conversationId} audit → mark_spam (${action.reason})`);
+          await deps.rest.changeStatus(conversationId, 'spam');
+          break;
+        case 'set_topic': {
+          const topicId = topics.find((t) => t.slug === action.topicSlug)?.id;
+          if (!topicId) {
+            log.warn(
+              `${conversationId} audit set_topic: no topic with slug ${action.topicSlug}`,
+            );
+            break;
+          }
+          log.info(`${conversationId} audit → set_topic ${action.topicSlug} (${action.reason})`);
+          await deps.rest.setTopic(conversationId, topicId);
+          break;
+        }
+      }
     } catch (err) {
-      args.log.error(
-        `${args.conversationId} audit handover call failed: ${
+      log.error(
+        `${conversationId} audit ${action.type} failed: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -19,10 +19,18 @@ export {
   type IncomingMessage,
   type OpenedMcp,
 } from './conversation-handler.js';
-export { auditReply, type AuditReplyArgs, type AuditVerdict } from './audit.js';
+export {
+  auditConversation,
+  type AuditAction,
+  type AuditConversationArgs,
+  type AuditTopic,
+  type AuditVerdict,
+} from './audit.js';
 export {
   createMuninRestClient,
   type ConversationDetail,
+  type ConversationStatus,
+  type ConversationTopic,
   type CreateMuninRestClientOptions,
   type DelegatedToken,
   type MuninRestClient,

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -21,11 +21,23 @@ export interface DelegatedToken {
   expiresAt: string;
 }
 
+export type ConversationStatus = 'open' | 'snoozed' | 'closed' | 'spam';
+
+export interface ConversationTopic {
+  id: string;
+  slug: string;
+  name: string;
+  color?: string | null;
+}
+
 export interface MuninRestClient {
   getConversation(id: string): Promise<ConversationDetail>;
   postAgentMessage(conversationId: string, body: string): Promise<void>;
   mintDelegatedToken(endUserId: string, ttlSeconds?: number): Promise<DelegatedToken>;
   toRuntimeHistory(detail: ConversationDetail): ConversationMessage[];
+  changeStatus(conversationId: string, status: ConversationStatus, snoozeUntil?: string): Promise<void>;
+  setTopic(conversationId: string, topicId: string | null): Promise<void>;
+  listTopics(): Promise<ConversationTopic[]>;
 }
 
 export interface CreateMuninRestClientOptions {
@@ -83,6 +95,27 @@ export function createMuninRestClient(opts: CreateMuninRestClientOptions): Munin
           body: m.body,
           createdAt: m.createdAt,
         }));
+    },
+    async changeStatus(
+      conversationId: string,
+      status: ConversationStatus,
+      snoozeUntil?: string,
+    ): Promise<void> {
+      const body: Record<string, unknown> = { status };
+      if (snoozeUntil) body.snoozeUntil = snoozeUntil;
+      await call<unknown>(`/api/conversations/${encodeURIComponent(conversationId)}/status`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+    },
+    async setTopic(conversationId: string, topicId: string | null): Promise<void> {
+      await call<unknown>(`/api/conversations/${encodeURIComponent(conversationId)}/topic`, {
+        method: 'POST',
+        body: JSON.stringify({ topicId }),
+      });
+    },
+    async listTopics(): Promise<ConversationTopic[]> {
+      return call<ConversationTopic[]>(`/api/conversations/topics`);
     },
   };
 }

--- a/packages/backend-core/src/control/conversations.controller.ts
+++ b/packages/backend-core/src/control/conversations.controller.ts
@@ -53,6 +53,10 @@ const HandoverBody = z
   })
   .partial();
 
+const TopicBody = z.object({
+  topicId: z.string().nullable(),
+});
+
 const TakeOverBody = z
   .object({
     ttlMinutes: z.number().int().positive().max(240).optional(),
@@ -105,6 +109,11 @@ export class ConversationsController {
       items: page.items,
       nextCursor: page.nextCursor ? encodeListCursor(page.nextCursor) : null,
     };
+  }
+
+  @Get('topics')
+  async listTopics(): Promise<Array<{ id: string; slug: string; name: string; color: string | null }>> {
+    return translate(() => this.conv.listTopics());
   }
 
   @Get(':id')
@@ -186,6 +195,19 @@ export class ConversationsController {
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return translate(() =>
       this.conv.requestHandover({ conversationId: id, reason: parsed.data.reason }),
+    );
+  }
+
+  @Post(':id/topic')
+  @HttpCode(200)
+  async setTopic(
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ): Promise<ConversationSummary> {
+    const parsed = TopicBody.safeParse(body);
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return translate(() =>
+      this.conv.setTopic({ conversationId: id, topicId: parsed.data.topicId }),
     );
   }
 }

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -162,6 +162,38 @@ export class ConvService {
     return toTopicDto(row!);
   }
 
+  async setTopic(input: {
+    conversationId: string;
+    topicId: string | null;
+  }): Promise<ConversationSummary> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    if (input.topicId !== null) {
+      const topicRows = await ctx.db
+        .select({ id: schema.convTopics.id })
+        .from(schema.convTopics)
+        .where(
+          and(
+            eq(schema.convTopics.id, input.topicId),
+            eq(schema.convTopics.orgId, actor.orgId),
+          ),
+        )
+        .limit(1);
+      if (!topicRows[0]) {
+        throw new NotFoundException(`conv_topic_not_found: ${input.topicId}`);
+      }
+    }
+    const [updated] = await ctx.db
+      .update(schema.convConversations)
+      .set({ topicId: input.topicId, updatedAt: new Date() })
+      .where(eq(schema.convConversations.id, input.conversationId))
+      .returning();
+    if (!updated) {
+      throw new NotFoundException(`conv_not_found: conversation ${input.conversationId}`);
+    }
+    return toConversationSummary(updated);
+  }
+
   // ─── Conversations ──────────────────────────────────────────────────────
 
   async listConversations(input: {

--- a/packages/backend-core/src/modules/conv/conv.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.tools.ts
@@ -56,6 +56,11 @@ const CreateTopicInput = z.object({
   color: z.string().max(16).optional(),
 });
 
+const SetTopicInput = z.object({
+  conversationId: z.string(),
+  topicId: z.string().nullable(),
+});
+
 const EmptyInput = z.object({});
 
 @Injectable()
@@ -227,5 +232,20 @@ export class ConvAdminTools {
   })
   createTopic(args: z.infer<typeof CreateTopicInput>) {
     return this.conv.createTopic(args);
+  }
+
+  @McpTool({
+    name: 'conv_set_topic',
+    title: 'Set or clear a conversation topic',
+    description:
+      'Tag a conversation with one of the org\'s existing topics, or pass `topicId: null` to clear the topic. Use `conv_list_topics` first to see what topics exist; topics must be pre-created via `conv_create_topic`.',
+    audiences: ['admin'],
+    scopes: ['conv:write'],
+    input: SetTopicInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  setTopic(args: z.infer<typeof SetTopicInput>) {
+    return this.conv.setTopic(args);
   }
 }


### PR DESCRIPTION
## Summary

Builds on [#49](https://github.com/getmunin/munin/pull/49) (the narrow handover-only audit, already merged). Generalizes the audit-pass machinery so it can recommend more than just handover. The verdict shape is now:

\`\`\`ts
{ actions: AuditAction[] }
\`\`\`

…with five action types:

- \`request_handover\` — reply implies handover but no tool call. Force-calls \`conv_request_handover_in_my_conversation\` via the per-conv delegated MCP.
- \`close_conversation\` — end-user said "thanks, that's all". Calls \`POST /api/conversations/:id/status\` (\`status: closed\`).
- \`snooze_conversation\` — user wants follow-up later. Same endpoint with \`snoozeUntil = now + untilHours\`.
- \`mark_spam\` — message is automated/promotional. Same endpoint with \`status: spam\`.
- \`set_topic\` — picks one of the org's existing topic slugs. Calls a new endpoint \`POST /api/conversations/:id/topic\`.

## Why REST and not a second admin MCP factory

The conversation handler already holds an admin-authed REST client (it fetches history and posts replies). Going through REST is one connection per action vs. opening a fresh admin MCP per audit pass, and the runner doesn't have to wire up another factory. Same trust boundary either way.

\`MuninRestClient\` grows three methods: \`changeStatus\`, \`setTopic\`, \`listTopics\`. The package's \`createMuninRestClient\` factory implements them against the new backend endpoints automatically, so neither the OSS sidecar nor the cloud curator runner need any changes.

## Topic catalog enforcement

\`set_topic\` is constrained to slugs in the org's actual topic catalog (fetched via \`rest.listTopics()\` per audit pass). The parser drops any hallucinated slugs — the LLM cannot invent topics. Topics still have to be admin-curated via \`conv_create_topic\`.

## What's added in OSS backend-core

- \`conv_set_topic({ conversationId, topicId | null })\` admin MCP tool — for admin agents (Claude Desktop, the cloud curator) that want to apply topics from MCP.
- \`POST /api/conversations/:id/topic\` and \`GET /api/conversations/topics\` REST endpoints, both admin-only via the existing AuthGuard chain.
- \`ConvService.setTopic\` — service method validates the topic exists in the caller's org, throws \`NotFoundException\` otherwise.

## Test plan

- [x] \`pnpm --filter @getmunin/agent-runtime typecheck && lint && test\` — 37/37 pass (11 new audit cases — one per action type, plus catalog enforcement, multi-action verdict, prose-wrapped JSON, fail-open paths).
- [x] \`pnpm --filter @getmunin/backend-core typecheck && lint\` — clean.
- [ ] Once published, restart the OSS sidecar and verify a thank-you message triggers \`close_conversation\`, an "I'll check back tomorrow" triggers \`snooze_conversation\`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)