### PR TITLE
feat(crm): merge proposals — table, tools, skill, backlog count

### DIFF
--- a/.changeset/crm-merge-proposals.md
+++ b/.changeset/crm-merge-proposals.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/db': minor
+---
+
+CRM merge proposals: new `crm_merge_proposals` table (migration `0007`) plus four admin MCP tools — `crm_propose_merge_candidate`, `crm_list_merge_proposals`, `crm_apply_merge_proposal`, `crm_dismiss_merge_proposal`. New `skill://crm/hygiene` walks an admin agent through filing structured proposals; `crm_apply_merge_proposal` atomically copies the recommended patch onto the keeper, archives the duplicate (`dedup-archived-YYYY-MM` tag + `customFields.mergedInto` + `doNotContact`), and marks the proposal applied. Pending proposals are unique per `(orgId, contactA, contactB)` pair so re-running the curator is idempotent. `OverviewBacklog` now exposes `crmMergeProposalsPending` for the dashboard backlog card.

--- a/packages/backend-core/src/control/overview.controller.integration.test.ts
+++ b/packages/backend-core/src/control/overview.controller.integration.test.ts
@@ -88,6 +88,7 @@ const skipReason = TEST_URL
   async function getBacklog(adminKey: string): Promise<{
     conversationsNeedingAttention: number;
     kbCurationPending: number;
+    crmMergeProposalsPending: number;
   }> {
     const res = await fetch(`${baseUrl}/api/overview/backlog`, {
       headers: { authorization: `Bearer ${adminKey}` },
@@ -96,6 +97,7 @@ const skipReason = TEST_URL
     return (await res.json()) as {
       conversationsNeedingAttention: number;
       kbCurationPending: number;
+      crmMergeProposalsPending: number;
     };
   }
 

--- a/packages/backend-core/src/control/overview.controller.integration.test.ts
+++ b/packages/backend-core/src/control/overview.controller.integration.test.ts
@@ -118,6 +118,7 @@ const skipReason = TEST_URL
     expect(backlog).toEqual({
       conversationsNeedingAttention: 0,
       kbCurationPending: 0,
+      crmMergeProposalsPending: 0,
     });
   });
 
@@ -174,5 +175,61 @@ const skipReason = TEST_URL
 
     const b = await getBacklog(adminKeyB);
     expect(b.kbCurationPending).toBe(1);
+  });
+
+  it('counts pending CRM merge proposals scoped to caller org and ignores applied/dismissed', async () => {
+    await withClient(adminKeyA, async (c) => {
+      const a = (await c.callTool({
+        name: 'crm_create_contact',
+        arguments: { name: 'A', email: 'merge@a.org' },
+      })) as { content: Array<{ text: string }> };
+      const b = (await c.callTool({
+        name: 'crm_create_contact',
+        arguments: { name: 'B', email: 'merge@a.org' },
+      })) as { content: Array<{ text: string }> };
+      const aId = (JSON.parse(a.content[0]!.text) as { id: string }).id;
+      const bId = (JSON.parse(b.content[0]!.text) as { id: string }).id;
+      await c.callTool({
+        name: 'crm_propose_merge_candidate',
+        arguments: {
+          contactAId: aId,
+          contactBId: bId,
+          confidence: 'high',
+          evidence: { sameEmail: 'merge@a.org' },
+          recommendedKeeperId: aId,
+        },
+      });
+      const c2 = (await c.callTool({
+        name: 'crm_create_contact',
+        arguments: { name: 'C', email: 'other@a.org' },
+      })) as { content: Array<{ text: string }> };
+      const d2 = (await c.callTool({
+        name: 'crm_create_contact',
+        arguments: { name: 'D', email: 'other@a.org' },
+      })) as { content: Array<{ text: string }> };
+      const cId = (JSON.parse(c2.content[0]!.text) as { id: string }).id;
+      const dId = (JSON.parse(d2.content[0]!.text) as { id: string }).id;
+      const dismissed = (await c.callTool({
+        name: 'crm_propose_merge_candidate',
+        arguments: {
+          contactAId: cId,
+          contactBId: dId,
+          confidence: 'medium',
+          evidence: {},
+          recommendedKeeperId: cId,
+        },
+      })) as { content: Array<{ text: string }> };
+      const dismissedId = (JSON.parse(dismissed.content[0]!.text) as { id: string }).id;
+      await c.callTool({
+        name: 'crm_dismiss_merge_proposal',
+        arguments: { id: dismissedId, reason: 'shared inbox' },
+      });
+    });
+
+    const a = await getBacklog(adminKeyA);
+    expect(a.crmMergeProposalsPending).toBe(1);
+
+    const b = await getBacklog(adminKeyB);
+    expect(b.crmMergeProposalsPending).toBe(0);
   });
 });

--- a/packages/backend-core/src/control/overview.controller.ts
+++ b/packages/backend-core/src/control/overview.controller.ts
@@ -10,6 +10,7 @@ import { CURATION_INBOX_SLUG } from '../modules/kb/kb.service.js';
 export interface OverviewBacklog {
   conversationsNeedingAttention: number;
   kbCurationPending: number;
+  crmMergeProposalsPending: number;
 }
 
 @Controller('api/overview')
@@ -35,9 +36,15 @@ export class OverviewController {
         ),
       );
 
+    const [crmMergeRow] = await ctx.db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(schema.crmMergeProposals)
+      .where(eq(schema.crmMergeProposals.status, 'pending'));
+
     return {
       conversationsNeedingAttention: convCountRow?.n ?? 0,
       kbCurationPending: kbCountRow?.n ?? 0,
+      crmMergeProposalsPending: crmMergeRow?.n ?? 0,
     };
   }
 }

--- a/packages/backend-core/src/modules/crm/crm.service.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.test.ts
@@ -50,6 +50,7 @@ const skipReason = TEST_URL
 
   beforeEach(async () => {
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    await db.execute(sql`DELETE FROM crm_merge_proposals WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM crm_activities WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM crm_deals WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM crm_stages WHERE org_id = ${orgId}`);
@@ -372,6 +373,198 @@ const skipReason = TEST_URL
   });
 
   // ─── RLS ─────────────────────────────────────────────────────────────
+
+  describe('merge proposals', () => {
+    it('proposeMerge canonicalizes pair and returns embedded contact summaries', async () => {
+      const a = await run(() => svc.createContact({ name: 'A', email: 'x@y' }));
+      const b = await run(() => svc.createContact({ name: 'B', email: 'x@y' }));
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: b.id,
+          contactBId: a.id,
+          confidence: 'high',
+          evidence: { sameEmail: 'x@y' },
+          recommendedKeeperId: a.id,
+        }),
+      );
+      const [first, second] = a.id < b.id ? [a.id, b.id] : [b.id, a.id];
+      expect(proposal.contactA.id).toBe(first);
+      expect(proposal.contactB.id).toBe(second);
+      expect(proposal.status).toBe('pending');
+      expect(proposal.confidence).toBe('high');
+    });
+
+    it('proposeMerge rejects self-merge', async () => {
+      const c = await run(() => svc.createContact({ name: 'A' }));
+      await expect(
+        run(() =>
+          svc.proposeMerge({
+            contactAId: c.id,
+            contactBId: c.id,
+            confidence: 'high',
+            evidence: {},
+            recommendedKeeperId: c.id,
+          }),
+        ),
+      ).rejects.toThrow(CrmInvalidError);
+    });
+
+    it('proposeMerge rejects keeper that is not in the pair', async () => {
+      const a = await run(() => svc.createContact({ name: 'A' }));
+      const b = await run(() => svc.createContact({ name: 'B' }));
+      const c = await run(() => svc.createContact({ name: 'C' }));
+      await expect(
+        run(() =>
+          svc.proposeMerge({
+            contactAId: a.id,
+            contactBId: b.id,
+            confidence: 'high',
+            evidence: {},
+            recommendedKeeperId: c.id,
+          }),
+        ),
+      ).rejects.toThrow(CrmInvalidError);
+    });
+
+    it('proposeMerge upserts the existing pending row for the same pair', async () => {
+      const a = await run(() => svc.createContact({ name: 'A', email: 'x@y' }));
+      const b = await run(() => svc.createContact({ name: 'B', email: 'x@y' }));
+      const first = await run(() =>
+        svc.proposeMerge({
+          contactAId: a.id,
+          contactBId: b.id,
+          confidence: 'medium',
+          evidence: { sameEmail: 'x@y' },
+          recommendedKeeperId: a.id,
+        }),
+      );
+      const second = await run(() =>
+        svc.proposeMerge({
+          contactAId: b.id,
+          contactBId: a.id,
+          confidence: 'high',
+          evidence: { sameEmail: 'x@y', samePhone: '+47900' },
+          recommendedKeeperId: a.id,
+          recommendedPatch: { tags: ['vip'] },
+        }),
+      );
+      expect(second.id).toBe(first.id);
+      expect(second.confidence).toBe('high');
+      expect(second.evidence).toMatchObject({ samePhone: '+47900' });
+      expect(second.recommendedPatch).toEqual({ tags: ['vip'] });
+      const list = await run(() => svc.listMergeProposals({ status: 'pending' }));
+      expect(list).toHaveLength(1);
+    });
+
+    it('listMergeProposals filters by status', async () => {
+      const a = await run(() => svc.createContact({ name: 'A', email: 'x@y' }));
+      const b = await run(() => svc.createContact({ name: 'B', email: 'x@y' }));
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: a.id,
+          contactBId: b.id,
+          confidence: 'high',
+          evidence: {},
+          recommendedKeeperId: a.id,
+        }),
+      );
+      const pending = await run(() => svc.listMergeProposals({ status: 'pending' }));
+      expect(pending.map((p) => p.id)).toContain(proposal.id);
+      const dismissed = await run(() => svc.listMergeProposals({ status: 'dismissed' }));
+      expect(dismissed).toHaveLength(0);
+    });
+
+    it('applyMergeProposal patches keeper, archives duplicate, marks applied', async () => {
+      const keeper = await run(() => svc.createContact({ name: 'Keeper', email: 'k@y', tags: ['vip'] }));
+      const dup = await run(() => svc.createContact({ name: 'Dup', email: 'k@y', tags: ['lead'] }));
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: keeper.id,
+          contactBId: dup.id,
+          confidence: 'high',
+          evidence: { sameEmail: 'k@y' },
+          recommendedKeeperId: keeper.id,
+          recommendedPatch: { title: 'Head of Ops', tags: ['vip', 'lead'] },
+        }),
+      );
+      const applied = await run(() => svc.applyMergeProposal({ id: proposal.id }));
+      expect(applied.status).toBe('applied');
+      expect(applied.decidedAt).not.toBeNull();
+      const refreshedKeeper = await run(() => svc.getContact(keeper.id));
+      expect(refreshedKeeper.title).toBe('Head of Ops');
+      expect(refreshedKeeper.tags).toEqual(['vip', 'lead']);
+      const refreshedDup = await run(() => svc.getContact(dup.id));
+      expect(refreshedDup.tags.some((t) => t.startsWith('dedup-archived-'))).toBe(true);
+      expect(refreshedDup.customFields.mergedInto).toBe(keeper.id);
+      expect(refreshedDup.doNotContact).toBe(true);
+    });
+
+    it('applyMergeProposal rejects non-pending proposals', async () => {
+      const a = await run(() => svc.createContact({ name: 'A', email: 'x@y' }));
+      const b = await run(() => svc.createContact({ name: 'B', email: 'x@y' }));
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: a.id,
+          contactBId: b.id,
+          confidence: 'high',
+          evidence: {},
+          recommendedKeeperId: a.id,
+        }),
+      );
+      await run(() => svc.applyMergeProposal({ id: proposal.id }));
+      await expect(run(() => svc.applyMergeProposal({ id: proposal.id }))).rejects.toThrow(
+        CrmInvalidError,
+      );
+    });
+
+    it('dismissMergeProposal records reason and switches status', async () => {
+      const a = await run(() => svc.createContact({ name: 'A', email: 'x@y' }));
+      const b = await run(() => svc.createContact({ name: 'B', email: 'x@y' }));
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: a.id,
+          contactBId: b.id,
+          confidence: 'medium',
+          evidence: {},
+          recommendedKeeperId: a.id,
+        }),
+      );
+      const dismissed = await run(() =>
+        svc.dismissMergeProposal({ id: proposal.id, reason: 'shared inbox' }),
+      );
+      expect(dismissed.status).toBe('dismissed');
+      expect(dismissed.dismissReason).toBe('shared inbox');
+      expect(dismissed.decidedAt).not.toBeNull();
+      const dismissedList = await run(() => svc.listMergeProposals({ status: 'dismissed' }));
+      expect(dismissedList).toHaveLength(1);
+    });
+
+    it('after dismissal a new proposal for the same pair can be filed (and lives alongside the dismissed one)', async () => {
+      const a = await run(() => svc.createContact({ name: 'A', email: 'x@y' }));
+      const b = await run(() => svc.createContact({ name: 'B', email: 'x@y' }));
+      const first = await run(() =>
+        svc.proposeMerge({
+          contactAId: a.id,
+          contactBId: b.id,
+          confidence: 'medium',
+          evidence: {},
+          recommendedKeeperId: a.id,
+        }),
+      );
+      await run(() => svc.dismissMergeProposal({ id: first.id }));
+      const second = await run(() =>
+        svc.proposeMerge({
+          contactAId: a.id,
+          contactBId: b.id,
+          confidence: 'high',
+          evidence: {},
+          recommendedKeeperId: a.id,
+        }),
+      );
+      expect(second.id).not.toBe(first.id);
+      expect(second.status).toBe('pending');
+    });
+  });
 
   describe('RLS', () => {
     it('cross-org isolation: another org cannot see this org\'s contacts', async () => {

--- a/packages/backend-core/src/modules/crm/crm.service.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.ts
@@ -101,6 +101,40 @@ export interface ActivityDto {
   createdAt: string;
 }
 
+export const MERGE_CONFIDENCES = ['high', 'medium'] as const;
+export type MergeConfidence = (typeof MERGE_CONFIDENCES)[number];
+
+export const MERGE_STATUSES = ['pending', 'applied', 'dismissed'] as const;
+export type MergeStatus = (typeof MERGE_STATUSES)[number];
+
+export interface MergeProposalContactSummary {
+  id: string;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  companyId: string | null;
+  endUserId: string | null;
+}
+
+export interface MergeProposalDto {
+  id: string;
+  contactA: MergeProposalContactSummary;
+  contactB: MergeProposalContactSummary;
+  confidence: MergeConfidence;
+  evidence: Record<string, unknown>;
+  recommendedKeeperId: string;
+  recommendedPatch: Record<string, unknown>;
+  status: MergeStatus;
+  dismissReason: string | null;
+  proposedByActorType: string;
+  proposedByActorId: string;
+  decidedByActorType: string | null;
+  decidedByActorId: string | null;
+  decidedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 @Injectable()
 export class CrmService {
   // ─── Contacts ───────────────────────────────────────────────────────────
@@ -569,6 +603,248 @@ export class CrmService {
       .limit(limit);
     return rows.map(toContactDto);
   }
+
+  // ─── Merge proposals ────────────────────────────────────────────────────
+
+  async proposeMerge(input: {
+    contactAId: string;
+    contactBId: string;
+    confidence: MergeConfidence;
+    evidence: Record<string, unknown>;
+    recommendedKeeperId: string;
+    recommendedPatch?: Record<string, unknown>;
+  }): Promise<MergeProposalDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    if (input.contactAId === input.contactBId) {
+      throw new CrmInvalidError('cannot propose a merge between a contact and itself');
+    }
+    const [a, b] = canonicalizePair(input.contactAId, input.contactBId);
+    const contacts = await ctx.db
+      .select()
+      .from(schema.crmContacts)
+      .where(or(eq(schema.crmContacts.id, a), eq(schema.crmContacts.id, b)));
+    const contactA = contacts.find((r) => r.id === a);
+    const contactB = contacts.find((r) => r.id === b);
+    if (!contactA) throw new NotFoundException(`crm_not_found: contact ${a}`);
+    if (!contactB) throw new NotFoundException(`crm_not_found: contact ${b}`);
+    if (input.recommendedKeeperId !== a && input.recommendedKeeperId !== b) {
+      throw new CrmInvalidError('recommendedKeeperId must be one of the two contacts');
+    }
+
+    const existingPending = await ctx.db
+      .select()
+      .from(schema.crmMergeProposals)
+      .where(
+        and(
+          eq(schema.crmMergeProposals.contactAId, a),
+          eq(schema.crmMergeProposals.contactBId, b),
+          eq(schema.crmMergeProposals.status, 'pending'),
+        ),
+      )
+      .limit(1);
+
+    if (existingPending[0]) {
+      const [updated] = await ctx.db
+        .update(schema.crmMergeProposals)
+        .set({
+          confidence: input.confidence,
+          evidence: input.evidence,
+          recommendedKeeperId: input.recommendedKeeperId,
+          recommendedPatch: input.recommendedPatch ?? {},
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.crmMergeProposals.id, existingPending[0].id))
+        .returning();
+      return toMergeProposalDto(updated!, contactA, contactB);
+    }
+
+    const [row] = await ctx.db
+      .insert(schema.crmMergeProposals)
+      .values({
+        orgId: actor.orgId,
+        contactAId: a,
+        contactBId: b,
+        confidence: input.confidence,
+        evidence: input.evidence,
+        recommendedKeeperId: input.recommendedKeeperId,
+        recommendedPatch: input.recommendedPatch ?? {},
+        status: 'pending',
+        proposedByActorType: actor.type === 'user' ? 'user' : 'agent',
+        proposedByActorId: actor.id,
+      })
+      .returning();
+    return toMergeProposalDto(row!, contactA, contactB);
+  }
+
+  async listMergeProposals(input: {
+    status?: MergeStatus;
+    limit?: number;
+  }): Promise<MergeProposalDto[]> {
+    const ctx = getCurrentContext();
+    const limit = clampLimit(input.limit, 50, 200);
+    const status = input.status ?? 'pending';
+    const proposals = await ctx.db
+      .select()
+      .from(schema.crmMergeProposals)
+      .where(eq(schema.crmMergeProposals.status, status))
+      .orderBy(desc(schema.crmMergeProposals.createdAt))
+      .limit(limit);
+    if (proposals.length === 0) return [];
+    const ids = new Set<string>();
+    for (const p of proposals) {
+      ids.add(p.contactAId);
+      ids.add(p.contactBId);
+    }
+    const contactRows = await ctx.db
+      .select()
+      .from(schema.crmContacts)
+      .where(or(...Array.from(ids).map((id) => eq(schema.crmContacts.id, id))));
+    const byId = new Map(contactRows.map((r) => [r.id, r]));
+    return proposals.map((p) => {
+      const a = byId.get(p.contactAId);
+      const b = byId.get(p.contactBId);
+      if (!a || !b) {
+        throw new CrmInvalidError(`merge proposal ${p.id} references missing contact`);
+      }
+      return toMergeProposalDto(p, a, b);
+    });
+  }
+
+  async getMergeProposal(id: string): Promise<MergeProposalDto> {
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select()
+      .from(schema.crmMergeProposals)
+      .where(eq(schema.crmMergeProposals.id, id))
+      .limit(1);
+    if (!rows[0]) throw new NotFoundException(`crm_not_found: merge proposal ${id}`);
+    const proposal = rows[0];
+    const contacts = await ctx.db
+      .select()
+      .from(schema.crmContacts)
+      .where(or(eq(schema.crmContacts.id, proposal.contactAId), eq(schema.crmContacts.id, proposal.contactBId)));
+    const a = contacts.find((r) => r.id === proposal.contactAId);
+    const b = contacts.find((r) => r.id === proposal.contactBId);
+    if (!a || !b) {
+      throw new CrmInvalidError(`merge proposal ${id} references missing contact`);
+    }
+    return toMergeProposalDto(proposal, a, b);
+  }
+
+  async applyMergeProposal(input: { id: string }): Promise<MergeProposalDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db
+      .select()
+      .from(schema.crmMergeProposals)
+      .where(eq(schema.crmMergeProposals.id, input.id))
+      .limit(1);
+    const proposal = rows[0];
+    if (!proposal) throw new NotFoundException(`crm_not_found: merge proposal ${input.id}`);
+    if (proposal.status !== 'pending') {
+      throw new CrmInvalidError(`merge proposal ${input.id} is ${proposal.status}, not pending`);
+    }
+    const keeperId = proposal.recommendedKeeperId;
+    const duplicateId = keeperId === proposal.contactAId ? proposal.contactBId : proposal.contactAId;
+    const contactRows = await ctx.db
+      .select()
+      .from(schema.crmContacts)
+      .where(or(eq(schema.crmContacts.id, keeperId), eq(schema.crmContacts.id, duplicateId)));
+    const keeperRow = contactRows.find((r) => r.id === keeperId);
+    const duplicateRow = contactRows.find((r) => r.id === duplicateId);
+    if (!keeperRow || !duplicateRow) {
+      throw new CrmInvalidError(`merge proposal ${input.id} references missing contact`);
+    }
+
+    const patch = proposal.recommendedPatch ?? {};
+    const keeperUpdates: Record<string, unknown> = { updatedAt: new Date() };
+    for (const [k, v] of Object.entries(patch)) {
+      if (v !== undefined) keeperUpdates[k] = v;
+    }
+    if (Object.keys(keeperUpdates).length > 1) {
+      await ctx.db
+        .update(schema.crmContacts)
+        .set(keeperUpdates)
+        .where(eq(schema.crmContacts.id, keeperId));
+    }
+
+    const archiveTag = `dedup-archived-${archiveMonth(new Date())}`;
+    const dupTags = duplicateRow.tags.includes(archiveTag)
+      ? duplicateRow.tags
+      : [...duplicateRow.tags, archiveTag];
+    const dupCustomFields = {
+      ...duplicateRow.customFields,
+      mergedInto: keeperId,
+      mergedAt: new Date().toISOString(),
+    };
+    await ctx.db
+      .update(schema.crmContacts)
+      .set({
+        tags: dupTags,
+        customFields: dupCustomFields,
+        doNotContact: true,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.crmContacts.id, duplicateId));
+
+    const [updatedProposal] = await ctx.db
+      .update(schema.crmMergeProposals)
+      .set({
+        status: 'applied',
+        decidedByActorType: actor.type === 'user' ? 'user' : 'agent',
+        decidedByActorId: actor.id,
+        decidedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.crmMergeProposals.id, input.id))
+      .returning();
+
+    const refreshed = await ctx.db
+      .select()
+      .from(schema.crmContacts)
+      .where(or(eq(schema.crmContacts.id, keeperId), eq(schema.crmContacts.id, duplicateId)));
+    const a = refreshed.find((r) => r.id === proposal.contactAId);
+    const b = refreshed.find((r) => r.id === proposal.contactBId);
+    return toMergeProposalDto(updatedProposal!, a!, b!);
+  }
+
+  async dismissMergeProposal(input: { id: string; reason?: string }): Promise<MergeProposalDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db
+      .select()
+      .from(schema.crmMergeProposals)
+      .where(eq(schema.crmMergeProposals.id, input.id))
+      .limit(1);
+    const proposal = rows[0];
+    if (!proposal) throw new NotFoundException(`crm_not_found: merge proposal ${input.id}`);
+    if (proposal.status !== 'pending') {
+      throw new CrmInvalidError(`merge proposal ${input.id} is ${proposal.status}, not pending`);
+    }
+    const [updated] = await ctx.db
+      .update(schema.crmMergeProposals)
+      .set({
+        status: 'dismissed',
+        dismissReason: input.reason ?? null,
+        decidedByActorType: actor.type === 'user' ? 'user' : 'agent',
+        decidedByActorId: actor.id,
+        decidedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.crmMergeProposals.id, input.id))
+      .returning();
+    const contactRows = await ctx.db
+      .select()
+      .from(schema.crmContacts)
+      .where(or(eq(schema.crmContacts.id, proposal.contactAId), eq(schema.crmContacts.id, proposal.contactBId)));
+    const a = contactRows.find((r) => r.id === proposal.contactAId);
+    const b = contactRows.find((r) => r.id === proposal.contactBId);
+    if (!a || !b) {
+      throw new CrmInvalidError(`merge proposal ${input.id} references missing contact`);
+    }
+    return toMergeProposalDto(updated!, a, b);
+  }
 }
 
 // ─── DTO mappers / helpers ─────────────────────────────────────────────────
@@ -650,6 +926,52 @@ function toActivityDto(row: typeof schema.crmActivities.$inferSelect): ActivityD
     completedAt: row.completedAt?.toISOString() ?? null,
     createdAt: row.createdAt.toISOString(),
   };
+}
+
+function toContactSummary(row: typeof schema.crmContacts.$inferSelect): MergeProposalContactSummary {
+  return {
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    phone: row.phone,
+    companyId: row.companyId,
+    endUserId: row.endUserId,
+  };
+}
+
+function toMergeProposalDto(
+  row: typeof schema.crmMergeProposals.$inferSelect,
+  contactA: typeof schema.crmContacts.$inferSelect,
+  contactB: typeof schema.crmContacts.$inferSelect,
+): MergeProposalDto {
+  return {
+    id: row.id,
+    contactA: toContactSummary(contactA),
+    contactB: toContactSummary(contactB),
+    confidence: row.confidence as MergeConfidence,
+    evidence: row.evidence,
+    recommendedKeeperId: row.recommendedKeeperId,
+    recommendedPatch: row.recommendedPatch,
+    status: row.status as MergeStatus,
+    dismissReason: row.dismissReason,
+    proposedByActorType: row.proposedByActorType,
+    proposedByActorId: row.proposedByActorId,
+    decidedByActorType: row.decidedByActorType,
+    decidedByActorId: row.decidedByActorId,
+    decidedAt: row.decidedAt?.toISOString() ?? null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function canonicalizePair(a: string, b: string): [string, string] {
+  return a < b ? [a, b] : [b, a];
+}
+
+function archiveMonth(d: Date): string {
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  return `${yyyy}-${mm}`;
 }
 
 function isValidSlug(slug: string): boolean {

--- a/packages/backend-core/src/modules/crm/crm.tools.ts
+++ b/packages/backend-core/src/modules/crm/crm.tools.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
-import { ACTIVITY_TYPES, CrmService } from './crm.service.js';
+import { ACTIVITY_TYPES, CrmService, MERGE_CONFIDENCES, MERGE_STATUSES } from './crm.service.js';
 
 const TagsSchema = z.array(z.string().min(1).max(64)).max(32);
 const ActivityType = z.enum(ACTIVITY_TYPES);
@@ -136,6 +136,32 @@ const SetAiSummaryInput = z.object({
 });
 
 const EmptyInput = z.object({});
+
+const MergeConfidenceSchema = z.enum(MERGE_CONFIDENCES);
+const MergeStatusSchema = z.enum(MERGE_STATUSES);
+
+const ProposeMergeInput = z.object({
+  contactAId: z.string().min(1).max(64),
+  contactBId: z.string().min(1).max(64),
+  confidence: MergeConfidenceSchema,
+  evidence: z.record(z.string(), z.unknown()),
+  recommendedKeeperId: z.string().min(1).max(64),
+  recommendedPatch: z.record(z.string(), z.unknown()).optional(),
+});
+
+const ListMergeProposalsInput = z.object({
+  status: MergeStatusSchema.optional(),
+  limit: z.number().int().positive().max(200).optional(),
+});
+
+const ApplyMergeProposalInput = z.object({
+  id: z.string().min(1).max(64),
+});
+
+const DismissMergeProposalInput = z.object({
+  id: z.string().min(1).max(64),
+  reason: z.string().max(500).optional(),
+});
 
 @Injectable()
 export class CrmAdminTools {
@@ -396,5 +422,67 @@ export class CrmAdminTools {
   })
   setAiSummary(args: z.infer<typeof SetAiSummaryInput>) {
     return this.crm.setAiSummary(args);
+  }
+
+  // Merge proposals ─────────────────────────────────────────────────────
+
+  @McpTool({
+    name: 'crm_propose_merge_candidate',
+    title: 'Propose a CRM merge candidate',
+    description:
+      'File a structured proposal that two contacts are the same person. Pass `confidence` ("high" | "medium"), `evidence` (the matched signals — same email, same phone, similar name, etc.), `recommendedKeeperId` (which row to keep), and optionally `recommendedPatch` (fields to copy onto the keeper from the duplicate). Idempotent on the (contactA, contactB) pair while a pending proposal exists — calling again upserts the existing pending row. The CRM hygiene curator runs this on a periodic cadence; see `skill://crm/hygiene`.',
+    audiences: ['admin'],
+    scopes: ['crm:write'],
+    input: ProposeMergeInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  proposeMergeCandidate(args: z.infer<typeof ProposeMergeInput>) {
+    return this.crm.proposeMerge(args);
+  }
+
+  @McpTool({
+    name: 'crm_list_merge_proposals',
+    title: 'List CRM merge proposals',
+    description:
+      'List CRM merge proposals, defaulting to `status: "pending"` (the operator review queue). Returns each proposal with both contacts embedded as summaries — no extra `crm_get_contact` calls needed. Pass `status: "dismissed"` once per curator pass to skip pairs the operator has already rejected.',
+    audiences: ['admin'],
+    scopes: ['crm:read'],
+    input: ListMergeProposalsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  listMergeProposals(args: z.infer<typeof ListMergeProposalsInput>) {
+    return this.crm.listMergeProposals(args);
+  }
+
+  @McpTool({
+    name: 'crm_apply_merge_proposal',
+    title: 'Apply a CRM merge proposal',
+    description:
+      "Atomically apply a pending merge proposal: copies `recommendedPatch` fields onto the keeper, archives the duplicate (adds `dedup-archived-YYYY-MM` tag, sets `customFields.mergedInto = <keeperId>`, sets `doNotContact: true`), and marks the proposal `applied`. Activities and deals stay on whichever contactId they were originally logged under — that's a documented v1 limitation. Throws if the proposal is not in `pending` status.",
+    audiences: ['admin'],
+    scopes: ['crm:write'],
+    input: ApplyMergeProposalInput,
+    readOnlyHint: false,
+    destructiveHint: true,
+  })
+  applyMergeProposal(args: z.infer<typeof ApplyMergeProposalInput>) {
+    return this.crm.applyMergeProposal(args);
+  }
+
+  @McpTool({
+    name: 'crm_dismiss_merge_proposal',
+    title: 'Dismiss a CRM merge proposal',
+    description:
+      'Mark a pending merge proposal as dismissed (the operator decided these are not the same person). The next CRM hygiene curator pass queries dismissed proposals and skips refiling the same pair. Optional `reason` is stored for audit. Throws if the proposal is not in `pending` status.',
+    audiences: ['admin'],
+    scopes: ['crm:write'],
+    input: DismissMergeProposalInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  dismissMergeProposal(args: z.infer<typeof DismissMergeProposalInput>) {
+    return this.crm.dismissMergeProposal(args);
   }
 }

--- a/packages/backend-core/src/modules/crm/skills/hygiene.md
+++ b/packages/backend-core/src/modules/crm/skills/hygiene.md
@@ -1,0 +1,139 @@
+---
+title: CRM hygiene pass
+description: Periodic curator pass — find duplicate / inconsistent contacts, file high-confidence pairs as structured merge proposals via crm_propose_merge_candidate. Designed to be run on a cadence by an admin agent (weekly is a good default). The operator reviews via crm_list_merge_proposals and resolves with crm_apply_merge_proposal / crm_dismiss_merge_proposal.
+audiences: [admin]
+---
+
+# CRM hygiene pass
+
+CRM data drifts. Imports re-add contacts under a slightly different email. Humans type the same person's name three different ways. Two reps log activity against the same prospect under separate rows because neither searched first. Left alone, this turns the CRM into a haystack — searches return three half-rows where there should be one complete one, segments under-count, and the next bulk import re-creates duplicates because the dedup key drifted.
+
+This skill walks an admin agent through one periodic hygiene pass: pull contacts, find suspect pairs, judge each pair, and file high-confidence pairs as **structured merge proposals** via `crm_propose_merge_candidate`. A human (or trusted admin agent) then reviews each pending proposal and resolves it with `crm_apply_merge_proposal` (atomic patch + archive) or `crm_dismiss_merge_proposal` (records the rejection so the next curator pass skips the pair).
+
+Run periodically. Don't run inline per CRM mutation — batching is cheaper and the suspect-pair signal is much stronger when you can see the whole population at once. The cloud product has a curator runner that schedules this weekly per enabled org.
+
+## TL;DR
+
+1. **Skim known dismissals** with `crm_list_merge_proposals({ status: "dismissed" })` — build a Set of dismissed `(contactA, contactB)` pairs to skip.
+2. **List contacts** with `crm_list_contacts`, paginating until you've seen the population (filter by `tag` or `companyId` for very large orgs).
+3. **Find suspect pairs** in your buffer: same lowercased email, same E.164 phone, very-similar name, or same name + company.
+4. **Judge each pair.** Skip clearly-not-the-same (different companies, shared inbox like `info@acme.com`, ambiguous role/title combinations). Keep clearly-same (same email + phone, same email + similar name, same phone + same company).
+5. **Pick the keeper** for each kept pair (heuristics below) and build a `recommendedPatch` of fields to copy from the duplicate onto the keeper.
+6. **File each pair** with `crm_propose_merge_candidate`. Idempotent on the pair while pending — re-running next week without the operator acting just upserts the pending row with refreshed evidence.
+7. **Stop.** The operator's review flow takes over — they call `crm_apply_merge_proposal` or `crm_dismiss_merge_proposal` at their cadence.
+
+## Step 1 — fetch dismissed pairs
+
+```jsonc
+{ "name": "crm_list_merge_proposals", "arguments": { "status": "dismissed", "limit": 200 } }
+```
+
+Build a lookup keyed by canonical pair (sorted contact-id tuple). Skip these in step 4. The unique-pending-pair index at the database level prevents *pending* duplicates automatically; this step prevents you from re-proposing pairs the operator already said no to.
+
+## Step 2 — pull contacts
+
+```jsonc
+{ "name": "crm_list_contacts", "arguments": { "limit": 200 } }
+```
+
+`limit` is capped at 200. For larger orgs, narrow by `tag` or `companyId` to keep batches tractable, or run multiple passes scoped to different segments.
+
+## Step 3 — group and find pairs
+
+In your buffer, build clusters keyed by:
+
+- Lowercased trimmed `email` — strongest dedup signal.
+- E.164-normalized `phone` — drop spaces, parens, dashes; if the number is ambiguous (no `+` prefix, can't infer country), skip it rather than guess.
+- Normalized `name` (lowercased, trimmed, whitespace-collapsed first + last) — soft-match suggestion only; more false positives.
+- `companyId` — a very-similar name at the same company is a stronger signal than the same name across two different companies.
+
+A pair is a *suspect pair* if any of those keys match. A cluster of size ≥ 2 emits one proposal per unordered pair, not one per cluster (an operator may want to merge A+B but keep C separate).
+
+## Step 4 — judge each pair
+
+For each suspect pair (skipping the dismissed set from step 1), decide:
+
+- **High confidence** — same email *and* same phone; same email + similar name; same phone + same `companyId`. → propose with `confidence: "high"`.
+- **Medium confidence** — similar name + same `companyId`, no email/phone overlap; same email but inbox-shaped (`info@`, `support@`, `team@`) and the names match. → propose with `confidence: "medium"`.
+- **Skip** — shared inbox with different names; different `companyId` and no overlap; clearly different role titles at the same company.
+- **Can't tell** — skip and note the pair in your pass summary so a human can eyeball it later.
+
+Be conservative. False positives waste the reviewer's time and erode trust in the curator. False negatives just mean we'll catch the pair on the next pass.
+
+## Step 5 — pick the keeper
+
+For each kept pair, the keeper is the contact that should remain. Heuristics in order:
+
+1. The one with `endUserId` set (linked to a real auth user — never lose this row).
+2. The most recent `lastContactedAt` (or, if both null, the most recent `updatedAt`).
+3. The one with the most non-null fields (most "complete").
+4. The oldest `createdAt` (preserves the original system-of-record row).
+
+Document the chosen heuristic inside the `evidence` object so the reviewer can sanity-check.
+
+## Step 6 — build the proposal
+
+Construct `recommendedPatch`: the set of fields to copy from the duplicate onto the keeper *if applied*. Only include fields where the duplicate has useful data the keeper lacks (or where the duplicate's value is clearly canonical).
+
+```jsonc
+{
+  "name": "crm_propose_merge_candidate",
+  "arguments": {
+    "contactAId": "cct_aaaaaa",
+    "contactBId": "cct_bbbbbb",
+    "confidence": "high",
+    "evidence": {
+      "sameEmail": "vita@acme.com",
+      "samePhoneNormalized": "+4790000000",
+      "nameMatch": { "a": "Vita Vivisectus", "b": "vita vivisectus" },
+      "sameCompanyId": "cco_acme",
+      "keeperReason": "has_end_user_id + more_recent_last_contacted"
+    },
+    "recommendedKeeperId": "cct_aaaaaa",
+    "recommendedPatch": {
+      "title": "Head of Ops",
+      "tags": ["customer", "imported-2026-q1"]
+    }
+  }
+}
+```
+
+Notes:
+
+- `tags` and `customFields` in `recommendedPatch` are **full replacements** in the apply step (matching `crm_update_contact` semantics). If you want the union of both contacts' tags, build the union here.
+- Don't put email/phone in the patch unless the duplicate's value is genuinely better — these are dedup keys and changing them on the keeper risks creating *new* duplicates.
+- `evidence` is freeform jsonb; include whatever helps the reviewer trust the proposal at a glance.
+
+## Step 7 — operator review (NOT the curator's job)
+
+After the curator's pass, the operator (human or admin agent acting on their authority) reviews:
+
+```jsonc
+{ "name": "crm_list_merge_proposals", "arguments": { "status": "pending", "limit": 50 } }
+```
+
+For each pending proposal, the operator either:
+
+- **Applies it:** `crm_apply_merge_proposal({ id })`. Atomically copies `recommendedPatch` onto the keeper, archives the duplicate (tag `dedup-archived-YYYY-MM` + `customFields.mergedInto: <keeperId>` + `doNotContact: true`), marks the proposal `applied`. Activities and deals stay on whichever contactId they were originally logged under — see "Future work" below.
+- **Dismisses it:** `crm_dismiss_merge_proposal({ id, reason })`. Records the rejection so the next curator pass skips this pair.
+
+The dashboard "Needs attention" backlog card surfaces the count of pending proposals via `/api/overview/backlog`.
+
+## What NOT to do
+
+- **Don't auto-apply.** v1 is propose-only. The cost of a wrong merge (lost activity history, wrong `endUserId` link) is much higher than the cost of one extra human review per pair.
+- **Don't propose pairs the operator already dismissed.** Step 1 exists for a reason. If you skip it, you'll churn the operator's review queue with noise.
+- **Don't include private end-user data in `evidence` beyond what's needed to decide.** No payment info, no internal account states, no health/legal/financial details. The matched email, the matched phone, the names, the companyId — that's enough.
+- **Don't run on every conversation.** This is a periodic batch pass. The cloud curator runner schedules it. If you're being asked to do it inline as part of a chat reply, push back — that's the wrong shape.
+- **Don't use `crm_update_contact` to "manually merge" instead of proposing.** The proposals table is the audit trail and the operator's review queue. Bypassing it loses both.
+
+## Future work
+
+- Atomic activity / deal / endUser-link reassignment in `crm_apply_merge_proposal`. Today the apply step archives the duplicate but leaves activities pointing at it; the keeper's history is incomplete until that's fixed. v2 adds a foreign-key sweep inside the same transaction.
+- Auto-apply for high-confidence proposals where the keeper is unambiguous and `recommendedPatch` is empty (a pure consolidation with no field choices). Gated behind an explicit org-level toggle.
+- Proposal-event webhooks (`crm.merge_proposal.proposed/applied/dismissed`) so the dashboard review queue updates without polling.
+
+## Related
+
+- `skill://crm/contact-deduplication` — manual reconcile pattern (no proposals table). Documents the same archive convention `crm_apply_merge_proposal` uses, so the manual and automated paths produce identical end states.
+- `skill://kb/curation` — sibling curator pass for conversation → KB document proposals. Different domain, same "propose, don't apply" philosophy.

--- a/packages/db/drizzle/0007_crm_merge_proposals.sql
+++ b/packages/db/drizzle/0007_crm_merge_proposals.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS "crm_merge_proposals" (
+  "id" text PRIMARY KEY NOT NULL,
+  "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+  "contact_a_id" text NOT NULL REFERENCES "crm_contacts"("id") ON DELETE CASCADE,
+  "contact_b_id" text NOT NULL REFERENCES "crm_contacts"("id") ON DELETE CASCADE,
+  "confidence" varchar(8) NOT NULL,
+  "evidence" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "recommended_keeper_id" text NOT NULL,
+  "recommended_patch" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "status" varchar(16) NOT NULL DEFAULT 'pending',
+  "dismiss_reason" text,
+  "proposed_by_actor_type" varchar(16) NOT NULL,
+  "proposed_by_actor_id" text NOT NULL,
+  "decided_by_actor_type" varchar(16),
+  "decided_by_actor_id" text,
+  "decided_at" timestamp with time zone,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "crm_merge_proposals_org_status_idx"
+  ON "crm_merge_proposals" ("org_id", "status");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "crm_merge_proposals_contact_a_idx"
+  ON "crm_merge_proposals" ("contact_a_id");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "crm_merge_proposals_contact_b_idx"
+  ON "crm_merge_proposals" ("contact_b_id");
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "crm_merge_proposals_pending_pair_uq"
+  ON "crm_merge_proposals" ("org_id", "contact_a_id", "contact_b_id")
+  WHERE "status" = 'pending';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777681200000,
       "tag": "0006_kb_document_slug",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1777681300000,
+      "tag": "0007_crm_merge_proposals",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -993,6 +993,52 @@ export const crmRelationships = pgTable(
   }),
 );
 
+// Merge proposals: structured "these two contacts look like the same
+// person, here's the recommended resolution" rows filed by the CRM
+// hygiene curator (or a human spot-checker). Operator reviews via
+// `crm_list_merge_proposals` and resolves with `crm_apply_merge_proposal`
+// or `crm_dismiss_merge_proposal`. Pair canonicalization (sorted ids) +
+// the partial unique index make repeated curator passes idempotent on
+// pending pairs without needing UPSERT semantics in the migration.
+export const crmMergeProposals = pgTable(
+  'crm_merge_proposals',
+  {
+    id: id('cmp'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    contactAId: text('contact_a_id')
+      .notNull()
+      .references(() => crmContacts.id, { onDelete: 'cascade' }),
+    contactBId: text('contact_b_id')
+      .notNull()
+      .references(() => crmContacts.id, { onDelete: 'cascade' }),
+    confidence: varchar('confidence', { length: 8 }).notNull(),
+    // 'high' | 'medium'
+    evidence: jsonb('evidence').$type<Record<string, unknown>>().notNull().default({}),
+    recommendedKeeperId: text('recommended_keeper_id').notNull(),
+    recommendedPatch: jsonb('recommended_patch').$type<Record<string, unknown>>().notNull().default({}),
+    status: varchar('status', { length: 16 }).notNull().default('pending'),
+    // 'pending' | 'applied' | 'dismissed'
+    dismissReason: text('dismiss_reason'),
+    proposedByActorType: varchar('proposed_by_actor_type', { length: 16 }).notNull(),
+    proposedByActorId: text('proposed_by_actor_id').notNull(),
+    decidedByActorType: varchar('decided_by_actor_type', { length: 16 }),
+    decidedByActorId: text('decided_by_actor_id'),
+    decidedAt: timestamp('decided_at', { withTimezone: true }),
+    createdAt,
+    updatedAt,
+  },
+  (t) => ({
+    orgStatusIdx: index('crm_merge_proposals_org_status_idx').on(t.orgId, t.status),
+    contactAIdx: index('crm_merge_proposals_contact_a_idx').on(t.contactAId),
+    contactBIdx: index('crm_merge_proposals_contact_b_idx').on(t.contactBId),
+    pendingPairUq: uniqueIndex('crm_merge_proposals_pending_pair_uq')
+      .on(t.orgId, t.contactAId, t.contactBId)
+      .where(sql`status = 'pending'`),
+  }),
+);
+
 // ───────────────────────── CMS (M6) ───────────────────────────────────
 // Headless CMS — schema-on-write: orgs define collections (with custom
 // fields) and store entries as JSON keyed by field name. Public delivery
@@ -1212,6 +1258,7 @@ export const allTables = {
   crmDeals,
   crmActivities,
   crmRelationships,
+  crmMergeProposals,
   cmsCollections,
   cmsEntries,
   cmsEntryVersions,

--- a/packages/db/src/sql/crm.sql
+++ b/packages/db/src/sql/crm.sql
@@ -98,3 +98,16 @@ CREATE POLICY tenant_isolation ON crm_relationships
     OR (org_id = app_org_id() AND app_end_user_id() = '')
   )
   WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
+-- Merge proposals: org-scoped, admin-only. Self-service tokens never see
+-- proposals (the curator is an admin actor, the operator review flow is
+-- admin/dashboard).
+ALTER TABLE crm_merge_proposals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE crm_merge_proposals FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON crm_merge_proposals;
+CREATE POLICY tenant_isolation ON crm_merge_proposals
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());


### PR DESCRIPTION
## Summary

- CRM-native proposal flow for the hygiene curator (replaces the abandoned KB-inbox shortcut). New `crm_merge_proposals` table + 4 admin MCP tools: `crm_propose_merge_candidate`, `crm_list_merge_proposals`, `crm_apply_merge_proposal`, `crm_dismiss_merge_proposal`.
- `crm_apply_merge_proposal` atomically copies `recommendedPatch` onto the keeper, archives the duplicate (`dedup-archived-YYYY-MM` tag + `customFields.mergedInto` + `doNotContact: true`), marks the proposal `applied`. Activities/deals stay on whichever contactId they were originally logged under — documented v1 limitation that matches the existing manual `skill://crm/contact-deduplication` archive convention.
- `skill://crm/hygiene` walks an admin agent through one periodic pass: pull dismissed pairs first, build suspect pairs, judge each, file structured proposals with evidence/keeper/patch.
- Pair canonicalization (lexicographic sort) + partial unique index (`WHERE status = 'pending'`) make repeated curator passes idempotent without UPSERT semantics in the migration.
- `OverviewBacklog.crmMergeProposalsPending` extends the dashboard backlog card.

## Out of scope (v2)

- Atomic activity/deal/endUser-link reassignment in `apply` (keeper's history is incomplete until that's fixed; v2 adds a foreign-key sweep inside the same transaction).
- Auto-apply for high-confidence proposals.
- Proposal-event webhooks (`crm.merge_proposal.proposed/applied/dismissed`) for dashboard live updates.

## Test plan

- [x] `pnpm --filter @getmunin/db build && pnpm --filter @getmunin/backend-core build` — clean (21 skills copied, was 20)
- [x] `MUNIN_MIGRATE_URL=… pnpm --filter @getmunin/db db:migrate` — `0007_crm_merge_proposals.sql` applies cleanly; table + 4 indexes + RLS policy verified via `\d+ crm_merge_proposals`
- [x] `pnpm --filter @getmunin/backend-core test` — 273 tests pass (9 new merge-proposal cases: canonicalization, self-merge guard, keeper validation, idempotent upsert, list-by-status, apply patches/archives, apply rejects non-pending, dismiss + reason, post-dismissal re-propose)
- [x] `pnpm --filter @getmunin/backend-core lint && pnpm --filter @getmunin/db lint` — clean
- [x] Repo-wide `pnpm -r test` — backend-core 273 / agent-runtime 31 / db 5 / core 41 / mcp-toolkit 5 / backend 4, all green
- [ ] After release: cloud `@munin-cloud/curator-runner` package (PR-B, separate plan) pins to this version of `@getmunin/backend-core` and wires the new `CrmHygieneCuratorService` to call these tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)