### PR TITLE
feat(crm,cms): atomic merge apply + proposal events + CMS stale-content skill

### DIFF
--- a/.changeset/crm-merge-apply-fk-sweep-and-events.md
+++ b/.changeset/crm-merge-apply-fk-sweep-and-events.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': minor
+---
+
+`crm_apply_merge_proposal` now atomically reassigns the duplicate's activities (`crm_activities.contact_id`), deals (`crm_deals.primary_contact_id`), and contact-typed relationships (`crm_relationships.from_id`/`to_id` where the type is `contact`) onto the keeper inside the same transaction. The duplicate's `endUserId` transfers to the keeper if the keeper had none; otherwise it's cleared on the duplicate. The previously-documented limitation that "activities and deals stay on the original contactId" is gone.
+
+Adds webhook + realtime events for merge proposals: `crm.merge_proposal.proposed`, `crm.merge_proposal.applied`, `crm.merge_proposal.dismissed`. The dashboard review queue can now subscribe via the existing realtime gateway instead of polling `/api/overview/backlog`.
+
+New `skill://cms/stale-content-review` walks an admin agent through a periodic stale-content audit (drafts, unrefreshed published entries, orphaned assets) and produces a structured action report. v1 is propose-only — no persistent inbox; the operator reviews the curator-runner's reply and acts via the existing `cms_*` tools.

--- a/packages/backend-core/src/modules/cms/skills/stale-content-review.md
+++ b/packages/backend-core/src/modules/cms/skills/stale-content-review.md
@@ -1,0 +1,140 @@
+---
+title: CMS stale-content review
+description: Periodic curator pass — find drafts that have stalled, published entries that haven't been touched in months, and orphaned assets. Reports findings with recommended actions. No persistence layer; the operator reviews the curator-runner's log/reply and acts manually via existing CMS tools.
+audiences: [admin]
+---
+
+# CMS stale-content review
+
+CMS data accumulates: drafts that someone started but never published, articles that were great two years ago but reference a product that's been retired, asset uploads from a campaign that ended last quarter. None of this is wrong individually — together it makes search worse, makes the editorial team trust the CMS less, and makes "is this current?" the first question every consumer asks.
+
+This skill walks an admin agent through one periodic stale-content pass. The agent finds suspect items, judges each one against the org's velocity and content style, and produces a structured report. There's no proposal queue or merge-table for v1 — the report goes back as the curator-runner's reply, the operator reads it, and they (or their admin agent) act on it via the existing `cms_*` tools.
+
+Run periodically. Quarterly is a good default for content-stable orgs; monthly for fast-moving ones. Don't run inline per CMS write — staleness is a population property, not a per-row property.
+
+## TL;DR
+
+1. **Inventory collections** with `cms_list_collections` so you know the velocity expectations of each (a docs collection is updated less often than a "weekly product update" collection).
+2. **Find stale drafts** — `cms_list_entries({ status: "draft" })`, filter to `updatedAt > 30 days ago`, and judge each one ("is this clearly abandoned?" vs "is this work in progress that just got blocked?").
+3. **Find stale published entries** — `cms_list_entries({ status: "published" })`, filter to `updatedAt > N months ago` per collection's velocity. For each, run `cms_list_inbound_references` to see if the entry is still load-bearing or has been superseded.
+4. **Find orphaned assets** — `cms_list_assets`, cross-reference against entry bodies (search for asset IDs in entries' `data` payloads) to find uploads no entry points to.
+5. **Compose a structured report** grouped by recommended action: `archive`, `refresh`, `delete-asset`, `keep`. Include enough evidence per item that a reviewer can decide without re-querying.
+6. **Stop.** The operator reviews the report (curator-runner log on the cloud product, or your reply-to-the-user output for ad-hoc runs) and acts on it manually using the existing `cms_*` tools.
+
+## Step 1 — collections inventory
+
+```jsonc
+{ "name": "cms_list_collections", "arguments": {} }
+```
+
+For each collection, infer a *velocity expectation* from its purpose:
+
+- **Reference / docs / FAQ** — published entries should be reviewed at least every 6 months; drafts older than 60 days are suspicious.
+- **News / weekly update / changelog** — published entries become stale fast (the news from 2 years ago isn't relevant); drafts older than 14 days are almost certainly abandoned.
+- **Marketing landing / campaign** — tied to specific dates; check the entry body for date references that have passed.
+- **Settings / configuration entries** — should be touched only when something changes; long stability is a feature, not staleness.
+
+Make the velocity threshold per-collection in your judgment. Don't apply one global cutoff — a 14-month-old "About us" page is fine, a 14-month-old "Q2 2024 promotions" page is not.
+
+## Step 2 — stale drafts
+
+```jsonc
+{ "name": "cms_list_entries", "arguments": { "status": "draft", "limit": 200 } }
+```
+
+For each draft older than the collection's threshold, decide:
+
+- **Abandoned** — recommend `archive` or `delete`. Triggers: same author hasn't touched it in 60+ days; very short body (<200 chars) suggesting it never got going; title suggests an event/launch that has passed.
+- **Work in progress** — leave alone. Triggers: long body actively being edited (use `cms_list_versions` to see edit velocity); recent author activity in other entries.
+- **Stuck on a blocker** — leave alone but flag for the reviewer to ping the author.
+
+## Step 3 — stale published entries
+
+```jsonc
+{ "name": "cms_list_entries", "arguments": { "status": "published", "limit": 200 } }
+```
+
+For each entry older than the collection's threshold (per Step 1's per-collection velocity), check inbound references:
+
+```jsonc
+{ "name": "cms_list_inbound_references", "arguments": { "entryId": "cme_..." } }
+```
+
+Then judge:
+
+- **Still load-bearing** — has many inbound references from active entries, or is in a top-level navigation collection. Recommend `refresh` (the operator should re-read it for accuracy) rather than archiving.
+- **Superseded but referenced** — newer entries cover the same topic and are linked-to in the same neighborhood. Recommend `archive` (`cms_unpublish_entry`) but flag the inbound references so the operator can decide whether to redirect or delete them.
+- **Orphaned** — no inbound references and `updatedAt` very old. Recommend `delete` (`cms_delete_entry`).
+- **Time-bound** — title or body references a date/event that has passed (campaign, version-specific docs). Recommend `archive` or `delete` with high confidence.
+
+## Step 4 — orphaned assets
+
+```jsonc
+{ "name": "cms_list_assets", "arguments": { "limit": 200 } }
+```
+
+For each asset, check whether any entry references it. Asset references typically appear inside entry `data` payloads (image fields, gallery fields, file uploads). The skill doesn't have a direct "list inbound references for this asset" tool — instead:
+
+- Use `cms_search` with the asset id as the query to find entries that mention it.
+- Or if the asset's filename is distinctive, search by filename.
+
+If no entries reference the asset *and* `createdAt` is more than 90 days old, recommend `delete-asset` (`cms_delete_asset`). Be careful with recently uploaded assets — they may be tied to a draft entry that's still in progress.
+
+## Step 5 — compose the report
+
+Structure the output so an operator can scan it. Group by recommended action, not by collection. Per item: id, title, collection, last-updated date, evidence, recommended action. Example:
+
+```markdown
+## CMS stale-content review — 2026-05-04
+
+### Archive (low-risk)
+
+- **cme_abc123** — *"Q4 2024 holiday promotions"* (campaigns) — last updated 2024-11-15
+  - Time-bound title, holiday already passed; 0 inbound references
+  - Action: `cms_unpublish_entry({ id: "cme_abc123" })`, then `cms_delete_entry` after a 30-day soft window
+
+### Refresh (still load-bearing, but stale)
+
+- **cme_def456** — *"Pricing"* (top-level) — last updated 2024-08-12
+  - 23 inbound references; in main navigation
+  - Action: re-read for accuracy; verify pricing tiers haven't changed; bump `updatedAt`
+
+### Delete (orphaned drafts)
+
+- **cme_ghi789** — *"Untitled draft"* (blog) — last updated 2025-09-01
+  - Body length 47 chars; never published; same author has not edited in 8 months
+  - Action: `cms_delete_entry({ id: "cme_ghi789" })`
+
+### Delete asset (orphaned upload)
+
+- **cma_jkl012** — *"campaign-banner-q3.png"* — uploaded 2024-06-20
+  - No entries reference this filename; not in any draft
+  - Action: `cms_delete_asset({ id: "cma_jkl012" })`
+
+### Keep (stable on purpose)
+
+- **cme_mno345** — *"About us"* (top-level) — last updated 2023-04-10
+  - Despite age, content is stable by design (org history); 12 inbound references
+  - Action: none (annotated for the next pass to skip)
+```
+
+The operator reviews this report and runs the recommended commands. None of the recommendations execute automatically.
+
+## What NOT to do
+
+- **Don't auto-execute.** v1 of this skill is propose-only. Even `delete` on an orphaned draft is the operator's call — the agent might be wrong about what's load-bearing.
+- **Don't apply one global staleness threshold.** A 14-month-old "About us" page is healthy; a 14-month-old "Q2 2024 promotions" page is not. Per-collection velocity in Step 1 is the whole point.
+- **Don't recommend deleting entries with active inbound references** without flagging the references explicitly — silent breakage is worse than visible staleness.
+- **Don't recurse into the full-text content of every published entry on every pass.** The pass should be cheap. Sample, prioritize obvious cases, and let next quarter's pass cover what this one didn't.
+- **Don't include private end-user data in the report** (a stale entry's body might contain customer names, account ids, etc.). Reference items by id + title; let the reviewer open them in context.
+
+## Future work
+
+- A `cms_curation_proposals` table (mirroring `crm_merge_proposals`) so this skill produces a persistent review queue instead of a one-shot report. Add when the volume justifies it.
+- Per-asset inbound-reference check (a dedicated tool that walks all entries' `data` for asset id mentions). Today the skill uses `cms_search` as a workaround.
+- Automated `cms_unpublish_entry` for the high-confidence "time-bound, expired, zero references" subset, gated behind an explicit org-level toggle.
+
+## Related
+
+- `skill://kb/curation` — sibling curator pass for conversation → KB document candidates. Different domain, similar "propose, don't apply" philosophy. KB curation has a persistent inbox; CMS stale-content review v1 does not.
+- `skill://crm/hygiene` — sibling curator pass for CRM merge proposals. Different domain, structured proposals table.

--- a/packages/backend-core/src/modules/crm/crm.service.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
+import { ActorIdentity, withContext, WebhookDispatcher, type RequestContext } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { eq, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
@@ -38,7 +38,7 @@ const skipReason = TEST_URL
     endUserId = eu!.id;
     actor = new ActorIdentity('admin_agent', 'agt_crm_test', orgId, ['*'], ['admin']);
 
-    svc = new CrmService();
+    svc = new CrmService(new WebhookDispatcher());
   });
 
   afterAll(async () => {
@@ -497,6 +497,132 @@ const skipReason = TEST_URL
       expect(refreshedDup.tags.some((t) => t.startsWith('dedup-archived-'))).toBe(true);
       expect(refreshedDup.customFields.mergedInto).toBe(keeper.id);
       expect(refreshedDup.doNotContact).toBe(true);
+    });
+
+    it('applyMergeProposal reassigns activities, deals, and contact-typed relationships from duplicate to keeper', async () => {
+      const keeper = await run(() => svc.createContact({ name: 'Keeper', email: 'k@y' }));
+      const dup = await run(() => svc.createContact({ name: 'Dup', email: 'k@y' }));
+      const other = await run(() => svc.createContact({ name: 'Other', email: 'o@y' }));
+
+      await run(() =>
+        svc.logActivity({ type: 'note', subject: 'on dup', contactId: dup.id }),
+      );
+      const pipeline = await run(() =>
+        svc.createPipeline({ name: 'p', slug: 'p1', stages: [{ name: 's' }] }),
+      );
+      const deal = await run(() =>
+        svc.createDeal({ name: 'd', pipelineId: pipeline.id, primaryContactId: dup.id }),
+      );
+
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.insert(schema.crmRelationships).values({
+        orgId,
+        fromType: 'contact',
+        fromId: dup.id,
+        toType: 'contact',
+        toId: other.id,
+        role: 'introduced_by',
+      });
+      await db.insert(schema.crmRelationships).values({
+        orgId,
+        fromType: 'contact',
+        fromId: other.id,
+        toType: 'contact',
+        toId: dup.id,
+        role: 'reports_to',
+      });
+
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: keeper.id,
+          contactBId: dup.id,
+          confidence: 'high',
+          evidence: {},
+          recommendedKeeperId: keeper.id,
+        }),
+      );
+      await run(() => svc.applyMergeProposal({ id: proposal.id }));
+
+      const keeperActivities = await run(() =>
+        svc.listActivities({ contactId: keeper.id, limit: 50 }),
+      );
+      expect(keeperActivities.find((a) => a.subject === 'on dup')).toBeDefined();
+      const dupActivities = await run(() =>
+        svc.listActivities({ contactId: dup.id, limit: 50 }),
+      );
+      expect(dupActivities).toHaveLength(0);
+
+      const refreshedDeals = await db
+        .select()
+        .from(schema.crmDeals)
+        .where(eq(schema.crmDeals.id, deal.id));
+      expect(refreshedDeals[0]?.primaryContactId).toBe(keeper.id);
+
+      const rels = await db
+        .select()
+        .from(schema.crmRelationships)
+        .where(eq(schema.crmRelationships.orgId, orgId));
+      const rewritten = rels.filter(
+        (r) =>
+          (r.fromType === 'contact' && r.fromId === keeper.id) ||
+          (r.toType === 'contact' && r.toId === keeper.id),
+      );
+      expect(rewritten.length).toBe(2);
+      const stillOnDup = rels.filter(
+        (r) =>
+          (r.fromType === 'contact' && r.fromId === dup.id) ||
+          (r.toType === 'contact' && r.toId === dup.id),
+      );
+      expect(stillOnDup).toHaveLength(0);
+    });
+
+    it('applyMergeProposal transfers endUserId to keeper when keeper has none and clears duplicate', async () => {
+      const keeper = await run(() => svc.createContact({ name: 'Keeper', email: 'k@y' }));
+      const dup = await run(() =>
+        svc.createContact({ name: 'Dup', email: 'k@y', endUserId }),
+      );
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: keeper.id,
+          contactBId: dup.id,
+          confidence: 'high',
+          evidence: {},
+          recommendedKeeperId: keeper.id,
+        }),
+      );
+      await run(() => svc.applyMergeProposal({ id: proposal.id }));
+      const refreshedKeeper = await run(() => svc.getContact(keeper.id));
+      const refreshedDup = await run(() => svc.getContact(dup.id));
+      expect(refreshedKeeper.endUserId).toBe(endUserId);
+      expect(refreshedDup.endUserId).toBeNull();
+    });
+
+    it('applyMergeProposal preserves keeper endUserId when both contacts have one (clears duplicate only)', async () => {
+      const otherEu = await db
+        .insert(schema.endUsers)
+        .values({ orgId, externalId: `eu-other-${Date.now()}`, name: 'Other EU' })
+        .returning();
+      const otherEuId = otherEu[0]!.id;
+      const keeper = await run(() =>
+        svc.createContact({ name: 'Keeper', email: 'k@y', endUserId }),
+      );
+      const dup = await run(() =>
+        svc.createContact({ name: 'Dup', email: 'k@y', endUserId: otherEuId }),
+      );
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: keeper.id,
+          contactBId: dup.id,
+          confidence: 'high',
+          evidence: {},
+          recommendedKeeperId: keeper.id,
+        }),
+      );
+      await run(() => svc.applyMergeProposal({ id: proposal.id }));
+      const refreshedKeeper = await run(() => svc.getContact(keeper.id));
+      const refreshedDup = await run(() => svc.getContact(dup.id));
+      expect(refreshedKeeper.endUserId).toBe(endUserId);
+      expect(refreshedDup.endUserId).toBeNull();
     });
 
     it('applyMergeProposal rejects non-pending proposals', async () => {

--- a/packages/backend-core/src/modules/crm/crm.service.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.ts
@@ -1,7 +1,7 @@
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { schema } from '@getmunin/db';
 import { and, asc, desc, eq, ilike, or, sql, type SQL } from 'drizzle-orm';
-import { getCurrentContext } from '@getmunin/core';
+import { getCurrentContext, WebhookDispatcher } from '@getmunin/core';
 
 export class CrmInvalidError extends Error {
   readonly code = 'crm_invalid';
@@ -137,6 +137,10 @@ export interface MergeProposalDto {
 
 @Injectable()
 export class CrmService {
+  constructor(
+    @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
+  ) {}
+
   // ─── Contacts ───────────────────────────────────────────────────────────
 
   async listContacts(input: {
@@ -656,7 +660,9 @@ export class CrmService {
         })
         .where(eq(schema.crmMergeProposals.id, existingPending[0].id))
         .returning();
-      return toMergeProposalDto(updated!, contactA, contactB);
+      const dto = toMergeProposalDto(updated!, contactA, contactB);
+      await this.emitMergeEvent('crm.merge_proposal.proposed', dto);
+      return dto;
     }
 
     const [row] = await ctx.db
@@ -674,7 +680,9 @@ export class CrmService {
         proposedByActorId: actor.id,
       })
       .returning();
-    return toMergeProposalDto(row!, contactA, contactB);
+    const dto = toMergeProposalDto(row!, contactA, contactB);
+    await this.emitMergeEvent('crm.merge_proposal.proposed', dto);
+    return dto;
   }
 
   async listMergeProposals(input: {
@@ -762,12 +770,44 @@ export class CrmService {
     for (const [k, v] of Object.entries(patch)) {
       if (v !== undefined) keeperUpdates[k] = v;
     }
+    if (!keeperRow.endUserId && duplicateRow.endUserId) {
+      keeperUpdates['endUserId'] = duplicateRow.endUserId;
+    }
     if (Object.keys(keeperUpdates).length > 1) {
       await ctx.db
         .update(schema.crmContacts)
         .set(keeperUpdates)
         .where(eq(schema.crmContacts.id, keeperId));
     }
+
+    await ctx.db
+      .update(schema.crmActivities)
+      .set({ contactId: keeperId })
+      .where(eq(schema.crmActivities.contactId, duplicateId));
+
+    await ctx.db
+      .update(schema.crmDeals)
+      .set({ primaryContactId: keeperId, updatedAt: new Date() })
+      .where(eq(schema.crmDeals.primaryContactId, duplicateId));
+
+    await ctx.db
+      .update(schema.crmRelationships)
+      .set({ fromId: keeperId })
+      .where(
+        and(
+          eq(schema.crmRelationships.fromType, 'contact'),
+          eq(schema.crmRelationships.fromId, duplicateId),
+        ),
+      );
+    await ctx.db
+      .update(schema.crmRelationships)
+      .set({ toId: keeperId })
+      .where(
+        and(
+          eq(schema.crmRelationships.toType, 'contact'),
+          eq(schema.crmRelationships.toId, duplicateId),
+        ),
+      );
 
     const archiveTag = `dedup-archived-${archiveMonth(new Date())}`;
     const dupTags = duplicateRow.tags.includes(archiveTag)
@@ -778,14 +818,18 @@ export class CrmService {
       mergedInto: keeperId,
       mergedAt: new Date().toISOString(),
     };
+    const dupUpdates: Record<string, unknown> = {
+      tags: dupTags,
+      customFields: dupCustomFields,
+      doNotContact: true,
+      updatedAt: new Date(),
+    };
+    if (duplicateRow.endUserId) {
+      dupUpdates['endUserId'] = null;
+    }
     await ctx.db
       .update(schema.crmContacts)
-      .set({
-        tags: dupTags,
-        customFields: dupCustomFields,
-        doNotContact: true,
-        updatedAt: new Date(),
-      })
+      .set(dupUpdates)
       .where(eq(schema.crmContacts.id, duplicateId));
 
     const [updatedProposal] = await ctx.db
@@ -806,7 +850,9 @@ export class CrmService {
       .where(or(eq(schema.crmContacts.id, keeperId), eq(schema.crmContacts.id, duplicateId)));
     const a = refreshed.find((r) => r.id === proposal.contactAId);
     const b = refreshed.find((r) => r.id === proposal.contactBId);
-    return toMergeProposalDto(updatedProposal!, a!, b!);
+    const dto = toMergeProposalDto(updatedProposal!, a!, b!);
+    await this.emitMergeEvent('crm.merge_proposal.applied', dto);
+    return dto;
   }
 
   async dismissMergeProposal(input: { id: string; reason?: string }): Promise<MergeProposalDto> {
@@ -843,7 +889,29 @@ export class CrmService {
     if (!a || !b) {
       throw new CrmInvalidError(`merge proposal ${input.id} references missing contact`);
     }
-    return toMergeProposalDto(updated!, a, b);
+    const dto = toMergeProposalDto(updated!, a, b);
+    await this.emitMergeEvent('crm.merge_proposal.dismissed', dto);
+    return dto;
+  }
+
+  private async emitMergeEvent(
+    type: 'crm.merge_proposal.proposed' | 'crm.merge_proposal.applied' | 'crm.merge_proposal.dismissed',
+    proposal: MergeProposalDto,
+  ): Promise<void> {
+    await this.webhooks.emit({
+      type,
+      payload: {
+        id: proposal.id,
+        contactAId: proposal.contactA.id,
+        contactBId: proposal.contactB.id,
+        recommendedKeeperId: proposal.recommendedKeeperId,
+        confidence: proposal.confidence,
+        status: proposal.status,
+        decidedByActorType: proposal.decidedByActorType,
+        decidedByActorId: proposal.decidedByActorId,
+        decidedAt: proposal.decidedAt,
+      },
+    });
   }
 }
 

--- a/packages/backend-core/src/modules/crm/skills/hygiene.md
+++ b/packages/backend-core/src/modules/crm/skills/hygiene.md
@@ -114,7 +114,7 @@ After the curator's pass, the operator (human or admin agent acting on their aut
 
 For each pending proposal, the operator either:
 
-- **Applies it:** `crm_apply_merge_proposal({ id })`. Atomically copies `recommendedPatch` onto the keeper, archives the duplicate (tag `dedup-archived-YYYY-MM` + `customFields.mergedInto: <keeperId>` + `doNotContact: true`), marks the proposal `applied`. Activities and deals stay on whichever contactId they were originally logged under — see "Future work" below.
+- **Applies it:** `crm_apply_merge_proposal({ id })`. In a single transaction: copies `recommendedPatch` onto the keeper; reassigns the duplicate's `crm_activities`, `crm_deals` (primary contact), and `crm_relationships` (contact-typed `from_id` / `to_id`) onto the keeper; transfers the duplicate's `endUserId` to the keeper if the keeper had none; archives the duplicate (`dedup-archived-YYYY-MM` tag + `customFields.mergedInto: <keeperId>` + `doNotContact: true`, `endUserId` cleared); marks the proposal `applied`.
 - **Dismisses it:** `crm_dismiss_merge_proposal({ id, reason })`. Records the rejection so the next curator pass skips this pair.
 
 The dashboard "Needs attention" backlog card surfaces the count of pending proposals via `/api/overview/backlog`.
@@ -129,9 +129,7 @@ The dashboard "Needs attention" backlog card surfaces the count of pending propo
 
 ## Future work
 
-- Atomic activity / deal / endUser-link reassignment in `crm_apply_merge_proposal`. Today the apply step archives the duplicate but leaves activities pointing at it; the keeper's history is incomplete until that's fixed. v2 adds a foreign-key sweep inside the same transaction.
 - Auto-apply for high-confidence proposals where the keeper is unambiguous and `recommendedPatch` is empty (a pure consolidation with no field choices). Gated behind an explicit org-level toggle.
-- Proposal-event webhooks (`crm.merge_proposal.proposed/applied/dismissed`) so the dashboard review queue updates without polling.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Three follow-ups to the curator family bundled into one PR (all CRM/CMS module-internal — no schema migration, no new endpoints).

**1. `crm_apply_merge_proposal` v2: atomic FK sweep.** Removes the documented "activities and deals stay on the original contactId" limitation. Apply now atomically reassigns:
- `crm_activities.contact_id` from duplicate → keeper
- `crm_deals.primary_contact_id` from duplicate → keeper
- `crm_relationships.from_id` and `to_id` (where the corresponding type is `contact`) from duplicate → keeper
- `crm_contacts.end_user_id`: transfers from duplicate to keeper if the keeper had none, otherwise cleared on the duplicate (keeper wins)

All inside the existing request transaction. Skill `skill://crm/hygiene` updated to describe the new behavior.

**2. Webhook + realtime events for merge proposals.** Emits via `WebhookDispatcher.emit()`:
- `crm.merge_proposal.proposed`
- `crm.merge_proposal.applied`
- `crm.merge_proposal.dismissed`

Same pattern as `kb.document.created` / `kb.curation_candidate.proposed`. Both webhook subscribers and the realtime gateway pick these up without further wiring. Lets the dashboard review queue update without polling.

**3. New skill `skill://cms/stale-content-review`.** Walks an admin agent through a periodic stale-content audit: stale drafts, published entries past collection-velocity threshold, orphaned assets. Produces a structured action report grouped by recommended action (`archive`, `refresh`, `delete`, `delete-asset`, `keep`). v1 is propose-only — no persistent inbox; the operator reviews the curator-runner's reply and acts manually via the existing `cms_*` tools. Uses only existing CMS tools — no new tool surface.

## Out of scope (deferred)

- Auto-apply for high-confidence merge proposals.
- A `cms_curation_proposals` table (mirroring `crm_merge_proposals`) for the CMS skill — added when the volume justifies a queue.
- A dedicated per-asset inbound-reference tool — today the CMS skill uses `cms_search` as a workaround.

## Test plan

- [x] `pnpm --filter @getmunin/backend-core typecheck && build` — clean (22 skills copied, was 21)
- [x] `pnpm --filter @getmunin/backend-core lint` — clean
- [x] `pnpm --filter @getmunin/backend-core test` — 276 tests pass (3 new merge tests: activity/deal/relationship reassignment, endUser transfer when keeper has none, endUser preserved on keeper when both have one)
- [ ] Cloud-side curator-runner picks up the new skill via `skill://cms/stale-content-review` (next PR — `CmsStaleContentCuratorService` subclass + dashboard review-queue subscription to the new realtime events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)