### PR TITLE
feat(dashboard): CRM merge proposals review page

### DIFF
--- a/.changeset/crm-merge-proposals-review-page.md
+++ b/.changeset/crm-merge-proposals-review-page.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Adds a CRM merge proposals review page to the dashboard. New REST controller exposes `GET /api/crm/merge-proposals`, `GET /api/crm/merge-proposals/:id`, `POST /api/crm/merge-proposals/:id/apply`, `POST /api/crm/merge-proposals/:id/dismiss` so the dashboard can list pending proposals and resolve them with one click. The page subscribes to the new `crm.merge_proposal.*` realtime events so the queue updates without polling, and falls back to a 60s poll. The "Needs attention" backlog tile gets a CRM merge counter that links to the page; nav adds a top-level "CRM merges" entry. en + nb i18n strings included.

--- a/apps/web/app/dashboard/crm-merge-proposals/page.tsx
+++ b/apps/web/app/dashboard/crm-merge-proposals/page.tsx
@@ -1,0 +1,1 @@
+export { CrmMergeProposalsPage as default } from '@getmunin/dashboard-pages';

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -10,6 +10,7 @@ import {
   MessageCircle,
   Newspaper,
   Settings,
+  Users,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { authClient, isOwnerOrAdmin, useActiveRole } from '@getmunin/dashboard-pages';
@@ -40,7 +41,7 @@ import { Label } from '@getmunin/ui';
 import { cn } from '@getmunin/ui';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 
-type NavLabelKey = 'conversations' | 'activity' | 'settings';
+type NavLabelKey = 'conversations' | 'activity' | 'crmMergeProposals' | 'settings';
 
 interface NavItem {
   href: Route;
@@ -52,6 +53,7 @@ interface NavItem {
 const NAV: NavItem[] = [
   { href: '/dashboard/conversations', labelKey: 'conversations', icon: MessageCircle },
   { href: '/dashboard/activity', labelKey: 'activity', icon: Newspaper },
+  { href: '/dashboard/crm-merge-proposals', labelKey: 'crmMergeProposals', icon: Users },
   { href: '/dashboard/settings', labelKey: 'settings', icon: Settings, ownerOrAdminOnly: true },
 ];
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -72,6 +72,7 @@
     "dataExport": "Data export",
     "conversations": "Conversations",
     "activity": "Activity log",
+    "crmMergeProposals": "CRM merges",
     "skills": "Skills",
     "suggestions": "Suggestions",
     "partnerAccess": "Partner access"
@@ -97,7 +98,34 @@
       "conversationsLabel": "conversations needing handover",
       "openConversations": "Open conversations →",
       "kbCurationLabel": "KB curation candidates pending review",
-      "kbCurationHint": "Open your connected admin agent and ask it to do a curation pass — it'll use skill://kb/curation."
+      "kbCurationHint": "Open your connected admin agent and ask it to do a curation pass — it'll use skill://kb/curation.",
+      "crmMergeProposalsLabel": "CRM merge proposals pending review",
+      "openMergeProposals": "Review merges →"
+    },
+    "crmMergeProposals": {
+      "title": "CRM merge proposals",
+      "subtitle": "Pending duplicate-contact merges proposed by the CRM hygiene curator. Apply to atomically copy the recommended patch onto the keeper, reassign activities and deals, and archive the duplicate. Dismiss to record that the pair is not the same person.",
+      "loading": "Loading…",
+      "empty": "No pending merge proposals.",
+      "hint": "The CRM hygiene curator runs weekly and re-files proposals if it finds the same suspect pair again — dismissing one prevents that.",
+      "keeperLabel": "Keeper",
+      "duplicateLabel": "Duplicate",
+      "evidenceToggle": "Show evidence",
+      "patchToggle": "Show recommended patch",
+      "applyButton": "Apply merge",
+      "dismissButton": "Dismiss",
+      "dismissPrompt": "Reason for dismissing? (optional)",
+      "working": "Working…",
+      "proposedAt": "Proposed {date}",
+      "confidence": {
+        "high": "High confidence",
+        "medium": "Medium confidence"
+      },
+      "errors": {
+        "load": "Failed to load merge proposals.",
+        "apply": "Failed to apply merge.",
+        "dismiss": "Failed to dismiss merge."
+      }
     },
     "agents": {
       "title": "Connected agents",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -72,6 +72,7 @@
     "dataExport": "Dataeksport",
     "conversations": "Samtaler",
     "activity": "Aktivitetslogg",
+    "crmMergeProposals": "CRM-sammenslåinger",
     "skills": "Ferdigheter",
     "suggestions": "Forslag",
     "partnerAccess": "Partnertilgang"
@@ -97,7 +98,34 @@
       "conversationsLabel": "samtaler som venter på overlevering",
       "openConversations": "Åpne samtaler →",
       "kbCurationLabel": "kunnskapsbase-kandidater venter på gjennomgang",
-      "kbCurationHint": "Åpne admin-agenten din og be den gjøre en kurateringsrunde – den bruker skill://kb/curation."
+      "kbCurationHint": "Åpne admin-agenten din og be den gjøre en kurateringsrunde – den bruker skill://kb/curation.",
+      "crmMergeProposalsLabel": "CRM-sammenslåinger venter på gjennomgang",
+      "openMergeProposals": "Gjennomgå sammenslåinger →"
+    },
+    "crmMergeProposals": {
+      "title": "CRM-sammenslåinger",
+      "subtitle": "Forslag om å slå sammen duplikate kontakter, foreslått av CRM-hygienekuratoren. \"Slå sammen\" kopierer den anbefalte oppdateringen til keeperen, overfører aktiviteter og avtaler, og arkiverer duplikatet — alt i én transaksjon. \"Avvis\" registrerer at paret ikke er samme person.",
+      "loading": "Laster …",
+      "empty": "Ingen ventende sammenslåingsforslag.",
+      "hint": "CRM-hygienekuratoren kjører ukentlig og foreslår samme par på nytt hvis det fremdeles ser duplikat ut — å avvise hindrer det.",
+      "keeperLabel": "Keeper",
+      "duplicateLabel": "Duplikat",
+      "evidenceToggle": "Vis grunnlag",
+      "patchToggle": "Vis foreslått oppdatering",
+      "applyButton": "Slå sammen",
+      "dismissButton": "Avvis",
+      "dismissPrompt": "Begrunnelse for avvisning? (valgfritt)",
+      "working": "Arbeider …",
+      "proposedAt": "Foreslått {date}",
+      "confidence": {
+        "high": "Høy tiltro",
+        "medium": "Middels tiltro"
+      },
+      "errors": {
+        "load": "Klarte ikke laste sammenslåingsforslag.",
+        "apply": "Klarte ikke slå sammen.",
+        "dismiss": "Klarte ikke avvise."
+      }
     },
     "agents": {
       "title": "Tilkoblede agenter",

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -11,7 +11,9 @@ import { WebhooksController } from './webhooks.controller.js';
 import { CmsDeliveryController } from './cms-delivery.controller.js';
 import { CmsModule } from '../modules/cms/cms.module.js';
 import { ConvModule } from '../modules/conv/conv.module.js';
+import { CrmModule } from '../modules/crm/crm.module.js';
 import { McpModule } from '../mcp/mcp.module.js';
+import { CrmMergeProposalsController } from './crm-merge-proposals.controller.js';
 import { PublicSkillsController } from './public-skills.controller.js';
 import { InvitationsController } from './invitations.controller.js';
 import { AcceptInvitationController } from './accept-invitation.controller.js';
@@ -32,7 +34,7 @@ import { OverviewController } from './overview.controller.js';
  * permitted on these endpoints — that's the privilege boundary.
  */
 @Module({
-  imports: [CmsModule, ConvModule, McpModule],
+  imports: [CmsModule, ConvModule, CrmModule, McpModule],
   controllers: [
     ApiKeysController,
     EndUsersController,
@@ -53,6 +55,7 @@ import { OverviewController } from './overview.controller.js';
     ActivityController,
     EndUserConversationsController,
     OverviewController,
+    CrmMergeProposalsController,
   ],
   providers: [InvitationsService],
 })

--- a/packages/backend-core/src/control/crm-merge-proposals.controller.ts
+++ b/packages/backend-core/src/control/crm-merge-proposals.controller.ts
@@ -1,0 +1,96 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { z } from 'zod';
+import { AuthGuard } from '../common/auth/auth.guard.js';
+import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.js';
+import { AuditInterceptor } from '../common/audit/audit.interceptor.js';
+import {
+  CrmService,
+  CrmInvalidError,
+  MERGE_STATUSES,
+  type MergeProposalDto,
+} from '../modules/crm/crm.service.js';
+
+const StatusSchema = z.enum(MERGE_STATUSES);
+
+const DismissBody = z
+  .object({
+    reason: z.string().max(500).optional(),
+  })
+  .partial();
+
+interface MergeProposalListResponse {
+  items: MergeProposalDto[];
+}
+
+@Controller('api/crm/merge-proposals')
+@UseGuards(AuthGuard)
+@UseInterceptors(TenancyInterceptor, AuditInterceptor)
+export class CrmMergeProposalsController {
+  constructor(private readonly crm: CrmService) {}
+
+  @Get()
+  async list(
+    @Query('status') status?: string,
+    @Query('limit') limit?: string,
+  ): Promise<MergeProposalListResponse> {
+    const parsedStatus = status ? StatusSchema.safeParse(status) : null;
+    if (parsedStatus && !parsedStatus.success) {
+      throw new BadRequestException(`invalid status: ${status}`);
+    }
+    const items = await translate(() =>
+      this.crm.listMergeProposals({
+        status: parsedStatus?.success ? parsedStatus.data : undefined,
+        limit: parseLimit(limit),
+      }),
+    );
+    return { items };
+  }
+
+  @Get(':id')
+  async get(@Param('id') id: string): Promise<MergeProposalDto> {
+    return translate(() => this.crm.getMergeProposal(id));
+  }
+
+  @Post(':id/apply')
+  @HttpCode(200)
+  async apply(@Param('id') id: string): Promise<MergeProposalDto> {
+    return translate(() => this.crm.applyMergeProposal({ id }));
+  }
+
+  @Post(':id/dismiss')
+  @HttpCode(200)
+  async dismiss(
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ): Promise<MergeProposalDto> {
+    const parsed = DismissBody.safeParse(body ?? {});
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return translate(() => this.crm.dismissMergeProposal({ id, reason: parsed.data.reason }));
+  }
+}
+
+async function translate<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof CrmInvalidError) throw new BadRequestException(err.message);
+    throw err;
+  }
+}
+
+function parseLimit(value: string | undefined): number | undefined {
+  const n = value ? Number.parseInt(value, 10) : NaN;
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.min(n, 200);
+}

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -14,6 +14,7 @@ export { TeamPage } from './pages/team';
 export { UsagePage } from './pages/usage';
 export { ConversationsPage } from './pages/conversations';
 export { ActivityPage } from './pages/activity';
+export { CrmMergeProposalsPage } from './pages/crm-merge-proposals';
 export {
   useRealtime,
   type RealtimeEventRow,

--- a/packages/dashboard-pages/src/pages/crm-merge-proposals.tsx
+++ b/packages/dashboard-pages/src/pages/crm-merge-proposals.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertCircle, CheckCircle2, Users, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@getmunin/ui';
+import { api, ApiError } from '../api';
+import { useRealtime } from '../realtime';
+
+interface ContactSummary {
+  id: string;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  companyId: string | null;
+  endUserId: string | null;
+}
+
+interface MergeProposalDto {
+  id: string;
+  contactA: ContactSummary;
+  contactB: ContactSummary;
+  confidence: 'high' | 'medium';
+  evidence: Record<string, unknown>;
+  recommendedKeeperId: string;
+  recommendedPatch: Record<string, unknown>;
+  status: 'pending' | 'applied' | 'dismissed';
+  dismissReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+  decidedAt: string | null;
+}
+
+interface ListResponse {
+  items: MergeProposalDto[];
+}
+
+const POLL_MS = 60_000;
+
+export function CrmMergeProposalsPage() {
+  const t = useTranslations('dashboard.crmMergeProposals');
+  const [proposals, setProposals] = useState<MergeProposalDto[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setError(null);
+      const res = await api<ListResponse>('/api/crm/merge-proposals?status=pending&limit=200');
+      setProposals(res.items);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : t('errors.load'));
+    }
+  }, [t]);
+
+  useEffect(() => {
+    void load();
+    const id = setInterval(() => void load(), POLL_MS);
+    return () => clearInterval(id);
+  }, [load]);
+
+  useRealtime([{ channel: 'org' }], (event) => {
+    if (event.type.startsWith('crm.merge_proposal.')) {
+      void load();
+    }
+  });
+
+  async function apply(id: string) {
+    setBusyId(id);
+    try {
+      await api(`/api/crm/merge-proposals/${id}/apply`, { method: 'POST' });
+      await load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : t('errors.apply'));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function dismiss(id: string) {
+    const reason = window.prompt(t('dismissPrompt')) ?? undefined;
+    setBusyId(id);
+    try {
+      await api(`/api/crm/merge-proposals/${id}/dismiss`, {
+        method: 'POST',
+        body: JSON.stringify(reason ? { reason } : {}),
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : t('errors.dismiss'));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const empty = useMemo(() => proposals !== null && proposals.length === 0, [proposals]);
+
+  return (
+    <>
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      {error && (
+        <Card>
+          <CardContent className="py-4 text-sm text-destructive">{error}</CardContent>
+        </Card>
+      )}
+
+      {proposals === null && !error && (
+        <p className="text-sm text-muted-foreground">{t('loading')}</p>
+      )}
+
+      {empty && (
+        <Card>
+          <CardContent className="flex items-center gap-3 py-6 text-sm text-muted-foreground">
+            <CheckCircle2 className="size-5" />
+            <span>{t('empty')}</span>
+          </CardContent>
+        </Card>
+      )}
+
+      {proposals && proposals.length > 0 && (
+        <ul className="space-y-3">
+          {proposals.map((p) => {
+            const keeper = p.contactA.id === p.recommendedKeeperId ? p.contactA : p.contactB;
+            const dup = p.contactA.id === p.recommendedKeeperId ? p.contactB : p.contactA;
+            const confLabel =
+              p.confidence === 'high' ? t('confidence.high') : t('confidence.medium');
+            return (
+              <li key={p.id}>
+                <Card>
+                  <CardHeader>
+                    <div className="flex items-center gap-2">
+                      <Users className="size-5 text-muted-foreground" />
+                      <CardTitle className="text-base">
+                        {contactLabel(keeper)} <span className="text-muted-foreground">↔</span>{' '}
+                        {contactLabel(dup)}
+                      </CardTitle>
+                      <span
+                        className={
+                          p.confidence === 'high'
+                            ? 'rounded-full bg-emerald-100 px-2 py-0.5 text-xs text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200'
+                            : 'rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-900 dark:bg-amber-900/30 dark:text-amber-200'
+                        }
+                      >
+                        {confLabel}
+                      </span>
+                    </div>
+                    <CardDescription>{t('proposedAt', { date: formatDate(p.createdAt) })}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <div className="grid gap-3 text-sm sm:grid-cols-2">
+                      <ContactCard label={t('keeperLabel')} contact={keeper} highlight />
+                      <ContactCard label={t('duplicateLabel')} contact={dup} />
+                    </div>
+                    {Object.keys(p.evidence).length > 0 && (
+                      <details className="text-xs">
+                        <summary className="cursor-pointer text-muted-foreground">
+                          {t('evidenceToggle')}
+                        </summary>
+                        <pre className="mt-2 overflow-x-auto rounded border bg-muted px-3 py-2">
+                          {JSON.stringify(p.evidence, null, 2)}
+                        </pre>
+                      </details>
+                    )}
+                    {Object.keys(p.recommendedPatch).length > 0 && (
+                      <details className="text-xs">
+                        <summary className="cursor-pointer text-muted-foreground">
+                          {t('patchToggle')}
+                        </summary>
+                        <pre className="mt-2 overflow-x-auto rounded border bg-muted px-3 py-2">
+                          {JSON.stringify(p.recommendedPatch, null, 2)}
+                        </pre>
+                      </details>
+                    )}
+                    <div className="flex items-center gap-2">
+                      <Button
+                        size="sm"
+                        disabled={busyId === p.id}
+                        onClick={() => void apply(p.id)}
+                      >
+                        <CheckCircle2 className="size-4" />
+                        {t('applyButton')}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={busyId === p.id}
+                        onClick={() => void dismiss(p.id)}
+                      >
+                        <X className="size-4" />
+                        {t('dismissButton')}
+                      </Button>
+                      {busyId === p.id && (
+                        <span className="text-xs text-muted-foreground">{t('working')}</span>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {!empty && proposals && (
+        <p className="flex items-center gap-2 text-xs text-muted-foreground">
+          <AlertCircle className="size-3" />
+          {t('hint')}
+        </p>
+      )}
+    </>
+  );
+}
+
+function ContactCard({
+  label,
+  contact,
+  highlight,
+}: {
+  label: string;
+  contact: ContactSummary;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={
+        highlight
+          ? 'rounded-md border-2 border-emerald-300 bg-emerald-50/40 px-3 py-2 dark:border-emerald-800 dark:bg-emerald-950/30'
+          : 'rounded-md border bg-muted/30 px-3 py-2'
+      }
+    >
+      <p className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="font-medium">{contact.name ?? contact.id}</p>
+      <p className="text-xs text-muted-foreground">{contact.email ?? '—'}</p>
+      <p className="text-xs text-muted-foreground">{contact.phone ?? '—'}</p>
+      <p className="font-mono text-[10px] text-muted-foreground">{contact.id}</p>
+    </div>
+  );
+}
+
+function contactLabel(c: ContactSummary): string {
+  return c.name ?? c.email ?? c.id;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -17,6 +17,7 @@ import { api } from '../api';
 interface BacklogDto {
   conversationsNeedingAttention: number;
   kbCurationPending: number;
+  crmMergeProposalsPending: number;
 }
 
 export function DashboardPage() {
@@ -34,7 +35,8 @@ export function DashboardPage() {
   const allClear =
     backlog !== null &&
     backlog.conversationsNeedingAttention === 0 &&
-    backlog.kbCurationPending === 0;
+    backlog.kbCurationPending === 0 &&
+    backlog.crmMergeProposalsPending === 0;
 
   return (
     <>
@@ -87,6 +89,20 @@ export function DashboardPage() {
                     <p className="mt-1 text-xs text-muted-foreground">
                       {tBacklog('kbCurationHint')}
                     </p>
+                  </li>
+                )}
+                {backlog.crmMergeProposalsPending > 0 && (
+                  <li className="flex items-center justify-between gap-3">
+                    <span>
+                      <strong className="font-medium">{backlog.crmMergeProposalsPending}</strong>{' '}
+                      {tBacklog('crmMergeProposalsLabel')}
+                    </span>
+                    <Link
+                      href="/dashboard/crm-merge-proposals"
+                      className="text-xs text-muted-foreground hover:underline"
+                    >
+                      {tBacklog('openMergeProposals')}
+                    </Link>
                   </li>
                 )}
               </ul>


### PR DESCRIPTION
## Summary

Adds a dashboard page that lists pending merge proposals from the CRM hygiene curator and lets the operator resolve them with one click.

**New REST controller** (`packages/backend-core/src/control/crm-merge-proposals.controller.ts`) wraps the existing `CrmService` merge methods so the dashboard can hit them via the standard `api()` helper:

- `GET /api/crm/merge-proposals?status=pending&limit=200`
- `GET /api/crm/merge-proposals/:id`
- `POST /api/crm/merge-proposals/:id/apply`
- `POST /api/crm/merge-proposals/:id/dismiss`

**New dashboard page** (`packages/dashboard-pages/src/pages/crm-merge-proposals.tsx`) renders each pending proposal as a card with both contacts side-by-side (keeper highlighted), collapsible evidence + recommended-patch JSON, and apply/dismiss buttons. Subscribes to the `org` realtime channel via `useRealtime` so the queue refreshes instantly when `crm.merge_proposal.*` events fire from the backend (PR getmunin/munin#54). Falls back to a 60s poll if realtime is down.

**Overview backlog tile** gets a third `crmMergeProposalsPending` counter that links to the new page.

**Nav** adds a top-level "CRM merges" entry between Activity and Settings.

**i18n**: en + nb strings for the page, the backlog tile entry, and the nav label.

## Test plan

- [x] `pnpm -r typecheck` — backend-core, dashboard-pages, web all clean
- [x] `pnpm -r build` — clean (21 skills copied)
- [x] `pnpm --filter @getmunin/backend-core test` — 273 tests pass (no new tests added; the controller is a thin wrapper around already-tested service methods)
- [ ] Manual: connect a real merge proposal via `crm_propose_merge_candidate`, refresh the dashboard, click apply, verify activities/deals were swept onto the keeper (depends on PR getmunin/munin#54 for the FK sweep — without it, the apply still works but doesn't reassign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)