### PR TITLE
fix(db): conv_next_display_id must bypass RLS

### DIFF
--- a/.changeset/conv-next-display-id-security-definer.md
+++ b/.changeset/conv-next-display-id-security-definer.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/db': patch
+---
+
+Fixes a bug where a second end-user starting a conversation in an org that already has another end-user's conversation would 500 with `conv_conversations_display_uq` collision. `conv_next_display_id(p_org_id)` was running under the caller's RLS context — when called from a delegated end-user token, it only saw that end-user's own conversations and computed `MAX(display_id) + 1` from the wrong baseline, picking values already taken by *other* end-users' rows. The application-layer retry couldn't recover because Postgres aborts the whole transaction after the first INSERT conflict. Marks the function `SECURITY DEFINER` (with a fixed `search_path`) so the per-org sequence is computed against all conversations in the org, regardless of caller tenancy. Added a regression test (`a second end-user can start a conversation after the first`) covering the exact pattern that triggered the bug.

--- a/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
@@ -209,6 +209,25 @@ const skipReason = TEST_URL
     expect(bobReply.status).toBe(404);
   }, 30_000);
 
+  it('a second end-user can start a conversation after the first (display_id sequence is org-wide, not RLS-filtered)', async () => {
+    const aliceStart = await rest<{ id: string; displayId: number }>(
+      aliceToken,
+      'POST',
+      '/api/end-user/conversations',
+      { body: 'first conversation' },
+    );
+    expect(aliceStart.status).toBe(201);
+
+    const bobStart = await rest<{ id: string; displayId: number }>(
+      bobToken,
+      'POST',
+      '/api/end-user/conversations',
+      { body: 'second conversation, different end-user' },
+    );
+    expect(bobStart.status).toBe(201);
+    expect(bobStart.body.displayId).toBeGreaterThan(aliceStart.body.displayId);
+  }, 30_000);
+
   it('POST /messages always stores authorType=end_user, ignoring any client field', async () => {
     const start = await rest<{ id: string }>(
       aliceToken,

--- a/packages/db/src/sql/conv.sql
+++ b/packages/db/src/sql/conv.sql
@@ -12,8 +12,17 @@
 -- block on the unique (org_id, display_id) index and retry at the
 -- application layer. Conversations service catches the conflict and retries.
 
+-- SECURITY DEFINER + the org_id arg means the per-org sequence is computed
+-- against ALL conversations in the org, not just rows visible to the caller's
+-- RLS context. End-user-delegated calls would otherwise see only their own
+-- conversations and re-pick display_id values already taken by other
+-- end-users — colliding with conv_conversations_display_uq. Postgres aborts
+-- the transaction after the first conflict, so the application-layer retry
+-- can't recover. SECURITY DEFINER keeps the unique-sequence invariant correct
+-- regardless of the caller's tenancy context.
 CREATE OR REPLACE FUNCTION conv_next_display_id(p_org_id text) RETURNS integer
-  LANGUAGE sql VOLATILE
+  LANGUAGE sql VOLATILE SECURITY DEFINER
+  SET search_path = pg_catalog, public
   AS $$
     SELECT COALESCE(MAX(display_id), 0) + 1
     FROM conv_conversations


### PR DESCRIPTION
## Summary

A second end-user starting a conversation in an org that already held another end-user's conversation would 500 with `conv_conversations_display_uq` collision. The display-id generator ran under the caller's RLS context — from a delegated end-user token it only saw that end-user's own rows and computed `MAX(display_id) + 1` from the wrong baseline, picking values already taken by *other* end-users.

The application-layer retry in `insertConversationWithRetry` could not recover because Postgres aborts the whole transaction after the first INSERT conflict, so subsequent retries in the same request all fail.

## The fix

`SECURITY DEFINER` on `conv_next_display_id`, with a fixed `search_path`, so the per-org sequence is computed against all conversations in the org regardless of caller tenancy.

The function:
- is read-only,
- takes the org id as an argument (no GUC trust involved),
- only ever returns an integer (no info-leak surface).

## Reproduction (before this fix)

1. Org has zero conversations.
2. End-user Alice (delegated token) starts a conversation → display_id=1, succeeds.
3. End-user Bob (different delegated token, same org) starts a conversation → 500 with `duplicate key value violates unique constraint "conv_conversations_display_uq"`.

In a real chat-widget deployment, every second-and-onwards visitor would hit this on their first message.

## Test plan

- [x] Regression test added: `a second end-user can start a conversation after the first` in `end-user-conversations.controller.integration.test.ts` — alice creates a conversation, then bob (different end-user, same org) creates one; both succeed, bob's `displayId > alice's`.
- [x] `pnpm --filter @getmunin/backend-core test` — 277 tests pass (was 276; +1 regression test).
- [x] `pnpm --filter @getmunin/db build` — clean.
- [x] Manual reproduction against a live backend confirmed before the fix; cleared after applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)