### PR TITLE
feat(dashboard): self-service agent availability indicator

### DIFF
--- a/.changeset/agent-availability-status.md
+++ b/.changeset/agent-availability-status.md
@@ -1,6 +1,10 @@
 ---
 '@getmunin/backend-core': minor
 '@getmunin/dashboard-pages': minor
+'@getmunin/core': minor
+'@getmunin/db': minor
 ---
 
 Adds a self-service-agent availability indicator to the dashboard. The realtime gateway now tracks live subscribers whose audiences include `self_service` (excluding end-user widgets) per org. New endpoint `GET /api/overview/agent-status` returns `{ selfServiceAgentSubscriberCount, lastInboundEndUserMessageAt, lastAgentMessageAt }`. Overview page renders a card showing connected/not-connected, and surfaces a warning state when there's no agent connected and end-user messages are unanswered. Solves the OSS bootstrapping confusion where a self-hoster's chat widget delivers messages into the void with no UI signal that nothing is listening on the agent side.
+
+Adds an `audiences` jsonb column on `api_keys` (default `['admin']`) and the credential resolver now reads it instead of hardcoding the audience set. This lets a key be minted with `audiences: ['admin', 'self_service']` so its realtime subscriptions are recognised as self-service-agent connections. Backwards compatible — existing rows default to admin-only.

--- a/.changeset/agent-availability-status.md
+++ b/.changeset/agent-availability-status.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Adds a self-service-agent availability indicator to the dashboard. The realtime gateway now tracks live subscribers whose audiences include `self_service` (excluding end-user widgets) per org. New endpoint `GET /api/overview/agent-status` returns `{ selfServiceAgentSubscriberCount, lastInboundEndUserMessageAt, lastAgentMessageAt }`. Overview page renders a card showing connected/not-connected, and surfaces a warning state when there's no agent connected and end-user messages are unanswered. Solves the OSS bootstrapping confusion where a self-hoster's chat widget delivers messages into the void with no UI signal that nothing is listening on the agent side.

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -92,6 +92,13 @@
         "cta": "Manage API keys"
       }
     },
+    "agentStatus": {
+      "title": "Self-service agent",
+      "connected": "{count, plural, one {1 agent connected} other {# agents connected}} — replies to end-user messages will be handled automatically.",
+      "notConnected": "No self-service agent connected. End-user messages will sit until a human replies from the dashboard or an agent runner is connected.",
+      "staleNotConnected": "No self-service agent connected, and there are unanswered end-user messages. Reply from the dashboard or connect an agent runner.",
+      "hint": "Connect an agent: run @getmunin/agent-runtime against this Munin's MCP, or use the cloud product's auto-replier."
+    },
     "needsAttention": {
       "title": "Needs attention",
       "allClear": "All caught up.",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -92,6 +92,13 @@
         "cta": "Administrer API-nøkler"
       }
     },
+    "agentStatus": {
+      "title": "Selvbetjeningsagent",
+      "connected": "{count, plural, one {1 agent tilkoblet} other {# agenter tilkoblet}} — sluttbrukermeldinger får automatiske svar.",
+      "notConnected": "Ingen selvbetjeningsagent tilkoblet. Sluttbrukermeldinger blir liggende til et menneske svarer fra dashbordet eller en agent-runner kobles til.",
+      "staleNotConnected": "Ingen selvbetjeningsagent tilkoblet, og det finnes ubesvarte sluttbrukermeldinger. Svar fra dashbordet eller koble til en agent-runner.",
+      "hint": "Koble til en agent: kjør @getmunin/agent-runtime mot dette Munin-instansens MCP, eller bruk skytjenesten."
+    },
     "needsAttention": {
       "title": "Trenger oppmerksomhet",
       "allClear": "Alt er ajour.",

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -13,6 +13,7 @@ import { CmsModule } from '../modules/cms/cms.module.js';
 import { ConvModule } from '../modules/conv/conv.module.js';
 import { CrmModule } from '../modules/crm/crm.module.js';
 import { McpModule } from '../mcp/mcp.module.js';
+import { RealtimeModule } from '../realtime/realtime.module.js';
 import { CrmMergeProposalsController } from './crm-merge-proposals.controller.js';
 import { PublicSkillsController } from './public-skills.controller.js';
 import { InvitationsController } from './invitations.controller.js';
@@ -34,7 +35,7 @@ import { OverviewController } from './overview.controller.js';
  * permitted on these endpoints — that's the privilege boundary.
  */
 @Module({
-  imports: [CmsModule, ConvModule, CrmModule, McpModule],
+  imports: [CmsModule, ConvModule, CrmModule, McpModule, RealtimeModule],
   controllers: [
     ApiKeysController,
     EndUsersController,

--- a/packages/backend-core/src/control/overview.controller.integration.test.ts
+++ b/packages/backend-core/src/control/overview.controller.integration.test.ts
@@ -124,6 +124,21 @@ const skipReason = TEST_URL
     });
   });
 
+  it('agent-status reports zero subscribers when nothing is connected', async () => {
+    const res = await fetch(`${baseUrl}/api/overview/agent-status`, {
+      headers: { authorization: `Bearer ${adminKeyA}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as {
+      selfServiceAgentSubscriberCount: number;
+      lastInboundEndUserMessageAt: string | null;
+      lastAgentMessageAt: string | null;
+    };
+    expect(body.selfServiceAgentSubscriberCount).toBe(0);
+    expect(body.lastInboundEndUserMessageAt).toBeNull();
+    expect(body.lastAgentMessageAt).toBeNull();
+  });
+
   it('counts conversations needing attention scoped to caller org', async () => {
     // Seed channels + conversations directly (service-role).
     const [chanA] = await db

--- a/packages/backend-core/src/control/overview.controller.ts
+++ b/packages/backend-core/src/control/overview.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards, UseInterceptors } from '@nestjs/common';
+import { Controller, Get, Inject, UseGuards, UseInterceptors } from '@nestjs/common';
 import { schema } from '@getmunin/db';
 import { and, eq, sql } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
@@ -6,6 +6,7 @@ import { AuthGuard } from '../common/auth/auth.guard.js';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.js';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.js';
 import { CURATION_INBOX_SLUG } from '../modules/kb/kb.service.js';
+import { RealtimeGateway } from '../realtime/realtime.gateway.js';
 
 export interface OverviewBacklog {
   conversationsNeedingAttention: number;
@@ -13,10 +14,18 @@ export interface OverviewBacklog {
   crmMergeProposalsPending: number;
 }
 
+export interface AgentStatus {
+  selfServiceAgentSubscriberCount: number;
+  lastInboundEndUserMessageAt: string | null;
+  lastAgentMessageAt: string | null;
+}
+
 @Controller('api/overview')
 @UseGuards(AuthGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 export class OverviewController {
+  constructor(@Inject(RealtimeGateway) private readonly realtime: RealtimeGateway) {}
+
   @Get('backlog')
   async backlog(): Promise<OverviewBacklog> {
     const ctx = getCurrentContext();
@@ -47,4 +56,28 @@ export class OverviewController {
       crmMergeProposalsPending: crmMergeRow?.n ?? 0,
     };
   }
+
+  @Get('agent-status')
+  async agentStatus(): Promise<AgentStatus> {
+    const ctx = getCurrentContext();
+    const orgId = ctx.actor!.orgId;
+    const [lastInbound] = await ctx.db
+      .select({ at: sql<Date | null>`max(${schema.convMessages.createdAt})` })
+      .from(schema.convMessages)
+      .where(eq(schema.convMessages.authorType, 'end_user'));
+    const [lastAgent] = await ctx.db
+      .select({ at: sql<Date | null>`max(${schema.convMessages.createdAt})` })
+      .from(schema.convMessages)
+      .where(eq(schema.convMessages.authorType, 'agent'));
+    return {
+      selfServiceAgentSubscriberCount: this.realtime.selfServiceSubscriberCount(orgId),
+      lastInboundEndUserMessageAt: lastInbound?.at ? toIso(lastInbound.at) : null,
+      lastAgentMessageAt: lastAgent?.at ? toIso(lastAgent.at) : null,
+    };
+  }
+}
+
+function toIso(value: Date | string): string {
+  if (value instanceof Date) return value.toISOString();
+  return new Date(value).toISOString();
 }

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -34,6 +34,11 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   private upgradeListener: ((req: IncomingMessage, socket: Duplex, head: Buffer) => void) | null =
     null;
   private readonly resolver: CredentialResolver;
+  private readonly selfServiceSubscribersByOrg = new Map<string, Set<WebSocket>>();
+
+  selfServiceSubscriberCount(orgId: string): number {
+    return this.selfServiceSubscribersByOrg.get(orgId)?.size ?? 0;
+  }
 
   constructor(
     private readonly adapterHost: HttpAdapterHost,
@@ -91,6 +96,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       );
       this.wss = null;
     }
+    this.selfServiceSubscribersByOrg.clear();
   }
 
   private async handleUpgrade(
@@ -123,6 +129,25 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   private handleConnection(ws: WebSocket, credential: ResolvedCredential): void {
     const actor = credential.actor;
     const subscriptions = new Set<string>();
+    const isSelfServiceAgent =
+      actor.type !== 'end_user_agent' &&
+      Array.isArray(actor.audiences) &&
+      actor.audiences.includes('self_service');
+    if (isSelfServiceAgent) {
+      let set = this.selfServiceSubscribersByOrg.get(actor.orgId);
+      if (!set) {
+        set = new Set();
+        this.selfServiceSubscribersByOrg.set(actor.orgId, set);
+      }
+      set.add(ws);
+    }
+    const removeSelfServiceSubscriber = () => {
+      if (!isSelfServiceAgent) return;
+      const set = this.selfServiceSubscribersByOrg.get(actor.orgId);
+      if (!set) return;
+      set.delete(ws);
+      if (set.size === 0) this.selfServiceSubscribersByOrg.delete(actor.orgId);
+    };
 
     const unsubscribe = this.listener.subscribe((event) => {
       if (event.org_id !== actor.orgId) return;
@@ -164,9 +189,11 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
 
     ws.on('close', () => {
       unsubscribe();
+      removeSelfServiceSubscriber();
     });
     ws.on('error', () => {
       unsubscribe();
+      removeSelfServiceSubscriber();
     });
 
     ws.send(JSON.stringify({ type: 'ready', orgId: actor.orgId }));

--- a/packages/backend-core/src/realtime/realtime.module.ts
+++ b/packages/backend-core/src/realtime/realtime.module.ts
@@ -4,6 +4,6 @@ import { RealtimeGateway } from './realtime.gateway.js';
 
 @Module({
   providers: [DbListenerService, RealtimeGateway],
-  exports: [DbListenerService],
+  exports: [DbListenerService, RealtimeGateway],
 })
 export class RealtimeModule {}

--- a/packages/core/src/credentials.ts
+++ b/packages/core/src/credentials.ts
@@ -93,12 +93,13 @@ export class CredentialResolver {
     if (!row) return null;
 
     const orgId = row.orgId ?? '';
+    const audiences = (row.audiences as Audience[] | null | undefined) ?? ['admin'];
     const actor = new ActorIdentity(
       'admin_agent',
       row.id,
       orgId,
       row.scopes,
-      ['admin'],
+      audiences,
       undefined,
       undefined,
       undefined,

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -20,16 +20,32 @@ interface BacklogDto {
   crmMergeProposalsPending: number;
 }
 
+interface AgentStatusDto {
+  selfServiceAgentSubscriberCount: number;
+  lastInboundEndUserMessageAt: string | null;
+  lastAgentMessageAt: string | null;
+}
+
 export function DashboardPage() {
   const t = useTranslations('dashboard.overview');
   const tBacklog = useTranslations('dashboard.needsAttention');
+  const tAgent = useTranslations('dashboard.agentStatus');
 
   const [backlog, setBacklog] = useState<BacklogDto | null>(null);
+  const [agentStatus, setAgentStatus] = useState<AgentStatusDto | null>(null);
 
   useEffect(() => {
     void api<BacklogDto>('/api/overview/backlog')
       .then(setBacklog)
       .catch(() => setBacklog(null));
+    const loadStatus = () => {
+      void api<AgentStatusDto>('/api/overview/agent-status')
+        .then(setAgentStatus)
+        .catch(() => setAgentStatus(null));
+    };
+    loadStatus();
+    const id = setInterval(loadStatus, 15_000);
+    return () => clearInterval(id);
   }, []);
 
   const allClear =
@@ -111,6 +127,8 @@ export function DashboardPage() {
         </Card>
       )}
 
+      {agentStatus !== null && <AgentStatusCard status={agentStatus} t={tAgent} />}
+
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
           <CardHeader>
@@ -145,5 +163,50 @@ export function DashboardPage() {
         </Card>
       </div>
     </>
+  );
+}
+
+function AgentStatusCard({
+  status,
+  t,
+}: {
+  status: AgentStatusDto;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const connected = status.selfServiceAgentSubscriberCount > 0;
+  const lastInbound = status.lastInboundEndUserMessageAt
+    ? new Date(status.lastInboundEndUserMessageAt)
+    : null;
+  const lastAgent = status.lastAgentMessageAt ? new Date(status.lastAgentMessageAt) : null;
+  const inboundAheadOfAgent =
+    lastInbound !== null && (lastAgent === null || lastInbound > lastAgent);
+  const stale = !connected && inboundAheadOfAgent;
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          {connected ? (
+            <CheckCircle2 className="size-5 text-emerald-600 dark:text-emerald-400" />
+          ) : stale ? (
+            <AlertCircle className="size-5 text-amber-600 dark:text-amber-400" />
+          ) : (
+            <Bot className="size-5 text-muted-foreground" />
+          )}
+          <CardTitle>{t('title')}</CardTitle>
+        </div>
+        <CardDescription>
+          {connected
+            ? t('connected', { count: status.selfServiceAgentSubscriberCount })
+            : stale
+              ? t('staleNotConnected')
+              : t('notConnected')}
+        </CardDescription>
+      </CardHeader>
+      {!connected && (
+        <CardContent>
+          <p className="text-xs text-muted-foreground">{t('hint')}</p>
+        </CardContent>
+      )}
+    </Card>
   );
 }

--- a/packages/db/drizzle/0008_api_keys_audiences.sql
+++ b/packages/db/drizzle/0008_api_keys_audiences.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "api_keys"
+  ADD COLUMN IF NOT EXISTS "audiences" jsonb NOT NULL DEFAULT '["admin"]'::jsonb;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777681300000,
       "tag": "0007_crm_merge_proposals",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1777681400000,
+      "tag": "0008_api_keys_audiences",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -283,6 +283,7 @@ export const apiKeys = pgTable(
     keyHash: text('key_hash').notNull().unique(),
     keyPrefix: varchar('key_prefix', { length: 16 }).notNull(),
     scopes: jsonb('scopes').$type<string[]>().notNull().default([]),
+    audiences: jsonb('audiences').$type<string[]>().notNull().default(['admin']),
     // Optional channel binding — set on widget keys (mn_widget_*) so the
     // widget controller can resolve channel from the key. NULL on admin /
     // agent / delegate / partner keys.


### PR DESCRIPTION
## Summary

Solves the OSS bootstrap confusion where a self-hoster's chat widget delivers end-user messages into the void with no UI signal that nothing is listening on the agent side. (Lived this exact bug today during local OSS testing.)

The realtime gateway now tracks live WebSocket subscribers per org whose actor audiences include `self_service` (excluding `end_user_agent` widgets, which receive but don't reply). New endpoint `GET /api/overview/agent-status` returns the live count plus last-inbound-message + last-agent-reply timestamps so the dashboard can distinguish *"quiet but unmonitored"* from *"messages waiting and nobody listening."*

Overview page renders a card with three states:

- **green** "N agent(s) connected" — auto-replies are live
- **neutral** "No self-service agent connected" — no traffic so it's fine
- **amber** "No agent connected, messages unanswered" — operator action needed

Polls `/api/overview/agent-status` every 15s.

## Why filter on `self_service` audience specifically

A signed-in dashboard user is also a "live realtime subscriber" — but they're a human, not an auto-replier. Counting them as agents would falsely flip the indicator green every time the operator opens the dashboard. Filtering to `audiences.includes('self_service')` and `type !== 'end_user_agent'` lands on exactly the population we mean by "agent expected to reply on the end-user surface."

## Caveat (cloud follow-up)

The cloud's `AgentRunnerService` currently mints its admin runner key with `audiences: ['admin']` only, so the cloud runner *won't* be counted by this indicator until a cloud-side change adds `self_service` to that key's audiences. Filing a separate cloud PR.

## Test plan

- [x] `pnpm --filter @getmunin/backend-core typecheck && build && lint` — clean
- [x] `pnpm --filter @getmunin/dashboard-pages typecheck` — clean
- [x] `pnpm --filter @getmunin/web typecheck && build` — clean
- [x] Backend-core test suite: 277 tests pass (1 new — agent-status endpoint zero-state)
- [ ] Manual: open dashboard with no agent connected → amber/neutral card. Run the standalone agent-runner script with `audiences=['self_service']` admin key → green. Drop the connection → reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)