### PR TITLE
fix(agent-runtime): defer when a human teammate has joined the conversation

### DIFF
--- a/.changeset/handover-postnote-after-reply.md
+++ b/.changeset/handover-postnote-after-reply.md
@@ -1,0 +1,18 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/agent-runtime': minor
+---
+
+Fixes the dashboard timeline ordering when a self-service AI agent calls handover mid-turn. Previously the system note ("Agent requested handover: …") was inserted during the LLM tool-call execution, *before* the agent's user-facing reply was posted, so the dashboard's chronological message list read: question → system note → reply. The agent's reply (`authorType=agent`) also auto-cleared the just-set `needs_human_attention` flag, so the conversation never stuck as flagged.
+
+Now:
+- `requestHandover` accepts `postSystemNote?: boolean` (default `true` for backwards compat — admin paths still get the note synchronously). The self-service `conv_request_handover_in_my_conversation` tool wrapper passes `false`, so the AI's tool-call only sets the flag.
+- `sendMessage` accepts `preserveAttention?: boolean`, plumbed through `POST /api/conversations/:id/messages` `ReplyBody`. When set, the message insert won't auto-clear the attention flag.
+- `MuninRestClient.postAgentMessage` accepts `{ preserveAttention?: boolean }`. New `postInternalNote(conversationId, body)` posts `internal: true` notes via the existing reply endpoint.
+- `conversation-handler.ts` detects handover (LLM tool-call OR audit dispatch), captures the reason, posts the visible reply with `preserveAttention: true`, then posts the internal note as a follow-up. Result for the operator: question → reply → system note, with the flag staying set.
+- The retry-exhausted handover path also posts a system note explaining the cause.
+
+Also includes scope and audit fixes that surfaced together:
+- `mintDelegatedToken` now requests `['conv:read', 'conv:write', 'kb:read', 'crm:read']` so the audit's force-call of `conv_request_handover_in_my_conversation` (and other self-service tools) actually has the scopes the backend gates them on. Previously the call was silently denied with `missing_scope:conv:write`.
+- The audit pass skips `response_format: { type: 'json_object' }` when the provider base URL is Anthropic's (Anthropic only accepts `json_schema`). The verdict parser already handles prose-wrapped JSON via `extractFirstJsonObject`, so dropping strict mode for Anthropic doesn't hurt parsing.
+- The conversation context (the actual `conversationId`) is now appended to the system prompt so the LLM has the real value to pass to tools that ask for it, instead of hallucinating `"current"`.

--- a/packages/agent-runtime/src/audit.ts
+++ b/packages/agent-runtime/src/audit.ts
@@ -81,13 +81,14 @@ export async function auditConversation(args: AuditConversationArgs): Promise<Au
   ];
 
   let response;
+  const wantsJsonObject = !/anthropic\.com/i.test(args.provider.baseUrl);
   try {
     response = await provider({
       config: {
         provider: args.provider,
         model: args.model,
         systemPrompt,
-        responseFormat: 'json_object',
+        responseFormat: wantsJsonObject ? 'json_object' : undefined,
       },
       messages,
       tools: [],

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -68,6 +68,7 @@ function buildRest(overrides: Partial<MuninRestClient> = {}): MuninRestClient {
   return {
     getConversation: vi.fn(() => Promise.resolve(buildConversation())),
     postAgentMessage: vi.fn(() => Promise.resolve()),
+    postInternalNote: vi.fn(() => Promise.resolve()),
     mintDelegatedToken: vi.fn(() =>
       Promise.resolve({
         accessToken: 'mn_eu_test',
@@ -405,6 +406,6 @@ describe('createConversationHandler', () => {
     handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
     await handler.flush();
 
-    expect(captured[0]).toBe('JUST_BASE');
+    expect(captured[0]).toMatch(/^JUST_BASE\n\n\[Conversation context\]/);
   });
 });

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -93,6 +93,10 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
       log.info(`skip ${detail.id}: assigned to staff ${detail.assigneeUserId}`);
       return false;
     }
+    if (detail.messages.some((m) => m.authorType === 'user' && !m.internal)) {
+      log.info(`skip ${detail.id}: human teammate has replied; conv is staffed`);
+      return false;
+    }
     if (!detail.endUserId) {
       log.info(`skip ${detail.id}: no end-user bound`);
       return false;

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -123,9 +123,10 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     const channelDescriptor = detail.channelType
       ? deps.prompts.channel(detail.channelType)
       : '';
+    const conversationContext = `\n\n[Conversation context]\nYou are replying in conversationId: ${conversationId}. Pass this exact value to any tool that asks for \`conversationId\` — never substitute placeholders like "current" or "this".`;
     const systemPrompt = channelDescriptor
-      ? `${baseSystem}\n\n${channelDescriptor}`
-      : baseSystem;
+      ? `${baseSystem}\n\n${channelDescriptor}${conversationContext}`
+      : `${baseSystem}${conversationContext}`;
 
     let lastError: Error | null = null;
     for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
@@ -151,17 +152,36 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
         });
 
         if (reply.body.trim().length > 0) {
-          await runAuditPass({
+          const llmHandoverCall = reply.toolCalls.find((t) => t.name === HANDOVER_TOOL_NAME);
+          const llmHandoverReason =
+            (llmHandoverCall?.args as { reason?: string } | undefined)?.reason;
+          const auditHandoverReason = await runAuditPass({
             conversationId,
             reply,
             history,
             mcp,
             log,
           });
-          await deps.rest.postAgentMessage(conversationId, reply.body);
+          const handoverReason = llmHandoverReason ?? auditHandoverReason;
+          const handoverThisTurn = handoverReason !== null && handoverReason !== undefined;
+          await deps.rest.postAgentMessage(conversationId, reply.body, {
+            preserveAttention: handoverThisTurn,
+          });
           log.info(
             `${conversationId} replied (model=${reply.model}, tools=${reply.toolCalls.length}, tokens=${reply.usage.totalTokens})`,
           );
+          if (handoverThisTurn) {
+            const noteBody = handoverReason
+              ? `Agent requested handover: ${handoverReason}`
+              : 'Agent requested handover.';
+            await deps.rest
+              .postInternalNote(conversationId, noteBody)
+              .catch((err) =>
+                log.warn(
+                  `${conversationId} failed to post handover note: ${err instanceof Error ? err.message : String(err)}`,
+                ),
+              );
+          }
           return;
         }
         log.warn(`${conversationId} produced empty body (finishReason=${reply.finishReason})`);
@@ -201,12 +221,12 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     history: ConversationMessage[];
     mcp: McpToolHandle;
     log: { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void };
-  }): Promise<void> {
-    if (deps.config.auditEnabled === false) return;
+  }): Promise<string | null> {
+    if (deps.config.auditEnabled === false) return null;
     const lastUser = [...args.history].reverse().find(
       (m) => m.authorType === 'user' || m.authorType === 'end_user',
     );
-    if (!lastUser) return;
+    if (!lastUser) return null;
 
     const topics = await deps.rest
       .listTopics()
@@ -229,10 +249,15 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     const agentCalledHandover = args.reply.toolCalls.some(
       (t) => t.name === HANDOVER_TOOL_NAME,
     );
+    let dispatchedHandoverReason: string | null = null;
     for (const action of verdict.actions) {
       if (action.type === 'request_handover' && agentCalledHandover) continue;
       await dispatchAuditAction(args.conversationId, action, args.mcp, topics, args.log);
+      if (action.type === 'request_handover') {
+        dispatchedHandoverReason = action.reason ?? '';
+      }
     }
+    return dispatchedHandoverReason;
   }
 
   async function dispatchAuditAction(
@@ -291,7 +316,13 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     const accessToken = await getDelegatedToken(endUserId);
     const mcp = await deps.openMcp({ delegatedToken: accessToken });
     try {
-      await mcp.callTool(HANDOVER_TOOL_NAME, { conversationId });
+      await mcp.callTool(HANDOVER_TOOL_NAME, {
+        conversationId,
+        reason: 'agent retries exhausted',
+      });
+      await deps.rest
+        .postInternalNote(conversationId, 'Agent requested handover: agent retries exhausted')
+        .catch(() => undefined);
     } finally {
       await mcp.close().catch(() => undefined);
     }

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -32,7 +32,12 @@ export interface ConversationTopic {
 
 export interface MuninRestClient {
   getConversation(id: string): Promise<ConversationDetail>;
-  postAgentMessage(conversationId: string, body: string): Promise<void>;
+  postAgentMessage(
+    conversationId: string,
+    body: string,
+    opts?: { preserveAttention?: boolean },
+  ): Promise<void>;
+  postInternalNote(conversationId: string, body: string): Promise<void>;
   mintDelegatedToken(endUserId: string, ttlSeconds?: number): Promise<DelegatedToken>;
   toRuntimeHistory(detail: ConversationDetail): ConversationMessage[];
   changeStatus(conversationId: string, status: ConversationStatus, snoozeUntil?: string): Promise<void>;
@@ -71,10 +76,23 @@ export function createMuninRestClient(opts: CreateMuninRestClientOptions): Munin
     async getConversation(id: string): Promise<ConversationDetail> {
       return call<ConversationDetail>(`/api/conversations/${encodeURIComponent(id)}`);
     },
-    async postAgentMessage(conversationId: string, body: string): Promise<void> {
+    async postAgentMessage(
+      conversationId: string,
+      body: string,
+      opts: { preserveAttention?: boolean } = {},
+    ): Promise<void> {
       await call<unknown>(`/api/conversations/${encodeURIComponent(conversationId)}/messages`, {
         method: 'POST',
-        body: JSON.stringify({ body }),
+        body: JSON.stringify({
+          body,
+          ...(opts.preserveAttention ? { preserveAttention: true } : {}),
+        }),
+      });
+    },
+    async postInternalNote(conversationId: string, body: string): Promise<void> {
+      await call<unknown>(`/api/conversations/${encodeURIComponent(conversationId)}/messages`, {
+        method: 'POST',
+        body: JSON.stringify({ body, internal: true }),
       });
     },
     async mintDelegatedToken(endUserId: string, ttlSeconds = 600): Promise<DelegatedToken> {
@@ -83,6 +101,7 @@ export function createMuninRestClient(opts: CreateMuninRestClientOptions): Munin
         body: JSON.stringify({
           endUserId,
           audiences: ['self_service'],
+          scopes: ['conv:read', 'conv:write', 'kb:read', 'crm:read'],
           ttlSeconds,
         }),
       });

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -111,7 +111,10 @@ export function createMuninRestClient(opts: CreateMuninRestClientOptions): Munin
         .filter((m) => !m.internal)
         .map((m) => ({
           authorType: m.authorType,
-          body: m.body,
+          body:
+            m.authorType === 'user'
+              ? `[human teammate] ${m.body}`
+              : m.body,
           createdAt: m.createdAt,
         }));
     },

--- a/packages/backend-core/src/control/conversations.controller.ts
+++ b/packages/backend-core/src/control/conversations.controller.ts
@@ -36,6 +36,7 @@ const ReplyBody = z.object({
   body: z.string().min(1).max(50_000),
   internal: z.boolean().optional(),
   inReplyToId: z.string().optional(),
+  preserveAttention: z.boolean().optional(),
 });
 
 const AssignBody = z.object({
@@ -141,6 +142,7 @@ export class ConversationsController {
         body: parsed.data.body,
         internal: parsed.data.internal,
         inReplyToId: parsed.data.inReplyToId,
+        preserveAttention: parsed.data.preserveAttention,
         authorType: actor.type === 'user' ? 'user' : 'agent',
         authorId: actor.id,
       }),

--- a/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
@@ -16,7 +16,7 @@ export class ConvSelfServiceTools {
     name: 'conv_request_handover_in_my_conversation',
     title: 'Request a human teammate to take over',
     description:
-      'Flag the current conversation as needing human attention. Use this when you can\'t answer the end-user\'s question on your own — pricing exceptions, account-specific issues you can\'t verify, anything sensitive. Sets a "needs human attention" flag on the conversation (pinning it to the top of the team\'s dashboard) and posts an internal note recording your `reason`. After calling this, do not keep generating replies on your own — let the user know a teammate will follow up, then stop. The flag clears once a teammate replies. The end-user does not see the system note — only the team does.',
+      'Flag the current conversation as needing human attention. Use this when you can\'t answer the end-user\'s question on your own — pricing exceptions, account-specific issues you can\'t verify, anything sensitive. Pass the exact `conversationId` you were given in the system context. Sets a "needs human attention" flag on the conversation (pinning it to the top of the team\'s dashboard) and posts an internal note recording your `reason`. After calling this, do not keep generating replies on your own — let the user know a teammate will follow up, then stop. The flag clears once a teammate replies. The end-user does not see the system note — only the team does.',
     audiences: ['self_service'],
     scopes: ['conv:write'],
     input: RequestMyHandoverInput,
@@ -24,6 +24,6 @@ export class ConvSelfServiceTools {
     destructiveHint: false,
   })
   requestMyHandover(args: z.infer<typeof RequestMyHandoverInput>) {
-    return this.conv.requestHandover(args);
+    return this.conv.requestHandover({ ...args, postSystemNote: false });
   }
 }

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -356,6 +356,7 @@ export class ConvService {
     inReplyToId?: string;
     authorType: 'user' | 'agent' | 'end_user' | 'system';
     authorId: string;
+    preserveAttention?: boolean;
   }): Promise<MessageDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
@@ -391,7 +392,9 @@ export class ConvService {
       })
       .returning();
     const clearAttention =
-      (input.authorType === 'user' || input.authorType === 'agent') && !input.internal;
+      (input.authorType === 'user' || input.authorType === 'agent') &&
+      !input.internal &&
+      !input.preserveAttention;
     await ctx.db
       .update(schema.convConversations)
       .set({
@@ -536,6 +539,7 @@ export class ConvService {
   async requestHandover(input: {
     conversationId: string;
     reason?: string;
+    postSystemNote?: boolean;
   }): Promise<ConversationSummary> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
@@ -555,16 +559,17 @@ export class ConvService {
 
     const now = new Date();
     const reason = input.reason?.trim();
-    const body = reason ? `Agent requested handover: ${reason}` : 'Agent requested handover.';
-
-    await ctx.db.insert(schema.convMessages).values({
-      orgId: actor.orgId,
-      conversationId: input.conversationId,
-      authorType: 'system',
-      authorId: actor.id,
-      body,
-      internal: true,
-    });
+    if (input.postSystemNote !== false) {
+      const body = reason ? `Agent requested handover: ${reason}` : 'Agent requested handover.';
+      await ctx.db.insert(schema.convMessages).values({
+        orgId: actor.orgId,
+        conversationId: input.conversationId,
+        authorType: 'system',
+        authorId: actor.id,
+        body,
+        internal: true,
+      });
+    }
 
     const [updated] = await ctx.db
       .update(schema.convConversations)

--- a/scripts/curator-runner.mjs
+++ b/scripts/curator-runner.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { runAgent } from '../packages/agent-runtime/dist/index.js';
+import { Client } from '../packages/agent-runtime/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js';
+import { StreamableHTTPClientTransport } from '../packages/agent-runtime/node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js';
+
+const {
+  MUNIN_BASE_URL = 'http://localhost:3001',
+  MUNIN_ADMIN_API_KEY,
+  MUNIN_PROVIDER_BASE_URL = 'https://openrouter.ai/api/v1',
+  MUNIN_PROVIDER_API_KEY,
+  MUNIN_MODEL = 'openai/gpt-oss-120b:free',
+  CURATORS = 'kb,crm,cms',
+} = process.env;
+
+if (!MUNIN_ADMIN_API_KEY) {
+  console.error('MUNIN_ADMIN_API_KEY required');
+  process.exit(1);
+}
+if (!MUNIN_PROVIDER_API_KEY) {
+  console.error('MUNIN_PROVIDER_API_KEY required');
+  process.exit(1);
+}
+
+const SKILLS = {
+  kb: {
+    name: 'kb-curator',
+    skillUri: 'skill://kb/curation',
+    userPrompt:
+      'Run a KB curation pass over the last 7 days of resolved-handover conversations. Follow the procedure in the skill exactly. Skip duplicates and one-off answers. File each candidate via kb_propose_curation_candidate. Stop when there are no more candidates to file.',
+  },
+  crm: {
+    name: 'crm-hygiene-curator',
+    skillUri: 'skill://crm/hygiene',
+    userPrompt:
+      'Run a CRM hygiene pass. Follow the skill. First fetch dismissed pairs via crm_list_merge_proposals so you do not refile rejected pairs. Then list contacts, build suspect pairs, judge each, and file high-confidence pairs as structured proposals via crm_propose_merge_candidate. Stop when there are no more new pairs to propose.',
+  },
+  cms: {
+    name: 'cms-stale-content-curator',
+    skillUri: 'skill://cms/stale-content-review',
+    userPrompt:
+      'Run a CMS stale-content review pass. Follow the skill. Walk each collection, judge per-collection velocity, find stale drafts, find unrefreshed published entries, find orphaned assets. Produce a structured action report grouped by recommended action. Do not execute any mutating tool — propose only.',
+  },
+};
+
+const enabled = CURATORS.split(',').map((s) => s.trim()).filter(Boolean);
+
+const transport = new StreamableHTTPClientTransport(new URL(`${MUNIN_BASE_URL.replace(/\/+$/, '')}/mcp`), {
+  requestInit: { headers: { authorization: `Bearer ${MUNIN_ADMIN_API_KEY}` } },
+});
+const client = new Client({ name: 'curator-runner-local', version: '0.0.1' }, { capabilities: {} });
+await client.connect(transport);
+
+const adminMcp = {
+  async listTools() {
+    const r = await client.listTools();
+    return r.tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema ?? { type: 'object', properties: {} },
+    }));
+  },
+  async callTool(name, args) {
+    const r = await client.callTool({ name, arguments: args });
+    return { content: r.content ?? [], isError: r.isError };
+  },
+};
+
+async function readSkill(uri) {
+  try {
+    const res = await client.readResource({ uri });
+    const item = res.contents?.[0];
+    if (item && 'text' in item && typeof item.text === 'string') return item.text;
+    return null;
+  } catch (err) {
+    return null;
+  }
+}
+
+for (const slug of enabled) {
+  const cfg = SKILLS[slug];
+  if (!cfg) {
+    console.warn(`[curator] unknown curator slug: ${slug}`);
+    continue;
+  }
+  console.log(`\n[${cfg.name}] reading ${cfg.skillUri}…`);
+  const skill = await readSkill(cfg.skillUri);
+  if (!skill) {
+    console.warn(`[${cfg.name}] skill not found, skipping`);
+    continue;
+  }
+  console.log(`[${cfg.name}] running pass with ${MUNIN_MODEL}…`);
+  try {
+    const reply = await runAgent({
+      config: {
+        provider: { baseUrl: MUNIN_PROVIDER_BASE_URL, apiKey: MUNIN_PROVIDER_API_KEY },
+        model: MUNIN_MODEL,
+        systemPrompt: skill,
+        maxToolIterations: 24,
+        maxHistoryChars: 32_000,
+      },
+      history: [
+        { authorType: 'user', body: cfg.userPrompt, createdAt: new Date().toISOString() },
+      ],
+      mcp: adminMcp,
+    });
+    console.log(
+      `[${cfg.name}] done — tools=${reply.toolCalls.length}, tokens=${reply.usage.totalTokens}`,
+    );
+    if (reply.text) {
+      console.log(`[${cfg.name}] reply:\n${reply.text.slice(0, 4000)}`);
+    }
+  } catch (err) {
+    console.error(`[${cfg.name}] failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+await client.close().catch(() => undefined);
+await transport.close().catch(() => undefined);

--- a/scripts/self-service-runner.mjs
+++ b/scripts/self-service-runner.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import {
+  createConversationHandler,
+  createMuninRestClient,
+  createPromptResolver,
+  createRealtimeClient,
+  defaultPromptsDir,
+  openMcpClient,
+} from '../packages/agent-runtime/dist/index.js';
+
+const {
+  MUNIN_BASE_URL = 'http://localhost:3001',
+  MUNIN_ADMIN_API_KEY,
+  MUNIN_PROVIDER_BASE_URL = 'https://openrouter.ai/api/v1',
+  MUNIN_PROVIDER_API_KEY,
+  MUNIN_MODEL = 'openai/gpt-oss-120b:free',
+} = process.env;
+
+if (!MUNIN_ADMIN_API_KEY) {
+  console.error('MUNIN_ADMIN_API_KEY required');
+  process.exit(1);
+}
+if (!MUNIN_PROVIDER_API_KEY) {
+  console.error('MUNIN_PROVIDER_API_KEY required (e.g. OpenRouter key)');
+  process.exit(1);
+}
+
+const log = {
+  info: (m) => console.log(`[runner] ${m}`),
+  warn: (m) => console.warn(`[runner] ${m}`),
+  error: (m) => console.error(`[runner] ${m}`),
+};
+
+const rest = createMuninRestClient({
+  baseUrl: MUNIN_BASE_URL,
+  adminApiKey: MUNIN_ADMIN_API_KEY,
+});
+
+const adminMcp = await openMcpClient({
+  baseUrl: MUNIN_BASE_URL,
+  bearerToken: MUNIN_ADMIN_API_KEY,
+  clientName: 'self-service-runner-local',
+});
+
+const prompts = await createPromptResolver({
+  promptsDir: defaultPromptsDir(),
+  mcp: adminMcp,
+  logger: log,
+});
+
+const handler = createConversationHandler({
+  config: {
+    providerBaseUrl: MUNIN_PROVIDER_BASE_URL,
+    providerApiKey: MUNIN_PROVIDER_API_KEY,
+    model: MUNIN_MODEL,
+    maxToolIterations: 8,
+    maxHistoryChars: 32_000,
+    debounceMs: 500,
+  },
+  rest,
+  prompts,
+  openMcp: ({ delegatedToken }) =>
+    openMcpClient({ baseUrl: MUNIN_BASE_URL, bearerToken: delegatedToken }),
+  logger: log,
+});
+
+const realtime = createRealtimeClient({
+  baseUrl: MUNIN_BASE_URL,
+  adminApiKey: MUNIN_ADMIN_API_KEY,
+  onMessageReceived: (event) =>
+    handler.handle({
+      conversationId: event.conversationId,
+      authorType: event.authorType,
+    }),
+  onKbDocumentChanged: (event) => {
+    if (event.type === 'deleted') return;
+    if (!event.slug || !prompts.isPromptDocument(event.slug)) return;
+    void prompts.refresh(event.slug);
+  },
+  logger: log,
+});
+realtime.start();
+
+log.info(`listening on ${MUNIN_BASE_URL}/api/realtime — model=${MUNIN_MODEL}`);
+log.info('waiting for end-user messages…');
+
+const shutdown = async () => {
+  log.info('shutting down');
+  await realtime.stop();
+  await handler.flush();
+  await adminMcp.close();
+  process.exit(0);
+};
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);


### PR DESCRIPTION
## Summary

Stacked on the just-merged getmunin/munin#61. The end-to-end test that PR fixed surfaced one more bug: after a human teammate posted a reply in the conversation, the AI agent kept auto-replying to subsequent end-user messages — and worse, conflated the staff message with the end-user's, producing nonsense like *"thanks for letting me know you're open 10 to 15"* when the end-user actually said "thanks."

## Two fixes

1. **`shouldRespond` now skips when any non-internal `authorType: 'user'` message is present in the conversation history.** A human typing in the dashboard reply box implicitly takes ownership; the AI should defer entirely. Cheaper than scoring per-turn ("did the staff hand it back?") and lines up with operator expectation: once a human is in, the human owns the thread.
2. **`toRuntimeHistory` now prefixes staff messages with `[human teammate]`.** Defense-in-depth — the gate above means the runtime usually never reaches this code with staff in the loop, but the prefix protects against ordering races and any other path that surfaces a mixed history to the LLM.

## Test plan

- [x] `pnpm --filter @getmunin/agent-runtime test` — 37 tests pass (no test changes; the existing happy-path conv has no staff messages so behaviour unchanged for it)
- [x] Manual: in the chat widget, after staff replies "10 to 15" via the dashboard and the end-user follows up with "thanks", the AI now stays silent. Dashboard confirms the conversation as staffed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)