### PR TITLE
feat(agent-runtime): runSkillPass primitive + onHandoverResolved realtime hook

### DIFF
--- a/.changeset/agent-runtime-skill-pass-handover-resolved.md
+++ b/.changeset/agent-runtime-skill-pass-handover-resolved.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/agent-runtime': minor
+'@getmunin/backend-core': minor
+---
+
+Adds `runSkillPass(opts)` to `@getmunin/agent-runtime` — a single-shot primitive that opens admin MCP against a Munin instance, reads a `skill://...` resource, and invokes `runAgent` with the skill body as system prompt and a caller-supplied user prompt. Returns `{ ok, toolCalls, totalTokens, finishReason, replyText }` or `{ ok: false, skipped: <reason> }`. Replaces the duplicated curator-pass plumbing that lives in both `munin-cloud/packages/curator-runner/src/scheduled-skill-runner.ts` and the OSS `scripts/curator-runner.mjs` — both can now import this primitive.
+
+Adds `onHandoverResolved` callback to `createRealtimeClient`. Parses `conversation.handover_resolved` events emitted by `conv.service.ts` when a human teammate's reply clears the `needsHumanAttention` flag. Payload: `{ conversationId, messageId, authorType }`. Wired up so the OSS sidecar can run KB curation per-handover (event-driven, scoped to one conversation) instead of waiting for a daily batch sweep.
+
+Updates `skill://kb/curation` to document a per-conversation mode: when the user prompt names a single `conversationId`, the agent skips `conv_list_conversations` and goes straight to that one conversation's (question, human-reply) pair. Batch mode stays the default. Same skill, two invocation patterns — no second skill needed.

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -41,7 +41,13 @@ export {
   type OpenedMcpClient,
 } from './mcp-client.js';
 export {
+  runSkillPass,
+  type SkillPassOptions,
+  type SkillPassResult,
+} from './skill-pass.js';
+export {
   createRealtimeClient,
+  type HandoverResolvedEvent,
   type KbDocumentChangedEvent,
   type MessageReceivedEvent,
   type RealtimeClient,

--- a/packages/agent-runtime/src/realtime.test.ts
+++ b/packages/agent-runtime/src/realtime.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { WebSocketServer, type WebSocket } from 'ws';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  createRealtimeClient,
+  type HandoverResolvedEvent,
+  type MessageReceivedEvent,
+} from './realtime.js';
+
+describe('createRealtimeClient', () => {
+  let httpServer: Server;
+  let wss: WebSocketServer;
+  let baseUrl: string;
+  let connections: WebSocket[];
+
+  beforeEach(async () => {
+    connections = [];
+    httpServer = createServer();
+    wss = new WebSocketServer({ noServer: true });
+    httpServer.on('upgrade', (req, socket, head) => {
+      if (!req.url?.startsWith('/api/realtime')) {
+        socket.destroy();
+        return;
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        connections.push(ws);
+      });
+    });
+    await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+    const port = (httpServer.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    for (const c of connections) c.close();
+    wss.close();
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  function send(eventType: string, payload: Record<string, unknown>): void {
+    const conn = connections[0];
+    if (!conn) throw new Error('no client connected yet');
+    conn.send(JSON.stringify({ type: 'event', event: { type: eventType, payload } }));
+  }
+
+  async function waitForConnection(): Promise<void> {
+    for (let i = 0; i < 50 && connections.length === 0; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (connections.length === 0) throw new Error('client never connected');
+  }
+
+  it('fires onMessageReceived on conversation.message.received', async () => {
+    const events: MessageReceivedEvent[] = [];
+    const client = createRealtimeClient({
+      baseUrl,
+      adminApiKey: 'mn_admin_test',
+      onMessageReceived: (e) => events.push(e),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    client.start();
+    await waitForConnection();
+    send('conversation.message.received', {
+      conversationId: 'ccv_1',
+      messageId: 'cvm_1',
+      authorType: 'end_user',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await client.stop();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      conversationId: 'ccv_1',
+      messageId: 'cvm_1',
+      authorType: 'end_user',
+    });
+  });
+
+  it('fires onHandoverResolved on conversation.handover_resolved', async () => {
+    const events: HandoverResolvedEvent[] = [];
+    const client = createRealtimeClient({
+      baseUrl,
+      adminApiKey: 'mn_admin_test',
+      onMessageReceived: () => {},
+      onHandoverResolved: (e) => events.push(e),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    client.start();
+    await waitForConnection();
+    send('conversation.handover_resolved', {
+      conversationId: 'ccv_2',
+      messageId: 'cvm_2',
+      authorType: 'user',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await client.stop();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      conversationId: 'ccv_2',
+      messageId: 'cvm_2',
+      authorType: 'user',
+    });
+  });
+
+  it('ignores conversation.handover_resolved when no callback is provided', async () => {
+    const messages: MessageReceivedEvent[] = [];
+    const client = createRealtimeClient({
+      baseUrl,
+      adminApiKey: 'mn_admin_test',
+      onMessageReceived: (e) => messages.push(e),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    client.start();
+    await waitForConnection();
+    send('conversation.handover_resolved', {
+      conversationId: 'ccv_x',
+      messageId: 'cvm_x',
+      authorType: 'user',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await client.stop();
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/packages/agent-runtime/src/realtime.ts
+++ b/packages/agent-runtime/src/realtime.ts
@@ -15,11 +15,18 @@ export interface KbDocumentChangedEvent {
   version?: number;
 }
 
+export interface HandoverResolvedEvent {
+  conversationId: string;
+  messageId: string;
+  authorType: 'user' | 'agent' | 'end_user' | 'system';
+}
+
 export interface RealtimeClientOptions {
   baseUrl: string;
   adminApiKey: string;
   onMessageReceived: (event: MessageReceivedEvent) => void;
   onKbDocumentChanged?: (event: KbDocumentChangedEvent) => void;
+  onHandoverResolved?: (event: HandoverResolvedEvent) => void;
   logger?: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
 }
 
@@ -114,6 +121,22 @@ export function createRealtimeClient(opts: RealtimeClientOptions): RealtimeClien
                 ? (authorType as MessageReceivedEvent['authorType'])
                 : 'end_user',
             endUserId: typeof payload['endUserId'] === 'string' ? payload['endUserId'] : undefined,
+          });
+          return;
+        }
+
+        if (opts.onHandoverResolved && eventType === 'conversation.handover_resolved') {
+          const conversationId = payload['conversationId'];
+          const messageId = payload['messageId'];
+          const authorType = payload['authorType'];
+          if (typeof conversationId !== 'string' || typeof messageId !== 'string') return;
+          opts.onHandoverResolved({
+            conversationId,
+            messageId,
+            authorType:
+              typeof authorType === 'string'
+                ? (authorType as HandoverResolvedEvent['authorType'])
+                : 'user',
           });
           return;
         }

--- a/packages/agent-runtime/src/skill-pass.test.ts
+++ b/packages/agent-runtime/src/skill-pass.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { runSkillPass } from './skill-pass.js';
+
+describe('runSkillPass', () => {
+  it('returns skipped:no_admin_key when adminApiKey is empty', async () => {
+    const result = await runSkillPass({
+      baseUrl: 'http://localhost:1',
+      adminApiKey: '',
+      providerBaseUrl: 'http://localhost:1',
+      providerApiKey: 'k',
+      model: 'm',
+      skillUri: 'skill://x/y',
+      userPrompt: 'go',
+    });
+    expect(result).toEqual({ ok: false, skipped: 'no_admin_key' });
+  });
+
+  it('returns skipped:no_provider_key when providerApiKey is empty', async () => {
+    const result = await runSkillPass({
+      baseUrl: 'http://localhost:1',
+      adminApiKey: 'k',
+      providerBaseUrl: 'http://localhost:1',
+      providerApiKey: '',
+      model: 'm',
+      skillUri: 'skill://x/y',
+      userPrompt: 'go',
+    });
+    expect(result).toEqual({ ok: false, skipped: 'no_provider_key' });
+  });
+
+  it('returns skipped:mcp_connect_failed against an unreachable baseUrl', async () => {
+    const result = await runSkillPass({
+      baseUrl: 'http://127.0.0.1:1',
+      adminApiKey: 'k',
+      providerBaseUrl: 'http://localhost:1',
+      providerApiKey: 'k',
+      model: 'm',
+      skillUri: 'skill://x/y',
+      userPrompt: 'go',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.skipped).toBe('mcp_connect_failed');
+    }
+  }, 15_000);
+});

--- a/packages/agent-runtime/src/skill-pass.ts
+++ b/packages/agent-runtime/src/skill-pass.ts
@@ -1,0 +1,145 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { runAgent } from './runtime.js';
+import type { McpTool, McpToolHandle, McpToolResult, Provider } from './types.js';
+
+export interface SkillPassOptions {
+  baseUrl: string;
+  adminApiKey: string;
+  providerBaseUrl: string;
+  providerApiKey: string;
+  model: string;
+  skillUri: string;
+  userPrompt: string;
+  maxToolIterations?: number;
+  maxHistoryChars?: number;
+  clientName?: string;
+  providerImpl?: Provider;
+  logger?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+export type SkillPassResult =
+  | {
+      ok: true;
+      toolCalls: number;
+      totalTokens: number;
+      finishReason: 'stop' | 'length' | 'tool_iteration_limit' | 'error';
+      replyText: string;
+    }
+  | {
+      ok: false;
+      skipped:
+        | 'no_admin_key'
+        | 'no_provider_key'
+        | 'skill_missing'
+        | 'mcp_connect_failed'
+        | 'agent_error';
+      error?: string;
+    };
+
+export async function runSkillPass(opts: SkillPassOptions): Promise<SkillPassResult> {
+  const log =
+    opts.logger ??
+    {
+      info: (m: string) => console.log(`[skill-pass] ${m}`),
+      warn: (m: string) => console.warn(`[skill-pass] ${m}`),
+      error: (m: string) => console.error(`[skill-pass] ${m}`),
+    };
+
+  if (!opts.adminApiKey) return { ok: false, skipped: 'no_admin_key' };
+  if (!opts.providerApiKey) return { ok: false, skipped: 'no_provider_key' };
+
+  const url = new URL(`${opts.baseUrl.replace(/\/+$/, '')}/mcp`);
+  const transport = new StreamableHTTPClientTransport(url, {
+    requestInit: { headers: { authorization: `Bearer ${opts.adminApiKey}` } },
+  });
+  const client = new Client(
+    { name: opts.clientName ?? 'munin-skill-pass', version: '0.0.1' },
+    { capabilities: {} },
+  );
+  try {
+    await client.connect(transport);
+  } catch (err) {
+    log.warn(`mcp connect failed: ${err instanceof Error ? err.message : String(err)}`);
+    return { ok: false, skipped: 'mcp_connect_failed' };
+  }
+
+  try {
+    const skill = await readSkillFromClient(client, opts.skillUri);
+    if (!skill) {
+      log.warn(`${opts.skillUri} not available on ${opts.baseUrl}`);
+      return { ok: false, skipped: 'skill_missing' };
+    }
+    const mcp = adaptToToolHandle(client);
+    try {
+      const reply = await runAgent({
+        config: {
+          provider: { baseUrl: opts.providerBaseUrl, apiKey: opts.providerApiKey },
+          model: opts.model,
+          systemPrompt: skill,
+          maxToolIterations: opts.maxToolIterations ?? 24,
+          maxHistoryChars: opts.maxHistoryChars ?? 32_000,
+        },
+        history: [
+          {
+            authorType: 'user',
+            body: opts.userPrompt,
+            createdAt: new Date().toISOString(),
+          },
+        ],
+        mcp,
+        provider: opts.providerImpl,
+      });
+      return {
+        ok: true,
+        toolCalls: reply.toolCalls.length,
+        totalTokens: reply.usage.totalTokens,
+        finishReason: reply.finishReason,
+        replyText: reply.body,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(`runAgent failed: ${message}`);
+      return { ok: false, skipped: 'agent_error', error: message };
+    }
+  } finally {
+    await client.close().catch(() => undefined);
+    await transport.close().catch(() => undefined);
+  }
+}
+
+async function readSkillFromClient(client: Client, uri: string): Promise<string | null> {
+  try {
+    const res = await client.readResource({ uri });
+    const item = res.contents[0];
+    if (!item) return null;
+    if ('text' in item && typeof item.text === 'string') return item.text;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function adaptToToolHandle(client: Client): McpToolHandle {
+  return {
+    async listTools(): Promise<McpTool[]> {
+      const result = await client.listTools();
+      return result.tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema ?? { type: 'object', properties: {} },
+      }));
+    },
+    async callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
+      const result = await client.callTool({ name, arguments: args });
+      return {
+        content: (result.content ?? []) as McpToolResult['content'],
+        isError: typeof result.isError === 'boolean' ? result.isError : undefined,
+      };
+    },
+  };
+}

--- a/packages/backend-core/src/modules/kb/skills/curation.md
+++ b/packages/backend-core/src/modules/kb/skills/curation.md
@@ -8,7 +8,12 @@ audiences: [admin]
 
 The self-service AI agent flags a conversation with `conv_request_handover_in_my_conversation` whenever it can't answer from the KB. A human (or another admin agent) then takes over and replies. That reply is the durable answer, but today it stays trapped in one conversation — the next end-user with the same question hits the same dead-end. Your job in a curation pass is to turn those (question, human-reply) pairs into KB documents so the agent can answer them next time.
 
-This skill walks through one pass. Run it on a cadence the operator picks (weekly, after a launch, before a vacation, …). Don't run it inline per conversation — batching is cheaper and gives you a chance to consolidate.
+This skill walks through one pass. It supports two modes:
+
+- **Per-conversation mode** — the user prompt names a single `conversationId` (e.g. *"Run a KB curation pass for conversation ccv_xxx"*). Skip Step 1 entirely and go straight to `conv_get_conversation(<id>)`. Apply Steps 2–5 to that one conversation only. This is what fires from the agent sidecar on every `conversation.handover_resolved` event — a (question, human-reply) pair just landed and we want to capture the answer in seconds, not next-week.
+- **Batch mode** (no `conversationId` in the prompt) — run Steps 1–6 over the last 7 days of resolved handovers. Used as a weekly safety-net sweep to catch anything missed while the sidecar was offline, and for ad-hoc operator-initiated runs.
+
+Both modes share Steps 2–6 below. Don't refile a candidate that's already in `kb-curation-inbox` for the same source conversation — `kb_propose_curation_candidate` tags candidates with `source:<conversationId>`, so check `kb_list_documents({ tag: "candidate" })` and skip pairs whose source you've already filed.
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary

PR-A of three for the sidecar/curator refactor. Foundational primitives the OSS sidecar (PR-B) and cloud (PR-C) both consume.

### `runSkillPass(opts)`

Single-shot helper exported from `@getmunin/agent-runtime`. Opens an admin MCP session against a Munin instance, reads a `skill://...` resource, invokes `runAgent` with the skill body as system prompt and a caller-supplied user prompt, returns either `{ ok: true, toolCalls, totalTokens, finishReason, replyText }` or `{ ok: false, skipped: <reason> }`.

Replaces the duplicated curator-pass plumbing that lives in two places today:
- `munin-cloud/packages/curator-runner/src/scheduled-skill-runner.ts`'s `runPass`
- The OSS `scripts/curator-runner.mjs` dev helper

Both will collapse onto this primitive in the follow-up PRs.

### `onHandoverResolved` realtime callback

`createRealtimeClient` gains an optional `onHandoverResolved(event)` callback. Parses `conversation.handover_resolved` events that `conv.service.ts` already emits when a human teammate's reply clears `needs_human_attention`. Payload `{ conversationId, messageId, authorType }`.

This is the wiring point for the OSS sidecar (PR-B) to run KB curation per-handover, scoped to that one conversation, within seconds of the resolution — instead of waiting for a daily batch sweep.

### `skill://kb/curation` per-conversation mode

Top-of-skill paragraph documenting two modes:

- **Per-conversation** — user prompt names a single `conversationId` → skip `conv_list_conversations`, go straight to `conv_get_conversation(<id>)`. What the sidecar's handover-resolved subscriber uses.
- **Batch** — no `conversationId` in the prompt → run the existing 7-day-window flow. Used as a weekly safety-net sweep and for ad-hoc operator runs.

Same skill, two invocation patterns — no second skill needed.

## Test plan

- [x] `pnpm --filter @getmunin/agent-runtime test` — 43 tests pass (4 new: `realtime.test.ts` covers parsing + the no-callback path; `skill-pass.test.ts` covers the three skip paths).
- [x] `pnpm --filter @getmunin/agent-runtime build && pnpm --filter @getmunin/backend-core build` — clean (22 skills copied; the curation skill change is prose-only).
- [ ] Manual end-to-end exercised in PR-B against the local OSS sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)