### PR TITLE
feat(agent-runtime): Anthropic prompt caching in openAiCompatibleProvider

### DIFF
--- a/.changeset/agent-runtime-prompt-caching.md
+++ b/.changeset/agent-runtime-prompt-caching.md
@@ -1,0 +1,24 @@
+---
+'@getmunin/agent-runtime': minor
+---
+
+Adds opt-in Anthropic prompt caching to `openAiCompatibleProvider`. When the request targets an Anthropic-compatible backend (`api.anthropic.com/*` or `openrouter.ai/*` with `anthropic/*` model), the provider attaches `cache_control: { type: 'ephemeral' }` markers to:
+
+- the first system message (wrapped as a typed text block), and
+- the last entry in the `tools` array (caches the full tool stack as one block).
+
+These two breakpoints — system prompt and tool definitions — are the largest static chunks in any agent loop. With Anthropic's 5-minute TTL, the *first* call writes the cache (small surcharge on input tokens) and *subsequent* calls within the window read it at ~10% the cost.
+
+Detection is automatic but overridable via `AgentConfig.enablePromptCache?: boolean`:
+
+- `undefined` (default) — auto-enable for `api.anthropic.com` or `openrouter.ai` with `anthropic/*` model; off otherwise.
+- `true` — force-on regardless of backend (use if your provider supports `cache_control` and you've verified the wire format).
+- `false` — force-off (escape hatch).
+
+Non-Anthropic backends (OpenAI, OpenRouter with non-anthropic models, local stubs, etc.) emit the standard request body unchanged.
+
+**Where this matters most:** tool-heavy curator passes. With our `withAllowedToolPrefixes` filter (KB curation: `['conv_', 'kb_']`) we already saw ~65% input-token reduction per pass. With Anthropic prompt caching layered on top, each cron-driven sweep reuses ~35K tokens of cached prompt prefix at 10% the cost — expected ~80% additional reduction on warm cache, biggest absolute savings on the highest-volume jobs.
+
+Conversational replies benefit too: per-conversation multi-turn within 5 min reuses the cached system prompt + tool stack.
+
+No API change — existing callers (sidecar `runConversationHandler`, sidecar worker, cloud `AgentRunnerService`, `runSkillPass`) automatically get caching when their provider matches the auto-detect heuristic.

--- a/packages/agent-runtime/src/providers/openai-compatible.test.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shouldEnablePromptCache,
+  withSystemPromptCache,
+  withToolsCache,
+} from './openai-compatible.js';
+import type { ChatMessage, ChatToolDefinition } from '../types.js';
+
+import { vi } from 'vitest';
+import { openAiCompatibleProvider } from './openai-compatible.js';
+
+describe('openAiCompatibleProvider request body', () => {
+  it('emits cache_control on system + last tool when targeting Anthropic', async () => {
+    const captured: { url?: string; body?: Record<string, unknown> } = {};
+    const fakeFetch = vi.fn((url: string, init: RequestInit) => {
+      captured.url = url;
+      captured.body = JSON.parse(init.body as string) as Record<string, unknown>;
+      return Promise.resolve(new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ));
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fakeFetch as typeof fetch;
+    try {
+      await openAiCompatibleProvider({
+        config: {
+          provider: { baseUrl: 'https://api.anthropic.com/v1', apiKey: 'sk-ant-xxx' },
+          model: 'claude-haiku-4-5',
+          systemPrompt: 'sys',
+        },
+        messages: [
+          { role: 'system', content: 'sys' },
+          { role: 'user', content: 'hi' },
+        ],
+        tools: [
+          { type: 'function', function: { name: 'a', description: 'a', parameters: {} } },
+          { type: 'function', function: { name: 'b', description: 'b', parameters: {} } },
+        ],
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const messages = captured.body?.messages as Array<{ role: string; content: unknown }>;
+    expect(messages[0]?.content).toEqual([
+      { type: 'text', text: 'sys', cache_control: { type: 'ephemeral' } },
+    ]);
+    expect(messages[1]).toEqual({ role: 'user', content: 'hi' });
+    const tools = captured.body?.tools as Array<Record<string, unknown>>;
+    expect(tools[0]?.cache_control).toBeUndefined();
+    expect(tools[1]?.cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('does NOT emit cache_control on plain OpenAI backend', async () => {
+    const captured: { body?: Record<string, unknown> } = {};
+    const fakeFetch = vi.fn((_url: string, init: RequestInit) => {
+      captured.body = JSON.parse(init.body as string) as Record<string, unknown>;
+      return Promise.resolve(new Response(
+        JSON.stringify({
+          choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ));
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fakeFetch as typeof fetch;
+    try {
+      await openAiCompatibleProvider({
+        config: {
+          provider: { baseUrl: 'https://api.openai.com/v1', apiKey: 'sk-xxx' },
+          model: 'gpt-4o-mini',
+          systemPrompt: 'sys',
+        },
+        messages: [{ role: 'system', content: 'sys' }],
+        tools: [{ type: 'function', function: { name: 'a', description: 'a', parameters: {} } }],
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    const messages = captured.body?.messages as Array<{ content: unknown }>;
+    expect(messages[0]?.content).toBe('sys');
+    const tools = captured.body?.tools as Array<Record<string, unknown>>;
+    expect(tools[0]?.cache_control).toBeUndefined();
+  });
+});
+
+describe('shouldEnablePromptCache', () => {
+  it('auto-enables for Anthropic native endpoint', () => {
+    expect(
+      shouldEnablePromptCache({
+        provider: { baseUrl: 'https://api.anthropic.com/v1' },
+        model: 'claude-haiku-4-5',
+      }),
+    ).toBe(true);
+  });
+
+  it('auto-enables for OpenRouter with anthropic/* model', () => {
+    expect(
+      shouldEnablePromptCache({
+        provider: { baseUrl: 'https://openrouter.ai/api/v1' },
+        model: 'anthropic/claude-haiku-4.5',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not auto-enable for OpenRouter with non-anthropic model', () => {
+    expect(
+      shouldEnablePromptCache({
+        provider: { baseUrl: 'https://openrouter.ai/api/v1' },
+        model: 'openai/gpt-4o-mini',
+      }),
+    ).toBe(false);
+  });
+
+  it('does not auto-enable for OpenAI', () => {
+    expect(
+      shouldEnablePromptCache({
+        provider: { baseUrl: 'https://api.openai.com/v1' },
+        model: 'gpt-4o-mini',
+      }),
+    ).toBe(false);
+  });
+
+  it('explicit false overrides auto-detection', () => {
+    expect(
+      shouldEnablePromptCache({
+        provider: { baseUrl: 'https://api.anthropic.com/v1' },
+        model: 'claude-haiku-4-5',
+        enablePromptCache: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('explicit true forces caching even on non-Anthropic backend', () => {
+    expect(
+      shouldEnablePromptCache({
+        provider: { baseUrl: 'https://api.openai.com/v1' },
+        model: 'gpt-4o-mini',
+        enablePromptCache: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('withSystemPromptCache', () => {
+  it('wraps the first system message content in a cache_control block', () => {
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: 'hi' },
+    ];
+    const result = withSystemPromptCache(messages) as Array<{ role: string; content: unknown }>;
+    expect(result[0]?.role).toBe('system');
+    expect(result[0]?.content).toEqual([
+      { type: 'text', text: 'You are a helpful assistant.', cache_control: { type: 'ephemeral' } },
+    ]);
+    expect(result[1]).toEqual({ role: 'user', content: 'hi' });
+  });
+
+  it('marks only the first system message when there are multiple', () => {
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'first' },
+      { role: 'user', content: 'q' },
+      { role: 'system', content: 'second' },
+    ];
+    const result = withSystemPromptCache(messages) as Array<{ role: string; content: unknown }>;
+    expect(Array.isArray(result[0]?.content)).toBe(true);
+    expect(result[2]?.content).toBe('second');
+  });
+
+  it('passes through when there is no system message', () => {
+    const messages: ChatMessage[] = [{ role: 'user', content: 'hi' }];
+    expect(withSystemPromptCache(messages)).toEqual(messages);
+  });
+
+  it('passes through when system content is empty', () => {
+    const messages: ChatMessage[] = [
+      { role: 'system', content: '' },
+      { role: 'user', content: 'hi' },
+    ];
+    expect(withSystemPromptCache(messages)).toEqual(messages);
+  });
+});
+
+describe('withToolsCache', () => {
+  it('marks the last tool with cache_control', () => {
+    const tools: ChatToolDefinition[] = [
+      { type: 'function', function: { name: 'a', description: 'a', parameters: {} } },
+      { type: 'function', function: { name: 'b', description: 'b', parameters: {} } },
+    ];
+    const result = withToolsCache(tools) as Array<Record<string, unknown>>;
+    expect(result[0]).toEqual(tools[0]);
+    expect(result[1]).toEqual({ ...tools[1], cache_control: { type: 'ephemeral' } });
+  });
+
+  it('marks the only tool when length is 1', () => {
+    const tools: ChatToolDefinition[] = [
+      { type: 'function', function: { name: 'a', description: 'a', parameters: {} } },
+    ];
+    const result = withToolsCache(tools) as Array<Record<string, unknown>>;
+    expect(result[0]).toEqual({ ...tools[0], cache_control: { type: 'ephemeral' } });
+  });
+
+  it('returns the same array when there are no tools', () => {
+    expect(withToolsCache([])).toEqual([]);
+  });
+});

--- a/packages/agent-runtime/src/providers/openai-compatible.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, Provider, ProviderResponse } from '../types.js';
+import type { ChatMessage, ChatToolDefinition, Provider, ProviderResponse } from '../types.js';
 
 interface OpenAIChoice {
   message: ChatMessage;
@@ -14,6 +14,8 @@ interface OpenAIResponse {
   };
 }
 
+const CACHE_CONTROL = { type: 'ephemeral' } as const;
+
 export const openAiCompatibleProvider: Provider = async ({
   config,
   messages,
@@ -21,12 +23,13 @@ export const openAiCompatibleProvider: Provider = async ({
   abortSignal,
 }) => {
   const url = `${config.provider.baseUrl.replace(/\/+$/, '')}/chat/completions`;
+  const cacheEnabled = shouldEnablePromptCache(config);
   const body: Record<string, unknown> = {
     model: config.model,
-    messages,
+    messages: cacheEnabled ? withSystemPromptCache(messages) : messages,
   };
   if (tools.length > 0) {
-    body.tools = tools;
+    body.tools = cacheEnabled ? withToolsCache(tools) : tools;
     body.tool_choice = 'auto';
   }
   if (typeof config.maxTokens === 'number') body.max_tokens = config.maxTokens;
@@ -82,4 +85,40 @@ export class ProviderError extends Error {
   ) {
     super(message);
   }
+}
+
+export function shouldEnablePromptCache(config: {
+  provider: { baseUrl: string };
+  model: string;
+  enablePromptCache?: boolean;
+}): boolean {
+  if (config.enablePromptCache === false) return false;
+  if (config.enablePromptCache === true) return true;
+  return isAnthropicCompatibleBackend(config.provider.baseUrl, config.model);
+}
+
+function isAnthropicCompatibleBackend(baseUrl: string, model: string): boolean {
+  if (/api\.anthropic\.com/i.test(baseUrl)) return true;
+  if (/openrouter\.ai/i.test(baseUrl) && /^anthropic\//i.test(model)) return true;
+  return false;
+}
+
+export function withSystemPromptCache(messages: ChatMessage[]): unknown[] {
+  let firstSystemMarked = false;
+  return messages.map((m) => {
+    if (m.role !== 'system' || firstSystemMarked) return m;
+    if (typeof m.content !== 'string' || m.content.length === 0) return m;
+    firstSystemMarked = true;
+    return {
+      ...m,
+      content: [{ type: 'text', text: m.content, cache_control: CACHE_CONTROL }],
+    };
+  });
+}
+
+export function withToolsCache(tools: ChatToolDefinition[]): unknown[] {
+  if (tools.length === 0) return tools;
+  return tools.map((tool, idx) =>
+    idx === tools.length - 1 ? { ...tool, cache_control: CACHE_CONTROL } : tool,
+  );
 }

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -20,6 +20,7 @@ export interface AgentConfig {
   temperature?: number;
   maxHistoryChars?: number;
   responseFormat?: 'json_object';
+  enablePromptCache?: boolean;
 }
 
 export interface McpTool {


### PR DESCRIPTION
## Summary

Auto-attaches \`cache_control: { type: 'ephemeral' }\` markers to the first system message + last tool definition when the request targets an Anthropic-compatible backend (\`api.anthropic.com\` or \`openrouter.ai\` with \`anthropic/*\` model). With Anthropic's 5-minute TTL, the first call writes the cache and subsequent calls within the window read it at ~10% the cost.

The two breakpoints (system prompt + tool stack) are the largest static blocks in any agent loop. Stacked on the per-skill tool allow-list from #65, this makes tool-heavy curator passes dramatically cheaper:
- Before #65: ~100K input tokens per KB curation pass
- After #65 (allow-list): ~35K tokens per pass
- After this PR (cache warm): expected ~3-5K tokens per pass on the cached path (system + tools served from cache, only fresh per-job user prompt + tool results paid in full)

## API surface

- New \`AgentConfig.enablePromptCache?: boolean\`
  - \`undefined\` (default) — auto-enable for Anthropic backends; off elsewhere
  - \`true\` — force-on regardless of backend
  - \`false\` — escape hatch

- Provider exports two transform helpers (\`withSystemPromptCache\`, \`withToolsCache\`) for callers that want to apply markers manually, e.g. wrapping a custom Provider.

No API change for downstream callers — sidecar's \`createConversationHandler\`, sidecar worker (curator-loop), cloud \`AgentRunnerService\`, and \`runSkillPass\` all auto-benefit when their backend matches the heuristic. Non-Anthropic backends emit the standard body unchanged.

## Test plan

- [x] 13 unit tests for detection (anthropic / openrouter+anthropic / openrouter+openai / plain openai / explicit \`true\` / explicit \`false\`)
- [x] Helper tests (\`withSystemPromptCache\` marks first system, skips empty/missing; \`withToolsCache\` marks last tool, handles single + empty arrays)
- [x] **Wire-level test** — invoke \`openAiCompatibleProvider\` with a fetch mock, assert the actual request body shape:
  - Anthropic backend → \`messages[0].content\` is array with \`cache_control\`, last tool has \`cache_control\`
  - OpenAI backend → no \`cache_control\` anywhere, system content stays a string

63 tests pass in \`@getmunin/agent-runtime\`; workspace typecheck + lint clean.

## Why default-off elsewhere

Most OpenAI-compatible providers (OpenAI, vLLM, Ollama, etc.) ignore unknown fields, so emitting \`cache_control\` to them would likely be harmless — but \"likely\" isn't \"verified.\" Defaulting off keeps the wire shape conservative for non-Anthropic backends; users who've verified their provider can flip \`enablePromptCache: true\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)