### PR TITLE
fix(changeset): drop private @getmunin/agent-sidecar from public release set

### DIFF
--- a/.changeset/crm-contact-extract-curator.md
+++ b/.changeset/crm-contact-extract-curator.md
@@ -1,6 +1,5 @@
 ---
 '@getmunin/backend-core': minor
-'@getmunin/agent-sidecar': patch
 ---
 
 CRM contact-extract curator — auto-applied per-conversation contact creation from chat.


### PR DESCRIPTION
## Summary

The post-merge release flow on PR #71 ([CI run](https://github.com/getmunin/munin/actions/runs/25403240595)) failed at the changesets `version` step:

> 🦋 error Error: Found mixed changeset crm-contact-extract-curator

Cause: `.changeset/crm-contact-extract-curator.md` listed `'@getmunin/agent-sidecar': patch` alongside `'@getmunin/backend-core': minor`. But `apps/agent-sidecar` is `private: true` (it's an app, not a library) — Changesets refuses to release a changeset that mixes published and private packages, since there's no clear way to publish the private one.

The user-facing delta the changeset described is the new `skill://crm/contact-extract` curator. That ships through `@getmunin/backend-core` (where the skill markdown + service hooks live). The sidecar's one-line `toolPrefixesFor` addition is a runtime change; it's deployed via the container image, not via npm.

## Fix

Drop the private package from the changeset frontmatter. No code change.

```diff
 ---
 '@getmunin/backend-core': minor
-'@getmunin/agent-sidecar': patch
 ---
```

Once this lands, the release flow can re-run and produce the `chore: release` PR for both this changeset and the two others currently waiting on main (`crm-segments-and-consent`, `event-emission-completeness`).

## Note for future PRs

Pattern: `apps/*` packages with `private: true` should never appear in changesets. The pending PR2 outreach branch already follows this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)