### PR TITLE
feat(outreach): campaigns + initial drafts + send-approve loop (PR2 of 3)

### DIFF
--- a/.changeset/crm-contact-extract-curator.md
+++ b/.changeset/crm-contact-extract-curator.md
@@ -1,6 +1,5 @@
 ---
 '@getmunin/backend-core': minor
-'@getmunin/agent-sidecar': patch
 ---
 
 CRM contact-extract curator — auto-applied per-conversation contact creation from chat.

--- a/.changeset/outreach-campaigns-initials.md
+++ b/.changeset/outreach-campaigns-initials.md
@@ -1,0 +1,42 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+'@getmunin/db': minor
+---
+
+Outreach feature, PR2 of 3 — campaigns + initial drafts + send-approve loop.
+
+The first user-visible piece of outbound: an operator defines a campaign (name + brief + CRM segment + email channel + cadence + CTA), the new `skill://outreach/draft-initial` curator drafts a personalised first-touch email per consenting contact in the segment, the operator reviews each draft on `/dashboard/review` (third tab), and approving sends via the existing email-channel outbound pipeline. Replies thread into normal conversations via the existing RFC 5322 thread-resolution.
+
+**Schema:**
+
+- `outreach_campaigns` — operator-defined campaigns (segment_id → `crm_segments`, channel_id → `conv_channels` (must be email), brief, cadence_rules JSONB, cta_url, enabled, unsubscribe_required). Unique `(org_id, name)`. RLS admin-only.
+- `outreach_proposals` — drafted email queue with `kind` (`initial` in PR2; `reply` in PR3), nullable `conversation_id` (set when sent), `status` lifecycle (pending → sent / dismissed / failed), evidence JSONB, audit fields. **Unique pending index on (campaign_id, contact_id, kind)** to prevent dup drafts. RLS admin-only.
+- `conv_conversations` gains `outreach_campaign_id` (nullable FK + index) — sticky once set, used for reply attribution and (in PR3) `agentMode` defaulting.
+- New `packages/db/src/sql/outreach.sql` with RLS policies, wired into `runMigrations`.
+
+**Service / MCP / REST** (all in new `@getmunin/backend-core/src/modules/outreach/`):
+
+- `OutreachService` — `listCampaigns`/`getCampaign`/`createCampaign`/`updateCampaign`/`listProposals`/`getProposal`/`proposeInitial`/`approveProposal`/`dismissProposal`. `approveProposal` re-checks suppression+consent at decision-time (the contact may have unsubscribed between draft and approval), creates a conversation with `outreach_campaign_id` set, sends via the existing email outbound pipeline, and appends a signed unsubscribe footer to the body server-side so it can't be tampered with at draft-time.
+- MCP tools (admin audience): `outreach_create_campaign`, `outreach_update_campaign`, `outreach_list_campaigns`, `outreach_get_campaign`, `outreach_list_proposals`, `outreach_propose_initial`.
+- REST: `GET/POST /api/outreach/campaigns`, `GET/POST /api/outreach/campaigns/:id`, `GET /api/outreach/proposals?status=pending&kind=initial&campaignId=…`, `GET /api/outreach/proposals/:id`, `POST /api/outreach/proposals/:id/approve`, `POST /api/outreach/proposals/:id/dismiss`. The proposals list/get embeds `contact` and `campaign` summaries so the dashboard doesn't need parallel fetches.
+- Realtime events: `outreach.proposal.created`, `outreach.proposal.sent`, `outreach.proposal.dismissed` (rides existing WebhookDispatcher).
+
+**Conv-side:** `ConvService.createConversation` now accepts `outreachCampaignId` and enqueues outbound delivery for non-end_user authors on email channels (it previously only did this from `sendMessage`, which broke first-touch sends). All existing flows are unaffected — they don't pass `outreachCampaignId` and their authorType doesn't trigger outbound enqueue.
+
+**Skill:** `skill://outreach/draft-initial` (markdown, copied into dist by the existing `copy-skills.mjs`). Procedure: list enabled campaigns → materialise audience via `crm_list_contacts_in_segment` (which already enforces the suppression+consent floor) → dedupe via `outreach_list_proposals` → ground in `kb_search` → draft 80–200 word personalised email → file via `outreach_propose_initial`. Strict formatting: no headings, plain prose, no JSON-escaping; the unsubscribe footer is appended at approve-time, not draft-time.
+
+**Curator scheduling:**
+
+- New sweep `curator-outreach-draft-initial` (default cron `'0 0 * * 0'` weekly, env `MUNIN_CURATOR_OUTREACH_INITIAL_CRON`).
+- Sidecar `toolPrefixesFor` adds `'skill://outreach/draft-initial'` → `['conv_', 'kb_', 'crm_', 'outreach_']`. Cloud `AgentRunnerService.toolPrefixesFor` needs the same one-line addition (separate cloud PR after this OSS release).
+
+**Dashboard:**
+
+- Third tab on `/dashboard/review`: `OutreachDraftsTab` lists pending proposals with markdown body (heading-flatten components shared with KB), Approve / Edit (placeholder; inline editing ships next) / Dismiss buttons. Realtime updates on `outreach.proposal.*` events.
+- New `/dashboard/settings/outreach` (under Monitoring → Workspace group) — list campaigns, create dialog with name + brief + segment dropdown + channel dropdown + CTA URL, enable/disable toggle. Empty-state nudges the operator if they have no email channels or segments yet.
+- i18n: `dashboard.outreach.*`, `dashboard.outreachDrafts.*`, `nav.outreach`, `dashboard.review.tabs.outreach` in en + nb.
+
+**Tests:** 9 new integration tests covering campaign CRUD (including non-email-channel rejection and duplicate-name conflict), `proposeInitial` (dedupe + consent floor), `approveProposal` (success path stamps conv id + delivery row, suppression-race refuses, disabled-campaign refuses), and `dismissProposal`. Existing 306 backend-core tests unchanged. `curator-scheduler.test.ts` updated to expect the new fourth cron job.
+
+**Out of PR2 scope (lands in PR3):** `agentMode` column + reply-curator skill + draft-on-reply loop. Operators currently get a one-way send; replies land in normal conversations and the AI agent will reply auto-mode by default until PR3 wires `agentMode = 'draft_only'` on outreach-originated conversations.

--- a/apps/agent-sidecar/src/curator-loop.ts
+++ b/apps/agent-sidecar/src/curator-loop.ts
@@ -183,6 +183,7 @@ function toolPrefixesFor(skillUri: string): string[] | undefined {
   if (skillUri === 'skill://kb/curation') return ['conv_', 'kb_'];
   if (skillUri === 'skill://crm/hygiene') return ['conv_', 'crm_'];
   if (skillUri === 'skill://crm/contact-extract') return ['conv_', 'crm_'];
+  if (skillUri === 'skill://outreach/draft-initial') return ['conv_', 'kb_', 'crm_', 'outreach_'];
   if (skillUri === 'skill://cms/stale-content-review') return ['cms_'];
   return undefined;
 }

--- a/apps/web/app/dashboard/settings/layout.tsx
+++ b/apps/web/app/dashboard/settings/layout.tsx
@@ -11,6 +11,7 @@ import {
   Gauge,
   KeyRound,
   Loader2,
+  Mail,
   MessageSquare,
   ShieldCheck,
   Users,
@@ -25,6 +26,7 @@ type GroupKey = 'workspace' | 'access' | 'monitoring';
 type ItemKey =
   | 'team'
   | 'channels'
+  | 'outreach'
   | 'apiKeys'
   | 'agents'
   | 'endUsers'
@@ -50,6 +52,7 @@ const GROUPS: SubNavGroup[] = [
     items: [
       { href: '/dashboard/settings/team', labelKey: 'team', icon: UsersRound },
       { href: '/dashboard/settings/channels', labelKey: 'channels', icon: MessageSquare },
+      { href: '/dashboard/settings/outreach', labelKey: 'outreach', icon: Mail },
       { href: '/dashboard/settings/export', labelKey: 'dataExport', icon: Download },
     ],
   },

--- a/apps/web/app/dashboard/settings/outreach/page.tsx
+++ b/apps/web/app/dashboard/settings/outreach/page.tsx
@@ -1,0 +1,1 @@
+export { OutreachCampaignsPage as default } from '@getmunin/dashboard-pages';

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -67,6 +67,7 @@
     "agents": "Connected agents",
     "apiKeys": "API keys",
     "channels": "Channels",
+    "outreach": "Outreach",
     "endUsers": "End-users",
     "usage": "Usage",
     "auditLog": "Audit log",
@@ -111,11 +112,62 @@
     },
     "review": {
       "title": "Review",
-      "subtitle": "KB suggestions and CRM merges proposed by curators. Approve to publish, dismiss to discard.",
+      "subtitle": "KB suggestions, CRM merges, and outreach drafts proposed by curators. Approve to publish/send, dismiss to discard.",
       "automateHint": "Fully automate this by connecting an <adminAgent>Admin Agent</adminAgent>.",
       "tabs": {
         "kb": "KB suggestions",
-        "crm": "CRM merges"
+        "crm": "CRM merges",
+        "outreach": "Outreach drafts"
+      }
+    },
+    "outreach": {
+      "title": "Outreach campaigns",
+      "subtitle": "Operator-defined outbound email campaigns. Each enabled campaign produces curator-drafted initials weekly; approve each draft from the Review surface before it sends. Suppression and consent are re-checked at approve-time.",
+      "addCampaign": "New campaign",
+      "needsEmailChannel": "Create an email channel under Channels first — outreach campaigns send via your configured SMTP.",
+      "needsSegment": "Create a CRM segment first — campaigns target a saved segment of consenting contacts.",
+      "emptyTitle": "No campaigns yet",
+      "emptyBody": "A campaign needs a name, a one-paragraph brief, a CRM segment as audience, and an email channel. New campaigns are off by default; flip Enable when you're ready for the curator to start drafting.",
+      "createTitle": "New outreach campaign",
+      "createDescription": "Drafts won't send automatically — every initial lands in the Review queue for human approval first.",
+      "nameLabel": "Internal name",
+      "namePlaceholder": "e.g. q2-onboarding-reach-out",
+      "briefLabel": "Brief",
+      "briefHint": "One paragraph in plain English describing what you want to say and why. The curator personalises per contact, grounding in your KB.",
+      "briefPlaceholder": "We just shipped self-serve onboarding for B2B teams. We'd like to talk to ops leaders at companies that recently raised, to learn how they're approaching this …",
+      "segmentLabel": "CRM segment",
+      "channelLabel": "Email channel",
+      "ctaLabel": "Optional CTA URL",
+      "create": "Create campaign",
+      "creating": "Creating…",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "enable": "Enable",
+      "disable": "Disable",
+      "segment": "Segment",
+      "channel": "Channel",
+      "errors": {
+        "load": "Could not load campaigns.",
+        "create": "Could not create campaign.",
+        "update": "Could not update campaign."
+      }
+    },
+    "outreachDrafts": {
+      "loading": "Loading…",
+      "emptyTitle": "No outreach drafts pending review",
+      "emptyBody": "When the draft-initial curator runs against an enabled campaign, drafts land here for approval. Approve to send via the campaign's email channel; dismiss to discard.",
+      "to": "to",
+      "via": "via",
+      "untitled": "(no subject)",
+      "approve": "Approve & send",
+      "edit": "Edit",
+      "editComingSoon": "Inline editing ships next — for now, dismiss and have the curator redraft, or rerun the campaign.",
+      "dismiss": "Dismiss",
+      "dismissPrompt": "Reason for dismissing? (optional)",
+      "errors": {
+        "load": "Could not load outreach drafts.",
+        "approve": "Could not approve draft (may be blocked by suppression / consent).",
+        "dismiss": "Could not dismiss draft."
       }
     },
     "kbCandidates": {

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -67,6 +67,7 @@
     "agents": "Tilkoblede agenter",
     "apiKeys": "API-nøkler",
     "channels": "Kanaler",
+    "outreach": "Utgående e-post",
     "endUsers": "Sluttbrukere",
     "usage": "Bruk",
     "auditLog": "Hendelseslogg",
@@ -111,11 +112,62 @@
     },
     "review": {
       "title": "Gjennomgang",
-      "subtitle": "KB-forslag og CRM-sammenslåinger fra kuratorene. Godkjenn for å publisere, avvis for å forkaste.",
+      "subtitle": "KB-forslag, CRM-sammenslåinger og utgående e-postutkast fra kuratorene. Godkjenn for å publisere/sende, avvis for å forkaste.",
       "automateHint": "Automatiser hele flyten ved å koble til en <adminAgent>admin-agent</adminAgent>.",
       "tabs": {
         "kb": "KB-forslag",
-        "crm": "CRM-sammenslåinger"
+        "crm": "CRM-sammenslåinger",
+        "outreach": "Utgående utkast"
+      }
+    },
+    "outreach": {
+      "title": "Utgående kampanjer",
+      "subtitle": "Operatørdefinerte e-postkampanjer. Hver aktiverte kampanje produserer kurator-utkast ukentlig; godkjenn hvert utkast fra Gjennomgang før det sendes. Suppresjon og samtykke kontrolleres på nytt ved godkjenning.",
+      "addCampaign": "Ny kampanje",
+      "needsEmailChannel": "Opprett en e-postkanal under Kanaler først — utgående kampanjer sender via din konfigurerte SMTP.",
+      "needsSegment": "Opprett et CRM-segment først — kampanjer målretter et lagret segment med samtykkende kontakter.",
+      "emptyTitle": "Ingen kampanjer ennå",
+      "emptyBody": "En kampanje trenger navn, ett kort avsnitt med brief, et CRM-segment som målgruppe, og en e-postkanal. Nye kampanjer er av som standard; aktiver når du er klar for at kuratoren skal begynne å skrive utkast.",
+      "createTitle": "Ny utgående kampanje",
+      "createDescription": "Utkast sendes ikke automatisk — hver første e-post havner i gjennomgangskøen for menneskelig godkjenning først.",
+      "nameLabel": "Internt navn",
+      "namePlaceholder": "f.eks. q2-onboarding-utreach",
+      "briefLabel": "Brief",
+      "briefHint": "Ett avsnitt på vanlig norsk som beskriver hva du vil si og hvorfor. Kuratoren personaliserer per kontakt og grunner i KB-en din.",
+      "briefPlaceholder": "Vi har akkurat lansert selvbetjent onboarding for B2B-team. Vi vil snakke med ops-ledere i selskaper som nylig hentet kapital, for å lære hvordan de tilnærmer seg dette …",
+      "segmentLabel": "CRM-segment",
+      "channelLabel": "E-postkanal",
+      "ctaLabel": "Valgfri CTA-URL",
+      "create": "Opprett kampanje",
+      "creating": "Oppretter …",
+      "enabled": "Aktiv",
+      "disabled": "Inaktiv",
+      "enable": "Aktiver",
+      "disable": "Deaktiver",
+      "segment": "Segment",
+      "channel": "Kanal",
+      "errors": {
+        "load": "Kunne ikke laste kampanjer.",
+        "create": "Kunne ikke opprette kampanje.",
+        "update": "Kunne ikke oppdatere kampanje."
+      }
+    },
+    "outreachDrafts": {
+      "loading": "Laster …",
+      "emptyTitle": "Ingen utgående utkast venter på gjennomgang",
+      "emptyBody": "Når draft-initial-kuratoren kjører mot en aktivert kampanje, havner utkast her for godkjenning. Godkjenn for å sende via kampanjens e-postkanal; avvis for å forkaste.",
+      "to": "til",
+      "via": "via",
+      "untitled": "(ingen emne)",
+      "approve": "Godkjenn & send",
+      "edit": "Rediger",
+      "editComingSoon": "Inline-redigering kommer snart — foreløpig: avvis og la kuratoren skrive på nytt, eller kjør kampanjen igjen.",
+      "dismiss": "Avvis",
+      "dismissPrompt": "Begrunnelse for avvisning? (valgfritt)",
+      "errors": {
+        "load": "Kunne ikke laste utgående utkast.",
+        "approve": "Kunne ikke godkjenne utkast (kan være blokkert av suppresjon / samtykke).",
+        "dismiss": "Kunne ikke avvise utkast."
       }
     },
     "kbCandidates": {

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -22,6 +22,9 @@ import { RealtimeModule } from '../realtime/realtime.module.js';
 import { CrmMergeProposalsController } from './crm-merge-proposals.controller.js';
 import { CrmSegmentsController } from './crm-segments.controller.js';
 import { OutreachUnsubscribeController } from './outreach-unsubscribe.controller.js';
+import { OutreachCampaignsController } from './outreach-campaigns.controller.js';
+import { OutreachProposalsController } from './outreach-proposals.controller.js';
+import { OutreachModule } from '../modules/outreach/outreach.module.js';
 import { PublicSkillsController } from './public-skills.controller.js';
 import { InvitationsController } from './invitations.controller.js';
 import { AcceptInvitationController } from './accept-invitation.controller.js';
@@ -42,7 +45,16 @@ import { OverviewController } from './overview.controller.js';
  * permitted on these endpoints — that's the privilege boundary.
  */
 @Module({
-  imports: [CmsModule, ConvModule, CrmModule, CuratorModule, KbModule, McpModule, RealtimeModule],
+  imports: [
+    CmsModule,
+    ConvModule,
+    CrmModule,
+    CuratorModule,
+    KbModule,
+    McpModule,
+    OutreachModule,
+    RealtimeModule,
+  ],
   controllers: [
     ApiKeysController,
     EndUsersController,
@@ -66,6 +78,8 @@ import { OverviewController } from './overview.controller.js';
     CrmMergeProposalsController,
     CrmSegmentsController,
     OutreachUnsubscribeController,
+    OutreachCampaignsController,
+    OutreachProposalsController,
     CuratorJobsController,
     ConvChannelsController,
     KbCandidatesController,

--- a/packages/backend-core/src/control/outreach-campaigns.controller.ts
+++ b/packages/backend-core/src/control/outreach-campaigns.controller.ts
@@ -1,0 +1,98 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { z } from 'zod';
+import { AuthGuard } from '../common/auth/auth.guard.js';
+import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.js';
+import { AuditInterceptor } from '../common/audit/audit.interceptor.js';
+import {
+  OutreachInvalidError,
+  OutreachService,
+  type CampaignDto,
+} from '../modules/outreach/outreach.service.js';
+
+const CadenceRulesSchema = z.object({
+  maxPerWeekPerContact: z.number().int().positive().max(7).optional(),
+  quietHoursStart: z.string().regex(/^[0-2]\d:[0-5]\d$/).optional(),
+  quietHoursEnd: z.string().regex(/^[0-2]\d:[0-5]\d$/).optional(),
+  blackoutDates: z.array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)).max(50).optional(),
+});
+
+const CreateBody = z.object({
+  name: z.string().min(1).max(120),
+  brief: z.string().min(1).max(5000),
+  segmentId: z.string().min(1).max(64),
+  channelId: z.string().min(1).max(64),
+  cadenceRules: CadenceRulesSchema.optional(),
+  ctaUrl: z.string().url().nullable().optional(),
+  enabled: z.boolean().optional(),
+  unsubscribeRequired: z.boolean().optional(),
+});
+
+const UpdateBody = z
+  .object({
+    name: z.string().min(1).max(120).optional(),
+    brief: z.string().min(1).max(5000).optional(),
+    segmentId: z.string().min(1).max(64).optional(),
+    channelId: z.string().min(1).max(64).optional(),
+    cadenceRules: CadenceRulesSchema.optional(),
+    ctaUrl: z.string().url().nullable().optional(),
+    enabled: z.boolean().optional(),
+    unsubscribeRequired: z.boolean().optional(),
+  })
+  .refine((p) => Object.keys(p).length > 0, { message: 'patch must contain at least one field' });
+
+interface CampaignListResponse {
+  items: CampaignDto[];
+}
+
+@Controller('api/outreach/campaigns')
+@UseGuards(AuthGuard)
+@UseInterceptors(TenancyInterceptor, AuditInterceptor)
+export class OutreachCampaignsController {
+  constructor(private readonly outreach: OutreachService) {}
+
+  @Get()
+  async list(): Promise<CampaignListResponse> {
+    const items = await translate(() => this.outreach.listCampaigns());
+    return { items };
+  }
+
+  @Get(':id')
+  async get(@Param('id') id: string): Promise<CampaignDto> {
+    return translate(() => this.outreach.getCampaign(id));
+  }
+
+  @Post()
+  @HttpCode(201)
+  async create(@Body() body: unknown): Promise<CampaignDto> {
+    const parsed = CreateBody.safeParse(body ?? {});
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return translate(() => this.outreach.createCampaign(parsed.data));
+  }
+
+  @Post(':id')
+  @HttpCode(200)
+  async update(@Param('id') id: string, @Body() body: unknown): Promise<CampaignDto> {
+    const parsed = UpdateBody.safeParse(body ?? {});
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return translate(() => this.outreach.updateCampaign({ id, patch: parsed.data }));
+  }
+}
+
+async function translate<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof OutreachInvalidError) throw new BadRequestException(err.message);
+    throw err;
+  }
+}

--- a/packages/backend-core/src/control/outreach-proposals.controller.ts
+++ b/packages/backend-core/src/control/outreach-proposals.controller.ts
@@ -1,0 +1,101 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { z } from 'zod';
+import { AuthGuard } from '../common/auth/auth.guard.js';
+import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.js';
+import { AuditInterceptor } from '../common/audit/audit.interceptor.js';
+import {
+  OutreachInvalidError,
+  OutreachService,
+  PROPOSAL_KINDS,
+  PROPOSAL_STATUSES,
+  type ProposalDto,
+} from '../modules/outreach/outreach.service.js';
+
+const StatusSchema = z.enum(PROPOSAL_STATUSES);
+const KindSchema = z.enum(PROPOSAL_KINDS);
+const DismissBody = z.object({ reason: z.string().max(500).optional() });
+
+interface ProposalListResponse {
+  items: ProposalDto[];
+}
+
+@Controller('api/outreach/proposals')
+@UseGuards(AuthGuard)
+@UseInterceptors(TenancyInterceptor, AuditInterceptor)
+export class OutreachProposalsController {
+  constructor(private readonly outreach: OutreachService) {}
+
+  @Get()
+  async list(
+    @Query('status') status?: string,
+    @Query('kind') kind?: string,
+    @Query('campaignId') campaignId?: string,
+    @Query('contactId') contactId?: string,
+    @Query('limit') limit?: string,
+  ): Promise<ProposalListResponse> {
+    const parsedStatus = status ? StatusSchema.safeParse(status) : null;
+    if (parsedStatus && !parsedStatus.success) {
+      throw new BadRequestException(`invalid status: ${status}`);
+    }
+    const parsedKind = kind ? KindSchema.safeParse(kind) : null;
+    if (parsedKind && !parsedKind.success) {
+      throw new BadRequestException(`invalid kind: ${kind}`);
+    }
+    const items = await translate(() =>
+      this.outreach.listProposals({
+        status: parsedStatus?.success ? parsedStatus.data : undefined,
+        kind: parsedKind?.success ? parsedKind.data : undefined,
+        campaignId,
+        contactId,
+        limit: parseLimit(limit),
+      }),
+    );
+    return { items };
+  }
+
+  @Get(':id')
+  async get(@Param('id') id: string): Promise<ProposalDto> {
+    return translate(() => this.outreach.getProposal(id));
+  }
+
+  @Post(':id/approve')
+  @HttpCode(200)
+  async approve(@Param('id') id: string): Promise<ProposalDto> {
+    const publicBaseUrl = process.env.MUNIN_PUBLIC_URL ?? 'http://localhost:3001';
+    return translate(() => this.outreach.approveProposal(id, { publicBaseUrl }));
+  }
+
+  @Post(':id/dismiss')
+  @HttpCode(200)
+  async dismiss(@Param('id') id: string, @Body() body: unknown): Promise<ProposalDto> {
+    const parsed = DismissBody.safeParse(body ?? {});
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return translate(() => this.outreach.dismissProposal({ id, reason: parsed.data.reason }));
+  }
+}
+
+async function translate<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof OutreachInvalidError) throw new BadRequestException(err.message);
+    throw err;
+  }
+}
+
+function parseLimit(value: string | undefined): number | undefined {
+  const n = value ? Number.parseInt(value, 10) : NaN;
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.min(n, 500);
+}

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -303,13 +303,18 @@ export class ConvService {
     endUserId?: string;
     contactId?: string;
     topicId?: string;
+    outreachCampaignId?: string;
     authorType: 'user' | 'agent' | 'end_user' | 'system';
     authorId: string;
   }): Promise<ConversationDetail> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     const channelRows = await ctx.db
-      .select({ id: schema.convChannels.id, active: schema.convChannels.active })
+      .select({
+        id: schema.convChannels.id,
+        active: schema.convChannels.active,
+        type: schema.convChannels.type,
+      })
       .from(schema.convChannels)
       .where(eq(schema.convChannels.id, input.channelId))
       .limit(1);
@@ -317,6 +322,7 @@ export class ConvService {
     if (!channelRows[0].active) {
       throw new ConvInvalidError(`channel ${input.channelId} is not active`);
     }
+    const channelType = channelRows[0].type;
 
     const conv = await this.insertConversationWithRetry({
       orgId: actor.orgId,
@@ -325,6 +331,7 @@ export class ConvService {
       endUserId: input.endUserId ?? null,
       topicId: input.topicId ?? null,
       subject: input.subject ?? null,
+      outreachCampaignId: input.outreachCampaignId ?? null,
     });
 
     const [firstMsg] = await ctx.db
@@ -359,6 +366,14 @@ export class ConvService {
         internal: false,
       },
     });
+
+    if (
+      channelType === 'email' &&
+      input.authorType !== 'end_user' &&
+      input.authorType !== 'system'
+    ) {
+      await this.enqueueEmailOutbound(firstMsg!.id, conv.id, conv.channelId);
+    }
 
     return this.getConversation(conv.id);
   }
@@ -772,6 +787,7 @@ export class ConvService {
     endUserId: string | null;
     topicId: string | null;
     subject: string | null;
+    outreachCampaignId?: string | null;
   }): Promise<typeof schema.convConversations.$inferSelect> {
     const ctx = getCurrentContext();
     let lastErr: unknown = null;

--- a/packages/backend-core/src/modules/curator/curator-scheduler.service.ts
+++ b/packages/backend-core/src/modules/curator/curator-scheduler.service.ts
@@ -14,6 +14,8 @@ const CRM_HYGIENE_PROMPT =
   'Run a CRM hygiene pass. Follow the skill. First fetch dismissed pairs via crm_list_merge_proposals so you do not refile rejected pairs. Then list contacts, build suspect pairs, judge each, and file high-confidence pairs as structured proposals via crm_propose_merge_candidate. Stop when there are no more new pairs to propose.';
 const CMS_STALE_PROMPT =
   'Run a CMS stale-content review pass. Follow the skill. Walk each collection, judge per-collection velocity, find stale drafts, find unrefreshed published entries, find orphaned assets. Produce a structured action report grouped by recommended action. Do not execute any mutating tool — propose only.';
+const OUTREACH_DRAFT_INITIAL_PROMPT =
+  'Run an outreach draft-initial pass. Follow skill://outreach/draft-initial exactly. List enabled campaigns, materialise each segment via crm_list_contacts_in_segment, dedupe via outreach_list_proposals, ground each draft in kb_search results, and file every new draft via outreach_propose_initial. Do NOT approve or send anything — drafts go to the operator review queue.';
 
 interface SweepDef {
   name: string;
@@ -67,6 +69,14 @@ export class CuratorSchedulerService implements OnModuleInit {
         skillUri: 'skill://cms/stale-content-review',
         userPrompt: CMS_STALE_PROMPT,
         dedupeKey: 'cms-stale:scheduled',
+      },
+      {
+        name: 'curator-outreach-draft-initial',
+        envCron: process.env.MUNIN_CURATOR_OUTREACH_INITIAL_CRON,
+        defaultCron: CronExpression.EVERY_WEEK,
+        skillUri: 'skill://outreach/draft-initial',
+        userPrompt: OUTREACH_DRAFT_INITIAL_PROMPT,
+        dedupeKey: 'outreach-draft-initial:scheduled',
       },
     ];
 

--- a/packages/backend-core/src/modules/curator/curator-scheduler.test.ts
+++ b/packages/backend-core/src/modules/curator/curator-scheduler.test.ts
@@ -22,7 +22,7 @@ describe('CuratorSchedulerService.onModuleInit', () => {
     return { svc, registry };
   }
 
-  it('registers the three default cron jobs when not disabled', () => {
+  it('registers the four default cron jobs when not disabled', () => {
     const { svc, registry } = build();
     svc.onModuleInit();
     const jobs = registry.getCronJobs();
@@ -30,6 +30,7 @@ describe('CuratorSchedulerService.onModuleInit', () => {
       'curator-cms-stale',
       'curator-crm-hygiene',
       'curator-kb-sweep',
+      'curator-outreach-draft-initial',
     ]);
   });
 

--- a/packages/backend-core/src/modules/outreach/outreach.module.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConvModule } from '../conv/conv.module.js';
+import { CrmModule } from '../crm/crm.module.js';
+import { OutreachService } from './outreach.service.js';
+import { OutreachAdminTools } from './outreach.tools.js';
+
+@Module({
+  imports: [ConvModule, CrmModule],
+  providers: [OutreachService, OutreachAdminTools],
+  exports: [OutreachService],
+})
+export class OutreachModule {}

--- a/packages/backend-core/src/modules/outreach/outreach.service.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import {
+  ActorIdentity,
+  WebhookDispatcher,
+  withContext,
+  type RequestContext,
+} from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { eq, sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { ConflictException } from '@nestjs/common';
+import { OutreachService, OutreachInvalidError } from './outreach.service.js';
+import { CrmService } from '../crm/crm.service.js';
+import { ConvService } from '../conv/conv.service.js';
+import { ConversationClaimsService } from '../conv/conv.claims.service.js';
+import { CuratorJobsService } from '../curator/curator-jobs.service.js';
+import { EmailService } from '../conv/email/email.service.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run outreach service tests.';
+
+(skipReason ? describe.skip : describe)('OutreachService', () => {
+  let db: ReturnType<typeof createDb>;
+  let appDb: ReturnType<typeof createDb>;
+  let svc: OutreachService;
+  let crm: CrmService;
+  let conv: ConvService;
+  let orgId: string;
+  let actor: ActorIdentity;
+  let segmentId: string;
+  let channelId: string;
+  let contactId: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    await runMigrations(TEST_URL!);
+    db = createDb(TEST_URL!, { serviceRole: true });
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    appDb = createDb(appUrl);
+
+    const ts = Date.now();
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Outreach Test Org', slug: `outreach-${ts}` })
+      .returning();
+    orgId = org!.id;
+    actor = new ActorIdentity('admin_agent', 'agt_outreach_test', orgId, ['*'], ['admin']);
+
+    const dispatcher = new WebhookDispatcher();
+    crm = new CrmService(dispatcher);
+    const claims = new ConversationClaimsService(dispatcher);
+    const curatorJobs = new CuratorJobsService(dispatcher);
+    conv = new ConvService(dispatcher, claims, curatorJobs);
+    const email = new EmailService();
+    svc = new OutreachService(dispatcher, conv, crm, email);
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  beforeEach(async () => {
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    await db.execute(sql`DELETE FROM outreach_proposals WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM outreach_campaigns WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM conv_message_deliveries WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM conv_messages WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM conv_conversations WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM conv_contacts WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM conv_channels WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM crm_contacts WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM crm_segments WHERE org_id = ${orgId}`);
+
+    // Seed: one email channel, one segment with one consenting contact.
+    const [ch] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'email',
+        name: 'support',
+        active: true,
+        config: { addressing: { fromAddress: 'support@example.com' } },
+      })
+      .returning();
+    channelId = ch!.id;
+
+    const [seg] = await db
+      .insert(schema.crmSegments)
+      .values({
+        orgId,
+        name: 'priority-prospects',
+        description: null,
+        filterDefinition: { tagsAny: ['priority'] },
+        createdByActorType: actor.type,
+        createdByActorId: actor.id,
+      })
+      .returning();
+    segmentId = seg!.id;
+
+    const [contact] = await db
+      .insert(schema.crmContacts)
+      .values({
+        orgId,
+        name: 'Jane Doe',
+        email: 'jane@acme.com',
+        consentLawfulBasis: 'legitimate_interest',
+        consentGivenAt: new Date(),
+        consentSource: 'imported-test',
+        tags: ['priority'],
+      })
+      .returning();
+    contactId = contact!.id;
+  });
+
+  function run<T>(fn: () => Promise<T>): Promise<T> {
+    return appDb.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
+      await tx.execute(sql`SELECT set_config('app.org_id', ${orgId}, true)`);
+      const ctx: RequestContext = {
+        db: tx,
+        actor,
+        correlationId: randomUUID(),
+      };
+      return withContext(ctx, fn);
+    });
+  }
+
+  describe('campaigns', () => {
+    it('creates a campaign with valid segment + email channel', async () => {
+      const c = await run(() =>
+        svc.createCampaign({
+          name: 'Q2 outreach',
+          brief: 'Re-engage prospects who showed interest last quarter.',
+          segmentId,
+          channelId,
+        }),
+      );
+      expect(c.name).toBe('Q2 outreach');
+      expect(c.enabled).toBe(false);
+      expect(c.unsubscribeRequired).toBe(true);
+    });
+
+    it('rejects a campaign whose channel is not email', async () => {
+      const [ch] = await db
+        .insert(schema.convChannels)
+        .values({ orgId, type: 'chat', name: 'web-widget', active: true, config: {} })
+        .returning();
+      await expect(
+        run(() =>
+          svc.createCampaign({
+            name: 'Wrong channel',
+            brief: 'x',
+            segmentId,
+            channelId: ch!.id,
+          }),
+        ),
+      ).rejects.toThrow(OutreachInvalidError);
+    });
+
+    it('rejects duplicate campaign names per org', async () => {
+      await run(() =>
+        svc.createCampaign({ name: 'dup', brief: 'a', segmentId, channelId }),
+      );
+      await expect(
+        run(() => svc.createCampaign({ name: 'dup', brief: 'b', segmentId, channelId })),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('proposals', () => {
+    it('proposeInitial → listProposals → approve sends and updates status', async () => {
+      const c = await run(() =>
+        svc.createCampaign({
+          name: 'launch',
+          brief: 'Reach out to priority prospects.',
+          segmentId,
+          channelId,
+          enabled: true,
+        }),
+      );
+      const p = await run(() =>
+        svc.proposeInitial({
+          campaignId: c.id,
+          contactId,
+          draftSubject: 'Hi Jane',
+          draftBody: 'We just shipped X — would you like a quick demo?',
+          evidence: { source: 'unit-test' },
+        }),
+      );
+      expect(p.status).toBe('pending');
+      expect(p.kind).toBe('initial');
+
+      const pending = await run(() => svc.listProposals({ status: 'pending' }));
+      expect(pending).toHaveLength(1);
+      expect(pending[0]!.contact?.email).toBe('jane@acme.com');
+      expect(pending[0]!.campaign?.name).toBe('launch');
+
+      const approved = await run(() =>
+        svc.approveProposal(p.id, { publicBaseUrl: 'https://test.local' }),
+      );
+      expect(approved.status).toBe('sent');
+      expect(approved.conversationId).toBeTruthy();
+      expect(approved.sentMessageId).toBeTruthy();
+
+      // Conversation has the campaign id stamped.
+      const convRows = await db.execute<{ outreach_campaign_id: string | null }>(
+        sql`SELECT outreach_campaign_id FROM conv_conversations WHERE id = ${approved.conversationId!}`,
+      );
+      expect(convRows[0]!.outreach_campaign_id).toBe(c.id);
+
+      // Message body contains the unsubscribe footer with our public base url.
+      const msgRows = await db.execute<{ body: string }>(
+        sql`SELECT body FROM conv_messages WHERE id = ${approved.sentMessageId!}`,
+      );
+      expect(msgRows[0]!.body).toContain('Unsubscribe: https://test.local/api/outreach/unsubscribe?token=');
+
+      // An outbound delivery row was queued (email channel + agent author).
+      const delivery = await db.execute<{ count: number }>(
+        sql`SELECT COUNT(*)::int AS count FROM conv_message_deliveries WHERE message_id = ${approved.sentMessageId!}`,
+      );
+      expect(delivery[0]!.count).toBe(1);
+    });
+
+    it('approve refuses when contact unsubscribed between draft and approval', async () => {
+      const c = await run(() =>
+        svc.createCampaign({
+          name: 'race',
+          brief: 'Race test.',
+          segmentId,
+          channelId,
+          enabled: true,
+        }),
+      );
+      const p = await run(() =>
+        svc.proposeInitial({
+          campaignId: c.id,
+          contactId,
+          draftSubject: 'subject',
+          draftBody: 'body',
+        }),
+      );
+      // Suppress the contact AFTER the draft.
+      await run(() =>
+        crm.updateContact({ id: contactId, patch: { doNotContact: true } }),
+      );
+      await expect(
+        run(() => svc.approveProposal(p.id, { publicBaseUrl: 'https://test.local' })),
+      ).rejects.toThrow(OutreachInvalidError);
+    });
+
+    it('approve refuses when campaign is disabled', async () => {
+      const c = await run(() =>
+        svc.createCampaign({
+          name: 'paused',
+          brief: 'paused brief',
+          segmentId,
+          channelId,
+          enabled: false,
+        }),
+      );
+      const p = await run(() =>
+        svc.proposeInitial({
+          campaignId: c.id,
+          contactId,
+          draftSubject: 'subject',
+          draftBody: 'body',
+        }),
+      );
+      await expect(
+        run(() => svc.approveProposal(p.id, { publicBaseUrl: 'https://test.local' })),
+      ).rejects.toThrow(OutreachInvalidError);
+    });
+
+    it('proposeInitial rejects a contact without consent', async () => {
+      await db
+        .update(schema.crmContacts)
+        .set({ consentLawfulBasis: null, consentGivenAt: null })
+        .where(eq(schema.crmContacts.id, contactId));
+      const c = await run(() =>
+        svc.createCampaign({ name: 'noc', brief: 'b', segmentId, channelId, enabled: true }),
+      );
+      await expect(
+        run(() =>
+          svc.proposeInitial({
+            campaignId: c.id,
+            contactId,
+            draftSubject: 's',
+            draftBody: 'b',
+          }),
+        ),
+      ).rejects.toThrow(OutreachInvalidError);
+    });
+
+    it('proposeInitial enforces uniqueness on (campaign, contact, kind=initial) while pending', async () => {
+      const c = await run(() =>
+        svc.createCampaign({ name: 'dup', brief: 'b', segmentId, channelId, enabled: true }),
+      );
+      await run(() =>
+        svc.proposeInitial({
+          campaignId: c.id,
+          contactId,
+          draftSubject: 's',
+          draftBody: 'b',
+        }),
+      );
+      await expect(
+        run(() =>
+          svc.proposeInitial({
+            campaignId: c.id,
+            contactId,
+            draftSubject: 's2',
+            draftBody: 'b2',
+          }),
+        ),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('dismissProposal marks pending→dismissed', async () => {
+      const c = await run(() =>
+        svc.createCampaign({ name: 'd', brief: 'b', segmentId, channelId, enabled: true }),
+      );
+      const p = await run(() =>
+        svc.proposeInitial({
+          campaignId: c.id,
+          contactId,
+          draftSubject: 's',
+          draftBody: 'b',
+        }),
+      );
+      const dismissed = await run(() =>
+        svc.dismissProposal({ id: p.id, reason: 'tone is off' }),
+      );
+      expect(dismissed.status).toBe('dismissed');
+      expect(dismissed.dismissReason).toBe('tone is off');
+    });
+  });
+});

--- a/packages/backend-core/src/modules/outreach/outreach.service.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.ts
@@ -1,0 +1,572 @@
+import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { schema } from '@getmunin/db';
+import { and, desc, eq, type SQL } from 'drizzle-orm';
+import { getCurrentContext, signUnsubscribeToken, WebhookDispatcher } from '@getmunin/core';
+import { ConvService } from '../conv/conv.service.js';
+import { CrmService, CrmInvalidError } from '../crm/crm.service.js';
+import { EmailService } from '../conv/email/email.service.js';
+
+export class OutreachInvalidError extends Error {
+  readonly code = 'outreach_invalid';
+  constructor(message: string) {
+    super(`outreach_invalid: ${message}`);
+  }
+}
+
+export const PROPOSAL_KINDS = ['initial', 'reply'] as const;
+export type ProposalKind = (typeof PROPOSAL_KINDS)[number];
+
+export const PROPOSAL_STATUSES = ['pending', 'approved', 'sent', 'failed', 'dismissed'] as const;
+export type ProposalStatus = (typeof PROPOSAL_STATUSES)[number];
+
+export interface CadenceRules {
+  maxPerWeekPerContact?: number;
+  quietHoursStart?: string;
+  quietHoursEnd?: string;
+  blackoutDates?: string[];
+}
+
+export interface CampaignDto {
+  id: string;
+  name: string;
+  brief: string;
+  segmentId: string;
+  channelId: string;
+  cadenceRules: CadenceRules;
+  ctaUrl: string | null;
+  enabled: boolean;
+  unsubscribeRequired: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProposalContactSummary {
+  id: string;
+  name: string | null;
+  email: string | null;
+  companyId: string | null;
+}
+
+export interface ProposalCampaignSummary {
+  id: string;
+  name: string;
+}
+
+export interface ProposalDto {
+  id: string;
+  campaignId: string;
+  contactId: string;
+  conversationId: string | null;
+  kind: ProposalKind;
+  draftSubject: string | null;
+  draftBody: string;
+  evidence: Record<string, unknown>;
+  proposedSendAt: string | null;
+  status: ProposalStatus;
+  proposedByActorType: string;
+  proposedByActorId: string;
+  decidedByActorType: string | null;
+  decidedByActorId: string | null;
+  decidedAt: string | null;
+  sentAt: string | null;
+  sentMessageId: string | null;
+  failureReason: string | null;
+  dismissReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+  contact: ProposalContactSummary | null;
+  campaign: ProposalCampaignSummary | null;
+}
+
+@Injectable()
+export class OutreachService {
+  constructor(
+    @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
+    @Inject(ConvService) private readonly conv: ConvService,
+    @Inject(CrmService) private readonly crm: CrmService,
+    @Inject(EmailService) private readonly email: EmailService,
+  ) {}
+
+  // ─── Campaigns ──────────────────────────────────────────────────────────
+
+  async listCampaigns(): Promise<CampaignDto[]> {
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select()
+      .from(schema.outreachCampaigns)
+      .orderBy(desc(schema.outreachCampaigns.updatedAt));
+    return rows.map(toCampaignDto);
+  }
+
+  async getCampaign(id: string): Promise<CampaignDto> {
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select()
+      .from(schema.outreachCampaigns)
+      .where(eq(schema.outreachCampaigns.id, id))
+      .limit(1);
+    if (!rows[0]) throw new NotFoundException(`outreach_not_found: campaign ${id}`);
+    return toCampaignDto(rows[0]);
+  }
+
+  async createCampaign(input: {
+    name: string;
+    brief: string;
+    segmentId: string;
+    channelId: string;
+    cadenceRules?: CadenceRules;
+    ctaUrl?: string | null;
+    enabled?: boolean;
+    unsubscribeRequired?: boolean;
+  }): Promise<CampaignDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    if (!input.name.trim()) throw new OutreachInvalidError('name must be non-empty');
+    if (!input.brief.trim()) throw new OutreachInvalidError('brief must be non-empty');
+    // Validate FK targets in this org.
+    await this.assertSegmentExists(input.segmentId);
+    await this.assertEmailChannelExists(input.channelId);
+    try {
+      const [row] = await ctx.db
+        .insert(schema.outreachCampaigns)
+        .values({
+          orgId: actor.orgId,
+          name: input.name,
+          brief: input.brief,
+          segmentId: input.segmentId,
+          channelId: input.channelId,
+          cadenceRules: input.cadenceRules ?? {},
+          ctaUrl: input.ctaUrl ?? null,
+          enabled: input.enabled ?? false,
+          unsubscribeRequired: input.unsubscribeRequired ?? true,
+          createdByActorType: actor.type,
+          createdByActorId: actor.id,
+        })
+        .returning();
+      return toCampaignDto(row!);
+    } catch (err) {
+      if (isUniqueViolation(err, 'outreach_campaigns_org_name_uq')) {
+        throw new ConflictException(`outreach_conflict: campaign with name "${input.name}" already exists`);
+      }
+      throw err;
+    }
+  }
+
+  async updateCampaign(input: {
+    id: string;
+    patch: Partial<{
+      name: string;
+      brief: string;
+      segmentId: string;
+      channelId: string;
+      cadenceRules: CadenceRules;
+      ctaUrl: string | null;
+      enabled: boolean;
+      unsubscribeRequired: boolean;
+    }>;
+  }): Promise<CampaignDto> {
+    const ctx = getCurrentContext();
+    if (input.patch.segmentId) await this.assertSegmentExists(input.patch.segmentId);
+    if (input.patch.channelId) await this.assertEmailChannelExists(input.patch.channelId);
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    for (const [k, v] of Object.entries(input.patch)) {
+      if (v !== undefined) updates[k] = v;
+    }
+    const result = await ctx.db
+      .update(schema.outreachCampaigns)
+      .set(updates)
+      .where(eq(schema.outreachCampaigns.id, input.id))
+      .returning();
+    if (!result[0]) throw new NotFoundException(`outreach_not_found: campaign ${input.id}`);
+    return toCampaignDto(result[0]);
+  }
+
+  // ─── Proposals ──────────────────────────────────────────────────────────
+
+  async listProposals(input: {
+    status?: ProposalStatus;
+    campaignId?: string;
+    kind?: ProposalKind;
+    contactId?: string;
+    limit?: number;
+  }): Promise<ProposalDto[]> {
+    const ctx = getCurrentContext();
+    const limit = clampLimit(input.limit, 100, 500);
+    const filters: SQL[] = [];
+    if (input.status) filters.push(eq(schema.outreachProposals.status, input.status));
+    if (input.campaignId) filters.push(eq(schema.outreachProposals.campaignId, input.campaignId));
+    if (input.kind) filters.push(eq(schema.outreachProposals.kind, input.kind));
+    if (input.contactId) filters.push(eq(schema.outreachProposals.contactId, input.contactId));
+    const rows = await ctx.db
+      .select({
+        proposal: schema.outreachProposals,
+        contact: {
+          id: schema.crmContacts.id,
+          name: schema.crmContacts.name,
+          email: schema.crmContacts.email,
+          companyId: schema.crmContacts.companyId,
+        },
+        campaign: {
+          id: schema.outreachCampaigns.id,
+          name: schema.outreachCampaigns.name,
+        },
+      })
+      .from(schema.outreachProposals)
+      .leftJoin(schema.crmContacts, eq(schema.crmContacts.id, schema.outreachProposals.contactId))
+      .leftJoin(
+        schema.outreachCampaigns,
+        eq(schema.outreachCampaigns.id, schema.outreachProposals.campaignId),
+      )
+      .where(filters.length === 0 ? undefined : and(...filters))
+      .orderBy(desc(schema.outreachProposals.createdAt))
+      .limit(limit);
+    return rows.map((r) => toProposalDto(r.proposal, r.contact, r.campaign));
+  }
+
+  async getProposal(id: string): Promise<ProposalDto> {
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select({
+        proposal: schema.outreachProposals,
+        contact: {
+          id: schema.crmContacts.id,
+          name: schema.crmContacts.name,
+          email: schema.crmContacts.email,
+          companyId: schema.crmContacts.companyId,
+        },
+        campaign: {
+          id: schema.outreachCampaigns.id,
+          name: schema.outreachCampaigns.name,
+        },
+      })
+      .from(schema.outreachProposals)
+      .leftJoin(schema.crmContacts, eq(schema.crmContacts.id, schema.outreachProposals.contactId))
+      .leftJoin(
+        schema.outreachCampaigns,
+        eq(schema.outreachCampaigns.id, schema.outreachProposals.campaignId),
+      )
+      .where(eq(schema.outreachProposals.id, id))
+      .limit(1);
+    if (!rows[0]) throw new NotFoundException(`outreach_not_found: proposal ${id}`);
+    return toProposalDto(rows[0].proposal, rows[0].contact, rows[0].campaign);
+  }
+
+  async proposeInitial(input: {
+    campaignId: string;
+    contactId: string;
+    draftSubject: string;
+    draftBody: string;
+    evidence?: Record<string, unknown>;
+    proposedSendAt?: string;
+  }): Promise<ProposalDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    if (!input.draftSubject.trim()) throw new OutreachInvalidError('draftSubject must be non-empty');
+    if (!input.draftBody.trim()) throw new OutreachInvalidError('draftBody must be non-empty');
+    // Validate FKs.
+    await this.getCampaign(input.campaignId);
+    const contact = await this.crm.getContact(input.contactId).catch((err) => {
+      if (err instanceof CrmInvalidError) throw new OutreachInvalidError(err.message);
+      throw err;
+    });
+    if (contact.doNotContact || contact.unsubscribedAt || !contact.consentLawfulBasis) {
+      throw new OutreachInvalidError(
+        `contact ${input.contactId} is suppressed or has no recorded lawful basis`,
+      );
+    }
+    try {
+      const [row] = await ctx.db
+        .insert(schema.outreachProposals)
+        .values({
+          orgId: actor.orgId,
+          campaignId: input.campaignId,
+          contactId: input.contactId,
+          kind: 'initial',
+          draftSubject: input.draftSubject,
+          draftBody: input.draftBody,
+          evidence: input.evidence ?? {},
+          proposedSendAt: input.proposedSendAt ? new Date(input.proposedSendAt) : null,
+          status: 'pending',
+          proposedByActorType: actor.type,
+          proposedByActorId: actor.id,
+        })
+        .returning();
+      await this.webhooks.emit({
+        type: 'outreach.proposal.created',
+        payload: {
+          proposalId: row!.id,
+          campaignId: row!.campaignId,
+          contactId: row!.contactId,
+          kind: row!.kind,
+        },
+      });
+      return toProposalDto(row!);
+    } catch (err) {
+      if (isUniqueViolation(err, 'outreach_proposals_pending_pair_uq')) {
+        throw new ConflictException(
+          `outreach_conflict: a pending initial proposal already exists for (campaign, contact)`,
+        );
+      }
+      throw err;
+    }
+  }
+
+  async approveProposal(id: string, opts: { publicBaseUrl: string }): Promise<ProposalDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const proposal = await this.getProposal(id);
+    if (proposal.status !== 'pending') {
+      throw new OutreachInvalidError(`proposal ${id} is ${proposal.status}, not pending`);
+    }
+    if (proposal.kind !== 'initial') {
+      throw new OutreachInvalidError(
+        `proposal ${id} is kind=${proposal.kind}; reply approval ships in PR3`,
+      );
+    }
+    const campaign = await this.getCampaign(proposal.campaignId);
+    if (!campaign.enabled) {
+      throw new OutreachInvalidError(`campaign ${campaign.id} is disabled`);
+    }
+
+    // Re-check suppression+consent at approve-time (the contact may have
+    // unsubscribed between draft generation and operator approval).
+    const contact = await this.crm.getContact(proposal.contactId);
+    if (contact.doNotContact || contact.unsubscribedAt || !contact.consentLawfulBasis) {
+      throw new OutreachInvalidError(
+        `contact ${contact.id} is no longer eligible (suppression or consent withdrawn)`,
+      );
+    }
+    if (!contact.email) {
+      throw new OutreachInvalidError(`contact ${contact.id} has no email — cannot send`);
+    }
+
+    // Find or create a conv_contacts row keyed on email so the email
+    // adapter's reply-threading can link inbound replies back here.
+    const convContact = await ctx.db.transaction(async (tx) => {
+      return this.email.findOrCreateContactByEmail(tx, actor.orgId, contact.email!, contact.name ?? undefined);
+    });
+
+    // Compose body: agent-drafted text + campaign CTA + unsubscribe footer.
+    // Footer is appended at approve-time (not draft-time) so the link can't
+    // be tampered with.
+    const unsubscribeUrl = buildUnsubscribeUrl({
+      publicBaseUrl: opts.publicBaseUrl,
+      orgId: actor.orgId,
+      contactId: contact.id,
+      campaignId: campaign.id,
+    });
+    const body = composeOutreachBody({
+      draftBody: proposal.draftBody,
+      ctaUrl: campaign.ctaUrl,
+      unsubscribeUrl,
+      unsubscribeRequired: campaign.unsubscribeRequired,
+    });
+
+    // Create conversation + send first message via the existing email
+    // outbound pipeline. createConversation enqueues the delivery row when
+    // channel is email and authorType !== end_user/system.
+    const conversation = await this.conv.createConversation({
+      channelId: campaign.channelId,
+      body,
+      subject: proposal.draftSubject ?? undefined,
+      contactId: convContact.id,
+      endUserId: contact.endUserId ?? undefined,
+      outreachCampaignId: campaign.id,
+      authorType: 'agent',
+      authorId: actor.id,
+    });
+
+    const firstMessageId = conversation.messages[0]?.id ?? null;
+
+    const [updated] = await ctx.db
+      .update(schema.outreachProposals)
+      .set({
+        status: 'sent',
+        conversationId: conversation.id,
+        sentMessageId: firstMessageId,
+        sentAt: new Date(),
+        decidedByActorType: actor.type,
+        decidedByActorId: actor.id,
+        decidedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.outreachProposals.id, id))
+      .returning();
+
+    // Bump the contact's lastContactedAt so cadence-aware filters notice.
+    await ctx.db
+      .update(schema.crmContacts)
+      .set({ lastContactedAt: new Date(), updatedAt: new Date() })
+      .where(eq(schema.crmContacts.id, contact.id));
+
+    await this.webhooks.emit({
+      type: 'outreach.proposal.sent',
+      payload: {
+        proposalId: id,
+        campaignId: campaign.id,
+        contactId: contact.id,
+        conversationId: conversation.id,
+        messageId: firstMessageId,
+      },
+    });
+
+    return toProposalDto(updated!);
+  }
+
+  async dismissProposal(input: { id: string; reason?: string }): Promise<ProposalDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const proposal = await this.getProposal(input.id);
+    if (proposal.status !== 'pending') {
+      throw new OutreachInvalidError(`proposal ${input.id} is ${proposal.status}, not pending`);
+    }
+    const [updated] = await ctx.db
+      .update(schema.outreachProposals)
+      .set({
+        status: 'dismissed',
+        dismissReason: input.reason ?? null,
+        decidedByActorType: actor.type,
+        decidedByActorId: actor.id,
+        decidedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.outreachProposals.id, input.id))
+      .returning();
+    await this.webhooks.emit({
+      type: 'outreach.proposal.dismissed',
+      payload: {
+        proposalId: input.id,
+        campaignId: proposal.campaignId,
+        contactId: proposal.contactId,
+        reason: input.reason ?? null,
+      },
+    });
+    return toProposalDto(updated!);
+  }
+
+  // ─── Internal helpers ───────────────────────────────────────────────────
+
+  private async assertSegmentExists(segmentId: string): Promise<void> {
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select({ id: schema.crmSegments.id })
+      .from(schema.crmSegments)
+      .where(eq(schema.crmSegments.id, segmentId))
+      .limit(1);
+    if (!rows[0]) throw new OutreachInvalidError(`segment ${segmentId} does not exist`);
+  }
+
+  private async assertEmailChannelExists(channelId: string): Promise<void> {
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select({ id: schema.convChannels.id, type: schema.convChannels.type })
+      .from(schema.convChannels)
+      .where(eq(schema.convChannels.id, channelId))
+      .limit(1);
+    if (!rows[0]) throw new OutreachInvalidError(`channel ${channelId} does not exist`);
+    if (rows[0].type !== 'email') {
+      throw new OutreachInvalidError(
+        `channel ${channelId} is type=${rows[0].type}; outreach campaigns require an email channel`,
+      );
+    }
+  }
+}
+
+// ─── DTO mappers / helpers ────────────────────────────────────────────────
+
+function toCampaignDto(row: typeof schema.outreachCampaigns.$inferSelect): CampaignDto {
+  return {
+    id: row.id,
+    name: row.name,
+    brief: row.brief,
+    segmentId: row.segmentId,
+    channelId: row.channelId,
+    cadenceRules: row.cadenceRules,
+    ctaUrl: row.ctaUrl,
+    enabled: row.enabled,
+    unsubscribeRequired: row.unsubscribeRequired,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function toProposalDto(
+  row: typeof schema.outreachProposals.$inferSelect,
+  contact: { id: string | null; name: string | null; email: string | null; companyId: string | null } | null = null,
+  campaign: { id: string | null; name: string | null } | null = null,
+): ProposalDto {
+  return {
+    id: row.id,
+    campaignId: row.campaignId,
+    contactId: row.contactId,
+    conversationId: row.conversationId,
+    kind: row.kind as ProposalKind,
+    draftSubject: row.draftSubject,
+    draftBody: row.draftBody,
+    evidence: row.evidence,
+    proposedSendAt: row.proposedSendAt?.toISOString() ?? null,
+    status: row.status as ProposalStatus,
+    proposedByActorType: row.proposedByActorType,
+    proposedByActorId: row.proposedByActorId,
+    decidedByActorType: row.decidedByActorType,
+    decidedByActorId: row.decidedByActorId,
+    decidedAt: row.decidedAt?.toISOString() ?? null,
+    sentAt: row.sentAt?.toISOString() ?? null,
+    sentMessageId: row.sentMessageId,
+    failureReason: row.failureReason,
+    dismissReason: row.dismissReason,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    contact:
+      contact && contact.id
+        ? { id: contact.id, name: contact.name, email: contact.email, companyId: contact.companyId }
+        : null,
+    campaign: campaign && campaign.id ? { id: campaign.id, name: campaign.name ?? '' } : null,
+  };
+}
+
+function isUniqueViolation(err: unknown, constraint: string): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const cause = (err as { cause?: unknown }).cause;
+  const target = (cause && typeof cause === 'object' ? cause : err) as {
+    code?: string;
+    constraint_name?: string;
+  };
+  return target.code === '23505' && target.constraint_name === constraint;
+}
+
+function clampLimit(value: number | undefined, fallback: number, max: number): number {
+  if (value === undefined || value <= 0) return fallback;
+  return Math.min(value, max);
+}
+
+function buildUnsubscribeUrl(input: {
+  publicBaseUrl: string;
+  orgId: string;
+  contactId: string;
+  campaignId: string;
+}): string {
+  const token = signUnsubscribeToken({
+    orgId: input.orgId,
+    contactId: input.contactId,
+    campaignId: input.campaignId,
+  });
+  const base = input.publicBaseUrl.replace(/\/+$/, '');
+  return `${base}/api/outreach/unsubscribe?token=${encodeURIComponent(token)}`;
+}
+
+function composeOutreachBody(input: {
+  draftBody: string;
+  ctaUrl: string | null;
+  unsubscribeUrl: string;
+  unsubscribeRequired: boolean;
+}): string {
+  let body = input.draftBody.trimEnd();
+  if (input.ctaUrl) {
+    body += `\n\n${input.ctaUrl}`;
+  }
+  if (input.unsubscribeRequired) {
+    body += `\n\n---\nUnsubscribe: ${input.unsubscribeUrl}`;
+  }
+  return body;
+}

--- a/packages/backend-core/src/modules/outreach/outreach.tools.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.tools.ts
@@ -1,0 +1,152 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpTool } from '@getmunin/mcp-toolkit';
+import { OutreachService, PROPOSAL_KINDS, PROPOSAL_STATUSES } from './outreach.service.js';
+
+const CadenceRulesSchema = z.object({
+  maxPerWeekPerContact: z.number().int().positive().max(7).optional(),
+  quietHoursStart: z.string().regex(/^[0-2]\d:[0-5]\d$/).optional(),
+  quietHoursEnd: z.string().regex(/^[0-2]\d:[0-5]\d$/).optional(),
+  blackoutDates: z.array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)).max(50).optional(),
+});
+
+const CreateCampaignInput = z.object({
+  name: z.string().min(1).max(120),
+  brief: z.string().min(1).max(5000),
+  segmentId: z.string().min(1).max(64),
+  channelId: z.string().min(1).max(64),
+  cadenceRules: CadenceRulesSchema.optional(),
+  ctaUrl: z.string().url().nullable().optional(),
+  enabled: z.boolean().optional(),
+  unsubscribeRequired: z.boolean().optional(),
+});
+
+const UpdateCampaignInput = z.object({
+  id: z.string().min(1).max(64),
+  patch: z
+    .object({
+      name: z.string().min(1).max(120).optional(),
+      brief: z.string().min(1).max(5000).optional(),
+      segmentId: z.string().min(1).max(64).optional(),
+      channelId: z.string().min(1).max(64).optional(),
+      cadenceRules: CadenceRulesSchema.optional(),
+      ctaUrl: z.string().url().nullable().optional(),
+      enabled: z.boolean().optional(),
+      unsubscribeRequired: z.boolean().optional(),
+    })
+    .refine((p) => Object.keys(p).length > 0, { message: 'patch must contain at least one field' }),
+});
+
+const GetCampaignInput = z.object({ id: z.string().min(1).max(64) });
+
+const ListProposalsInput = z.object({
+  status: z.enum(PROPOSAL_STATUSES).optional(),
+  campaignId: z.string().min(1).max(64).optional(),
+  kind: z.enum(PROPOSAL_KINDS).optional(),
+  contactId: z.string().min(1).max(64).optional(),
+  limit: z.number().int().positive().max(500).optional(),
+});
+
+const ProposeInitialInput = z.object({
+  campaignId: z.string().min(1).max(64),
+  contactId: z.string().min(1).max(64),
+  draftSubject: z.string().min(1).max(300),
+  draftBody: z.string().min(1).max(20_000),
+  evidence: z.record(z.string(), z.unknown()).optional(),
+  proposedSendAt: z.string().datetime().optional(),
+});
+
+const EmptyInput = z.object({});
+
+@Injectable()
+export class OutreachAdminTools {
+  constructor(@Inject(OutreachService) private readonly outreach: OutreachService) {}
+
+  @McpTool({
+    name: 'outreach_list_campaigns',
+    title: 'List outreach campaigns',
+    description:
+      'List outbound-campaign definitions for this org. Each row carries the brief, the targeted CRM segment, the email channel used to send, cadence rules, CTA URL, and the enabled flag. The draft-initial curator only drafts proposals for `enabled = true` campaigns.',
+    audiences: ['admin'],
+    scopes: ['crm:read'],
+    input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  listCampaigns() {
+    return this.outreach.listCampaigns();
+  }
+
+  @McpTool({
+    name: 'outreach_get_campaign',
+    title: 'Read one outreach campaign',
+    description: 'Read a single campaign by id, including brief and cadence rules.',
+    audiences: ['admin'],
+    scopes: ['crm:read'],
+    input: GetCampaignInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  getCampaign(args: z.infer<typeof GetCampaignInput>) {
+    return this.outreach.getCampaign(args.id);
+  }
+
+  @McpTool({
+    name: 'outreach_create_campaign',
+    title: 'Create outreach campaign',
+    description:
+      'Create an outbound-campaign definition. Operators write `brief` as a one-paragraph human description of intent (the curator personalises per contact from this). `segmentId` chooses the audience; the curator calls `crm_list_contacts_in_segment` (which always enforces suppression+consent floor) to materialize it. `channelId` must reference an email channel. New campaigns default `enabled: false` so the curator does not start drafting until you flip it on.',
+    audiences: ['admin'],
+    scopes: ['crm:write'],
+    input: CreateCampaignInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  createCampaign(args: z.infer<typeof CreateCampaignInput>) {
+    return this.outreach.createCampaign(args);
+  }
+
+  @McpTool({
+    name: 'outreach_update_campaign',
+    title: 'Update outreach campaign',
+    description: 'Patch fields on a campaign — rename, swap segment, adjust cadence, toggle enabled.',
+    audiences: ['admin'],
+    scopes: ['crm:write'],
+    input: UpdateCampaignInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  updateCampaign(args: z.infer<typeof UpdateCampaignInput>) {
+    return this.outreach.updateCampaign(args);
+  }
+
+  @McpTool({
+    name: 'outreach_list_proposals',
+    title: 'List outreach proposals',
+    description:
+      'List drafted outreach proposals (initials in PR2; replies in PR3). Defaults to all statuses. The draft-initial curator queries `status: "pending", kind: "initial"` filtered by `(campaignId, contactId)` to dedupe before drafting a new candidate. The operator review surface queries `status: "pending"`.',
+    audiences: ['admin'],
+    scopes: ['crm:read'],
+    input: ListProposalsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  listProposals(args: z.infer<typeof ListProposalsInput>) {
+    return this.outreach.listProposals(args);
+  }
+
+  @McpTool({
+    name: 'outreach_propose_initial',
+    title: 'Propose an initial outreach draft',
+    description:
+      'File one drafted initial outreach email per (campaign, contact) for human approval. Idempotent: re-proposing the same (campaign, contact, kind=initial) while a pending row exists throws — call `outreach_list_proposals` first to dedupe. Suppression and consent are re-checked at approve-time too; this tool refuses up-front if the contact is already suppressed.',
+    audiences: ['admin'],
+    scopes: ['crm:write'],
+    input: ProposeInitialInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  proposeInitial(args: z.infer<typeof ProposeInitialInput>) {
+    return this.outreach.proposeInitial(args);
+  }
+}

--- a/packages/backend-core/src/modules/outreach/skills/draft-initial.md
+++ b/packages/backend-core/src/modules/outreach/skills/draft-initial.md
@@ -1,0 +1,119 @@
+---
+title: Outreach — draft initial emails
+description: Periodic curator pass that drafts personalised first-touch outreach emails for every enabled campaign. One pending proposal per (campaign, contact). Drafts go into the operator review queue — never auto-send. Runs weekly by default; the operator approves each draft before it leaves the org.
+audiences: [admin]
+---
+
+# Outreach — draft initial emails
+
+Operators set up campaigns (`outreach_create_campaign`) with a one-paragraph **brief** and a target **CRM segment**. Your job in a pass is to materialise the segment, draft a personalised first-touch email per contact, and file each draft as a pending **proposal** for human review. **You never send anything.** The operator approves each proposal one by one (or a trusted admin agent does on their behalf), at which point the system sends via the campaign's email channel and threads any reply back into the same conversation.
+
+This pass is symmetric with `skill://kb/curation` (drafted candidates) but for outreach instead of KB. Always-propose is non-negotiable: an LLM-drafted cold email going straight to a prospect is exactly how you ship a tone-deaf message you can't take back. Human approval is the system invariant.
+
+A separate `skill://crm/hygiene` runs weekly to merge any duplicate contacts this and other curators leave behind. Don't try to do hygiene's job here — keep the per-campaign pass narrow.
+
+## TL;DR
+
+1. **List enabled campaigns** with `outreach_list_campaigns`. Skip rows where `enabled = false`.
+2. **For each campaign**, materialise the audience with `crm_list_contacts_in_segment(campaign.segmentId)`. The list is *already* filtered for suppression (`do_not_contact`, `unsubscribed_at`) and lawful basis (`consent_lawful_basis IS NOT NULL`) — that floor is non-overridable in the service. Treat what comes back as the eligible set.
+3. **For each contact in the audience**, dedupe via `outreach_list_proposals({ status: "pending", kind: "initial", campaignId, contactId })`. Skip if a pending proposal already exists.
+4. **Pull product context** with `kb_search` against the brief — find 1–3 relevant KB snippets to ground the email in real facts (don't fabricate features).
+5. **Draft** an 80–200-word email, personalised to the contact's name + company. Plain prose, no headings, sparing bold/italic, no JSON-escaping. The unsubscribe footer is appended **at approve-time** by the system — do not include one in your draft.
+6. **File** with `outreach_propose_initial({ campaignId, contactId, draftSubject, draftBody, evidence })`. The `evidence` JSONB carries the (KB doc ids, contact-tag matches, reasoning summary) you'd want a human reviewer to see — keep it short and structured.
+7. **Stop.** No further calls. The operator's approval flow does the sending.
+
+## Step 1 — list enabled campaigns
+
+```jsonc
+{ "name": "outreach_list_campaigns", "arguments": {} }
+```
+
+Each row carries `id`, `name`, `brief`, `segmentId`, `channelId`, `cadenceRules`, `ctaUrl`, `enabled`, `unsubscribeRequired`. Filter to `enabled = true`. Skim `cadenceRules.maxPerWeekPerContact` for sanity (it doesn't gate you here — it's enforced at send-time — but if you see `1` you should be especially conservative about re-running too often).
+
+## Step 2 — materialise the audience
+
+```jsonc
+{ "name": "crm_list_contacts_in_segment", "arguments": { "id": "<segmentId>", "limit": 200 } }
+```
+
+You get `ContactDto[]` already pre-filtered. Each contact has `id`, `name`, `email`, `companyId`, `tags`, `consentLawfulBasis`, `lastContactedAt`, etc. **Do not** call `crm_list_contacts` directly — that surface bypasses the suppression+consent floor.
+
+If the segment returns 0 contacts, skip this campaign entirely.
+
+## Step 3 — dedupe before drafting
+
+```jsonc
+{
+  "name": "outreach_list_proposals",
+  "arguments": { "status": "pending", "kind": "initial", "campaignId": "<id>", "contactId": "<id>" }
+}
+```
+
+If non-empty, the contact already has a pending draft — skip. Don't re-propose; the unique index will reject you anyway, and you'll waste an LLM call.
+
+You may also want to skip when the contact's `lastContactedAt` was within `cadenceRules.maxPerWeekPerContact / 7` days — but for the initial pass, skipping based on a pending proposal is the only hard rule.
+
+## Step 4 — pull product context
+
+The campaign's brief is operator-written intent ("we just shipped a feature for X-shaped customers"). Don't paraphrase claims you can't ground. Use `kb_search` to pull supporting docs:
+
+```jsonc
+{ "name": "kb_search", "arguments": { "query": "<keywords from brief>", "limit": 3 } }
+```
+
+If `kb_search` returns nothing relevant, your draft must rely strictly on the brief — don't invent features or numbers. If the brief itself is a thin prompt and there's no KB grounding, write the email at a higher level ("we'd like to learn how you're approaching X" rather than "we ship X feature with Y latency").
+
+## Step 5 — draft
+
+Strict rules:
+
+- **Subject** — concrete and specific. 6–12 words. No clickbait, no all-caps. Avoid generic openers ("Quick question?"); reference the brief or the contact's company.
+- **Body** — 80–200 words. Personalisation is one short sentence at most ("saw you're at Acme — congrats on the recent funding" only if you can ground it in evidence; otherwise drop it). The rest is brief, the value prop, one direct ask.
+- **Format** — plain prose. Bold/italic sparingly for one or two key terms. Bullets are OK for a list of 2–3 short items. **No `#`/`##`/`###` headings.** No tables, no images.
+- **JSON literals** — pass real strings with real newlines. Do not stringify the body so it ends up containing `\n` characters.
+- **Voice** — second person, plain language, the way an operator would write if they had time.
+- **Unsubscribe footer** — do **NOT** include one. The system appends a signed unsubscribe link at approve-time so it can't be tampered with at draft-time.
+
+## Step 6 — file the proposal
+
+```jsonc
+{
+  "name": "outreach_propose_initial",
+  "arguments": {
+    "campaignId": "ocmp_…",
+    "contactId": "cct_…",
+    "draftSubject": "Quick thought on Acme's onboarding loop",
+    "draftBody": "Hi Jane,\n\nI noticed Acme just shipped self-serve onboarding — congrats. We help similar B2B teams cut time-to-first-value by ~40% by …",
+    "evidence": {
+      "kbDocIds": ["kdoc_abc", "kdoc_def"],
+      "contactSignals": ["title=Head of Ops", "tag=enterprise"],
+      "reasoning": "Brief targets ops leaders; contact title matches; one KB doc on onboarding loops."
+    }
+  }
+}
+```
+
+Behavior:
+
+- The proposal lands in `pending` status, visible to the operator on `/dashboard/review` (Outreach drafts tab).
+- An `outreach.proposal.created` realtime event fires.
+- Re-running this skill on the same (campaign, contact) before the operator decides will reject with a uniqueness conflict — that's the dedup signal.
+
+## Step 7 — review and approve (the operator's loop)
+
+Out of scope for this skill. The operator (or a trusted admin agent acting on their authority) calls `outreach_list_proposals({ status: "pending" })`, reviews each row in the dashboard, then either approves (which sends via the campaign's email channel and creates an outbound conversation) or dismisses with a reason.
+
+## What NOT to do
+
+- **Don't auto-approve.** The plan-level invariant: every outreach email ships through a human-approved gate. If you're tempted to call `outreach_propose_initial` followed by `outreach_approve_proposal`, stop. The latter tool does not exist for the curator; only operators or operator-delegated admin agents reach the approve surface.
+- **Don't bypass `crm_list_contacts_in_segment`.** Calling `crm_list_contacts` directly bypasses the suppression+consent floor and will eventually file proposals for someone who already unsubscribed — even if the operator catches it at approve-time, the audit trail looks bad.
+- **Don't fabricate facts.** If the brief says "we shipped feature X" and KB has no doc on X, write at a higher level. Better to send a vaguer email than a confidently wrong one.
+- **Don't write headings or pseudo-templates.** No `# Hello {name}` or `## About us`. Real emails are plain prose.
+- **Don't include an unsubscribe link in the draft body.** The system appends one. If you write your own, the operator will see two and the system one is the only signed/verifiable one.
+- **Don't propose a reply.** PR3 ships `outreach_propose_reply` and a separate skill (`skill://outreach/draft-reply`). For now, you only file `kind: "initial"`.
+
+## Related
+
+- `skill://kb/curation` — symmetric pattern (per-conversation curator that proposes, human approves) for KB instead of outreach.
+- `skill://crm/hygiene` — population-level dedup that catches duplicates this and other curators create.
+- `skill://crm/contact-extract` — auto-applied (NOT propose-and-review) per-conversation contact creation. The asymmetry vs this skill: extracting what the user typed is faithful transcription; drafting outreach is generative — different risk profiles.

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -18,6 +18,8 @@ export { ActivityPage } from './pages/activity';
 export { CrmMergeProposalsPage } from './pages/crm-merge-proposals';
 export { ReviewPage } from './pages/review';
 export { KbCandidatesTab } from './pages/kb-candidates';
+export { OutreachDraftsTab } from './pages/outreach-drafts';
+export { OutreachCampaignsPage } from './pages/outreach-campaigns';
 export {
   useRealtime,
   type RealtimeEventRow,

--- a/packages/dashboard-pages/src/pages/outreach-campaigns.tsx
+++ b/packages/dashboard-pages/src/pages/outreach-campaigns.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { Mail, Plus } from 'lucide-react';
+import { useFormatter, useTranslations } from 'next-intl';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from '@getmunin/ui';
+import { api, ApiError } from '../api';
+
+interface CampaignDto {
+  id: string;
+  name: string;
+  brief: string;
+  segmentId: string;
+  channelId: string;
+  cadenceRules: {
+    maxPerWeekPerContact?: number;
+    quietHoursStart?: string;
+    quietHoursEnd?: string;
+    blackoutDates?: string[];
+  };
+  ctaUrl: string | null;
+  enabled: boolean;
+  unsubscribeRequired: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface SegmentDto {
+  id: string;
+  name: string;
+}
+
+interface ChannelDto {
+  id: string;
+  type: string;
+  name: string;
+  active: boolean;
+}
+
+export function OutreachCampaignsPage() {
+  const t = useTranslations('dashboard.outreach');
+  const tCommon = useTranslations('common');
+  const format = useFormatter();
+  const [campaigns, setCampaigns] = useState<CampaignDto[] | null>(null);
+  const [segments, setSegments] = useState<SegmentDto[]>([]);
+  const [emailChannels, setEmailChannels] = useState<ChannelDto[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  async function load() {
+    try {
+      setError(null);
+      const [campaignsRes, segmentsRes, channelsRes] = await Promise.all([
+        api<{ items: CampaignDto[] }>('/api/outreach/campaigns'),
+        api<{ items: SegmentDto[] }>('/api/crm/segments').catch(() => ({ items: [] })),
+        api<{ items: ChannelDto[] }>('/api/conv/channels').catch(() => ({ items: [] })),
+      ]);
+      setCampaigns(campaignsRes.items);
+      setSegments(segmentsRes.items);
+      setEmailChannels(channelsRes.items.filter((c) => c.type === 'email' && c.active));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : t('errors.load'));
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function toggleEnabled(id: string, enabled: boolean) {
+    setBusyId(id);
+    try {
+      await api(`/api/outreach/campaigns/${id}`, {
+        method: 'POST',
+        body: JSON.stringify({ enabled }),
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : t('errors.update'));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <>
+      <div className="space-y-6">
+        <header className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+            <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+          </div>
+          <Button onClick={() => setCreateOpen(true)} disabled={emailChannels.length === 0 || segments.length === 0}>
+            <Plus className="size-4" />
+            {t('addCampaign')}
+          </Button>
+        </header>
+
+        {error && (
+          <Card>
+            <CardContent className="py-4 text-sm text-destructive">{error}</CardContent>
+          </Card>
+        )}
+
+        {(emailChannels.length === 0 || segments.length === 0) && (
+          <Card>
+            <CardContent className="py-4 text-sm text-muted-foreground">
+              {emailChannels.length === 0 ? t('needsEmailChannel') : t('needsSegment')}
+            </CardContent>
+          </Card>
+        )}
+
+        {campaigns === null ? (
+          <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
+        ) : campaigns.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('emptyTitle')}</CardTitle>
+              <CardDescription>{t('emptyBody')}</CardDescription>
+            </CardHeader>
+          </Card>
+        ) : (
+          <ul className="space-y-3">
+            {campaigns.map((c) => {
+              const segmentName = segments.find((s) => s.id === c.segmentId)?.name ?? c.segmentId;
+              const channelName =
+                emailChannels.find((ch) => ch.id === c.channelId)?.name ?? c.channelId;
+              const updatedLabel = format.dateTime(new Date(c.updatedAt), {
+                dateStyle: 'medium',
+              });
+              return (
+                <Card key={c.id}>
+                  <CardHeader>
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0 space-y-1">
+                        <div className="flex items-center gap-2">
+                          <Mail className="size-4 text-muted-foreground" />
+                          <CardTitle className="text-base">{c.name}</CardTitle>
+                          {c.enabled ? (
+                            <Badge variant="success">{t('enabled')}</Badge>
+                          ) : (
+                            <Badge variant="outline">{t('disabled')}</Badge>
+                          )}
+                        </div>
+                        <CardDescription className="line-clamp-2">{c.brief}</CardDescription>
+                        <p className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                          <span>
+                            {t('segment')}: <strong className="font-medium">{segmentName}</strong>
+                          </span>
+                          <span>
+                            {t('channel')}: <strong className="font-medium">{channelName}</strong>
+                          </span>
+                          <span>{updatedLabel}</span>
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 gap-2">
+                        <Button
+                          size="sm"
+                          variant={c.enabled ? 'outline' : 'default'}
+                          disabled={busyId === c.id}
+                          onClick={() => void toggleEnabled(c.id, !c.enabled)}
+                        >
+                          {c.enabled ? t('disable') : t('enable')}
+                        </Button>
+                      </div>
+                    </div>
+                  </CardHeader>
+                </Card>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <CreateCampaignDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        segments={segments}
+        emailChannels={emailChannels}
+        onCreated={() => {
+          setCreateOpen(false);
+          void load();
+        }}
+      />
+    </>
+  );
+}
+
+interface CreateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  segments: SegmentDto[];
+  emailChannels: ChannelDto[];
+  onCreated: () => void;
+}
+
+function CreateCampaignDialog({ open, onOpenChange, segments, emailChannels, onCreated }: CreateDialogProps) {
+  const t = useTranslations('dashboard.outreach');
+  const tCommon = useTranslations('common');
+  const [name, setName] = useState('');
+  const [brief, setBrief] = useState('');
+  const [segmentId, setSegmentId] = useState('');
+  const [channelId, setChannelId] = useState('');
+  const [ctaUrl, setCtaUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setName('');
+      setBrief('');
+      setSegmentId(segments[0]?.id ?? '');
+      setChannelId(emailChannels[0]?.id ?? '');
+      setCtaUrl('');
+      setErr(null);
+      setSubmitting(false);
+    }
+  }, [open, segments, emailChannels]);
+
+  function submit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSubmitting(true);
+    setErr(null);
+    void (async () => {
+      try {
+        await api('/api/outreach/campaigns', {
+          method: 'POST',
+          body: JSON.stringify({
+            name: name.trim(),
+            brief: brief.trim(),
+            segmentId,
+            channelId,
+            ctaUrl: ctaUrl.trim() || null,
+          }),
+        });
+        onCreated();
+      } catch (e2) {
+        setErr(e2 instanceof ApiError ? e2.message : t('errors.create'));
+      } finally {
+        setSubmitting(false);
+      }
+    })();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('createTitle')}</DialogTitle>
+          <DialogDescription>{t('createDescription')}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={submit} className="mt-4 space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="campaign-name">{t('nameLabel')}</Label>
+            <Input
+              id="campaign-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              placeholder={t('namePlaceholder')}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="campaign-brief">{t('briefLabel')}</Label>
+            <textarea
+              id="campaign-brief"
+              value={brief}
+              onChange={(e) => setBrief(e.target.value)}
+              required
+              rows={5}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+              placeholder={t('briefPlaceholder')}
+            />
+            <p className="text-xs text-muted-foreground">{t('briefHint')}</p>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="campaign-segment">{t('segmentLabel')}</Label>
+            <select
+              id="campaign-segment"
+              value={segmentId}
+              onChange={(e) => setSegmentId(e.target.value)}
+              required
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              {segments.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="campaign-channel">{t('channelLabel')}</Label>
+            <select
+              id="campaign-channel"
+              value={channelId}
+              onChange={(e) => setChannelId(e.target.value)}
+              required
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              {emailChannels.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="campaign-cta">{t('ctaLabel')}</Label>
+            <Input
+              id="campaign-cta"
+              type="url"
+              value={ctaUrl}
+              onChange={(e) => setCtaUrl(e.target.value)}
+              placeholder="https://…"
+            />
+          </div>
+          {err && <p className="text-sm text-destructive">{err}</p>}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              {tCommon('cancel')}
+            </Button>
+            <Button type="submit" disabled={submitting || !name.trim() || !brief.trim()}>
+              {submitting ? t('creating') : t('create')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard-pages/src/pages/outreach-drafts.tsx
+++ b/packages/dashboard-pages/src/pages/outreach-drafts.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Check, Pencil, X } from 'lucide-react';
+import { useFormatter, useTranslations } from 'next-intl';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@getmunin/ui';
+import { api, ApiError } from '../api';
+
+interface ProposalContactSummary {
+  id: string;
+  name: string | null;
+  email: string | null;
+  companyId: string | null;
+}
+
+interface ProposalCampaignSummary {
+  id: string;
+  name: string;
+}
+
+interface ProposalDto {
+  id: string;
+  campaignId: string;
+  contactId: string;
+  conversationId: string | null;
+  kind: 'initial' | 'reply';
+  draftSubject: string | null;
+  draftBody: string;
+  evidence: Record<string, unknown>;
+  proposedSendAt: string | null;
+  status: 'pending' | 'approved' | 'sent' | 'failed' | 'dismissed';
+  createdAt: string;
+  updatedAt: string;
+  contact: ProposalContactSummary | null;
+  campaign: ProposalCampaignSummary | null;
+}
+
+const POLL_MS = 60_000;
+
+function FlattenedHeading({ children }: { children?: React.ReactNode }) {
+  return <p className="font-semibold">{children}</p>;
+}
+
+const MARKDOWN_COMPONENTS: Components = {
+  h1: FlattenedHeading,
+  h2: FlattenedHeading,
+  h3: FlattenedHeading,
+  h4: FlattenedHeading,
+  h5: FlattenedHeading,
+  h6: FlattenedHeading,
+};
+
+interface OutreachDraftsTabProps {
+  onCountChange?: (count: number) => void;
+}
+
+export function OutreachDraftsTab({ onCountChange }: OutreachDraftsTabProps) {
+  const t = useTranslations('dashboard.outreachDrafts');
+  const format = useFormatter();
+  const [proposals, setProposals] = useState<ProposalDto[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setError(null);
+      const list = await api<{ items: ProposalDto[] }>(
+        '/api/outreach/proposals?status=pending&limit=200',
+      );
+      setProposals(list.items);
+      onCountChange?.(list.items.length);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : t('errors.load'));
+    }
+  }, [t, onCountChange]);
+
+  useEffect(() => {
+    void load();
+    const id = setInterval(() => void load(), POLL_MS);
+    return () => clearInterval(id);
+  }, [load]);
+
+  async function approve(p: ProposalDto) {
+    setBusyId(p.id);
+    try {
+      await api(`/api/outreach/proposals/${p.id}/approve`, { method: 'POST' });
+      await load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : t('errors.approve'));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function dismiss(p: ProposalDto) {
+    const reason = window.prompt(t('dismissPrompt')) ?? undefined;
+    setBusyId(p.id);
+    try {
+      await api(`/api/outreach/proposals/${p.id}/dismiss`, {
+        method: 'POST',
+        body: JSON.stringify(reason ? { reason } : {}),
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : t('errors.dismiss'));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (proposals === null) {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <Card>
+          <CardContent className="py-4 text-sm text-destructive">{error}</CardContent>
+        </Card>
+      )}
+
+      {proposals.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('emptyTitle')}</CardTitle>
+            <CardDescription>{t('emptyBody')}</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <ul className="space-y-3">
+          {proposals.map((p) => {
+            const contact = p.contact;
+            const campaign = p.campaign;
+            const updatedLabel = format.dateTime(new Date(p.updatedAt), {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+            });
+            return (
+              <Card key={p.id}>
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 space-y-1">
+                      <CardTitle className="text-base">
+                        {p.draftSubject ?? t('untitled')}
+                      </CardTitle>
+                      <p className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <Badge variant="outline" className="capitalize">
+                          {p.kind}
+                        </Badge>
+                        <span>{updatedLabel}</span>
+                        {campaign && (
+                          <span>
+                            {t('via')} <strong className="font-medium">{campaign.name}</strong>
+                          </span>
+                        )}
+                        {contact && (
+                          <span>
+                            {t('to')}{' '}
+                            <strong className="font-medium">
+                              {contact.name ?? contact.email ?? contact.id}
+                            </strong>
+                            {contact.email && contact.name && (
+                              <span className="text-muted-foreground"> ({contact.email})</span>
+                            )}
+                          </span>
+                        )}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => void approve(p)}
+                        disabled={busyId === p.id}
+                      >
+                        <Check className="size-4" />
+                        {t('approve')}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => alert(t('editComingSoon'))}
+                        disabled={busyId === p.id}
+                      >
+                        <Pencil className="size-4" />
+                        {t('edit')}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => void dismiss(p)}
+                        disabled={busyId === p.id}
+                      >
+                        <X className="size-4" />
+                        {t('dismiss')}
+                      </Button>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="prose prose-sm max-w-none rounded-md border bg-muted/30 p-3 dark:prose-invert">
+                    <ReactMarkdown components={MARKDOWN_COMPONENTS}>{p.draftBody}</ReactMarkdown>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard-pages/src/pages/review.tsx
+++ b/packages/dashboard-pages/src/pages/review.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Bookmark, Bot, Users } from 'lucide-react';
+import { Bookmark, Bot, Mail, Users } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import {
   Badge,
@@ -13,6 +13,7 @@ import {
 } from '@getmunin/ui';
 import { CrmMergeProposalsPage } from './crm-merge-proposals';
 import { KbCandidatesTab } from './kb-candidates';
+import { OutreachDraftsTab } from './outreach-drafts';
 import { api, ApiError } from '../api';
 import { useRealtime } from '../realtime';
 
@@ -21,21 +22,29 @@ const POLL_MS = 60_000;
 interface CountState {
   kb: number;
   crm: number;
+  outreach: number;
 }
 
 export function ReviewPage() {
   const t = useTranslations('dashboard.review');
-  const [counts, setCounts] = useState<CountState>({ kb: 0, crm: 0 });
+  const [counts, setCounts] = useState<CountState>({ kb: 0, crm: 0, outreach: 0 });
 
   const loadCounts = useCallback(async () => {
     try {
-      const [kbRes, crmRes] = await Promise.all([
+      const [kbRes, crmRes, outreachRes] = await Promise.all([
         api<{ items: unknown[] }>('/api/kb/curation/candidates').catch(() => ({ items: [] })),
         api<{ items: unknown[] }>('/api/crm/merge-proposals?status=pending&limit=200').catch(
           () => ({ items: [] }),
         ),
+        api<{ items: unknown[] }>('/api/outreach/proposals?status=pending&limit=200').catch(
+          () => ({ items: [] }),
+        ),
       ]);
-      setCounts({ kb: kbRes.items.length, crm: crmRes.items.length });
+      setCounts({
+        kb: kbRes.items.length,
+        crm: crmRes.items.length,
+        outreach: outreachRes.items.length,
+      });
     } catch (err) {
       if (err instanceof ApiError) return;
       throw err;
@@ -49,7 +58,11 @@ export function ReviewPage() {
   }, [loadCounts]);
 
   useRealtime([{ channel: 'org' }], (event) => {
-    if (event.type.startsWith('kb.') || event.type.startsWith('crm.merge_proposal.')) {
+    if (
+      event.type.startsWith('kb.') ||
+      event.type.startsWith('crm.merge_proposal.') ||
+      event.type.startsWith('outreach.proposal.')
+    ) {
       void loadCounts();
     }
   });
@@ -86,12 +99,20 @@ export function ReviewPage() {
             {t('tabs.crm')}
             {counts.crm > 0 && <Badge variant="secondary">{counts.crm}</Badge>}
           </TabsTrigger>
+          <TabsTrigger value="outreach" className="gap-2">
+            <Mail className="size-4" />
+            {t('tabs.outreach')}
+            {counts.outreach > 0 && <Badge variant="secondary">{counts.outreach}</Badge>}
+          </TabsTrigger>
         </TabsList>
         <TabsPanel value="kb">
           <KbCandidatesTab onCountChange={(n) => setCounts((c) => ({ ...c, kb: n }))} />
         </TabsPanel>
         <TabsPanel value="crm">
           <CrmMergeProposalsPage />
+        </TabsPanel>
+        <TabsPanel value="outreach">
+          <OutreachDraftsTab onCountChange={(n) => setCounts((c) => ({ ...c, outreach: n }))} />
         </TabsPanel>
       </Tabs>
     </div>

--- a/packages/db/drizzle/0012_outreach_campaigns_proposals.sql
+++ b/packages/db/drizzle/0012_outreach_campaigns_proposals.sql
@@ -1,0 +1,73 @@
+CREATE TABLE IF NOT EXISTS "outreach_campaigns" (
+  "id" text PRIMARY KEY NOT NULL,
+  "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+  "name" text NOT NULL,
+  "brief" text NOT NULL,
+  "segment_id" text NOT NULL REFERENCES "crm_segments"("id") ON DELETE RESTRICT,
+  "channel_id" text NOT NULL REFERENCES "conv_channels"("id") ON DELETE RESTRICT,
+  "cadence_rules" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "cta_url" text,
+  "enabled" boolean NOT NULL DEFAULT false,
+  "unsubscribe_required" boolean NOT NULL DEFAULT true,
+  "created_by_actor_type" varchar(16) NOT NULL,
+  "created_by_actor_id" text NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "outreach_campaigns_org_idx" ON "outreach_campaigns" ("org_id");
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "outreach_campaigns_org_name_uq" ON "outreach_campaigns" ("org_id", "name");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "outreach_campaigns_enabled_idx" ON "outreach_campaigns" ("org_id", "enabled") WHERE "enabled" = true;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "outreach_proposals" (
+  "id" text PRIMARY KEY NOT NULL,
+  "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+  "campaign_id" text NOT NULL REFERENCES "outreach_campaigns"("id") ON DELETE CASCADE,
+  "contact_id" text NOT NULL REFERENCES "crm_contacts"("id") ON DELETE CASCADE,
+  "conversation_id" text REFERENCES "conv_conversations"("id") ON DELETE SET NULL,
+  "kind" varchar(16) NOT NULL,
+  "draft_subject" text,
+  "draft_body" text NOT NULL,
+  "evidence" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "proposed_send_at" timestamp with time zone,
+  "status" varchar(16) NOT NULL DEFAULT 'pending',
+  "proposed_by_actor_type" varchar(16) NOT NULL,
+  "proposed_by_actor_id" text NOT NULL,
+  "decided_by_actor_type" varchar(16),
+  "decided_by_actor_id" text,
+  "decided_at" timestamp with time zone,
+  "sent_at" timestamp with time zone,
+  "sent_message_id" text REFERENCES "conv_messages"("id") ON DELETE SET NULL,
+  "failure_reason" text,
+  "dismiss_reason" text,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "outreach_proposals_org_status_idx" ON "outreach_proposals" ("org_id", "status");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "outreach_proposals_campaign_idx" ON "outreach_proposals" ("campaign_id");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "outreach_proposals_contact_idx" ON "outreach_proposals" ("contact_id");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "outreach_proposals_conversation_idx" ON "outreach_proposals" ("conversation_id");
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "outreach_proposals_pending_pair_uq" ON "outreach_proposals" ("campaign_id", "contact_id", "kind") WHERE "status" = 'pending';
+--> statement-breakpoint
+
+ALTER TABLE "conv_conversations"
+  ADD COLUMN IF NOT EXISTS "outreach_campaign_id" text REFERENCES "outreach_campaigns"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "conv_conversations_outreach_campaign_idx" ON "conv_conversations" ("outreach_campaign_id");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777681700000,
       "tag": "0011_crm_segments_consent",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1777681800000,
+      "tag": "0012_outreach_campaigns_proposals",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -34,6 +34,7 @@ export async function runMigrations(connectionString: string, migrationsFolder?:
   const crmPath = resolve(sqlDir, 'crm.sql');
   const cmsPath = resolve(sqlDir, 'cms.sql');
   const convChannelsPath = resolve(sqlDir, 'conv-channels.sql');
+  const outreachPath = resolve(sqlDir, 'outreach.sql');
 
   const client = postgres(connectionString, { max: 1 });
   const db = drizzle(client);
@@ -55,6 +56,7 @@ export async function runMigrations(connectionString: string, migrationsFolder?:
   await client.unsafe(readFileSync(crmPath, 'utf8'));
   await client.unsafe(readFileSync(cmsPath, 'utf8'));
   await client.unsafe(readFileSync(convChannelsPath, 'utf8'));
+  await client.unsafe(readFileSync(outreachPath, 'utf8'));
 
   // 4. App role (idempotent). Password defaults to the role name; override
   //    via MUNIN_APP_PASSWORD for non-dev deployments.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -686,6 +686,10 @@ export const convConversations = pgTable(
     needsHumanAttentionAt: timestamp('needs_human_attention_at', { withTimezone: true }),
     runnerHolder: text('runner_holder'),
     runnerLeaseExpiresAt: timestamp('runner_lease_expires_at', { withTimezone: true }),
+    outreachCampaignId: text('outreach_campaign_id').references(
+      (): AnyPgColumn => outreachCampaigns.id,
+      { onDelete: 'set null' },
+    ),
     metadata: jsonb('metadata').$type<Record<string, unknown>>().notNull().default({}),
     createdAt,
     updatedAt,
@@ -700,6 +704,7 @@ export const convConversations = pgTable(
     needsAttentionIdx: index('conv_conversations_needs_attention_idx')
       .on(t.orgId, t.needsHumanAttentionAt)
       .where(sql`needs_human_attention = true`),
+    outreachCampaignIdx: index('conv_conversations_outreach_campaign_idx').on(t.outreachCampaignId),
   }),
 );
 
@@ -1299,6 +1304,103 @@ export const curatorJobs = pgTable(
   }),
 );
 
+// ─────────────────────────────── Outreach ────────────────────────────
+// Operator-defined campaigns (segment + brief + email channel + cadence)
+// and the per-contact proposal queue. The contact-extract / hygiene
+// curators pre-populate `crm_contacts`; the outreach curator drafts
+// initials per (campaign, contact) → review → approve → send via the
+// existing email channel. Replies thread into normal conversations
+// (reply attribution via `conv_conversations.outreach_campaign_id`).
+export const outreachCampaigns = pgTable(
+  'outreach_campaigns',
+  {
+    id: id('ocmp'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    brief: text('brief').notNull(),
+    segmentId: text('segment_id')
+      .notNull()
+      .references(() => crmSegments.id, { onDelete: 'restrict' }),
+    channelId: text('channel_id')
+      .notNull()
+      .references(() => convChannels.id, { onDelete: 'restrict' }),
+    cadenceRules: jsonb('cadence_rules')
+      .$type<{
+        maxPerWeekPerContact?: number;
+        quietHoursStart?: string;
+        quietHoursEnd?: string;
+        blackoutDates?: string[];
+      }>()
+      .notNull()
+      .default({}),
+    ctaUrl: text('cta_url'),
+    enabled: boolean('enabled').notNull().default(false),
+    unsubscribeRequired: boolean('unsubscribe_required').notNull().default(true),
+    createdByActorType: varchar('created_by_actor_type', { length: 16 }).notNull(),
+    createdByActorId: text('created_by_actor_id').notNull(),
+    createdAt,
+    updatedAt,
+  },
+  (t) => ({
+    orgIdx: index('outreach_campaigns_org_idx').on(t.orgId),
+    nameUq: uniqueIndex('outreach_campaigns_org_name_uq').on(t.orgId, t.name),
+    enabledIdx: index('outreach_campaigns_enabled_idx')
+      .on(t.orgId, t.enabled)
+      .where(sql`enabled = true`),
+  }),
+);
+
+export const outreachProposals = pgTable(
+  'outreach_proposals',
+  {
+    id: id('oprp'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    campaignId: text('campaign_id')
+      .notNull()
+      .references(() => outreachCampaigns.id, { onDelete: 'cascade' }),
+    contactId: text('contact_id')
+      .notNull()
+      .references(() => crmContacts.id, { onDelete: 'cascade' }),
+    conversationId: text('conversation_id').references(() => convConversations.id, {
+      onDelete: 'set null',
+    }),
+    kind: varchar('kind', { length: 16 }).notNull(),
+    // 'initial' | 'reply'
+    draftSubject: text('draft_subject'),
+    draftBody: text('draft_body').notNull(),
+    evidence: jsonb('evidence').$type<Record<string, unknown>>().notNull().default({}),
+    proposedSendAt: timestamp('proposed_send_at', { withTimezone: true }),
+    status: varchar('status', { length: 16 }).notNull().default('pending'),
+    // 'pending' | 'approved' | 'sent' | 'failed' | 'dismissed'
+    proposedByActorType: varchar('proposed_by_actor_type', { length: 16 }).notNull(),
+    proposedByActorId: text('proposed_by_actor_id').notNull(),
+    decidedByActorType: varchar('decided_by_actor_type', { length: 16 }),
+    decidedByActorId: text('decided_by_actor_id'),
+    decidedAt: timestamp('decided_at', { withTimezone: true }),
+    sentAt: timestamp('sent_at', { withTimezone: true }),
+    sentMessageId: text('sent_message_id').references(() => convMessages.id, {
+      onDelete: 'set null',
+    }),
+    failureReason: text('failure_reason'),
+    dismissReason: text('dismiss_reason'),
+    createdAt,
+    updatedAt,
+  },
+  (t) => ({
+    orgStatusIdx: index('outreach_proposals_org_status_idx').on(t.orgId, t.status),
+    campaignIdx: index('outreach_proposals_campaign_idx').on(t.campaignId),
+    contactIdx: index('outreach_proposals_contact_idx').on(t.contactId),
+    conversationIdx: index('outreach_proposals_conversation_idx').on(t.conversationId),
+    pendingPairUq: uniqueIndex('outreach_proposals_pending_pair_uq')
+      .on(t.campaignId, t.contactId, t.kind)
+      .where(sql`status = 'pending'`),
+  }),
+);
+
 // All the tables exported as a single namespace for convenience:
 export const allTables = {
   orgs,
@@ -1339,6 +1441,9 @@ export const allTables = {
   crmActivities,
   crmRelationships,
   crmMergeProposals,
+  crmSegments,
+  outreachCampaigns,
+  outreachProposals,
   cmsCollections,
   cmsEntries,
   cmsEntryVersions,

--- a/packages/db/src/sql/outreach.sql
+++ b/packages/db/src/sql/outreach.sql
@@ -1,0 +1,27 @@
+-- ============================================================================
+-- Munin Outreach RLS policies. Applied during migrations after schema.
+-- ============================================================================
+
+-- Campaigns: org-scoped, admin-only. Self-service tokens never see
+-- campaigns (operator-internal targeting + brief).
+ALTER TABLE outreach_campaigns ENABLE ROW LEVEL SECURITY;
+ALTER TABLE outreach_campaigns FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON outreach_campaigns;
+CREATE POLICY tenant_isolation ON outreach_campaigns
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
+-- Proposals: org-scoped, admin-only. The curator (admin actor) writes;
+-- the operator review flow reads/decides via dashboard.
+ALTER TABLE outreach_proposals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE outreach_proposals FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON outreach_proposals;
+CREATE POLICY tenant_isolation ON outreach_proposals
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());


### PR DESCRIPTION
## Summary

PR2 of the 3-part outreach plan. **PR1 (segments + GDPR consent + contact-extract curator) shipped in #71. PR3 (`agentMode` + reply-curator + draft-on-reply) is next.**

The first user-visible piece of outbound. Operators define a campaign (name + brief + CRM segment + email channel + cadence + CTA), the new `skill://outreach/draft-initial` curator drafts a personalised first-touch email per consenting contact, the operator reviews each draft on `/dashboard/review` (third tab), and approving sends via the existing email-channel outbound pipeline. Replies thread into normal conversations via existing RFC 5322 thread-resolution.

## Sequencing

This PR also includes a small fix to `.changeset/crm-contact-extract-curator.md` (drops the private `@getmunin/agent-sidecar` from the release set) so PR1's release flow can complete. The same fix is on #72; whichever lands first is fine. If #72 lands before this PR, the changeset edit becomes a no-op merge.

## Schema

- `outreach_campaigns` — operator-defined (segment_id, channel_id (must be email), brief, cadence_rules JSONB, cta_url, enabled, unsubscribe_required). Unique `(org_id, name)`. RLS admin-only.
- `outreach_proposals` — drafted email queue. `kind` enum (`initial` in PR2; `reply` in PR3). Nullable `conversation_id` (set when sent), `status` lifecycle (pending → sent / dismissed / failed), evidence JSONB, full audit trail. **Unique pending index on `(campaign_id, contact_id, kind)`** prevents duplicate drafts. RLS admin-only.
- `conv_conversations` gains `outreach_campaign_id` (nullable FK + index). Sticky once set; used for reply attribution and (in PR3) `agentMode` defaulting.
- New `packages/db/src/sql/outreach.sql`, wired into `runMigrations`.

## Service / MCP / REST (new `@getmunin/backend-core/src/modules/outreach/`)

- `OutreachService` — `listCampaigns/getCampaign/createCampaign/updateCampaign/listProposals/getProposal/proposeInitial/approveProposal/dismissProposal`.
- `approveProposal` re-checks suppression + consent at decision-time (the contact may have unsubscribed between draft and approval), creates a conversation with `outreach_campaign_id` set, sends via the existing email outbound pipeline, and **appends a signed unsubscribe footer server-side** so it can't be tampered with at draft-time.
- MCP tools (admin): `outreach_create_campaign`, `outreach_update_campaign`, `outreach_list_campaigns`, `outreach_get_campaign`, `outreach_list_proposals`, `outreach_propose_initial`.
- REST routes (under `/api/outreach/campaigns` and `/api/outreach/proposals`). Proposals list/get embed `contact` + `campaign` summaries so the dashboard avoids N+1 fetches.
- Realtime events: `outreach.proposal.{created,sent,dismissed}` (rides the existing `WebhookDispatcher`).

## Conv-side

`ConvService.createConversation` now accepts `outreachCampaignId` AND enqueues outbound email delivery for non-end_user authors on email channels — it previously only did so from `sendMessage`, which broke first-touch sends. All existing flows are unaffected.

## Skill `skill://outreach/draft-initial`

Markdown skill, loaded by the existing `copy-skills.mjs`. Procedure: list enabled campaigns → materialise audience via `crm_list_contacts_in_segment` (which already enforces the suppression+consent floor) → dedupe via `outreach_list_proposals` → ground in `kb_search` → draft 80–200 word personalised email → file via `outreach_propose_initial`. Strict formatting: no headings, plain prose, no JSON-escaping, no unsubscribe footer in draft (system appends one).

## Curator scheduling

- New sweep `curator-outreach-draft-initial` (default cron `'0 0 * * 0'` weekly, env `MUNIN_CURATOR_OUTREACH_INITIAL_CRON`).
- Sidecar `toolPrefixesFor` adds `'skill://outreach/draft-initial'` → `['conv_', 'kb_', 'crm_', 'outreach_']`.
- Cloud `AgentRunnerService.toolPrefixesFor` needs the same one-line addition (separate cloud PR after this OSS release; pattern same as #71's cloud follow-up at getmunin/munin-cloud#25).

## Dashboard

- Third tab on `/dashboard/review`: `OutreachDraftsTab` lists pending proposals with markdown body (heading-flatten components shared with KB), Approve / Edit (placeholder; inline editing ships next) / Dismiss buttons. Realtime updates on `outreach.proposal.*`.
- New `/dashboard/settings/outreach` (Settings → Workspace) — list campaigns, create dialog with name + brief textarea + segment dropdown + channel dropdown + CTA URL, enable/disable toggle. Empty-state nudges if no email channels or segments yet.
- i18n: `dashboard.outreach.*`, `dashboard.outreachDrafts.*`, `nav.outreach`, `dashboard.review.tabs.outreach` in en + nb.

## Tests

9 new outreach.service integration tests covering campaign CRUD (incl. non-email-channel rejection + duplicate-name conflict), `proposeInitial` (consent floor + uniqueness), `approveProposal` (success path stamps conv id + queues delivery; suppression-race and disabled-campaign refuse), and `dismissProposal`. `curator-scheduler.test.ts` updated for the fourth cron entry. **All 315 backend-core tests pass.**

## Out of PR2 scope (lands in PR3)

`agentMode` column on `conv_conversations` + reply-curator skill (`skill://outreach/draft-reply`) + draft-on-reply loop. Until PR3 lands, replies to outreach-originated conversations are handled by the existing AI runner in auto mode.

## Test plan

- [ ] Migration applies cleanly (`pnpm --filter @getmunin/db migrate`).
- [ ] Create a CRM segment (PR1) with one consenting contact.
- [ ] Create a campaign in `/dashboard/settings/outreach` pointing at that segment + an email channel; flip enabled.
- [ ] Run `MUNIN_CURATOR_OUTREACH_INITIAL_CRON='*/2 * * * *'` for dev; observe a curator job + an `outreach.proposal.created` event for the contact.
- [ ] Open `/dashboard/review` → Outreach drafts tab; click Approve.
- [ ] Verify a `conv_conversations` row appears with `outreach_campaign_id` set, a `conv_messages` row with the draft body + appended unsubscribe footer, a `conv_message_deliveries` row queued.
- [ ] (Local SMTP) verify the email is actually sent.
- [ ] Mark the contact `do_not_contact = true` after a draft is filed; approving must refuse with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)