### PR TITLE
feat(outreach): agentMode + reply-curator + draft-on-reply loop (PR3 of 3)

### DIFF
--- a/.changeset/outreach-agent-mode-reply-drafts.md
+++ b/.changeset/outreach-agent-mode-reply-drafts.md
@@ -1,0 +1,33 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/agent-runtime': minor
+'@getmunin/dashboard-pages': minor
+'@getmunin/db': minor
+---
+
+Outreach feature, PR3 of 3 — `agentMode` + draft-on-reply loop. Closes the outreach loop: every reply on an outreach-originated conversation gets drafted by an admin agent and waits for human approval. The AI conversational runner never auto-replies on these conversations, even when the prospect responds.
+
+**`agentMode` on conversations.** New enum column `agent_mode` on `conv_conversations` with values `auto | draft_only | off`, default `auto`. Orthogonal to claims (claims are *who's working it now, with TTL*; agentMode is *what posture the agent takes, durable*). Reusable beyond outreach — a customer can flip a single conversation or a whole channel into `draft_only` for trust-building, moderation, or VIP review.
+
+- `ConvService.setAgentMode(id, mode)` + REST `POST /api/conversations/:id/agent-mode`.
+- `ConvService.createConversation` accepts `agentMode` (default `'auto'`).
+- `ConversationSummary`/`Detail` DTOs now expose `agentMode` and `outreachCampaignId`.
+- `agent-runtime`'s `ConversationHandler.shouldRespond` defers when `agentMode !== 'auto'` (logged as `skip <id>: agentMode=draft_only`). Two new unit tests cover both `draft_only` and `off`.
+- `MuninRestClient.ConversationDetail` adds `agentMode` and `outreachCampaignId`.
+
+**Outreach reply-curator skill.** New `skill://outreach/draft-reply`. Triggered event-driven: when an inbound message lands on a conversation that has both `outreachCampaignId` set and `agentMode='draft_only'`, `ConvService.sendMessage` enqueues a curator job (dedupe-keyed by message id). The skill reads the thread, identifies the prospect's intent (question / decline / ask-for-human / off-topic / hostile), grounds factual claims via `kb_search`, drafts a 30–120-word reply, and files it via `outreach_propose_reply` for human approval. Strict rules: no unsubscribe footer (initials carry it; replies thread inside), no auto-send.
+
+**Outreach service.**
+- `OutreachService.proposeReply({ conversationId, draftBody, evidence })` — files a `kind='reply'` proposal. Rejects when the conversation is not outreach-originated. Resolves CRM contact via the conversation's `conv_contacts.email`.
+- `OutreachService.approveProposal` now branches on kind. `kind='initial'` flips the new conversation to `agentMode='draft_only'` (so the AI runner defers on subsequent inbound messages). `kind='reply'` sends the draft body verbatim via `conv.sendMessage` on the existing conversation — no unsubscribe footer.
+- New MCP tool `outreach_propose_reply` (admin audience). The reply skill calls it.
+
+**Sidecar `toolPrefixesFor`** adds `'skill://outreach/draft-reply'` → `['conv_', 'kb_', 'crm_', 'outreach_']`. Cloud `AgentRunnerService.toolPrefixesFor` needs the same one-line addition (separate cloud PR after this OSS release).
+
+**Dashboard.** `OutreachDraftsTab` differentiates kind with a coloured badge (`Reply` filled, `Initial` outline). Reply cards link to `/dashboard/conversations?id=<id>` so the operator can see thread context before approving. i18n string `viewThread` added in en + nb.
+
+**Schema migration** `0013_conv_agent_mode.sql` — single column add; default `'auto'` so all existing conversations are unaffected. Outreach conversations created via `approveProposal` going forward land in `'draft_only'`.
+
+**Tests.** 6 new (2 in agent-runtime for the defer; 2 in conv.service for the inbound-on-outreach enqueue path; 4 in outreach.service for proposeReply, approveReply send + no-footer assertion, agentMode=draft_only on initial approve, and the not-outreach-conversation rejection). All 321 backend-core tests pass; 67 agent-runtime tests pass.
+
+**End-to-end:** an operator can now run a campaign where the entire loop — first send and every reply — is human-approved. Combined with PR1's suppression+consent floor and the unsubscribe infrastructure, this is the GDPR-compliant, never-auto-sends outbound channel the plan promised.

--- a/apps/agent-sidecar/src/curator-loop.ts
+++ b/apps/agent-sidecar/src/curator-loop.ts
@@ -184,6 +184,7 @@ function toolPrefixesFor(skillUri: string): string[] | undefined {
   if (skillUri === 'skill://crm/hygiene') return ['conv_', 'crm_'];
   if (skillUri === 'skill://crm/contact-extract') return ['conv_', 'crm_'];
   if (skillUri === 'skill://outreach/draft-initial') return ['conv_', 'kb_', 'crm_', 'outreach_'];
+  if (skillUri === 'skill://outreach/draft-reply') return ['conv_', 'kb_', 'crm_', 'outreach_'];
   if (skillUri === 'skill://cms/stale-content-review') return ['cms_'];
   return undefined;
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -158,6 +158,7 @@
       "emptyBody": "When the draft-initial curator runs against an enabled campaign, drafts land here for approval. Approve to send via the campaign's email channel; dismiss to discard.",
       "to": "to",
       "via": "via",
+      "viewThread": "View thread →",
       "untitled": "(no subject)",
       "approve": "Approve & send",
       "edit": "Edit",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -158,6 +158,7 @@
       "emptyBody": "Når draft-initial-kuratoren kjører mot en aktivert kampanje, havner utkast her for godkjenning. Godkjenn for å sende via kampanjens e-postkanal; avvis for å forkaste.",
       "to": "til",
       "via": "via",
+      "viewThread": "Vis samtale →",
       "untitled": "(ingen emne)",
       "approve": "Godkjenn & send",
       "edit": "Rediger",

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -172,6 +172,48 @@ describe('createConversationHandler', () => {
     expect(postSpy).not.toHaveBeenCalled();
   });
 
+  it('skips when agentMode is draft_only (an outreach-originated conv)', async () => {
+    const rest = buildRest({
+      getConversation: vi.fn(() =>
+        Promise.resolve(buildConversation({ agentMode: 'draft_only' })),
+      ),
+    });
+    const postSpy = vi.fn(() => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      prompts: buildPrompts(),
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+    });
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips when agentMode is off', async () => {
+    const rest = buildRest({
+      getConversation: vi.fn(() =>
+        Promise.resolve(buildConversation({ agentMode: 'off' })),
+      ),
+    });
+    const postSpy = vi.fn(() => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      prompts: buildPrompts(),
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+    });
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
   it('skips when a staff member holds an active claim', async () => {
     const rest = buildRest({
       getConversation: vi.fn(() =>

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -98,6 +98,10 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
       log.info(`skip ${detail.id}: assigned to staff ${detail.assigneeUserId}`);
       return false;
     }
+    if (detail.agentMode && detail.agentMode !== 'auto') {
+      log.info(`skip ${detail.id}: agentMode=${detail.agentMode}`);
+      return false;
+    }
     if (detail.claim && detail.claim.holderType === 'user') {
       log.info(`skip ${detail.id}: claimed by ${detail.claim.holderId} until ${detail.claim.expiresAt}`);
       return false;

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -11,6 +11,8 @@ export interface ConversationDetail {
     holderId: string;
     expiresAt: string;
   } | null;
+  agentMode?: 'auto' | 'draft_only' | 'off';
+  outreachCampaignId?: string | null;
   messages: Array<{
     id: string;
     authorType: 'user' | 'agent' | 'end_user' | 'system';

--- a/packages/backend-core/src/control/conversations.controller.ts
+++ b/packages/backend-core/src/control/conversations.controller.ts
@@ -24,6 +24,7 @@ import {
   ConvService,
   ConvInvalidError,
   AgentReplyRaceError,
+  AGENT_MODES,
   HandoverActiveError,
   STATUSES,
   type ConversationDetail,
@@ -32,6 +33,8 @@ import {
 } from '../modules/conv/conv.service.js';
 
 const StatusSchema = z.enum(STATUSES);
+const AgentModeSchema = z.enum(AGENT_MODES);
+const AgentModeBody = z.object({ mode: AgentModeSchema });
 
 const ReplyBody = z.object({
   body: z.string().min(1).max(50_000),
@@ -207,6 +210,17 @@ export class ConversationsController {
     const parsed = StatusBody.safeParse(body);
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return translate(() => this.conv.changeStatus({ id, ...parsed.data }));
+  }
+
+  @Post(':id/agent-mode')
+  @HttpCode(200)
+  async agentMode(
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ): Promise<ConversationSummary> {
+    const parsed = AgentModeBody.safeParse(body);
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return translate(() => this.conv.setAgentMode({ id, mode: parsed.data.mode }));
   }
 
   @Post(':id/take-over')

--- a/packages/backend-core/src/modules/conv/conv.service.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.test.ts
@@ -64,6 +64,9 @@ const skipReason = TEST_URL
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
     await db.execute(sql`DELETE FROM conv_message_deliveries WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM curator_jobs WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM outreach_proposals WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM outreach_campaigns WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM crm_segments WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM conv_messages WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM conv_conversations WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM conv_topics WHERE org_id = ${orgId}`);
@@ -419,6 +422,73 @@ const skipReason = TEST_URL
       const extractJob = rows.find((r) => r.skill_uri === 'skill://crm/contact-extract');
       expect(extractJob).toBeDefined();
       expect(extractJob!.dedupe_key).toBe(`crm-contact-extract:conv:${conv.id}`);
+    });
+
+    it('inbound end_user message on outreach conv (draft_only) enqueues outreach reply-draft', async () => {
+      const ch = await run(() => svc.createChannel({ type: 'email', name: 'outreach-ch' }));
+      const [seg] = await db
+        .insert(schema.crmSegments)
+        .values({
+          orgId,
+          name: 'outreach-seg',
+          filterDefinition: {},
+          createdByActorType: 'admin_agent',
+          createdByActorId: 'test',
+        })
+        .returning();
+      const [camp] = await db
+        .insert(schema.outreachCampaigns)
+        .values({
+          orgId,
+          name: 'outreach-camp',
+          brief: 'test',
+          segmentId: seg!.id,
+          channelId: ch.id,
+          enabled: true,
+          createdByActorType: 'admin_agent',
+          createdByActorId: 'test',
+        })
+        .returning();
+      const conv = await run(() =>
+        svc.createConversation({
+          channelId: ch.id,
+          body: 'first outreach email',
+          authorType: 'agent',
+          authorId: actor.id,
+          outreachCampaignId: camp!.id,
+          agentMode: 'draft_only',
+        }),
+      );
+      // Now an inbound end_user reply lands.
+      await run(() =>
+        svc.sendMessage({
+          conversationId: conv.id,
+          body: 'Tell me more',
+          authorType: 'end_user',
+          authorId: 'eu_test',
+        }),
+      );
+      const rows = await db.execute<{ skill_uri: string; dedupe_key: string | null }>(
+        sql`SELECT skill_uri, dedupe_key FROM curator_jobs WHERE org_id = ${orgId} AND skill_uri = 'skill://outreach/draft-reply'`,
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0]!.dedupe_key).toMatch(/^outreach-draft-reply:msg:cvm_/);
+    });
+
+    it('inbound on a non-outreach conv does NOT enqueue reply-draft', async () => {
+      const conv = await seedConv();
+      await run(() =>
+        svc.sendMessage({
+          conversationId: conv.id,
+          body: 'hi',
+          authorType: 'end_user',
+          authorId: 'eu_test',
+        }),
+      );
+      const rows = await db.execute<{ skill_uri: string }>(
+        sql`SELECT skill_uri FROM curator_jobs WHERE org_id = ${orgId} AND skill_uri = 'skill://outreach/draft-reply'`,
+      );
+      expect(rows.length).toBe(0);
     });
 
     it('changeStatus to non-closed (e.g. snoozed) does NOT enqueue contact-extract', async () => {

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -33,8 +33,10 @@ export class AgentReplyRaceError extends Error {
 
 export const CHANNEL_TYPES = ['email', 'voice', 'chat', 'sms'] as const;
 export const STATUSES = ['open', 'snoozed', 'closed', 'spam'] as const;
+export const AGENT_MODES = ['auto', 'draft_only', 'off'] as const;
 export type ChannelType = (typeof CHANNEL_TYPES)[number];
 export type ConversationStatus = (typeof STATUSES)[number];
+export type AgentMode = (typeof AGENT_MODES)[number];
 
 export interface ChannelDto {
   id: string;
@@ -84,6 +86,8 @@ export interface ConversationSummary {
   lastMessageAt: string | null;
   needsHumanAttention: boolean;
   needsHumanAttentionAt: string | null;
+  agentMode: AgentMode;
+  outreachCampaignId: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -304,6 +308,7 @@ export class ConvService {
     contactId?: string;
     topicId?: string;
     outreachCampaignId?: string;
+    agentMode?: AgentMode;
     authorType: 'user' | 'agent' | 'end_user' | 'system';
     authorId: string;
   }): Promise<ConversationDetail> {
@@ -332,6 +337,7 @@ export class ConvService {
       topicId: input.topicId ?? null,
       subject: input.subject ?? null,
       outreachCampaignId: input.outreachCampaignId ?? null,
+      agentMode: input.agentMode ?? 'auto',
     });
 
     const [firstMsg] = await ctx.db
@@ -396,6 +402,8 @@ export class ConvService {
         channelId: schema.convConversations.channelId,
         channelType: schema.convChannels.type,
         needsHumanAttention: schema.convConversations.needsHumanAttention,
+        outreachCampaignId: schema.convConversations.outreachCampaignId,
+        agentMode: schema.convConversations.agentMode,
       })
       .from(schema.convConversations)
       .innerJoin(schema.convChannels, eq(schema.convChannels.id, schema.convConversations.channelId))
@@ -486,6 +494,28 @@ export class ConvService {
           internal: false,
         },
       });
+
+      if (
+        input.authorType === 'end_user' &&
+        conv.outreachCampaignId &&
+        conv.agentMode === 'draft_only'
+      ) {
+        await this.curatorJobs.enqueue({
+          skillUri: 'skill://outreach/draft-reply',
+          userPrompt:
+            `Run an outreach reply-draft pass for conversation ${input.conversationId}. ` +
+            `Follow skill://outreach/draft-reply exactly. Read the thread, identify the prospect's ` +
+            `intent on the latest end-user message, and file a draft via outreach_propose_reply. ` +
+            `Do NOT send anything — drafts go to the operator review queue.`,
+          sourceEventType: 'conversation.message.received',
+          sourceEventPayload: {
+            conversationId: input.conversationId,
+            messageId: row!.id,
+            outreachCampaignId: conv.outreachCampaignId,
+          },
+          dedupeKey: `outreach-draft-reply:msg:${row!.id}`,
+        });
+      }
 
       if (clearAttention && conv.needsHumanAttention) {
         await this.webhooks.emit({
@@ -587,6 +617,27 @@ export class ConvService {
       payload: { conversationId: input.id, assigneeUserId: input.assigneeUserId },
     });
     return toConversationSummary(result[0]);
+  }
+
+  async setAgentMode(input: {
+    id: string;
+    mode: AgentMode;
+  }): Promise<ConversationSummary> {
+    if (!AGENT_MODES.includes(input.mode)) {
+      throw new ConvInvalidError(`agentMode must be one of ${AGENT_MODES.join(', ')}`);
+    }
+    const ctx = getCurrentContext();
+    const [updated] = await ctx.db
+      .update(schema.convConversations)
+      .set({ agentMode: input.mode, updatedAt: new Date() })
+      .where(eq(schema.convConversations.id, input.id))
+      .returning();
+    if (!updated) throw new NotFoundException(`conv_not_found: conversation ${input.id}`);
+    await this.webhooks.emit({
+      type: 'conversation.agent_mode_changed',
+      payload: { conversationId: input.id, agentMode: input.mode },
+    });
+    return toConversationSummary(updated);
   }
 
   async changeStatus(input: {
@@ -788,6 +839,7 @@ export class ConvService {
     topicId: string | null;
     subject: string | null;
     outreachCampaignId?: string | null;
+    agentMode?: AgentMode;
   }): Promise<typeof schema.convConversations.$inferSelect> {
     const ctx = getCurrentContext();
     let lastErr: unknown = null;
@@ -847,6 +899,8 @@ function toConversationSummary(
     lastMessageAt: row.lastMessageAt?.toISOString() ?? null,
     needsHumanAttention: row.needsHumanAttention,
     needsHumanAttentionAt: row.needsHumanAttentionAt?.toISOString() ?? null,
+    agentMode: row.agentMode as AgentMode,
+    outreachCampaignId: row.outreachCampaignId,
     updatedAt: row.updatedAt.toISOString(),
     createdAt: row.createdAt.toISOString(),
   };

--- a/packages/backend-core/src/modules/outreach/outreach.service.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.test.ts
@@ -66,6 +66,7 @@ const skipReason = TEST_URL
 
   beforeEach(async () => {
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    await db.execute(sql`DELETE FROM curator_jobs WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM outreach_proposals WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM outreach_campaigns WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM conv_message_deliveries WHERE org_id = ${orgId}`);
@@ -73,6 +74,7 @@ const skipReason = TEST_URL
     await db.execute(sql`DELETE FROM conv_conversations WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM conv_contacts WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM conv_channels WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM crm_activities WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM crm_contacts WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM crm_segments WHERE org_id = ${orgId}`);
 
@@ -318,6 +320,114 @@ const skipReason = TEST_URL
           }),
         ),
       ).rejects.toThrow(ConflictException);
+    });
+
+    it('approveProposal initial flips conversation to agentMode=draft_only', async () => {
+      const c = await run(() =>
+        svc.createCampaign({ name: 'mode', brief: 'b', segmentId, channelId, enabled: true }),
+      );
+      const p = await run(() =>
+        svc.proposeInitial({
+          campaignId: c.id,
+          contactId,
+          draftSubject: 's',
+          draftBody: 'b',
+        }),
+      );
+      const approved = await run(() =>
+        svc.approveProposal(p.id, { publicBaseUrl: 'https://test.local' }),
+      );
+      const rows = await db.execute<{ agent_mode: string }>(
+        sql`SELECT agent_mode FROM conv_conversations WHERE id = ${approved.conversationId!}`,
+      );
+      expect(rows[0]!.agent_mode).toBe('draft_only');
+    });
+
+    it('proposeReply files a kind=reply proposal on an outreach conversation', async () => {
+      const c = await run(() =>
+        svc.createCampaign({ name: 'reply-a', brief: 'b', segmentId, channelId, enabled: true }),
+      );
+      const initial = await run(() =>
+        svc.proposeInitial({
+          campaignId: c.id,
+          contactId,
+          draftSubject: 's',
+          draftBody: 'b',
+        }),
+      );
+      const sent = await run(() =>
+        svc.approveProposal(initial.id, { publicBaseUrl: 'https://test.local' }),
+      );
+      const reply = await run(() =>
+        svc.proposeReply({
+          conversationId: sent.conversationId!,
+          draftBody: 'Thanks for getting back to us — yes, we integrate with Slack.',
+          evidence: { intent: 'question_about_integration' },
+        }),
+      );
+      expect(reply.kind).toBe('reply');
+      expect(reply.status).toBe('pending');
+      expect(reply.conversationId).toBe(sent.conversationId);
+      expect(reply.contactId).toBe(contactId);
+    });
+
+    it('approveProposal reply sends via sendMessage on the existing conversation (no unsubscribe footer)', async () => {
+      const c = await run(() =>
+        svc.createCampaign({ name: 'reply-b', brief: 'b', segmentId, channelId, enabled: true }),
+      );
+      const initial = await run(() =>
+        svc.proposeInitial({
+          campaignId: c.id,
+          contactId,
+          draftSubject: 's',
+          draftBody: 'b',
+        }),
+      );
+      const sent = await run(() =>
+        svc.approveProposal(initial.id, { publicBaseUrl: 'https://test.local' }),
+      );
+      const reply = await run(() =>
+        svc.proposeReply({
+          conversationId: sent.conversationId!,
+          draftBody: 'Sure — Tuesday works.',
+        }),
+      );
+      const approved = await run(() =>
+        svc.approveProposal(reply.id, { publicBaseUrl: 'https://test.local' }),
+      );
+      expect(approved.status).toBe('sent');
+      expect(approved.conversationId).toBe(sent.conversationId);
+      expect(approved.sentMessageId).toBeTruthy();
+
+      const msgRows = await db.execute<{ body: string }>(
+        sql`SELECT body FROM conv_messages WHERE id = ${approved.sentMessageId!}`,
+      );
+      expect(msgRows[0]!.body).toBe('Sure — Tuesday works.');
+      expect(msgRows[0]!.body).not.toMatch(/Unsubscribe:/);
+    });
+
+    it('proposeReply rejects when the conversation has no outreachCampaignId', async () => {
+      const ch = await run(() =>
+        svc.createCampaign({ name: 'plain', brief: 'b', segmentId, channelId, enabled: true }),
+      );
+      void ch; // not used; we want a bare conversation
+      const [plain] = await db
+        .insert(schema.convConversations)
+        .values({
+          orgId,
+          channelId,
+          displayId: 99999,
+          status: 'open',
+        })
+        .returning();
+      await expect(
+        run(() =>
+          svc.proposeReply({
+            conversationId: plain!.id,
+            draftBody: 'irrelevant',
+          }),
+        ),
+      ).rejects.toThrow(OutreachInvalidError);
     });
 
     it('dismissProposal marks pending→dismissed', async () => {

--- a/packages/backend-core/src/modules/outreach/outreach.service.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.ts
@@ -311,6 +311,81 @@ export class OutreachService {
     }
   }
 
+  async proposeReply(input: {
+    conversationId: string;
+    draftBody: string;
+    evidence?: Record<string, unknown>;
+  }): Promise<ProposalDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    if (!input.draftBody.trim()) throw new OutreachInvalidError('draftBody must be non-empty');
+    const conv = await this.conv.getConversation(input.conversationId);
+    if (!conv.outreachCampaignId) {
+      throw new OutreachInvalidError(
+        `conversation ${input.conversationId} is not outreach-originated (no campaign attached)`,
+      );
+    }
+    if (!conv.contactId) {
+      throw new OutreachInvalidError(
+        `conversation ${input.conversationId} has no contact bound — cannot file reply draft`,
+      );
+    }
+    // The conversation's contactId is conv_contacts.id, but the proposal's
+    // contactId is crm_contacts.id. Resolve via email match.
+    const convContactRows = await ctx.db
+      .select({ email: schema.convContacts.email })
+      .from(schema.convContacts)
+      .where(eq(schema.convContacts.id, conv.contactId))
+      .limit(1);
+    const email = convContactRows[0]?.email;
+    if (!email) {
+      throw new OutreachInvalidError(
+        `conv contact ${conv.contactId} has no email — cannot resolve to a CRM contact`,
+      );
+    }
+    const crmContact = await this.crm.findContact({ email });
+    if (!crmContact) {
+      throw new OutreachInvalidError(
+        `no CRM contact found for ${email} on conversation ${input.conversationId}`,
+      );
+    }
+    try {
+      const [row] = await ctx.db
+        .insert(schema.outreachProposals)
+        .values({
+          orgId: actor.orgId,
+          campaignId: conv.outreachCampaignId,
+          contactId: crmContact.id,
+          conversationId: input.conversationId,
+          kind: 'reply',
+          draftBody: input.draftBody,
+          evidence: input.evidence ?? {},
+          status: 'pending',
+          proposedByActorType: actor.type,
+          proposedByActorId: actor.id,
+        })
+        .returning();
+      await this.webhooks.emit({
+        type: 'outreach.proposal.created',
+        payload: {
+          proposalId: row!.id,
+          campaignId: row!.campaignId,
+          contactId: row!.contactId,
+          conversationId: row!.conversationId,
+          kind: row!.kind,
+        },
+      });
+      return toProposalDto(row!);
+    } catch (err) {
+      if (isUniqueViolation(err, 'outreach_proposals_pending_pair_uq')) {
+        throw new ConflictException(
+          `outreach_conflict: a pending reply proposal already exists for this conversation`,
+        );
+      }
+      throw err;
+    }
+  }
+
   async approveProposal(id: string, opts: { publicBaseUrl: string }): Promise<ProposalDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
@@ -318,11 +393,18 @@ export class OutreachService {
     if (proposal.status !== 'pending') {
       throw new OutreachInvalidError(`proposal ${id} is ${proposal.status}, not pending`);
     }
-    if (proposal.kind !== 'initial') {
-      throw new OutreachInvalidError(
-        `proposal ${id} is kind=${proposal.kind}; reply approval ships in PR3`,
-      );
+    if (proposal.kind === 'initial') {
+      return this.approveInitial(proposal, actor, opts);
     }
+    return this.approveReply(proposal, actor);
+  }
+
+  private async approveInitial(
+    proposal: ProposalDto,
+    actor: NonNullable<ReturnType<typeof getCurrentContext>['actor']>,
+    opts: { publicBaseUrl: string },
+  ): Promise<ProposalDto> {
+    const ctx = getCurrentContext();
     const campaign = await this.getCampaign(proposal.campaignId);
     if (!campaign.enabled) {
       throw new OutreachInvalidError(`campaign ${campaign.id} is disabled`);
@@ -346,9 +428,6 @@ export class OutreachService {
       return this.email.findOrCreateContactByEmail(tx, actor.orgId, contact.email!, contact.name ?? undefined);
     });
 
-    // Compose body: agent-drafted text + campaign CTA + unsubscribe footer.
-    // Footer is appended at approve-time (not draft-time) so the link can't
-    // be tampered with.
     const unsubscribeUrl = buildUnsubscribeUrl({
       publicBaseUrl: opts.publicBaseUrl,
       orgId: actor.orgId,
@@ -362,9 +441,9 @@ export class OutreachService {
       unsubscribeRequired: campaign.unsubscribeRequired,
     });
 
-    // Create conversation + send first message via the existing email
-    // outbound pipeline. createConversation enqueues the delivery row when
-    // channel is email and authorType !== end_user/system.
+    // Create the conversation in `agentMode='draft_only'` so the AI runner
+    // defers on subsequent inbound messages — replies should be drafted by
+    // `skill://outreach/draft-reply` and human-approved, not auto-sent.
     const conversation = await this.conv.createConversation({
       channelId: campaign.channelId,
       body,
@@ -372,6 +451,7 @@ export class OutreachService {
       contactId: convContact.id,
       endUserId: contact.endUserId ?? undefined,
       outreachCampaignId: campaign.id,
+      agentMode: 'draft_only',
       authorType: 'agent',
       authorId: actor.id,
     });
@@ -390,10 +470,9 @@ export class OutreachService {
         decidedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(schema.outreachProposals.id, id))
+      .where(eq(schema.outreachProposals.id, proposal.id))
       .returning();
 
-    // Bump the contact's lastContactedAt so cadence-aware filters notice.
     await ctx.db
       .update(schema.crmContacts)
       .set({ lastContactedAt: new Date(), updatedAt: new Date() })
@@ -402,11 +481,63 @@ export class OutreachService {
     await this.webhooks.emit({
       type: 'outreach.proposal.sent',
       payload: {
-        proposalId: id,
+        proposalId: proposal.id,
         campaignId: campaign.id,
         contactId: contact.id,
         conversationId: conversation.id,
         messageId: firstMessageId,
+      },
+    });
+
+    return toProposalDto(updated!);
+  }
+
+  private async approveReply(
+    proposal: ProposalDto,
+    actor: NonNullable<ReturnType<typeof getCurrentContext>['actor']>,
+  ): Promise<ProposalDto> {
+    const ctx = getCurrentContext();
+    if (!proposal.conversationId) {
+      throw new OutreachInvalidError(
+        `reply proposal ${proposal.id} has no conversationId — cannot send`,
+      );
+    }
+    // No unsubscribe footer on replies — the original initial already
+    // carries the link, and replies thread inside the same conversation.
+    const sent = await this.conv.sendMessage({
+      conversationId: proposal.conversationId,
+      body: proposal.draftBody,
+      authorType: 'agent',
+      authorId: actor.id,
+    });
+
+    const [updated] = await ctx.db
+      .update(schema.outreachProposals)
+      .set({
+        status: 'sent',
+        sentMessageId: sent.id,
+        sentAt: new Date(),
+        decidedByActorType: actor.type,
+        decidedByActorId: actor.id,
+        decidedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.outreachProposals.id, proposal.id))
+      .returning();
+
+    await ctx.db
+      .update(schema.crmContacts)
+      .set({ lastContactedAt: new Date(), updatedAt: new Date() })
+      .where(eq(schema.crmContacts.id, proposal.contactId));
+
+    await this.webhooks.emit({
+      type: 'outreach.proposal.sent',
+      payload: {
+        proposalId: proposal.id,
+        campaignId: proposal.campaignId,
+        contactId: proposal.contactId,
+        conversationId: proposal.conversationId,
+        messageId: sent.id,
       },
     });
 

--- a/packages/backend-core/src/modules/outreach/outreach.tools.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.tools.ts
@@ -56,6 +56,12 @@ const ProposeInitialInput = z.object({
   proposedSendAt: z.string().datetime().optional(),
 });
 
+const ProposeReplyInput = z.object({
+  conversationId: z.string().min(1).max(64),
+  draftBody: z.string().min(1).max(20_000),
+  evidence: z.record(z.string(), z.unknown()).optional(),
+});
+
 const EmptyInput = z.object({});
 
 @Injectable()
@@ -148,5 +154,20 @@ export class OutreachAdminTools {
   })
   proposeInitial(args: z.infer<typeof ProposeInitialInput>) {
     return this.outreach.proposeInitial(args);
+  }
+
+  @McpTool({
+    name: 'outreach_propose_reply',
+    title: 'Propose an outreach reply draft',
+    description:
+      "File a drafted reply to an inbound message on an outreach-originated conversation, for human approval. The conversation must have an `outreachCampaignId` set (it's an outreach conversation) and a CRM contact resolvable by email. Idempotent: re-proposing while a pending reply exists for the same conversation throws — the operator should approve or dismiss the existing one first. Reply approvals send via `conv_send_message` on the existing conversation; no unsubscribe footer is appended (replies thread inside the existing email chain that already carries the unsubscribe link).",
+    audiences: ['admin'],
+    scopes: ['crm:write'],
+    input: ProposeReplyInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  proposeReply(args: z.infer<typeof ProposeReplyInput>) {
+    return this.outreach.proposeReply(args);
   }
 }

--- a/packages/backend-core/src/modules/outreach/skills/draft-reply.md
+++ b/packages/backend-core/src/modules/outreach/skills/draft-reply.md
@@ -1,0 +1,107 @@
+---
+title: Outreach — draft replies
+description: Per-message curator pass that drafts a suggested reply when an inbound message lands on an outreach-originated conversation. Drafts go to the operator review queue — never auto-send. Triggered event-driven from `conversation.message.received` whenever the conversation has an `outreachCampaignId` and `agentMode='draft_only'`.
+audiences: [admin]
+---
+
+# Outreach — draft replies
+
+When a prospect replies to an outreach email, that reply lands as an inbound message on the conversation we created from the approved initial. **The AI runner is configured to skip these conversations** (`agentMode='draft_only'`), so without this curator the conversation just sits there. Your job is to read the thread, draft a sensible reply, and file it as a `kind: 'reply'` proposal for human approval — same Review tab, same approve/dismiss flow as initials.
+
+This is fundamentally different from `skill://outreach/draft-initial`:
+
+- **Initial** is generative: campaign brief + KB context → personalized first email per contact.
+- **Reply** is reactive: read the inbound message + thread context → addressed-to-the-message reply.
+
+Replies must answer what the prospect actually said. If they asked a question, answer it. If they declined, acknowledge graciously and (if the campaign brief has a soft alternative ask) offer it once. If they want to talk to a human, your reply should suggest a handoff path; the operator approving will route accordingly.
+
+## TL;DR
+
+1. **Read the conversation** with `conv_get_conversation(<conversationId>)` (the user prompt names it). Note the `outreachCampaignId`.
+2. **Read the campaign** with `outreach_get_campaign(<campaignId>)` for the brief — the reply should stay on-message.
+3. **Identify the latest end-user message** — that's what you're replying TO. Earlier messages are context only.
+4. **Decide intent**: question, decline, ask-for-human, off-topic, low-quality, etc. The right reply differs sharply by intent.
+5. **Ground product claims** with `kb_search` if the prospect asked something factual.
+6. **Draft** a 30–120-word reply that addresses the inbound. Plain prose, no headings, no JSON-escaping. **No unsubscribe footer** — replies thread inside the existing email chain which already carries the original link.
+7. **File** with `outreach_propose_reply({ conversationId, draftBody, evidence })`. The proposal lands `pending`; the operator approves on `/dashboard/review`. Approving sends via `conv_send_message`.
+
+## Step 1 — read the conversation
+
+```jsonc
+{ "name": "conv_get_conversation", "arguments": { "id": "ccv_…" } }
+```
+
+The response includes `outreachCampaignId`, `messages[]`, `agentMode`. Verify `agentMode === 'draft_only'` (otherwise the trigger fired in error and you should stop). Verify `outreachCampaignId !== null` (same — should not have been triggered).
+
+## Step 2 — read the campaign
+
+```jsonc
+{ "name": "outreach_get_campaign", "arguments": { "id": "ocmp_…" } }
+```
+
+The brief tells you what the campaign is about. Stay on-message. If the inbound veered off-topic ("you wouldn't believe my weekend"), the reply should politely redirect to the original ask, not engage the off-topic detail.
+
+## Step 3 — what to skip
+
+- **A pending reply already exists for this conversation** — `outreach_propose_reply` will reject. Run `outreach_list_proposals({ status: 'pending', kind: 'reply', campaignId, contactId })` first to dedupe.
+- **The latest message is internal** (`internal: true`) — that's a staff side-comment, not a prospect reply. Skip.
+- **The latest message is from `authorType: 'user'` or `'agent'`** — that's an outbound message we already sent (or that someone just approved). The trigger should not fire on those, but defend.
+- **The conversation is closed or staffed** (`status !== 'open'` or `assigneeUserId` set). The operator is handling it; don't draft on top of them.
+
+## Step 4 — read intent
+
+- **Question**: "What pricing tier covers <thing>?" → answer concretely from KB; if KB doesn't cover it, acknowledge and propose a follow-up (call, email, or handoff to a human).
+- **Decline**: "Not interested." → one short, gracious sentence. Don't push back. Optionally one open-ended ask only if the brief has a soft alternative.
+- **Ask for human**: "Can we talk to someone?" → "Of course — I'll have someone reach out today" + thank them. The operator approving the reply is implicitly that handoff.
+- **Off-topic / pleasantry**: brief friendly response then redirect to the original ask.
+- **Hostile / unsubscribe-intent**: don't engage. Draft a one-line acknowledgement. Operator should likely dismiss the draft AND mark the contact suppressed.
+
+## Step 5 — ground product claims
+
+If the prospect asked something specific that needs a factual answer ("does X integrate with Y?"), do a `kb_search` and ground in what comes back. Don't invent. If the KB has nothing, write at the level of "we'd love to walk you through X — when's good for a 15-minute call?" — punt to the operator with a defensible position.
+
+## Step 6 — draft
+
+- **30–120 words.** Replies are short. Conciseness signals respect for their time.
+- **Plain prose.** No headings, no markdown structure, no bullet lists unless 2–3 items genuinely cluster (e.g. listing product capabilities they asked about).
+- **Address what they said.** First sentence acknowledges or answers; second offers a next step if appropriate.
+- **No unsubscribe footer.** The original initial carries the (signed, surviving-forwarding) link. Replies inside the same thread don't need a duplicate; including one looks robotic.
+- **Voice**: warm, second-person, the way an operator would write if they had time.
+
+## Step 7 — file the proposal
+
+```jsonc
+{
+  "name": "outreach_propose_reply",
+  "arguments": {
+    "conversationId": "ccv_…",
+    "draftBody": "Hi Jane,\n\nGreat question — yes, we integrate with Slack via OAuth (one-click; takes ~30 seconds). I'd be happy to walk you through it on a 15-minute call this week. Would Tuesday or Thursday work better?\n\n— Munin",
+    "evidence": {
+      "intent": "question_about_integration",
+      "kbDocIds": ["kdoc_slack_integration_overview"],
+      "reasoning": "Prospect asked about Slack support; KB confirms; offering a quick demo is on-brief."
+    }
+  }
+}
+```
+
+Behavior:
+
+- The proposal lands in `pending` status, visible to the operator on `/dashboard/review` Outreach tab with a Reply badge.
+- An `outreach.proposal.created` realtime event fires.
+- Approving sends the body verbatim via `conv_send_message` on the same conversation. No unsubscribe footer is added.
+
+## What NOT to do
+
+- **Don't auto-send.** No `conv_send_message` from this skill. Drafts only.
+- **Don't ignore the inbound.** A reply that doesn't address what the prospect actually said reads as either a bot or a careless human.
+- **Don't push when they declined.** "Just one more thing" is the cardinal sin of cold outreach. One acknowledgement, one optional soft ask, done.
+- **Don't include an unsubscribe footer.** Initials carry it; replies thread inside.
+- **Don't draft on a closed / staffed conversation.** A human is handling it.
+- **Don't propose multiple replies per conversation.** Idempotency on `(campaign, contact, kind=reply, status=pending)` will reject.
+
+## Related
+
+- `skill://outreach/draft-initial` — the symmetric pattern for first-touch emails.
+- `skill://kb/curation` — the original "drafted candidates, human approves" pattern this skill follows.
+- `agentMode` on `conv_conversations` — `'draft_only'` is what gates the AI runner from auto-replying. Outreach conversations get this set automatically when their initial is approved.

--- a/packages/dashboard-pages/src/pages/outreach-drafts.tsx
+++ b/packages/dashboard-pages/src/pages/outreach-drafts.tsx
@@ -154,7 +154,10 @@ export function OutreachDraftsTab({ onCountChange }: OutreachDraftsTabProps) {
                         {p.draftSubject ?? t('untitled')}
                       </CardTitle>
                       <p className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                        <Badge variant="outline" className="capitalize">
+                        <Badge
+                          variant={p.kind === 'reply' ? 'secondary' : 'outline'}
+                          className="capitalize"
+                        >
                           {p.kind}
                         </Badge>
                         <span>{updatedLabel}</span>
@@ -173,6 +176,14 @@ export function OutreachDraftsTab({ onCountChange }: OutreachDraftsTabProps) {
                               <span className="text-muted-foreground"> ({contact.email})</span>
                             )}
                           </span>
+                        )}
+                        {p.kind === 'reply' && p.conversationId && (
+                          <a
+                            href={`/dashboard/conversations?id=${p.conversationId}`}
+                            className="text-primary underline-offset-2 hover:underline"
+                          >
+                            {t('viewThread')}
+                          </a>
                         )}
                       </p>
                     </div>

--- a/packages/db/drizzle/0013_conv_agent_mode.sql
+++ b/packages/db/drizzle/0013_conv_agent_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "conv_conversations"
+  ADD COLUMN IF NOT EXISTS "agent_mode" varchar(16) NOT NULL DEFAULT 'auto';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1777681800000,
       "tag": "0012_outreach_campaigns_proposals",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1777681900000,
+      "tag": "0013_conv_agent_mode",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -690,6 +690,8 @@ export const convConversations = pgTable(
       (): AnyPgColumn => outreachCampaigns.id,
       { onDelete: 'set null' },
     ),
+    agentMode: varchar('agent_mode', { length: 16 }).notNull().default('auto'),
+    // 'auto' | 'draft_only' | 'off'
     metadata: jsonb('metadata').$type<Record<string, unknown>>().notNull().default({}),
     createdAt,
     updatedAt,


### PR DESCRIPTION
## Summary

Final PR of the 3-part outreach plan — closes the outreach loop. Every reply on an outreach-originated conversation gets drafted by an admin agent and waits for human approval. The AI conversational runner never auto-replies on these conversations, even when the prospect responds.

(PR1 #71 segments + GDPR consent + auto-extract curator. PR2 #73 campaigns + initial drafts + send-approve. This PR adds the reply leg and the new `agentMode` posture column.)

## `agentMode` on conversations

New enum column `agent_mode` on `conv_conversations` with values `auto | draft_only | off`, default `auto`.

Orthogonal to claims (claims = *who's working it now, TTL'd*; agentMode = *what posture the agent takes, durable*). Reusable beyond outreach: a customer can flip a single conversation or a whole channel into `draft_only` for trust-building, moderation, or VIP review without touching the outreach module.

- `ConvService.setAgentMode(id, mode)` + REST `POST /api/conversations/:id/agent-mode`.
- `ConvService.createConversation` accepts `agentMode` (default `'auto'`).
- `ConversationSummary` / `Detail` DTOs surface `agentMode` and `outreachCampaignId`.
- `agent-runtime`'s `ConversationHandler.shouldRespond` defers when `agentMode !== 'auto'` (logged: `skip <id>: agentMode=draft_only`). Two new unit tests cover both `draft_only` and `off`.
- `MuninRestClient.ConversationDetail` exposes `agentMode` and `outreachCampaignId` so any consumer of the runtime sees the same signal.

## Reply-curator

New `skill://outreach/draft-reply`, triggered event-driven from `ConvService.sendMessage` when an `end_user` message lands on a conversation with both `outreachCampaignId` set and `agentMode='draft_only'`. Curator job dedupes per inbound message id.

The skill reads the thread, identifies the prospect's intent (question / decline / ask-for-human / off-topic / hostile), grounds factual claims in `kb_search` results, drafts a 30–120-word reply, and files it via `outreach_propose_reply` for human approval. Strict rules: no unsubscribe footer (initials carry it; replies thread inside the same chain), no auto-send.

## Outreach service

- `OutreachService.proposeReply({ conversationId, draftBody, evidence })` — files a `kind='reply'` proposal. Rejects when the conversation is not outreach-originated. Resolves CRM contact via `conv_contacts.email` match.
- `OutreachService.approveProposal` now branches on kind:
  - `kind='initial'` flips the new conversation to `agentMode='draft_only'` so the AI runner defers on subsequent inbound messages.
  - `kind='reply'` sends draft body verbatim via `conv.sendMessage` on the existing conversation, no unsubscribe footer (the original initial already carries the signed link, and the reply threads inside the same email chain).
- New MCP tool `outreach_propose_reply` (admin audience).

## Sidecar / cloud

- `apps/agent-sidecar/src/curator-loop.ts` `toolPrefixesFor` adds `'skill://outreach/draft-reply'` → `['conv_', 'kb_', 'crm_', 'outreach_']`.
- Cloud `AgentRunnerService.toolPrefixesFor` needs the same one-line addition (separate cloud PR after this OSS release; same pattern as the existing follow-ups).

## Dashboard

`OutreachDraftsTab` differentiates kind via a coloured badge (`Reply` filled, `Initial` outline). Reply cards include a `View thread →` link to `/dashboard/conversations?id=<id>` so the operator can read the prospect's actual message before approving. New i18n string `viewThread` in en + nb.

## Schema migration

`0013_conv_agent_mode.sql` — single column add. Default `'auto'` so all existing conversations are unaffected. Outreach conversations created via `approveProposal` from this PR forward land in `'draft_only'`.

## Tests

6 new:

- `agent-runtime/conversation-handler.test.ts` — defer on `draft_only`, defer on `off`.
- `backend-core/conv.service.test.ts` — inbound on outreach conv enqueues `skill://outreach/draft-reply`; inbound on plain conv does not.
- `backend-core/outreach.service.test.ts` — `approveProposal` initial flips conv `agent_mode='draft_only'`; `proposeReply` files kind=reply; `approveProposal` reply sends via `sendMessage` (no unsubscribe footer in body); `proposeReply` rejects non-outreach conversations.

All 321 backend-core tests pass. All 67 agent-runtime tests pass. Lint clean.

## End-to-end

An operator can now run a campaign where the entire loop — first send and every reply — is human-approved. Combined with PR1's suppression + consent floor and the unsubscribe infrastructure, this is the GDPR-compliant, never-auto-sends outbound channel the plan promised.

## Test plan

- [ ] Migration applies cleanly.
- [ ] PR2 setup: create a CRM segment + email channel + campaign, flip enabled, fire `MUNIN_CURATOR_OUTREACH_INITIAL_CRON='*/2 * * * *'`, observe an initial draft, approve.
- [ ] Verify the new conversation has `agent_mode='draft_only'`.
- [ ] Reply to the email from the prospect side (via mailpit / actual mailbox).
- [ ] Sidecar fires the reply curator within ~5s; a `kind='reply'` proposal lands on `/dashboard/review` Outreach tab with a `Reply` badge.
- [ ] Click `View thread →` — lands on `/dashboard/conversations?id=...` with the inbound message visible.
- [ ] Approve the reply — it sends via the existing email outbound pipeline; the body has no unsubscribe footer; the prospect can reply again to keep the thread going.
- [ ] Toggle `agentMode` to `'auto'` on the conv via `POST /api/conversations/:id/agent-mode` — the AI runner takes over future replies. Toggle back to `'draft_only'` — the curator drafts again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)