### PR TITLE
fix(realtime): drop self_service audience requirement for agent detection

### DIFF
--- a/.changeset/realtime-self-service-detection.md
+++ b/.changeset/realtime-self-service-detection.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Fix self-service agent detection in realtime gateway. The dashboard's "agent connected" indicator was checking `actor.audiences.includes('self_service')` — but OSS admin API keys default to `['admin']` only (cloud mints runner keys with both audiences as a flag). Self-hosters running `@getmunin/agent-runtime` against their local Munin saw "no agent connected" even with chat working fine.
+
+Drop the audience overlay. A live WebSocket subscriber that isn't an end-user-agent token *is* the runner — there's no other admin caller that opens a sustained WS in OSS (dashboard uses session cookies, control-plane scripts don't subscribe). Removes the OSS/cloud asymmetry. No migration needed; existing keys work immediately.

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -129,10 +129,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   private handleConnection(ws: WebSocket, credential: ResolvedCredential): void {
     const actor = credential.actor;
     const subscriptions = new Set<string>();
-    const isSelfServiceAgent =
-      actor.type !== 'end_user_agent' &&
-      Array.isArray(actor.audiences) &&
-      actor.audiences.includes('self_service');
+    const isSelfServiceAgent = actor.type !== 'end_user_agent';
     if (isSelfServiceAgent) {
       let set = this.selfServiceSubscribersByOrg.get(actor.orgId);
       if (!set) {


### PR DESCRIPTION
## Summary
Self-hosters running \`@getmunin/agent-runtime\` against their local Munin saw the dashboard's "agent connected" indicator stuck on **"No self-service agent connected"** even while chat worked end-to-end.

**Cause:** \`RealtimeGateway.handleConnection\` counted only subscribers whose actor \`audiences\` included \`'self_service'\`. OSS admin API keys default to \`['admin']\` (cloud mints its runner keys with both audiences as a flag); the OSS api-keys controller has no UI/API to set audiences. So no admin-key subscriber ever counted.

**Fix:** Drop the audience overlay. A live WS subscriber that isn't an end-user-agent token *is* the runner — nothing else opens a sustained WS with admin credentials in OSS (dashboard uses session cookies, control-plane scripts don't subscribe to realtime). Removes the OSS/cloud asymmetry. No migration; existing keys work immediately.

## Test plan
- [x] \`pnpm --filter @getmunin/backend-core test\` — 7 realtime tests pass
- [x] \`pnpm --filter @getmunin/backend-core typecheck\` clean
- [x] Manual: with sidecar running, \`/api/overview/agent-status\` returns \`selfServiceAgentSubscriberCount: 1\`; dashboard shows "1 agent connected"
- [x] Manual: stop sidecar, count drops to 0, dashboard shows "No self-service agent connected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)