### PR TITLE
feat(agent-host): scaffold shared in-process runner package

### DIFF
--- a/packages/agent-host/eslint.config.mjs
+++ b/packages/agent-host/eslint.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@getmunin/eslint-config';

--- a/packages/agent-host/package.json
+++ b/packages/agent-host/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@getmunin/agent-host",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "In-process agent runner host: config CRUD, /v1/models proxy, ConversationHandler + curator-loop. Used by both OSS backend and cloud backend.",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getmunin/munin.git",
+    "directory": "packages/agent-host"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@getmunin/agent-runtime": "workspace:*",
+    "@getmunin/backend-core": "workspace:*",
+    "@getmunin/core": "workspace:*",
+    "@getmunin/db": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@nestjs/common": "^11.1.19",
+    "@nestjs/core": "^11.1.19",
+    "drizzle-orm": "^0.45.2",
+    "postgres": "^3.4.5",
+    "reflect-metadata": "^0.2.2",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@getmunin/eslint-config": "workspace:*",
+    "@getmunin/tsconfig": "workspace:*",
+    "@types/node": "^22.7.0",
+    "eslint": "^9.10.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/agent-host/src/admin-key-provider.ts
+++ b/packages/agent-host/src/admin-key-provider.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+
+export interface AdminKeyProvider {
+  mint(configId: string): Promise<void>;
+  revoke(configId: string, adminApiKeyId: string): Promise<void>;
+}
+
+@Injectable()
+export class NoopAdminKeyProvider implements AdminKeyProvider {
+  async mint(): Promise<void> {}
+  async revoke(): Promise<void> {}
+}

--- a/packages/agent-host/src/auto-mint-admin-key-provider.ts
+++ b/packages/agent-host/src/auto-mint-admin-key-provider.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import {
+  buildApiKey,
+  encryptSecretSql,
+  getCurrentContext,
+  hashSecret,
+  keyPrefix,
+} from '@getmunin/core';
+import { schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import type { AdminKeyProvider } from './admin-key-provider.js';
+
+@Injectable()
+export class AutoMintAdminKeyProvider implements AdminKeyProvider {
+  async mint(configId: string): Promise<void> {
+    const ctx = getCurrentContext();
+    const rawKey = buildApiKey('admin');
+    const [row] = await ctx.db
+      .insert(schema.apiKeys)
+      .values({
+        orgId: configId,
+        type: 'admin',
+        name: 'self-service-ai-runner',
+        keyHash: hashSecret(rawKey),
+        keyPrefix: keyPrefix(rawKey),
+        scopes: ['*'],
+        audiences: ['admin', 'self_service'],
+        createdByUserId: ctx.actor?.userId ?? null,
+      })
+      .returning({ id: schema.apiKeys.id });
+    if (!row) throw new Error('failed to mint runner admin key');
+    await ctx.db.execute(
+      sql`UPDATE agent_config
+          SET admin_api_key_ct = ${encryptSecretSql(rawKey)},
+              admin_api_key_id = ${row.id},
+              updated_at = now()
+          WHERE id = ${configId}`,
+    );
+  }
+
+  async revoke(configId: string, adminApiKeyId: string): Promise<void> {
+    const ctx = getCurrentContext();
+    await ctx.db.execute(
+      sql`UPDATE api_keys SET revoked_at = now()
+          WHERE id = ${adminApiKeyId} AND org_id = ${configId} AND revoked_at IS NULL`,
+    );
+    await ctx.db.execute(
+      sql`UPDATE agent_config
+          SET admin_api_key_ct = NULL, admin_api_key_id = NULL, updated_at = now()
+          WHERE id = ${configId}`,
+    );
+  }
+}

--- a/packages/agent-host/src/config.controller.ts
+++ b/packages/agent-host/src/config.controller.ts
@@ -1,0 +1,64 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  Inject,
+  Put,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { z } from 'zod';
+import { getCurrentContext } from '@getmunin/core';
+import { AuditInterceptor, AuthGuard, TenancyInterceptor } from '@getmunin/backend-core';
+import { AgentConfigService, type AgentConfigDto } from './config.service.js';
+import { AgentModelsService, type ListModelsResult } from './models.service.js';
+
+const UpsertDto = z.object({
+  enabled: z.boolean().optional(),
+  chatModel: z.string().min(1).optional(),
+  curatorModel: z.string().min(1).nullable().optional(),
+  providerBaseUrl: z.string().url().optional(),
+  providerApiKey: z.string().min(1).nullable().optional(),
+  maxHistoryChars: z.number().int().positive().optional(),
+  maxToolIterations: z.number().int().positive().optional(),
+  debounceMs: z.number().int().nonnegative().optional(),
+});
+
+@Controller('api/agent-config')
+@UseGuards(AuthGuard)
+@UseInterceptors(TenancyInterceptor, AuditInterceptor)
+export class AgentConfigController {
+  constructor(
+    @Inject(AgentConfigService) private readonly service: AgentConfigService,
+    @Inject(AgentModelsService) private readonly models: AgentModelsService,
+  ) {}
+
+  @Get()
+  async get(): Promise<AgentConfigDto> {
+    requireUserActor();
+    return this.service.getForCurrentActor();
+  }
+
+  @Put()
+  async upsert(@Body() body: unknown): Promise<AgentConfigDto> {
+    requireUserActor();
+    const parsed = UpsertDto.safeParse(body);
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return this.service.upsertForCurrentActor(parsed.data);
+  }
+
+  @Get('models')
+  async listModels(): Promise<ListModelsResult> {
+    requireUserActor();
+    return this.models.listForCurrentActor();
+  }
+}
+
+function requireUserActor(): void {
+  const actor = getCurrentContext().actor;
+  if (!actor || actor.type !== 'user') {
+    throw new ForbiddenException('agent config is only editable from a signed-in dashboard session');
+  }
+}

--- a/packages/agent-host/src/config.repository.ts
+++ b/packages/agent-host/src/config.repository.ts
@@ -1,0 +1,34 @@
+export interface AgentConfigRow {
+  id: string;
+  enabled: boolean;
+  chatModel: string;
+  curatorModel: string | null;
+  providerBaseUrl: string;
+  providerApiKeySet: boolean;
+  maxHistoryChars: number;
+  maxToolIterations: number;
+  debounceMs: number;
+  adminApiKeyId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AgentConfigPatch {
+  enabled?: boolean;
+  chatModel?: string;
+  curatorModel?: string | null;
+  providerBaseUrl?: string;
+  providerApiKey?: string | null;
+  maxHistoryChars?: number;
+  maxToolIterations?: number;
+  debounceMs?: number;
+}
+
+export interface AgentConfigRepository {
+  resolveCurrentId(): string;
+  read(id: string): Promise<AgentConfigRow>;
+  update(id: string, patch: AgentConfigPatch): Promise<AgentConfigRow>;
+  listEnabledIds(): Promise<string[]>;
+  readDecryptedProviderKey(id: string): Promise<string | null>;
+  readDecryptedAdminKey(id: string): Promise<string | null>;
+}

--- a/packages/agent-host/src/config.service.ts
+++ b/packages/agent-host/src/config.service.ts
@@ -1,0 +1,66 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { AGENT_CONFIG_REPOSITORY, ADMIN_KEY_PROVIDER } from './injection-tokens.js';
+import type {
+  AgentConfigPatch,
+  AgentConfigRepository,
+  AgentConfigRow,
+} from './config.repository.js';
+import type { AdminKeyProvider } from './admin-key-provider.js';
+
+export interface AgentConfigDto {
+  id: string;
+  enabled: boolean;
+  chatModel: string;
+  curatorModel: string | null;
+  providerBaseUrl: string;
+  providerApiKeySet: boolean;
+  maxHistoryChars: number;
+  maxToolIterations: number;
+  debounceMs: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+@Injectable()
+export class AgentConfigService {
+  constructor(
+    @Inject(AGENT_CONFIG_REPOSITORY) private readonly repo: AgentConfigRepository,
+    @Inject(ADMIN_KEY_PROVIDER) private readonly adminKey: AdminKeyProvider,
+  ) {}
+
+  async getForCurrentActor(): Promise<AgentConfigDto> {
+    const id = this.repo.resolveCurrentId();
+    const row = await this.repo.read(id);
+    return toDto(row);
+  }
+
+  async upsertForCurrentActor(input: AgentConfigPatch): Promise<AgentConfigDto> {
+    const id = this.repo.resolveCurrentId();
+    const before = await this.repo.read(id);
+    const after = await this.repo.update(id, input);
+
+    if (input.enabled === true && !before.adminApiKeyId) {
+      await this.adminKey.mint(id);
+    } else if (input.enabled === false && before.adminApiKeyId) {
+      await this.adminKey.revoke(id, before.adminApiKeyId);
+    }
+
+    return toDto(after);
+  }
+}
+
+function toDto(row: AgentConfigRow): AgentConfigDto {
+  return {
+    id: row.id,
+    enabled: row.enabled,
+    chatModel: row.chatModel,
+    curatorModel: row.curatorModel,
+    providerBaseUrl: row.providerBaseUrl,
+    providerApiKeySet: row.providerApiKeySet,
+    maxHistoryChars: row.maxHistoryChars,
+    maxToolIterations: row.maxToolIterations,
+    debounceMs: row.debounceMs,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}

--- a/packages/agent-host/src/index.ts
+++ b/packages/agent-host/src/index.ts
@@ -1,0 +1,37 @@
+export {
+  agentConfig,
+  AGENT_HOST_SINGLETON_DDL,
+  AGENT_HOST_MULTI_TENANT_DDL,
+  SINGLETON_ID,
+} from './schema.js';
+
+export type {
+  AgentConfigRow,
+  AgentConfigPatch,
+  AgentConfigRepository,
+} from './config.repository.js';
+
+export { SingletonConfigRepository } from './singleton-config.repository.js';
+export { PerOrgConfigRepository } from './per-org-config.repository.js';
+
+export {
+  AGENT_CONFIG_REPOSITORY,
+  ADMIN_KEY_PROVIDER,
+  AGENT_HOST_DB,
+} from './injection-tokens.js';
+
+export { AgentHostRunner, type AgentHostRunnerOptions } from './runner.service.js';
+export { runWithServiceContext } from './service-context.js';
+export { AgentHostModule, type AgentHostModuleOptions } from './module.js';
+export { ReplicaLockManager } from './replica-lock.js';
+
+export { AgentConfigService, type AgentConfigDto } from './config.service.js';
+export { AgentConfigController } from './config.controller.js';
+export {
+  AgentModelsService,
+  type ListModelsResult,
+  type ModelEntry,
+} from './models.service.js';
+
+export { type AdminKeyProvider, NoopAdminKeyProvider } from './admin-key-provider.js';
+export { AutoMintAdminKeyProvider } from './auto-mint-admin-key-provider.js';

--- a/packages/agent-host/src/injection-tokens.ts
+++ b/packages/agent-host/src/injection-tokens.ts
@@ -1,0 +1,3 @@
+export const AGENT_CONFIG_REPOSITORY = Symbol('AGENT_CONFIG_REPOSITORY');
+export const ADMIN_KEY_PROVIDER = Symbol('ADMIN_KEY_PROVIDER');
+export const AGENT_HOST_DB = Symbol('AGENT_HOST_DB');

--- a/packages/agent-host/src/models.service.ts
+++ b/packages/agent-host/src/models.service.ts
@@ -1,0 +1,138 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { AGENT_CONFIG_REPOSITORY } from './injection-tokens.js';
+import type { AgentConfigRepository } from './config.repository.js';
+
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+export interface ModelEntry {
+  id: string;
+  contextLength: number | null;
+  promptCostPerMillion: number | null;
+  completionCostPerMillion: number | null;
+}
+
+export interface ListModelsResult {
+  supported: boolean;
+  models: ModelEntry[];
+  fetchedAt: string;
+}
+
+interface CacheEntry {
+  result: ListModelsResult;
+  expiresAt: number;
+}
+
+@Injectable()
+export class AgentModelsService {
+  private readonly logger = new Logger(AgentModelsService.name);
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(
+    @Inject(AGENT_CONFIG_REPOSITORY) private readonly repo: AgentConfigRepository,
+  ) {}
+
+  async listForCurrentActor(): Promise<ListModelsResult> {
+    const id = this.repo.resolveCurrentId();
+    const config = await this.repo.read(id);
+    const apiKey = await this.repo.readDecryptedProviderKey(id);
+    if (!apiKey) {
+      return { supported: false, models: [], fetchedAt: new Date().toISOString() };
+    }
+
+    const cacheKey = `${id}|${config.providerBaseUrl}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) return cached.result;
+
+    const result = await this.fetchModels(config.providerBaseUrl, apiKey);
+    this.cache.set(cacheKey, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+    return result;
+  }
+
+  private async fetchModels(baseUrl: string, apiKey: string): Promise<ListModelsResult> {
+    const url = `${baseUrl.replace(/\/+$/, '')}/models`;
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          accept: 'application/json',
+        },
+      });
+    } catch (err) {
+      this.logger.warn(`fetch ${url} failed: ${describe(err)}`);
+      return { supported: false, models: [], fetchedAt: new Date().toISOString() };
+    }
+    if (!res.ok) {
+      this.logger.warn(`${url} returned ${res.status}`);
+      return { supported: false, models: [], fetchedAt: new Date().toISOString() };
+    }
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch (err) {
+      this.logger.warn(`${url} returned non-JSON: ${describe(err)}`);
+      return { supported: false, models: [], fetchedAt: new Date().toISOString() };
+    }
+    const models = parseOpenAiCompatModels(body);
+    if (!models) {
+      return { supported: false, models: [], fetchedAt: new Date().toISOString() };
+    }
+    return {
+      supported: true,
+      models,
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+}
+
+function parseOpenAiCompatModels(body: unknown): ModelEntry[] | null {
+  if (!body || typeof body !== 'object') return null;
+  const data = (body as { data?: unknown }).data;
+  if (!Array.isArray(data)) return null;
+  const out: ModelEntry[] = [];
+  for (const item of data) {
+    if (!item || typeof item !== 'object') continue;
+    const id = (item as { id?: unknown }).id;
+    if (typeof id !== 'string') continue;
+    out.push({
+      id,
+      contextLength: readContextLength(item),
+      promptCostPerMillion: readPromptCost(item),
+      completionCostPerMillion: readCompletionCost(item),
+    });
+  }
+  return out;
+}
+
+function readContextLength(item: unknown): number | null {
+  if (!item || typeof item !== 'object') return null;
+  const candidate = (item as Record<string, unknown>)['context_length'];
+  return typeof candidate === 'number' && Number.isFinite(candidate) ? candidate : null;
+}
+
+function readPromptCost(item: unknown): number | null {
+  if (!item || typeof item !== 'object') return null;
+  const pricing = (item as Record<string, unknown>)['pricing'];
+  if (!pricing || typeof pricing !== 'object') return null;
+  const raw = (pricing as Record<string, unknown>)['prompt'];
+  return parsePerMillion(raw);
+}
+
+function readCompletionCost(item: unknown): number | null {
+  if (!item || typeof item !== 'object') return null;
+  const pricing = (item as Record<string, unknown>)['pricing'];
+  if (!pricing || typeof pricing !== 'object') return null;
+  const raw = (pricing as Record<string, unknown>)['completion'];
+  return parsePerMillion(raw);
+}
+
+function parsePerMillion(raw: unknown): number | null {
+  const n = typeof raw === 'string' ? Number(raw) : typeof raw === 'number' ? raw : null;
+  if (n === null || !Number.isFinite(n)) return null;
+  return n * 1_000_000;
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/agent-host/src/module.ts
+++ b/packages/agent-host/src/module.ts
@@ -1,0 +1,64 @@
+import { DynamicModule, Module, Provider, Type } from '@nestjs/common';
+import type { Db } from '@getmunin/db';
+import { AgentConfigService } from './config.service.js';
+import { AgentConfigController } from './config.controller.js';
+import { AgentModelsService } from './models.service.js';
+import { AgentHostRunner, type AgentHostRunnerOptions } from './runner.service.js';
+import {
+  ADMIN_KEY_PROVIDER,
+  AGENT_CONFIG_REPOSITORY,
+  AGENT_HOST_DB,
+} from './injection-tokens.js';
+import type { AgentConfigRepository } from './config.repository.js';
+import type { AdminKeyProvider } from './admin-key-provider.js';
+
+export interface AgentHostModuleOptions {
+  configRepository: Type<AgentConfigRepository>;
+  adminKeyProvider: Type<AdminKeyProvider>;
+  db: Db;
+  runnerOptions?: AgentHostRunnerOptions;
+}
+
+@Module({})
+export class AgentHostModule {
+  static forRoot(options: AgentHostModuleOptions): DynamicModule {
+    const repoProvider: Provider = {
+      provide: AGENT_CONFIG_REPOSITORY,
+      useClass: options.configRepository,
+    };
+    const keyProvider: Provider = {
+      provide: ADMIN_KEY_PROVIDER,
+      useClass: options.adminKeyProvider,
+    };
+    const dbProvider: Provider = {
+      provide: AGENT_HOST_DB,
+      useValue: options.db,
+    };
+    const runnerOptionsProvider: Provider = {
+      provide: 'AGENT_HOST_RUNNER_OPTIONS',
+      useValue: options.runnerOptions ?? {},
+    };
+    return {
+      module: AgentHostModule,
+      providers: [
+        repoProvider,
+        keyProvider,
+        dbProvider,
+        runnerOptionsProvider,
+        options.configRepository,
+        options.adminKeyProvider,
+        AgentConfigService,
+        AgentModelsService,
+        AgentHostRunner,
+      ],
+      controllers: [AgentConfigController],
+      exports: [
+        AgentConfigService,
+        AgentModelsService,
+        AGENT_CONFIG_REPOSITORY,
+        ADMIN_KEY_PROVIDER,
+        AGENT_HOST_DB,
+      ],
+    };
+  }
+}

--- a/packages/agent-host/src/per-org-config.repository.ts
+++ b/packages/agent-host/src/per-org-config.repository.ts
@@ -1,0 +1,154 @@
+import { Injectable } from '@nestjs/common';
+import { decryptSecretSql, encryptSecretSql, getCurrentContext } from '@getmunin/core';
+import { eq, sql } from 'drizzle-orm';
+import { agentConfig } from './schema.js';
+import type {
+  AgentConfigPatch,
+  AgentConfigRepository,
+  AgentConfigRow,
+} from './config.repository.js';
+
+const DEFAULT_CHAT_MODEL = 'anthropic/claude-haiku-4.5';
+const DEFAULT_PROVIDER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+@Injectable()
+export class PerOrgConfigRepository implements AgentConfigRepository {
+  resolveCurrentId(): string {
+    const actor = getCurrentContext().actor;
+    if (!actor) throw new Error('PerOrgConfigRepository requires an authenticated actor');
+    return actor.orgId;
+  }
+
+  async read(id: string): Promise<AgentConfigRow> {
+    return readOrMaterialize(id);
+  }
+
+  async update(id: string, patch: AgentConfigPatch): Promise<AgentConfigRow> {
+    await readOrMaterialize(id);
+    await applyPatch(id, patch);
+    return readOrMaterialize(id);
+  }
+
+  async listEnabledIds(): Promise<string[]> {
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select({ id: agentConfig.id })
+      .from(agentConfig)
+      .where(eq(agentConfig.enabled, true));
+    return rows.map((r) => r.id);
+  }
+
+  async readDecryptedProviderKey(id: string): Promise<string | null> {
+    return readDecryptedKey(id, 'provider_api_key_ct');
+  }
+
+  async readDecryptedAdminKey(id: string): Promise<string | null> {
+    return readDecryptedKey(id, 'admin_api_key_ct');
+  }
+}
+
+async function readOrMaterialize(id: string): Promise<AgentConfigRow> {
+  const ctx = getCurrentContext();
+  const rows = await ctx.db
+    .select({
+      id: agentConfig.id,
+      enabled: agentConfig.enabled,
+      chatModel: agentConfig.chatModel,
+      curatorModel: agentConfig.curatorModel,
+      providerBaseUrl: agentConfig.providerBaseUrl,
+      providerKeySet: sql<boolean>`(${agentConfig.providerApiKeyCt} IS NOT NULL)`,
+      maxHistoryChars: agentConfig.maxHistoryChars,
+      maxToolIterations: agentConfig.maxToolIterations,
+      debounceMs: agentConfig.debounceMs,
+      adminApiKeyId: agentConfig.adminApiKeyId,
+      createdAt: agentConfig.createdAt,
+      updatedAt: agentConfig.updatedAt,
+    })
+    .from(agentConfig)
+    .where(eq(agentConfig.id, id))
+    .limit(1);
+  const row = rows[0];
+  if (row) {
+    return {
+      id: row.id,
+      enabled: row.enabled,
+      chatModel: row.chatModel,
+      curatorModel: row.curatorModel,
+      providerBaseUrl: row.providerBaseUrl,
+      providerApiKeySet: row.providerKeySet,
+      maxHistoryChars: row.maxHistoryChars,
+      maxToolIterations: row.maxToolIterations,
+      debounceMs: row.debounceMs,
+      adminApiKeyId: row.adminApiKeyId,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+  const [created] = await ctx.db
+    .insert(agentConfig)
+    .values({
+      id,
+      enabled: false,
+      chatModel: DEFAULT_CHAT_MODEL,
+      providerBaseUrl: DEFAULT_PROVIDER_BASE_URL,
+    })
+    .returning();
+  if (!created) throw new Error(`failed to materialize agent_config row for id=${id}`);
+  return {
+    id: created.id,
+    enabled: created.enabled,
+    chatModel: created.chatModel,
+    curatorModel: created.curatorModel,
+    providerBaseUrl: created.providerBaseUrl,
+    providerApiKeySet: false,
+    maxHistoryChars: created.maxHistoryChars,
+    maxToolIterations: created.maxToolIterations,
+    debounceMs: created.debounceMs,
+    adminApiKeyId: created.adminApiKeyId,
+    createdAt: created.createdAt,
+    updatedAt: created.updatedAt,
+  };
+}
+
+async function applyPatch(id: string, patch: AgentConfigPatch): Promise<void> {
+  const ctx = getCurrentContext();
+  const setClauses: Record<string, unknown> = {};
+  if (patch.enabled !== undefined) setClauses['enabled'] = patch.enabled;
+  if (patch.chatModel !== undefined) setClauses['chatModel'] = patch.chatModel;
+  if (patch.curatorModel !== undefined) setClauses['curatorModel'] = patch.curatorModel;
+  if (patch.providerBaseUrl !== undefined) setClauses['providerBaseUrl'] = patch.providerBaseUrl;
+  if (patch.maxHistoryChars !== undefined) setClauses['maxHistoryChars'] = patch.maxHistoryChars;
+  if (patch.maxToolIterations !== undefined) setClauses['maxToolIterations'] = patch.maxToolIterations;
+  if (patch.debounceMs !== undefined) setClauses['debounceMs'] = patch.debounceMs;
+  setClauses['updatedAt'] = new Date();
+
+  if (Object.keys(setClauses).length > 1) {
+    await ctx.db.update(agentConfig).set(setClauses).where(eq(agentConfig.id, id));
+  }
+
+  if (patch.providerApiKey === null) {
+    await ctx.db.execute(
+      sql`UPDATE agent_config SET provider_api_key_ct = NULL, updated_at = now()
+          WHERE id = ${id}`,
+    );
+  } else if (typeof patch.providerApiKey === 'string' && patch.providerApiKey.length > 0) {
+    await ctx.db.execute(
+      sql`UPDATE agent_config
+          SET provider_api_key_ct = ${encryptSecretSql(patch.providerApiKey)},
+              updated_at = now()
+          WHERE id = ${id}`,
+    );
+  }
+}
+
+async function readDecryptedKey(id: string, column: string): Promise<string | null> {
+  const ctx = getCurrentContext();
+  const colSql = sql.raw(column);
+  const rows = await ctx.db.execute<{ key: string | null } & Record<string, unknown>>(
+    sql`SELECT ${decryptSecretSql(colSql)} AS key
+        FROM agent_config
+        WHERE id = ${id} AND ${colSql} IS NOT NULL
+        LIMIT 1`,
+  );
+  return rows[0]?.key ?? null;
+}

--- a/packages/agent-host/src/replica-lock.ts
+++ b/packages/agent-host/src/replica-lock.ts
@@ -1,0 +1,94 @@
+import { Logger } from '@nestjs/common';
+import postgres from 'postgres';
+
+const LOCK_NAMESPACE = 'agent_host';
+
+export class ReplicaLockManager {
+  private readonly logger = new Logger(ReplicaLockManager.name);
+  private readonly sql: postgres.Sql;
+  private reserved: postgres.ReservedSql | null = null;
+  private readonly held = new Set<string>();
+  private stopped = false;
+
+  constructor(connectionString: string) {
+    this.sql = postgres(connectionString, { max: 1, prepare: false });
+  }
+
+  holds(id: string): boolean {
+    return this.held.has(id);
+  }
+
+  async tryAcquire(id: string): Promise<boolean> {
+    if (this.stopped) return false;
+    if (this.held.has(id)) return true;
+    const reserved = await this.ensureReserved();
+    if (!reserved) return false;
+    try {
+      const result = await reserved<Array<{ got: boolean }>>`
+        SELECT pg_try_advisory_lock(hashtextextended(${`${LOCK_NAMESPACE}:${id}`}, 0)) AS got
+      `;
+      const got = result[0]?.got === true;
+      if (got) this.held.add(id);
+      return got;
+    } catch (err) {
+      this.logger.warn(`tryAcquire(${id}) failed; resetting reservation: ${describe(err)}`);
+      this.resetReservation();
+      return false;
+    }
+  }
+
+  async release(id: string): Promise<void> {
+    if (!this.held.has(id) || !this.reserved) {
+      this.held.delete(id);
+      return;
+    }
+    try {
+      await this.reserved`
+        SELECT pg_advisory_unlock(hashtextextended(${`${LOCK_NAMESPACE}:${id}`}, 0))
+      `;
+    } catch (err) {
+      this.logger.warn(`release(${id}) failed: ${describe(err)}`);
+    }
+    this.held.delete(id);
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.reserved) {
+      try {
+        await this.reserved`SELECT pg_advisory_unlock_all()`;
+      } catch (err) {
+        this.logger.warn(`unlock_all on stop failed (connection may already be dead): ${describe(err)}`);
+      }
+      this.reserved.release();
+      this.reserved = null;
+    }
+    this.held.clear();
+    await this.sql.end({ timeout: 5 }).catch((err: unknown) => {
+      this.logger.warn(`sql.end() on stop failed: ${describe(err)}`);
+    });
+  }
+
+  private async ensureReserved(): Promise<postgres.ReservedSql | null> {
+    if (this.reserved) return this.reserved;
+    try {
+      this.reserved = await this.sql.reserve();
+      return this.reserved;
+    } catch (err) {
+      this.logger.warn(`reserve() failed: ${describe(err)}`);
+      return null;
+    }
+  }
+
+  private resetReservation(): void {
+    if (this.reserved) {
+      this.reserved.release();
+      this.reserved = null;
+    }
+    this.held.clear();
+  }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -1,0 +1,406 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  OnModuleDestroy,
+  Optional,
+} from '@nestjs/common';
+import { hostname } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import type { Db } from '@getmunin/db';
+import {
+  createConversationHandler,
+  createMuninRestClient,
+  createPromptResolver,
+  createRealtimeClient,
+  defaultPromptsDir,
+  openMcpClient,
+  runSkillPass,
+  type ConversationHandler,
+  type CuratorJob,
+  type CuratorJobPendingEvent,
+  type HandlerConfig,
+  type KbDocumentChangedEvent,
+  type MessageReceivedEvent,
+  type MuninRestClient,
+  type PromptResolver,
+  type SkillPassResult,
+} from '@getmunin/agent-runtime';
+import { AGENT_CONFIG_REPOSITORY, AGENT_HOST_DB } from './injection-tokens.js';
+import type { AgentConfigRepository, AgentConfigRow } from './config.repository.js';
+import { runWithServiceContext } from './service-context.js';
+import { ReplicaLockManager } from './replica-lock.js';
+
+const RECONCILE_INTERVAL_MS = 30_000;
+const CURATOR_LEASE_SECONDS = 600;
+const CURATOR_MAX_SCHEDULED_DELAY_MS = 24 * 60 * 60 * 1000;
+
+export interface AgentHostRunnerOptions {
+  baseUrl?: string;
+  fallbackAdminApiKey?: string;
+  promptsDir?: string;
+  databaseUrl?: string;
+}
+
+interface PerConfigRunner {
+  realtime: { stop: () => Promise<void> };
+  handler: ConversationHandler;
+  prompts: PromptResolver;
+  adminMcp: { close: () => Promise<void> };
+  curatorWorker: CuratorWorker;
+}
+
+interface CuratorWorker {
+  onPending(event: CuratorJobPendingEvent): void;
+  onConnected(): void;
+  stop(): Promise<void>;
+}
+
+@Injectable()
+export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy {
+  private readonly logger = new Logger(AgentHostRunner.name);
+  private readonly runners = new Map<string, PerConfigRunner>();
+  private reconcileTimer: NodeJS.Timeout | null = null;
+  private stopped = false;
+  private readonly baseUrl: string;
+  private readonly fallbackAdminApiKey: string | undefined;
+  private readonly promptsDir: string;
+  private readonly holderId: string;
+  private readonly lockManager: ReplicaLockManager | null;
+
+  constructor(
+    @Inject(AGENT_CONFIG_REPOSITORY) private readonly repo: AgentConfigRepository,
+    @Inject(AGENT_HOST_DB) private readonly db: Db,
+    @Optional() @Inject('AGENT_HOST_RUNNER_OPTIONS') options?: AgentHostRunnerOptions,
+  ) {
+    this.baseUrl = options?.baseUrl ?? process.env.MUNIN_BASE_URL ?? 'http://localhost:3001';
+    this.fallbackAdminApiKey = options?.fallbackAdminApiKey ?? process.env.MUNIN_ADMIN_API_KEY;
+    this.promptsDir = options?.promptsDir ?? defaultPromptsDir();
+    this.holderId =
+      process.env.MUNIN_AGENT_HOLDER_ID ??
+      `agent-host-${hostname()}-${randomUUID().slice(0, 8)}`;
+    const databaseUrl = options?.databaseUrl ?? process.env.DATABASE_URL;
+    this.lockManager = databaseUrl ? new ReplicaLockManager(databaseUrl) : null;
+    if (!this.lockManager) {
+      this.logger.warn(
+        'no DATABASE_URL — chat sub-loop runs unconditionally; safe only on a single replica',
+      );
+    }
+  }
+
+  onApplicationBootstrap(): void {
+    if (process.env.MUNIN_BUILTIN_AGENT === '0') {
+      this.logger.log('bundled agent runner disabled via MUNIN_BUILTIN_AGENT=0');
+      return;
+    }
+    void this.reconcile();
+    this.reconcileTimer = setInterval(() => void this.reconcile(), RECONCILE_INTERVAL_MS);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.stopped = true;
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = null;
+    }
+    await Promise.all(
+      [...this.runners.values()].map(async (r) => {
+        await r.realtime.stop();
+        await r.handler.flush();
+        await r.curatorWorker.stop();
+        await r.adminMcp.close().catch((err: unknown) => {
+          this.logger.warn(`adminMcp.close() on shutdown failed: ${describe(err)}`);
+        });
+      }),
+    );
+    this.runners.clear();
+    if (this.lockManager) await this.lockManager.stop();
+  }
+
+  private async reconcile(): Promise<void> {
+    if (this.stopped) return;
+    let enabledIds: string[];
+    try {
+      enabledIds = await runWithServiceContext(this.db, '_reconcile', () =>
+        this.repo.listEnabledIds(),
+      );
+    } catch (err) {
+      this.logger.warn(`reconcile: failed to list configs: ${describe(err)}`);
+      return;
+    }
+
+    const desired = new Set(enabledIds);
+
+    for (const [id, runner] of this.runners) {
+      if (!desired.has(id)) {
+        this.logger.log(`stopping runner for ${id}`);
+        await runner.realtime.stop();
+        await runner.handler.flush();
+        await runner.curatorWorker.stop();
+        await runner.adminMcp.close().catch((err: unknown) => {
+          this.logger.warn(`${id}: adminMcp.close() on stop failed: ${describe(err)}`);
+        });
+        this.runners.delete(id);
+        if (this.lockManager) await this.lockManager.release(id);
+      }
+    }
+
+    for (const id of enabledIds) {
+      if (this.runners.has(id)) continue;
+      try {
+        const runner = await this.spawnRunner(id);
+        if (runner) {
+          this.runners.set(id, runner);
+          this.logger.log(`started runner for ${id}`);
+        }
+      } catch (err) {
+        this.logger.error(`failed to start runner for ${id}: ${describe(err)}`);
+      }
+    }
+
+    if (this.lockManager) {
+      for (const id of enabledIds) {
+        const got = await this.lockManager.tryAcquire(id);
+        if (got && !this.lockManager.holds(id)) {
+          this.logger.log(`acquired chat lock for ${id}`);
+        }
+      }
+    }
+  }
+
+  private async spawnRunner(id: string): Promise<PerConfigRunner | null> {
+    const config = await runWithServiceContext(this.db, id, () => this.repo.read(id));
+    const adminApiKey =
+      (await runWithServiceContext(this.db, id, () =>
+        this.repo.readDecryptedAdminKey(id),
+      )) ?? this.fallbackAdminApiKey;
+    const providerApiKey = await runWithServiceContext(this.db, id, () =>
+      this.repo.readDecryptedProviderKey(id),
+    );
+
+    if (!adminApiKey) {
+      this.logger.warn(`${id}: enabled but no admin API key (configure or set MUNIN_ADMIN_API_KEY)`);
+      return null;
+    }
+    if (!providerApiKey) {
+      this.logger.warn(`${id}: enabled but no LLM provider API key`);
+      return null;
+    }
+
+    const rest = createMuninRestClient({ baseUrl: this.baseUrl, adminApiKey });
+
+    const adminMcp = await openMcpClient({
+      baseUrl: this.baseUrl,
+      bearerToken: adminApiKey,
+      clientName: `agent-host-${id}`,
+    });
+
+    const prompts = await createPromptResolver({
+      promptsDir: this.promptsDir,
+      mcp: adminMcp,
+      logger: this.scopedLogger(id, 'prompts'),
+    });
+
+    const handlerConfig: HandlerConfig = {
+      providerBaseUrl: config.providerBaseUrl,
+      providerApiKey,
+      model: config.chatModel,
+      maxToolIterations: config.maxToolIterations,
+      maxHistoryChars: config.maxHistoryChars,
+      debounceMs: config.debounceMs,
+    };
+
+    const handler = createConversationHandler({
+      config: handlerConfig,
+      rest,
+      prompts,
+      openMcp: ({ delegatedToken }) =>
+        openMcpClient({ baseUrl: this.baseUrl, bearerToken: delegatedToken }),
+      holderId: this.holderId,
+      logger: this.scopedLogger(id, 'chat'),
+    });
+
+    const curatorWorker = this.buildCuratorWorker({ id, config, providerApiKey, rest });
+
+    const realtime = createRealtimeClient({
+      baseUrl: this.baseUrl,
+      adminApiKey,
+      onMessageReceived: (event: MessageReceivedEvent) => {
+        if (this.lockManager && !this.lockManager.holds(id)) return;
+        handler.handle({ conversationId: event.conversationId, authorType: event.authorType });
+      },
+      onCuratorJobPending: (event) => curatorWorker.onPending(event),
+      onConnected: () => curatorWorker.onConnected(),
+      onKbDocumentChanged: (event: KbDocumentChangedEvent) => {
+        if (event.type === 'deleted') return;
+        if (!event.slug || !prompts.isPromptDocument(event.slug)) return;
+        void prompts.refresh(event.slug);
+      },
+      logger: this.scopedLogger(id, 'realtime'),
+    });
+    realtime.start();
+
+    return { realtime, handler, prompts, adminMcp, curatorWorker };
+  }
+
+  private buildCuratorWorker(opts: {
+    id: string;
+    config: AgentConfigRow;
+    providerApiKey: string;
+    rest: MuninRestClient;
+  }): CuratorWorker {
+    const log = this.scopedLogger(opts.id, 'curator');
+    const inFlight = new Set<Promise<unknown>>();
+    const scheduledByJob = new Map<string, NodeJS.Timeout>();
+    let pollPending: Promise<void> | null = null;
+    let stopped = false;
+
+    const track = <T,>(p: Promise<T>): Promise<T> => {
+      inFlight.add(p);
+      void p.finally(() => inFlight.delete(p));
+      return p;
+    };
+
+    const curatorModel = opts.config.curatorModel ?? opts.config.chatModel;
+
+    const executeOne = async (job: CuratorJob): Promise<void> => {
+      log.info(`running ${job.skillUri} for ${job.id} (attempt ${job.attempts}/${job.maxAttempts})`);
+      let result: SkillPassResult;
+      try {
+        result = await runSkillPass({
+          baseUrl: this.baseUrl,
+          adminApiKey: (await runWithServiceContext(this.db, opts.id, () =>
+            this.repo.readDecryptedAdminKey(opts.id),
+          )) ?? this.fallbackAdminApiKey ?? '',
+          providerBaseUrl: opts.config.providerBaseUrl,
+          providerApiKey: opts.providerApiKey,
+          model: curatorModel,
+          skillUri: job.skillUri,
+          userPrompt: job.userPrompt,
+          maxToolIterations: 24,
+          maxHistoryChars: opts.config.maxHistoryChars,
+          clientName: `agent-host-curator-${job.id.slice(-6)}`,
+          allowedToolPrefixes: toolPrefixesFor(job.skillUri),
+          logger: log,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        await opts.rest
+          .failCuratorJob(job.id, { error: message })
+          .catch((e) => log.error(`fail-report failed: ${describe(e)}`));
+        return;
+      }
+
+      if (result.ok) {
+        log.info(`${job.id} done (tools=${result.toolCalls}, tokens=${result.totalTokens})`);
+        await opts.rest
+          .ackCuratorJob(job.id, {
+            replyText: result.replyText,
+            toolCalls: result.toolCalls,
+            totalTokens: result.totalTokens,
+          })
+          .catch((e) => log.error(`ack failed: ${describe(e)}`));
+        return;
+      }
+
+      const retryable =
+        result.skipped !== 'skill_missing' &&
+        result.skipped !== 'no_admin_key' &&
+        result.skipped !== 'no_provider_key';
+      log.warn(`${job.id} skipped: ${result.skipped}${result.error ? ` (${result.error})` : ''}`);
+      await opts.rest
+        .failCuratorJob(job.id, {
+          error: `${result.skipped}${result.error ? `: ${result.error}` : ''}`,
+          retryable,
+        })
+        .catch((e) => log.error(`fail-report failed: ${describe(e)}`));
+    };
+
+    const pollOnce = async (): Promise<void> => {
+      if (stopped) return;
+      let jobs: CuratorJob[];
+      try {
+        jobs = await opts.rest.claimCuratorJobs({
+          holder: this.holderId,
+          limit: 1,
+          leaseSeconds: CURATOR_LEASE_SECONDS,
+        });
+      } catch (err) {
+        log.warn(`claim failed: ${describe(err)}`);
+        return;
+      }
+      for (const job of jobs) {
+        if (stopped) break;
+        await executeOne(job);
+      }
+    };
+
+    const triggerPoll = (): void => {
+      if (stopped) return;
+      if (pollPending) return;
+      pollPending = track(
+        pollOnce().finally(() => {
+          pollPending = null;
+        }),
+      );
+    };
+
+    return {
+      onPending(event) {
+        if (stopped) return;
+        const dueAt = new Date(event.nextAttemptAt).getTime();
+        const delay = Number.isFinite(dueAt) ? dueAt - Date.now() : 0;
+        if (delay <= 1000) {
+          triggerPoll();
+          return;
+        }
+        const existing = scheduledByJob.get(event.jobId);
+        if (existing) clearTimeout(existing);
+        const clamped = Math.min(delay, CURATOR_MAX_SCHEDULED_DELAY_MS);
+        const timer = setTimeout(() => {
+          scheduledByJob.delete(event.jobId);
+          triggerPoll();
+        }, clamped);
+        scheduledByJob.set(event.jobId, timer);
+      },
+      onConnected() {
+        if (stopped) return;
+        log.info('realtime connected — draining queue');
+        triggerPoll();
+      },
+      async stop() {
+        stopped = true;
+        for (const t of scheduledByJob.values()) clearTimeout(t);
+        scheduledByJob.clear();
+        await Promise.allSettled([...inFlight]);
+      },
+    };
+  }
+
+  private scopedLogger(id: string, sub: string): {
+    info: (m: string) => void;
+    warn: (m: string) => void;
+    error: (m: string) => void;
+  } {
+    return {
+      info: (m) => this.logger.log(`${id} ${sub}: ${m}`),
+      warn: (m) => this.logger.warn(`${id} ${sub}: ${m}`),
+      error: (m) => this.logger.error(`${id} ${sub}: ${m}`),
+    };
+  }
+}
+
+function toolPrefixesFor(skillUri: string): string[] | undefined {
+  if (skillUri === 'skill://kb/curation') return ['conv_', 'kb_'];
+  if (skillUri === 'skill://crm/hygiene') return ['conv_', 'crm_'];
+  if (skillUri === 'skill://crm/contact-extract') return ['conv_', 'crm_'];
+  if (skillUri === 'skill://outreach/draft-initial') return ['conv_', 'kb_', 'crm_', 'outreach_'];
+  if (skillUri === 'skill://outreach/draft-reply') return ['conv_', 'kb_', 'crm_', 'outreach_'];
+  if (skillUri === 'skill://cms/stale-content-review') return ['cms_'];
+  return undefined;
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/agent-host/src/schema.ts
+++ b/packages/agent-host/src/schema.ts
@@ -1,0 +1,73 @@
+import { sql } from 'drizzle-orm';
+import { boolean, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+const createdAt = timestamp('created_at', { withTimezone: true }).notNull().defaultNow();
+const updatedAt = timestamp('updated_at', { withTimezone: true }).notNull().defaultNow();
+
+export const agentConfig = pgTable('agent_config', {
+  id: text('id').primaryKey(),
+  enabled: boolean('enabled').notNull().default(false),
+  chatModel: text('chat_model').notNull(),
+  curatorModel: text('curator_model'),
+  providerBaseUrl: text('provider_base_url').notNull(),
+  providerApiKeyCt: text('provider_api_key_ct'),
+  adminApiKeyCt: text('admin_api_key_ct'),
+  adminApiKeyId: text('admin_api_key_id'),
+  maxHistoryChars: integer('max_history_chars').notNull().default(32_000),
+  maxToolIterations: integer('max_tool_iterations').notNull().default(8),
+  debounceMs: integer('debounce_ms').notNull().default(500),
+  createdAt,
+  updatedAt,
+});
+
+export const SINGLETON_ID = 'singleton' as const;
+
+const DEFAULT_CHAT_MODEL = 'anthropic/claude-haiku-4.5';
+const DEFAULT_PROVIDER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+export const AGENT_HOST_SINGLETON_DDL = sql`
+  CREATE TABLE IF NOT EXISTS agent_config (
+    id text PRIMARY KEY DEFAULT 'singleton',
+    enabled boolean NOT NULL DEFAULT false,
+    chat_model text NOT NULL DEFAULT ${DEFAULT_CHAT_MODEL},
+    curator_model text,
+    provider_base_url text NOT NULL DEFAULT ${DEFAULT_PROVIDER_BASE_URL},
+    provider_api_key_ct text,
+    admin_api_key_ct text,
+    admin_api_key_id text,
+    max_history_chars integer NOT NULL DEFAULT 32000,
+    max_tool_iterations integer NOT NULL DEFAULT 8,
+    debounce_ms integer NOT NULL DEFAULT 500,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT agent_config_singleton_chk CHECK (id = 'singleton')
+  );
+
+  INSERT INTO agent_config (id) VALUES ('singleton') ON CONFLICT (id) DO NOTHING;
+
+  CREATE INDEX IF NOT EXISTS agent_config_enabled_idx
+    ON agent_config(enabled) WHERE enabled = true;
+`;
+
+export const AGENT_HOST_MULTI_TENANT_DDL = sql`
+  CREATE TABLE IF NOT EXISTS agent_config (
+    id text PRIMARY KEY REFERENCES orgs(id) ON DELETE CASCADE,
+    enabled boolean NOT NULL DEFAULT false,
+    chat_model text NOT NULL,
+    curator_model text,
+    provider_base_url text NOT NULL,
+    provider_api_key_ct text,
+    admin_api_key_ct text,
+    admin_api_key_id text,
+    max_history_chars integer NOT NULL DEFAULT 32000,
+    max_tool_iterations integer NOT NULL DEFAULT 8,
+    debounce_ms integer NOT NULL DEFAULT 500,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+  );
+
+  ALTER TABLE agent_config ADD COLUMN IF NOT EXISTS curator_model text;
+
+  CREATE INDEX IF NOT EXISTS agent_config_enabled_idx
+    ON agent_config(enabled) WHERE enabled = true;
+`;

--- a/packages/agent-host/src/service-context.ts
+++ b/packages/agent-host/src/service-context.ts
@@ -1,0 +1,17 @@
+import { randomUUID } from 'node:crypto';
+import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
+import type { Db } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+
+export function runWithServiceContext<T>(
+  db: Db,
+  configId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const actor = new ActorIdentity('system', 'agent-host', configId, ['*'], ['admin']);
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+    const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+    return withContext(ctx, fn);
+  });
+}

--- a/packages/agent-host/src/singleton-config.repository.ts
+++ b/packages/agent-host/src/singleton-config.repository.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { decryptSecretSql, encryptSecretSql, getCurrentContext } from '@getmunin/core';
+import { eq, sql } from 'drizzle-orm';
+import { agentConfig, SINGLETON_ID } from './schema.js';
+import type {
+  AgentConfigPatch,
+  AgentConfigRepository,
+  AgentConfigRow,
+} from './config.repository.js';
+
+@Injectable()
+export class SingletonConfigRepository implements AgentConfigRepository {
+  resolveCurrentId(): string {
+    return SINGLETON_ID;
+  }
+
+  async read(id: string): Promise<AgentConfigRow> {
+    assertSingleton(id);
+    return readRow(SINGLETON_ID, true);
+  }
+
+  async update(id: string, patch: AgentConfigPatch): Promise<AgentConfigRow> {
+    assertSingleton(id);
+    await applyPatch(SINGLETON_ID, patch);
+    return readRow(SINGLETON_ID, false);
+  }
+
+  async listEnabledIds(): Promise<string[]> {
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select({ id: agentConfig.id })
+      .from(agentConfig)
+      .where(eq(agentConfig.enabled, true))
+      .limit(1);
+    return rows.map((r) => r.id);
+  }
+
+  async readDecryptedProviderKey(id: string): Promise<string | null> {
+    return readDecryptedKey(id, 'provider_api_key_ct');
+  }
+
+  async readDecryptedAdminKey(id: string): Promise<string | null> {
+    return readDecryptedKey(id, 'admin_api_key_ct');
+  }
+}
+
+function assertSingleton(id: string): void {
+  if (id !== SINGLETON_ID) {
+    throw new Error(`SingletonConfigRepository only handles id='${SINGLETON_ID}', got '${id}'`);
+  }
+}
+
+async function readRow(id: string, createIfMissing: boolean): Promise<AgentConfigRow> {
+  const ctx = getCurrentContext();
+  const rows = await ctx.db
+    .select({
+      id: agentConfig.id,
+      enabled: agentConfig.enabled,
+      chatModel: agentConfig.chatModel,
+      curatorModel: agentConfig.curatorModel,
+      providerBaseUrl: agentConfig.providerBaseUrl,
+      providerKeySet: sql<boolean>`(${agentConfig.providerApiKeyCt} IS NOT NULL)`,
+      maxHistoryChars: agentConfig.maxHistoryChars,
+      maxToolIterations: agentConfig.maxToolIterations,
+      debounceMs: agentConfig.debounceMs,
+      adminApiKeyId: agentConfig.adminApiKeyId,
+      createdAt: agentConfig.createdAt,
+      updatedAt: agentConfig.updatedAt,
+    })
+    .from(agentConfig)
+    .where(eq(agentConfig.id, id))
+    .limit(1);
+  const row = rows[0];
+  if (row) {
+    return {
+      id: row.id,
+      enabled: row.enabled,
+      chatModel: row.chatModel,
+      curatorModel: row.curatorModel,
+      providerBaseUrl: row.providerBaseUrl,
+      providerApiKeySet: row.providerKeySet,
+      maxHistoryChars: row.maxHistoryChars,
+      maxToolIterations: row.maxToolIterations,
+      debounceMs: row.debounceMs,
+      adminApiKeyId: row.adminApiKeyId,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+  if (!createIfMissing) {
+    throw new Error(`agent_config row missing for id='${id}'`);
+  }
+  await ctx.db.execute(
+    sql`INSERT INTO agent_config (id) VALUES (${id}) ON CONFLICT (id) DO NOTHING`,
+  );
+  return readRow(id, false);
+}
+
+async function applyPatch(id: string, patch: AgentConfigPatch): Promise<void> {
+  const ctx = getCurrentContext();
+  const setClauses: Record<string, unknown> = {};
+  if (patch.enabled !== undefined) setClauses['enabled'] = patch.enabled;
+  if (patch.chatModel !== undefined) setClauses['chatModel'] = patch.chatModel;
+  if (patch.curatorModel !== undefined) setClauses['curatorModel'] = patch.curatorModel;
+  if (patch.providerBaseUrl !== undefined) setClauses['providerBaseUrl'] = patch.providerBaseUrl;
+  if (patch.maxHistoryChars !== undefined) setClauses['maxHistoryChars'] = patch.maxHistoryChars;
+  if (patch.maxToolIterations !== undefined) setClauses['maxToolIterations'] = patch.maxToolIterations;
+  if (patch.debounceMs !== undefined) setClauses['debounceMs'] = patch.debounceMs;
+  setClauses['updatedAt'] = new Date();
+
+  if (Object.keys(setClauses).length > 1) {
+    await ctx.db.update(agentConfig).set(setClauses).where(eq(agentConfig.id, id));
+  }
+
+  if (patch.providerApiKey === null) {
+    await ctx.db.execute(
+      sql`UPDATE agent_config SET provider_api_key_ct = NULL, updated_at = now()
+          WHERE id = ${id}`,
+    );
+  } else if (typeof patch.providerApiKey === 'string' && patch.providerApiKey.length > 0) {
+    await ctx.db.execute(
+      sql`UPDATE agent_config
+          SET provider_api_key_ct = ${encryptSecretSql(patch.providerApiKey)},
+              updated_at = now()
+          WHERE id = ${id}`,
+    );
+  }
+}
+
+async function readDecryptedKey(id: string, column: string): Promise<string | null> {
+  const ctx = getCurrentContext();
+  const colSql = sql.raw(column);
+  const rows = await ctx.db.execute<{ key: string | null } & Record<string, unknown>>(
+    sql`SELECT ${decryptSecretSql(colSql)} AS key
+        FROM agent_config
+        WHERE id = ${id} AND ${colSql} IS NOT NULL
+        LIMIT 1`,
+  );
+  return rows[0]?.key ?? null;
+}

--- a/packages/agent-host/tsconfig.json
+++ b/packages/agent-host/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@getmunin/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
 import { WebSocketServer, type WebSocket } from 'ws';
-import type { IncomingMessage } from 'node:http';
+import type { IncomingMessage, Server as HttpServer } from 'node:http';
 import type { Duplex } from 'node:stream';
 import type { Db } from '@getmunin/db';
 import { CredentialResolver, type ResolvedCredential } from '@getmunin/core';
@@ -56,9 +56,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       this.logger.log('realtime gateway disabled via MUNIN_REALTIME_DISABLED');
       return;
     }
-    const httpServer = this.adapterHost.httpAdapter.getHttpServer() as
-      | { on(event: string, listener: (...args: unknown[]) => void): void }
-      | null;
+    const httpServer = this.adapterHost.httpAdapter.getHttpServer() as HttpServer | null;
     if (!httpServer) {
       this.logger.warn('http server not available; realtime gateway inactive');
       return;
@@ -81,10 +79,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       void this.handleUpgrade(req, socket, head);
     };
     this.upgradeListener = listener;
-    (httpServer as unknown as { on: (e: string, l: typeof listener) => void }).on(
-      'upgrade',
-      listener,
-    );
+    httpServer.on('upgrade', listener);
     this.logger.log(`gateway listening on ${PATH}`);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ importers:
         version: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl:
         specifier: ^4.11.0
-        version: 4.11.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.11.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -248,6 +248,61 @@ importers:
       tailwindcss:
         specifier: ^3.4.13
         version: 3.4.19(tsx@4.21.0)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)(jiti@1.21.7)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)
+
+  packages/agent-host:
+    dependencies:
+      '@getmunin/agent-runtime':
+        specifier: workspace:*
+        version: link:../agent-runtime
+      '@getmunin/backend-core':
+        specifier: workspace:*
+        version: link:../backend-core
+      '@getmunin/core':
+        specifier: workspace:*
+        version: link:../core
+      '@getmunin/db':
+        specifier: workspace:*
+        version: link:../db
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+      '@nestjs/common':
+        specifier: ^11.1.19
+        version: 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.1.19
+        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.16)(postgres@3.4.9)
+      postgres:
+        specifier: ^3.4.5
+        version: 3.4.9
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@getmunin/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@getmunin/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^22.7.0
+        version: 22.19.17
+      eslint:
+        specifier: ^9.10.0
+        version: 9.39.4(jiti@1.21.7)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -482,7 +537,7 @@ importers:
         version: 1.14.0(react@19.2.5)
       next-intl:
         specifier: ^4.0.0
-        version: 4.11.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.11.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -10134,7 +10189,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.11.0: {}
 
-  next-intl@4.11.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+  next-intl@4.11.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.5
       '@parcel/watcher': 2.5.6


### PR DESCRIPTION
## Summary

New \`@getmunin/agent-host\` package — a hosting layer that lets either single-tenant or multi-tenant backends run the agent in-process. This is foundation work; nothing imports the package yet, so it can sit dormant and merge independently.

Motivating threads:
- **DX for OSS adoption**: today the agent runs in a separate \`apps/agent-sidecar\` process behind an opt-in docker-compose profile. Bundling matches what cloud already does and gives one-container quickstart.
- **Curator model split**: end-user chat and KB/CRM/CMS curation share one \`model\` field today. Curation runs less often but reasons over more text — needs a stronger model. Schema can't express this. Was the root cause of the malformed \`<parameter name=\"sourceConversationId\">\` leak we hit on 2026-05-06.
- **Reduce duplication**: \`@munin-cloud/self-service-ai\` is 80% of what OSS also needs. Folding it into a shared package (and deleting the cloud-only one in a follow-up PR) keeps a single mental model.

## What's in the package

- **\`agent_config\` table** with two DDL variants (\`AGENT_HOST_SINGLETON_DDL\`, \`AGENT_HOST_MULTI_TENANT_DDL\`) and a \`chat_model\` / \`curator_model\` split.
- **\`AgentConfigRepository\`** + \`SingletonConfigRepository\` and \`PerOrgConfigRepository\` impls. Decrypted secrets via the existing pgcrypto helpers from \`@getmunin/core\`.
- **\`AdminKeyProvider\`** + \`NoopAdminKeyProvider\` (operator-provisioned creds) and \`AutoMintAdminKeyProvider\` (mints/revokes per-config admin keys on enable/disable).
- **\`AgentHostRunner\`** — bundled reconcile loop. Multi-replica safe:
  - Curator drains on every replica via existing \`SELECT … FOR UPDATE SKIP LOCKED\` → linear throughput scaling.
  - Realtime subscribes per replica.
  - Chat handler gated by \`ReplicaLockManager.holds(id)\` so only the lock-holder replies.
  - Per-tenant lock distribution: replica A may hold orgs {1,3,5}, replica B {2,4,6}; on A crash, B picks up A's locks within ~30s.
  - Two-tier dispatch: \`chatModel\` for ConversationHandler, \`curatorModel ?? chatModel\` for \`runSkillPass\`.
- **\`ReplicaLockManager\`** — pins a postgres-js connection via \`sql.reserve()\` and uses \`pg_try_advisory_lock(hashtextextended('agent_host:<id>', 0))\`. Auto-resets on connection drop.
- **\`AgentModelsService\`** — \`/v1/models\` proxy. Returns objective fields (\`id\`, \`contextLength\`, \`promptCostPerMillion\`, \`completionCostPerMillion\`) parsed from OpenAI-compat responses (OpenRouter and Anthropic include these; raw OpenAI gives \`null\`). 10-min in-memory cache. Falls back to \`{ supported: false }\` on non-OAI-compat providers so the UI can render a free-text input.
- **\`AgentConfigController\`** — \`GET/PUT /api/agent-config\` + \`GET /api/agent-config/models\`, user-actor only.
- **\`AgentHostModule.forRoot({ configRepository, adminKeyProvider, db, runnerOptions })\`** wires it all up.

Also includes a small drive-by cleanup: \`backend-core/realtime.gateway.ts\` was double-casting \`httpServer\` through \`as unknown as { on(…) }\`. Now uses Node's \`http.Server\` type directly — no \`unknown\` cast.

## Follow-up PRs (planned)

1. Wire OSS backend to \`AgentHostModule\` + apply singleton DDL.
2. Setup wizard + \`/setup\` route in OSS.
3. Slim \`apps/agent-sidecar\` to a thin REST shell over the same module.
4. Switch cloud to the new package + delete \`@munin-cloud/self-service-ai\`.

## Test plan

- [x] \`pnpm --filter @getmunin/agent-host build\` clean
- [x] \`pnpm --filter @getmunin/agent-host typecheck\` clean
- [x] \`pnpm --filter @getmunin/agent-host lint\` clean
- [x] \`pnpm --filter @getmunin/backend-core typecheck && lint\` clean (after gateway cleanup)
- [ ] End-to-end (deferred to wiring PRs)
- [ ] Multi-replica regression with two backend replicas + advisory-lock failover (deferred to wiring PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)