### PR TITLE
feat(backend): wire AgentHostModule into OSS backend

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,11 +8,13 @@
     "build": "nest build",
     "dev": "nest start --watch",
     "start": "node dist/main.js",
+    "migrate": "tsx src/migrate.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@getmunin/agent-host": "workspace:*",
     "@getmunin/backend-core": "workspace:*",
     "@getmunin/core": "workspace:*",
     "@getmunin/db": "workspace:*",
@@ -22,6 +24,7 @@
     "better-auth": "^1.1.0",
     "drizzle-orm": "^0.45.2",
     "express": "^5.1.0",
+    "postgres": "^3.4.5",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "@sentry/nestjs": "^10.51.0",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -6,10 +6,23 @@ import {
   BACKEND_BASE_PROVIDERS,
   BACKEND_FEATURE_MODULES_NO_AUTH,
 } from '@getmunin/backend-core';
+import {
+  AgentHostModule,
+  NoopAdminKeyProvider,
+  SingletonConfigRepository,
+} from '@getmunin/agent-host';
 import { AuthModule } from './auth/auth.module.js';
 
 @Module({
-  imports: [SentryModule.forRoot(), ...BACKEND_FEATURE_MODULES_NO_AUTH, AuthModule],
+  imports: [
+    SentryModule.forRoot(),
+    ...BACKEND_FEATURE_MODULES_NO_AUTH,
+    AuthModule,
+    AgentHostModule.forRoot({
+      configRepository: SingletonConfigRepository,
+      adminKeyProvider: NoopAdminKeyProvider,
+    }),
+  ],
   controllers: BACKEND_BASE_CONTROLLERS,
   providers: [{ provide: APP_FILTER, useClass: SentryGlobalFilter }, ...BACKEND_BASE_PROVIDERS],
 })

--- a/apps/backend/src/migrate.ts
+++ b/apps/backend/src/migrate.ts
@@ -1,0 +1,36 @@
+/**
+ * OSS migration entry point. Runs the shared schema (extensions, RLS,
+ * module SQL, app role) from @getmunin/db, then layers the agent-host
+ * singleton DDL on top.
+ *
+ *   pnpm --filter @getmunin/backend migrate
+ *
+ * Reads MUNIN_MIGRATE_URL (privileged superuser URL — not the runtime
+ * munin_app role). Both halves are idempotent.
+ */
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { runMigrations } from '@getmunin/db';
+import { AGENT_HOST_SINGLETON_DDL } from '@getmunin/agent-host';
+
+async function main(): Promise<void> {
+  const url = process.env.MUNIN_MIGRATE_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    console.error('MUNIN_MIGRATE_URL (or DATABASE_URL) is required');
+    process.exit(1);
+  }
+
+  await runMigrations(url);
+  console.log('OSS schema applied');
+
+  const client = postgres(url, { max: 1 });
+  try {
+    const db = drizzle(client);
+    await db.execute(AGENT_HOST_SINGLETON_DDL);
+    console.log('agent-host singleton DDL applied');
+  } finally {
+    await client.end();
+  }
+}
+
+void main();

--- a/packages/agent-host/src/module.ts
+++ b/packages/agent-host/src/module.ts
@@ -1,5 +1,5 @@
 import { DynamicModule, Module, Provider, Type } from '@nestjs/common';
-import type { Db } from '@getmunin/db';
+import { DB, DbModule } from '@getmunin/backend-core';
 import { AgentConfigService } from './config.service.js';
 import { AgentConfigController } from './config.controller.js';
 import { AgentModelsService } from './models.service.js';
@@ -15,7 +15,6 @@ import type { AdminKeyProvider } from './admin-key-provider.js';
 export interface AgentHostModuleOptions {
   configRepository: Type<AgentConfigRepository>;
   adminKeyProvider: Type<AdminKeyProvider>;
-  db: Db;
   runnerOptions?: AgentHostRunnerOptions;
 }
 
@@ -30,9 +29,9 @@ export class AgentHostModule {
       provide: ADMIN_KEY_PROVIDER,
       useClass: options.adminKeyProvider,
     };
-    const dbProvider: Provider = {
+    const dbAliasProvider: Provider = {
       provide: AGENT_HOST_DB,
-      useValue: options.db,
+      useExisting: DB,
     };
     const runnerOptionsProvider: Provider = {
       provide: 'AGENT_HOST_RUNNER_OPTIONS',
@@ -40,10 +39,11 @@ export class AgentHostModule {
     };
     return {
       module: AgentHostModule,
+      imports: [DbModule],
       providers: [
         repoProvider,
         keyProvider,
-        dbProvider,
+        dbAliasProvider,
         runnerOptionsProvider,
         options.configRepository,
         options.adminKeyProvider,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
 
   apps/backend:
     dependencies:
+      '@getmunin/agent-host':
+        specifier: workspace:*
+        version: link:../../packages/agent-host
       '@getmunin/backend-core':
         specifier: workspace:*
         version: link:../../packages/backend-core
@@ -102,6 +105,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      postgres:
+        specifier: ^3.4.5
+        version: 3.4.9
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -186,7 +192,7 @@ importers:
         version: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl:
         specifier: ^4.11.0
-        version: 4.11.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.11.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -537,7 +543,7 @@ importers:
         version: 1.14.0(react@19.2.5)
       next-intl:
         specifier: ^4.0.0
-        version: 4.11.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.11.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -10189,7 +10195,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.11.0: {}
 
-  next-intl@4.11.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+  next-intl@4.11.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.5
       '@parcel/watcher': 2.5.6


### PR DESCRIPTION
## Summary

Wires \`@getmunin/agent-host\` (added in #84) into \`apps/backend\`. The OSS backend now hosts the agent runner in-process — same model as cloud, replacing the separate \`apps/agent-sidecar\` process for the default deployment.

- **Single-tenant shape**: \`SingletonConfigRepository\` + \`NoopAdminKeyProvider\`. The agent_config row is materialized as id=\`'singleton'\` on first migration.
- **Gating**: runner respects \`MUNIN_BUILTIN_AGENT\` (default on). Multi-replica deploys: chat handler is gated by a per-config Postgres advisory lock so only the lock-holder replies. Curator queue drains on every replica via existing \`SELECT … FOR UPDATE SKIP LOCKED\` → linear throughput.
- **Admin creds**: this PR keeps the simplest model — the operator provides \`MUNIN_ADMIN_API_KEY\`. (No auto-minting; \`NoopAdminKeyProvider\` no-ops on enable/disable.)
- **Migrate orchestrator**: new \`apps/backend/src/migrate.ts\` mirrors the cloud equivalent — runs OSS schema via \`@getmunin/db\`, then \`db.execute(AGENT_HOST_SINGLETON_DDL)\`. Wired via \`pnpm --filter @getmunin/backend migrate\`.

## Drive-by refactor

\`AgentHostModule.forRoot\` previously took a \`db: Db\` value. That was awkward in Nest's DI lifecycle (the host had to construct the Db before module decoration). Now it uses \`useExisting: DB\` against \`@getmunin/backend-core\`'s \`@Global\` \`DbModule\`. Hosts pass only repository + admin-key-provider classes. Cloud wiring (later PR) benefits from the same simplification.

## What this does NOT do (deferred to follow-up PRs)

- Setup wizard (\`/setup\` route in \`apps/web\`) — operators currently set creds via REST or directly in DB.
- Sidecar slim — \`apps/agent-sidecar\` still runs as before. Follow-up PR makes it a thin REST shell over the same module.
- Cloud wiring + delete \`@munin-cloud/self-service-ai\` — separate PR; that one carries the production schema rename.

## Test plan

- [x] \`pnpm -r typecheck\` — all 17 packages clean
- [x] \`pnpm --filter @getmunin/backend lint\` clean
- [x] \`pnpm --filter @getmunin/backend build\` clean
- [ ] Local smoke: fresh DB, \`pnpm --filter @getmunin/backend migrate\`, start the backend, confirm \`agent_config\` row exists with id='singleton' and the runner logs \`bundled agent runner disabled via MUNIN_BUILTIN_AGENT=0\` when explicitly disabled.
- [ ] Multi-replica advisory-lock failover (requires a real two-replica deploy; deferred to verification PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)