### PR TITLE
feat(web): /setup route for agent configuration

### DIFF
--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { AgentSetupPage, authClient } from '@getmunin/dashboard-pages';
+import { PageSpinner } from '@getmunin/ui';
+
+export default function SetupRoute() {
+  const router = useRouter();
+  const { data: session, isPending } = authClient.useSession();
+
+  useEffect(() => {
+    if (!isPending && !session) router.push('/login');
+  }, [isPending, session, router]);
+
+  if (isPending || !session) {
+    return <PageSpinner className="min-h-screen bg-bone dark:bg-background" />;
+  }
+
+  return <AgentSetupPage />;
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -377,6 +377,49 @@
       }
     }
   },
+  "agentSetup": {
+    "title": "Configure AI agent",
+    "lede": "Pick an LLM provider, paste an API key, and choose models for chat and curation. The agent only runs once enabled.",
+    "saved": "Saved.",
+    "errors": {
+      "load": "Couldn't load agent config.",
+      "test": "Connection test failed.",
+      "fetchModels": "Couldn't fetch model list.",
+      "save": "Couldn't save."
+    },
+    "provider": {
+      "title": "Provider",
+      "lede": "OpenAI-compatible endpoint. OpenRouter offers a single key with access to many providers.",
+      "urlLabel": "Base URL"
+    },
+    "apiKey": {
+      "title": "API key",
+      "ledeStored": "An API key is stored. Paste a new one to replace it.",
+      "ledeMissing": "Paste your provider API key. Stored encrypted at rest.",
+      "label": "Key",
+      "placeholderStored": "•••••••• (stored)"
+    },
+    "connection": {
+      "test": "Save & test",
+      "testing": "Testing…",
+      "testOk": "Connected — {count} models available.",
+      "testUnsupported": "Connected, but the provider doesn't expose /v1/models. Enter model ids manually."
+    },
+    "models": {
+      "title": "Models",
+      "curatorHint": "Curation runs less often but reasons over more text. Pick a stronger model than chat.",
+      "needKey": "Save an API key to load the model list.",
+      "unsupported": "Provider didn't return a model list. Enter model ids manually (e.g. anthropic/claude-haiku-4.5).",
+      "chat": "Chat model",
+      "curator": "Curator model",
+      "curatorSameAsChat": "Same as chat"
+    },
+    "enable": {
+      "title": "Enable",
+      "lede": "When enabled, the in-process runner starts replying to end-user messages and draining the curator queue.",
+      "checkbox": "AI agent enabled"
+    }
+  },
   "acceptInvite": {
     "pendingTitle": "Accepting your invitation…",
     "pendingBody": "One moment.",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -377,6 +377,49 @@
       }
     }
   },
+  "agentSetup": {
+    "title": "Sett opp AI-agent",
+    "lede": "Velg en LLM-leverandør, lim inn en API-nøkkel, og velg modeller for chat og kurering. Agenten kjører først når den er aktivert.",
+    "saved": "Lagret.",
+    "errors": {
+      "load": "Kunne ikke laste agent-konfigurasjon.",
+      "test": "Tilkoblingstest feilet.",
+      "fetchModels": "Kunne ikke hente modell-liste.",
+      "save": "Kunne ikke lagre."
+    },
+    "provider": {
+      "title": "Leverandør",
+      "lede": "OpenAI-kompatibelt endepunkt. OpenRouter gir én nøkkel med tilgang til mange leverandører.",
+      "urlLabel": "Base-URL"
+    },
+    "apiKey": {
+      "title": "API-nøkkel",
+      "ledeStored": "En API-nøkkel er lagret. Lim inn en ny for å erstatte.",
+      "ledeMissing": "Lim inn API-nøkkelen din. Lagres kryptert.",
+      "label": "Nøkkel",
+      "placeholderStored": "•••••••• (lagret)"
+    },
+    "connection": {
+      "test": "Lagre og test",
+      "testing": "Tester…",
+      "testOk": "Tilkoblet — {count} modeller tilgjengelig.",
+      "testUnsupported": "Tilkoblet, men leverandøren støtter ikke /v1/models. Skriv inn modell-ID-er manuelt."
+    },
+    "models": {
+      "title": "Modeller",
+      "curatorHint": "Kurering kjører sjeldnere, men resonnerer over mer tekst. Velg en sterkere modell enn for chat.",
+      "needKey": "Lagre en API-nøkkel for å hente modell-listen.",
+      "unsupported": "Leverandøren returnerte ingen modell-liste. Skriv inn modell-ID-er manuelt (f.eks. anthropic/claude-haiku-4.5).",
+      "chat": "Chat-modell",
+      "curator": "Kurator-modell",
+      "curatorSameAsChat": "Samme som chat"
+    },
+    "enable": {
+      "title": "Aktivér",
+      "lede": "Når aktivert vil den innebygde runneren begynne å svare på sluttbruker-meldinger og tømme kurator-køen.",
+      "checkbox": "AI-agent aktivert"
+    }
+  },
   "acceptInvite": {
     "pendingTitle": "Aksepterer invitasjonen…",
     "pendingBody": "Et øyeblikk.",

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -5,6 +5,7 @@ export { PageShell, nativeFieldClass } from './components/page-shell';
 export { useActiveRole, isOwnerOrAdmin, type OrgRole } from './auth/use-active-role';
 
 export { AcceptInvitePage } from './pages/accept-invite';
+export { AgentSetupPage } from './pages/agent-setup';
 export { AgentsPage } from './pages/agents';
 export { ApiKeysPage } from './pages/api-keys';
 export { AuditLogPage } from './pages/audit-log';

--- a/packages/dashboard-pages/src/pages/agent-setup.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup.tsx
@@ -1,0 +1,397 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Hero,
+  Input,
+  Label,
+} from '@getmunin/ui';
+import { api } from '../api';
+import { nativeFieldClass } from '../components/page-shell';
+import { useTranslateError } from '../i18n/translate-error';
+
+interface AgentConfigDto {
+  id: string;
+  enabled: boolean;
+  chatModel: string;
+  curatorModel: string | null;
+  providerBaseUrl: string;
+  providerApiKeySet: boolean;
+  maxHistoryChars: number;
+  maxToolIterations: number;
+  debounceMs: number;
+}
+
+interface ModelEntry {
+  id: string;
+  contextLength: number | null;
+  promptCostPerMillion: number | null;
+  completionCostPerMillion: number | null;
+}
+
+interface ListModelsResult {
+  supported: boolean;
+  models: ModelEntry[];
+}
+
+interface UpsertBody {
+  providerBaseUrl?: string;
+  providerApiKey?: string | null;
+  chatModel?: string;
+  curatorModel?: string | null;
+  enabled?: boolean;
+}
+
+const PROVIDER_PRESETS = [
+  { id: 'openrouter', name: 'OpenRouter', url: 'https://openrouter.ai/api/v1' },
+  { id: 'anthropic', name: 'Anthropic', url: 'https://api.anthropic.com/v1' },
+  { id: 'openai', name: 'OpenAI', url: 'https://api.openai.com/v1' },
+  { id: 'custom', name: 'Custom', url: '' },
+] as const;
+
+type PresetId = (typeof PROVIDER_PRESETS)[number]['id'];
+
+function presetForUrl(url: string): PresetId {
+  const match = PROVIDER_PRESETS.find((p) => p.url === url);
+  return match?.id ?? 'custom';
+}
+
+export function AgentSetupPage() {
+  const t = useTranslations('agentSetup');
+  const tCommon = useTranslations('common');
+  const translate = useTranslateError();
+
+  const [config, setConfig] = useState<AgentConfigDto | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [preset, setPreset] = useState<PresetId>('openrouter');
+  const [providerBaseUrl, setProviderBaseUrl] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [keyDirty, setKeyDirty] = useState(false);
+
+  const [chatModel, setChatModel] = useState('');
+  const [curatorModel, setCuratorModel] = useState('');
+  const [enabled, setEnabled] = useState(false);
+
+  const [models, setModels] = useState<ListModelsResult | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoadError(null);
+      const cfg = await api<AgentConfigDto>('/api/agent-config');
+      setConfig(cfg);
+      setProviderBaseUrl(cfg.providerBaseUrl);
+      setPreset(presetForUrl(cfg.providerBaseUrl));
+      setChatModel(cfg.chatModel);
+      setCuratorModel(cfg.curatorModel ?? '');
+      setEnabled(cfg.enabled);
+    } catch (err) {
+      setLoadError(translate(err) || t('errors.load'));
+    }
+  }, [t, translate]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const refreshModels = useCallback(async () => {
+    try {
+      const result = await api<ListModelsResult>('/api/agent-config/models');
+      setModels(result);
+    } catch (err) {
+      setActionError(translate(err) || t('errors.fetchModels'));
+    }
+  }, [t, translate]);
+
+  useEffect(() => {
+    if (config?.providerApiKeySet) {
+      void refreshModels();
+    }
+  }, [config?.providerApiKeySet, refreshModels]);
+
+  function selectPreset(id: PresetId) {
+    setPreset(id);
+    const match = PROVIDER_PRESETS.find((p) => p.id === id);
+    if (match && id !== 'custom') setProviderBaseUrl(match.url);
+  }
+
+  async function saveConnection() {
+    setActionError(null);
+    setActionMessage(null);
+    setTesting(true);
+    try {
+      const body: UpsertBody = { providerBaseUrl };
+      if (keyDirty && apiKey.length > 0) body.providerApiKey = apiKey;
+      const updated = await api<AgentConfigDto>('/api/agent-config', {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      });
+      setConfig(updated);
+      setApiKey('');
+      setKeyDirty(false);
+      const result = await api<ListModelsResult>('/api/agent-config/models');
+      setModels(result);
+      setActionMessage(
+        result.supported
+          ? t('connection.testOk', { count: result.models.length })
+          : t('connection.testUnsupported'),
+      );
+    } catch (err) {
+      setActionError(translate(err) || t('errors.test'));
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  async function saveModelsAndEnable() {
+    setActionError(null);
+    setActionMessage(null);
+    setSaving(true);
+    try {
+      const updated = await api<AgentConfigDto>('/api/agent-config', {
+        method: 'PUT',
+        body: JSON.stringify({
+          chatModel,
+          curatorModel: curatorModel || null,
+          enabled,
+        }),
+      });
+      setConfig(updated);
+      setActionMessage(t('saved'));
+    } catch (err) {
+      setActionError(translate(err) || t('errors.save'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const sortedModels = useMemo(() => {
+    if (!models?.supported) return [];
+    return [...models.models].sort((a, b) => a.id.localeCompare(b.id));
+  }, [models]);
+
+  const canSaveModels =
+    config?.providerApiKeySet === true &&
+    chatModel.length > 0 &&
+    !saving;
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-6 py-12">
+      <Hero title={t('title')} lede={t('lede')} />
+
+      {loadError && (
+        <Card className="mt-6">
+          <CardContent className="py-4 text-sm text-destructive">{loadError}</CardContent>
+        </Card>
+      )}
+
+      {config === null && !loadError && (
+        <p className="mt-6 text-sm text-muted-foreground">{tCommon('loading')}</p>
+      )}
+
+      {config && (
+        <div className="mt-8 space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('provider.title')}</CardTitle>
+              <CardDescription>{t('provider.lede')}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                {PROVIDER_PRESETS.map((p) => (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() => selectPreset(p.id)}
+                    className={
+                      'rounded-input border px-3 py-2 text-sm transition-colors ' +
+                      (preset === p.id
+                        ? 'border-cobalt bg-cobalt/5 text-ink dark:text-foreground'
+                        : 'border-rule-soft text-muted-foreground hover:text-ink dark:hover:text-foreground')
+                    }
+                  >
+                    {p.name}
+                  </button>
+                ))}
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="providerBaseUrl">{t('provider.urlLabel')}</Label>
+                <Input
+                  id="providerBaseUrl"
+                  value={providerBaseUrl}
+                  onChange={(e) => {
+                    setProviderBaseUrl(e.target.value);
+                    setPreset('custom');
+                  }}
+                  placeholder="https://..."
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('apiKey.title')}</CardTitle>
+              <CardDescription>
+                {config.providerApiKeySet
+                  ? t('apiKey.ledeStored')
+                  : t('apiKey.ledeMissing')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="apiKey">{t('apiKey.label')}</Label>
+                <Input
+                  id="apiKey"
+                  type="password"
+                  value={apiKey}
+                  placeholder={config.providerApiKeySet ? t('apiKey.placeholderStored') : ''}
+                  onChange={(e) => {
+                    setApiKey(e.target.value);
+                    setKeyDirty(true);
+                  }}
+                />
+              </div>
+              <div className="flex items-center gap-3">
+                <Button
+                  type="button"
+                  onClick={() => void saveConnection()}
+                  disabled={
+                    testing ||
+                    providerBaseUrl.length === 0 ||
+                    (!config.providerApiKeySet && apiKey.length === 0)
+                  }
+                >
+                  {testing ? t('connection.testing') : t('connection.test')}
+                </Button>
+                {actionMessage && (
+                  <span className="text-sm text-muted-foreground">{actionMessage}</span>
+                )}
+              </div>
+              {actionError && (
+                <p className="text-sm text-destructive">{actionError}</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('models.title')}</CardTitle>
+              <CardDescription>{t('models.curatorHint')}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {!config.providerApiKeySet ? (
+                <p className="text-sm text-muted-foreground">{t('models.needKey')}</p>
+              ) : models?.supported ? (
+                <>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="chatModel">{t('models.chat')}</Label>
+                    <select
+                      id="chatModel"
+                      className={nativeFieldClass}
+                      value={chatModel}
+                      onChange={(e) => setChatModel(e.target.value)}
+                    >
+                      {sortedModels.map((m) => (
+                        <option key={m.id} value={m.id}>
+                          {formatModel(m)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="curatorModel">{t('models.curator')}</Label>
+                    <select
+                      id="curatorModel"
+                      className={nativeFieldClass}
+                      value={curatorModel}
+                      onChange={(e) => setCuratorModel(e.target.value)}
+                    >
+                      <option value="">{t('models.curatorSameAsChat')}</option>
+                      {sortedModels.map((m) => (
+                        <option key={m.id} value={m.id}>
+                          {formatModel(m)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </>
+              ) : models && !models.supported ? (
+                <>
+                  <p className="text-sm text-muted-foreground">{t('models.unsupported')}</p>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="chatModelText">{t('models.chat')}</Label>
+                    <Input
+                      id="chatModelText"
+                      value={chatModel}
+                      onChange={(e) => setChatModel(e.target.value)}
+                      placeholder="provider/model-name"
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="curatorModelText">{t('models.curator')}</Label>
+                    <Input
+                      id="curatorModelText"
+                      value={curatorModel}
+                      onChange={(e) => setCuratorModel(e.target.value)}
+                      placeholder={t('models.curatorSameAsChat')}
+                    />
+                  </div>
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('enable.title')}</CardTitle>
+              <CardDescription>{t('enable.lede')}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={enabled}
+                  onChange={(e) => setEnabled(e.target.checked)}
+                />
+                <span>{t('enable.checkbox')}</span>
+              </label>
+              <Button
+                type="button"
+                onClick={() => void saveModelsAndEnable()}
+                disabled={!canSaveModels}
+              >
+                {saving ? tCommon('save') + '…' : tCommon('save')}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </main>
+  );
+}
+
+function formatModel(m: ModelEntry): string {
+  const parts: string[] = [m.id];
+  if (m.contextLength) parts.push(`${(m.contextLength / 1000).toFixed(0)}k ctx`);
+  if (m.promptCostPerMillion !== null) {
+    parts.push(`$${m.promptCostPerMillion.toFixed(2)}/M in`);
+  }
+  if (m.completionCostPerMillion !== null) {
+    parts.push(`$${m.completionCostPerMillion.toFixed(2)}/M out`);
+  }
+  return parts.join(' · ');
+}


### PR DESCRIPTION
## Summary

First-run UX for the bundled agent runner. Adds a \`/setup\` page where operators pick a provider, paste an API key, and choose chat + curator models — all on one page with progressive reveal.

## Flow

1. Pick a provider preset (OpenRouter / Anthropic / OpenAI / Custom URL) → fills in base URL.
2. Paste API key → "Save & test".
3. On success: page loads the provider's \`/v1/models\` and shows two dropdowns (chat + curator). Curator has a "Same as chat" default and a hint line: *"Curation runs less often but reasons over more text. Pick a stronger model than chat."*
4. On providers without \`/v1/models\` (raw OpenAI, some self-hosted endpoints): falls back to free-text inputs.
5. Toggle "AI agent enabled" and save.

Model option labels include context length and prompt/completion price per million when the provider returns them (OpenRouter and Anthropic include these; OpenAI/null otherwise).

## Auth

The route is auth-gated (redirects to \`/login\` when no session) using the same \`authClient.useSession()\` pattern as \`/dashboard\`. Not auto-redirected to from dashboard — operators visit \`/setup\` when they want to enable the agent. A soft "configure AI" banner from the dashboard can come later as polish.

## Files

- \`apps/web/app/setup/page.tsx\` — Next.js route shell with auth gate
- \`packages/dashboard-pages/src/pages/agent-setup.tsx\` — the page component
- \`apps/web/messages/{en,nb}.json\` — i18n strings under \`agentSetup\`

Reuses the existing \`GET/PUT /api/agent-config\` and \`GET /api/agent-config/models\` endpoints from \`@getmunin/agent-host\` (shipped in #84, wired into the OSS backend in #85).

## Test plan

- [x] \`pnpm -r typecheck\` clean
- [x] \`pnpm -r lint\` clean
- [x] \`pnpm --filter @getmunin/web build\` clean — \`/setup\` route appears in route tree
- [ ] Manual: fresh DB → migrate → sign up → visit \`/setup\` → paste OpenRouter key → save & test → pick haiku for chat, sonnet for curator → enable → confirm \`agent_config\` row reflects choices.
- [ ] Manual: revisit \`/setup\` after first save → form pre-populated with current config (key shown as stored, models pre-selected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)