### PR TITLE
test(agent-host): unit cover models proxy + config service

### DIFF
--- a/packages/agent-host/src/config.service.test.ts
+++ b/packages/agent-host/src/config.service.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AgentConfigService } from './config.service.js';
+import type {
+  AgentConfigPatch,
+  AgentConfigRepository,
+  AgentConfigRow,
+} from './config.repository.js';
+import type { AdminKeyProvider } from './admin-key-provider.js';
+
+const baseRow: AgentConfigRow = {
+  id: 'singleton',
+  enabled: false,
+  chatModel: 'anthropic/claude-haiku-4.5',
+  curatorModel: null,
+  providerBaseUrl: 'https://provider.example/v1',
+  providerApiKeySet: false,
+  maxHistoryChars: 32_000,
+  maxToolIterations: 8,
+  debounceMs: 500,
+  adminApiKeyId: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+function makeRepo(opts: {
+  before: AgentConfigRow;
+  after: AgentConfigRow;
+}): AgentConfigRepository & { update: ReturnType<typeof vi.fn> } {
+  const update = vi.fn().mockResolvedValue(opts.after);
+  return {
+    resolveCurrentId: () => opts.before.id,
+    read: vi.fn().mockResolvedValue(opts.before),
+    update,
+    listEnabledIds: vi.fn().mockResolvedValue([]),
+    readDecryptedProviderKey: vi.fn().mockResolvedValue(null),
+    readDecryptedAdminKey: vi.fn().mockResolvedValue(null),
+  };
+}
+
+function makeAdminKey(): AdminKeyProvider & {
+  mint: ReturnType<typeof vi.fn>;
+  revoke: ReturnType<typeof vi.fn>;
+} {
+  return {
+    mint: vi.fn().mockResolvedValue(undefined),
+    revoke: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('AgentConfigService', () => {
+  it('reads + serialises the row into a DTO with ISO timestamps', async () => {
+    const repo = makeRepo({ before: baseRow, after: baseRow });
+    const svc = new AgentConfigService(repo, makeAdminKey());
+    const dto = await svc.getForCurrentActor();
+    expect(dto.id).toBe('singleton');
+    expect(dto.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(dto.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('mints an admin key when enabling and none exists yet', async () => {
+    const after: AgentConfigRow = { ...baseRow, enabled: true };
+    const repo = makeRepo({ before: baseRow, after });
+    const adminKey = makeAdminKey();
+    const svc = new AgentConfigService(repo, adminKey);
+
+    const patch: AgentConfigPatch = { enabled: true };
+    await svc.upsertForCurrentActor(patch);
+
+    expect(adminKey.mint).toHaveBeenCalledWith('singleton');
+    expect(adminKey.revoke).not.toHaveBeenCalled();
+  });
+
+  it('does NOT mint when enabling but an admin key id already exists', async () => {
+    const before: AgentConfigRow = { ...baseRow, adminApiKeyId: 'ak_existing' };
+    const after: AgentConfigRow = { ...before, enabled: true };
+    const repo = makeRepo({ before, after });
+    const adminKey = makeAdminKey();
+    const svc = new AgentConfigService(repo, adminKey);
+
+    await svc.upsertForCurrentActor({ enabled: true });
+
+    expect(adminKey.mint).not.toHaveBeenCalled();
+    expect(adminKey.revoke).not.toHaveBeenCalled();
+  });
+
+  it('revokes the admin key when disabling and one exists', async () => {
+    const before: AgentConfigRow = {
+      ...baseRow,
+      enabled: true,
+      adminApiKeyId: 'ak_to_revoke',
+    };
+    const after: AgentConfigRow = { ...before, enabled: false };
+    const repo = makeRepo({ before, after });
+    const adminKey = makeAdminKey();
+    const svc = new AgentConfigService(repo, adminKey);
+
+    await svc.upsertForCurrentActor({ enabled: false });
+
+    expect(adminKey.revoke).toHaveBeenCalledWith('singleton', 'ak_to_revoke');
+    expect(adminKey.mint).not.toHaveBeenCalled();
+  });
+
+  it('skips mint/revoke for patches that do not flip enabled', async () => {
+    const repo = makeRepo({ before: baseRow, after: baseRow });
+    const adminKey = makeAdminKey();
+    const svc = new AgentConfigService(repo, adminKey);
+
+    await svc.upsertForCurrentActor({ chatModel: 'anthropic/claude-sonnet-4-6' });
+
+    expect(adminKey.mint).not.toHaveBeenCalled();
+    expect(adminKey.revoke).not.toHaveBeenCalled();
+  });
+
+  it('passes the patch through to the repo verbatim', async () => {
+    const repo = makeRepo({ before: baseRow, after: baseRow });
+    const svc = new AgentConfigService(repo, makeAdminKey());
+
+    const patch: AgentConfigPatch = {
+      chatModel: 'a',
+      curatorModel: 'b',
+      providerBaseUrl: 'https://x',
+      maxHistoryChars: 64_000,
+    };
+    await svc.upsertForCurrentActor(patch);
+
+    expect(repo.update).toHaveBeenCalledWith('singleton', patch);
+  });
+});

--- a/packages/agent-host/src/models.service.test.ts
+++ b/packages/agent-host/src/models.service.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentModelsService } from './models.service.js';
+import type { AgentConfigRepository, AgentConfigRow } from './config.repository.js';
+
+const baseRow: AgentConfigRow = {
+  id: 'singleton',
+  enabled: false,
+  chatModel: 'anthropic/claude-haiku-4.5',
+  curatorModel: null,
+  providerBaseUrl: 'https://provider.example/v1',
+  providerApiKeySet: true,
+  maxHistoryChars: 32_000,
+  maxToolIterations: 8,
+  debounceMs: 500,
+  adminApiKeyId: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function makeRepo(overrides: { apiKey?: string | null; row?: AgentConfigRow } = {}): AgentConfigRepository {
+  const row = overrides.row ?? baseRow;
+  const apiKey = 'apiKey' in overrides ? overrides.apiKey : 'sk-test';
+  return {
+    resolveCurrentId: () => row.id,
+    read: vi.fn().mockResolvedValue(row),
+    update: vi.fn().mockResolvedValue(row),
+    listEnabledIds: vi.fn().mockResolvedValue([]),
+    readDecryptedProviderKey: vi.fn().mockResolvedValue(apiKey),
+    readDecryptedAdminKey: vi.fn().mockResolvedValue(null),
+  };
+}
+
+function mockFetch(response: { status: number; body?: unknown }): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: response.status >= 200 && response.status < 300,
+      status: response.status,
+      json: () => Promise.resolve(response.body),
+    }),
+  );
+}
+
+describe('AgentModelsService', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns supported:false when no provider key is stored', async () => {
+    const repo = makeRepo({ apiKey: null });
+    const svc = new AgentModelsService(repo);
+    const result = await svc.listForCurrentActor();
+    expect(result.supported).toBe(false);
+    expect(result.models).toEqual([]);
+  });
+
+  it('parses OpenRouter-shaped responses with context_length and pricing', async () => {
+    mockFetch({
+      status: 200,
+      body: {
+        data: [
+          {
+            id: 'anthropic/claude-haiku-4.5',
+            context_length: 200_000,
+            pricing: { prompt: '0.000001', completion: '0.000005' },
+          },
+          {
+            id: 'anthropic/claude-sonnet-4-6',
+            context_length: 200_000,
+            pricing: { prompt: '0.000003', completion: '0.000015' },
+          },
+        ],
+      },
+    });
+    const svc = new AgentModelsService(makeRepo());
+    const result = await svc.listForCurrentActor();
+    expect(result.supported).toBe(true);
+    expect(result.models).toHaveLength(2);
+    expect(result.models[0]).toEqual({
+      id: 'anthropic/claude-haiku-4.5',
+      contextLength: 200_000,
+      promptCostPerMillion: 1,
+      completionCostPerMillion: 5,
+    });
+    expect(result.models[1]?.promptCostPerMillion).toBe(3);
+  });
+
+  it('handles entries without pricing or context_length (raw OpenAI shape)', async () => {
+    mockFetch({
+      status: 200,
+      body: {
+        data: [
+          { id: 'gpt-4o-mini', object: 'model', created: 0, owned_by: 'openai' },
+        ],
+      },
+    });
+    const svc = new AgentModelsService(makeRepo());
+    const result = await svc.listForCurrentActor();
+    expect(result.supported).toBe(true);
+    expect(result.models[0]).toEqual({
+      id: 'gpt-4o-mini',
+      contextLength: null,
+      promptCostPerMillion: null,
+      completionCostPerMillion: null,
+    });
+  });
+
+  it('returns supported:false when the provider returns 404', async () => {
+    mockFetch({ status: 404 });
+    const svc = new AgentModelsService(makeRepo());
+    const result = await svc.listForCurrentActor();
+    expect(result.supported).toBe(false);
+    expect(result.models).toEqual([]);
+  });
+
+  it('returns supported:false when the body is not the expected shape', async () => {
+    mockFetch({ status: 200, body: { unexpected: 'shape' } });
+    const svc = new AgentModelsService(makeRepo());
+    const result = await svc.listForCurrentActor();
+    expect(result.supported).toBe(false);
+  });
+
+  it('caches the response for the same (id, baseUrl) pair', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: [{ id: 'm-1' }] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const svc = new AgentModelsService(makeRepo());
+    await svc.listForCurrentActor();
+    await svc.listForCurrentActor();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips trailing slashes from the base URL before appending /models', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const repo = makeRepo({
+      row: { ...baseRow, providerBaseUrl: 'https://provider.example/v1//' },
+    });
+    const svc = new AgentModelsService(repo);
+    await svc.listForCurrentActor();
+    const calledUrl: unknown = fetchMock.mock.calls[0]?.[0];
+    expect(calledUrl).toBe('https://provider.example/v1/models');
+  });
+});


### PR DESCRIPTION
## Summary

Two new test files for \`@getmunin/agent-host\` covering the parts most worth locking in before downstream consumers wire it up. 13 tests, all pass under \`pnpm --filter @getmunin/agent-host test\`.

## \`models.service.test.ts\` (7 tests)

- \`supported: false\` short-circuit when no provider key is stored
- OpenRouter-shaped responses parse \`context_length\` + \`pricing\` into per-million USD numbers
- Raw OpenAI shape (no \`context_length\` / \`pricing\`) leaves those fields \`null\` instead of throwing
- \`404\` from the provider → \`supported: false\`
- Body without a \`data\` array → \`supported: false\`
- 10-minute cache: second call doesn't re-fetch
- Trailing slashes on \`providerBaseUrl\` are stripped before appending \`/models\`

The 404 test legitimately exercises the warning logger, so you'll see one expected \`[AgentModelsService] ... returned 404\` line in the test output. All other tests stub fetch.

## \`config.service.test.ts\` (6 tests)

- DTO serialisation round-trips ISO timestamps
- Enabling with no admin key id → \`AdminKeyProvider.mint()\` is called
- Enabling when admin key id already exists → skips mint (idempotent)
- Disabling with admin key id → \`AdminKeyProvider.revoke()\` is called
- Patch without an \`enabled\` flip → neither mint nor revoke
- Patch is forwarded to the repo verbatim

## Bug found while writing tests

The first iteration of \`makeRepo\` used \`overrides.apiKey ?? 'sk-test'\` which doesn't fall through on \`null\` (only on \`undefined\`). The "no provider key" test was passing for the wrong reason — fetch was actually being called and failing, which happens to also return \`supported: false\`. Fixed to use \`'apiKey' in overrides\` so a literal \`null\` is honoured.

## Test plan

- [x] \`pnpm --filter @getmunin/agent-host test\` — 13 tests pass
- [x] \`pnpm --filter @getmunin/agent-host typecheck\` clean
- [x] \`pnpm --filter @getmunin/agent-host lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)