### PR TITLE
fix(agent-host): inline DEFAULT literals in singleton DDL

### DIFF
--- a/.changeset/agent-host-ddl-defaults-fix.md
+++ b/.changeset/agent-host-ddl-defaults-fix.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/agent-host': patch
+---
+
+fix(agent-host): inline DEFAULT literals in singleton DDL
+
+The drizzle `sql` template was interpolating two string constants
+(`DEFAULT_CHAT_MODEL`, `DEFAULT_PROVIDER_BASE_URL`) as parameters
+($1, $2). Postgres rejects parameter binding in `DEFAULT` clauses
+on `CREATE TABLE` with syntax error 42601, so `pnpm --filter
+@getmunin/backend migrate` failed on a fresh database. Inline the
+literal values directly into the SQL.
+
+Multi-tenant DDL was unaffected (no DEFAULTs).

--- a/packages/agent-host/src/schema.ts
+++ b/packages/agent-host/src/schema.ts
@@ -22,16 +22,13 @@ export const agentConfig = pgTable('agent_config', {
 
 export const SINGLETON_ID = 'singleton' as const;
 
-const DEFAULT_CHAT_MODEL = 'anthropic/claude-haiku-4.5';
-const DEFAULT_PROVIDER_BASE_URL = 'https://openrouter.ai/api/v1';
-
 export const AGENT_HOST_SINGLETON_DDL = sql`
   CREATE TABLE IF NOT EXISTS agent_config (
     id text PRIMARY KEY DEFAULT 'singleton',
     enabled boolean NOT NULL DEFAULT false,
-    chat_model text NOT NULL DEFAULT ${DEFAULT_CHAT_MODEL},
+    chat_model text NOT NULL DEFAULT 'anthropic/claude-haiku-4.5',
     curator_model text,
-    provider_base_url text NOT NULL DEFAULT ${DEFAULT_PROVIDER_BASE_URL},
+    provider_base_url text NOT NULL DEFAULT 'https://openrouter.ai/api/v1',
     provider_api_key_ct text,
     admin_api_key_ct text,
     admin_api_key_id text,


### PR DESCRIPTION
## Summary

Fixes a fresh-install migrate failure for OSS users on \`@getmunin/agent-host@0.24.0\`.

## What broke

The singleton DDL had:

\`\`\`ts
chat_model text NOT NULL DEFAULT \${DEFAULT_CHAT_MODEL},
provider_base_url text NOT NULL DEFAULT \${DEFAULT_PROVIDER_BASE_URL},
\`\`\`

Drizzle's \`sql\` template interpolates string values as bind parameters (\`$1\`, \`$2\`). Postgres rejects parameter binding in \`DEFAULT\` clauses on \`CREATE TABLE\` (syntax error 42601), so \`pnpm --filter @getmunin/backend migrate\` failed on a fresh DB:

\`\`\`
CREATE TABLE IF NOT EXISTS agent_config (
  ...
  chat_model text NOT NULL DEFAULT $1,
  ...
\`\`\`

I caught this against a real local Postgres while smoke-testing the \`/setup\` wizard.

## Fix

Inline the literal values directly into the SQL string. The constants weren't reused elsewhere — the runtime defaults in \`PerOrgConfigRepository\` have their own copies.

The multi-tenant DDL was unaffected (it has no \`DEFAULT\` clauses on \`chat_model\` / \`provider_base_url\`).

Includes a patch changeset so this releases as \`0.24.1\`.

## Verified locally

\`\`\`
$ pnpm --filter @getmunin/backend migrate
...
OSS schema applied
agent-host singleton DDL applied

$ psql "\$DATABASE_URL" -c "SELECT id, enabled, chat_model, provider_base_url FROM agent_config;"
    id     | enabled |         chat_model         |      provider_base_url
-----------+---------+----------------------------+------------------------------
 singleton | f       | anthropic/claude-haiku-4.5 | https://openrouter.ai/api/v1
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)