### PR TITLE
fix(agent-host): use native auth for Anthropic /v1/models

### DIFF
--- a/.changeset/agent-host-anthropic-models.md
+++ b/.changeset/agent-host-anthropic-models.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/agent-host': patch
+---
+
+fix(agent-host): use native auth for Anthropic /v1/models
+
+Anthropic's OAI-compat shim accepts `Authorization: Bearer ...` for
+`/v1/chat/completions` but not for `/v1/models` — that endpoint
+requires the native `x-api-key` + `anthropic-version` headers.
+
+`AgentModelsService.fetchModels` now picks headers based on the
+provider URL: `x-api-key` + `anthropic-version: 2023-06-01` when the
+URL is `api.anthropic.com`, Bearer otherwise (OpenRouter, OpenAI,
+custom OAI-compat endpoints).

--- a/packages/agent-host/src/models.service.test.ts
+++ b/packages/agent-host/src/models.service.test.ts
@@ -152,4 +152,39 @@ describe('AgentModelsService', () => {
     const calledUrl: unknown = fetchMock.mock.calls[0]?.[0];
     expect(calledUrl).toBe('https://provider.example/v1/models');
   });
+
+  it('uses Bearer auth for OAI-compat providers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const svc = new AgentModelsService(makeRepo({ apiKey: 'sk-or-test' }));
+    await svc.listForCurrentActor();
+    const call = fetchMock.mock.calls[0] as [unknown, { headers: Record<string, string> }];
+    const init = call[1];
+    expect(init.headers.authorization).toBe('Bearer sk-or-test');
+    expect(init.headers['x-api-key']).toBeUndefined();
+  });
+
+  it('uses x-api-key + anthropic-version on api.anthropic.com', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const repo = makeRepo({
+      apiKey: 'sk-ant-test',
+      row: { ...baseRow, providerBaseUrl: 'https://api.anthropic.com/v1' },
+    });
+    const svc = new AgentModelsService(repo);
+    await svc.listForCurrentActor();
+    const call = fetchMock.mock.calls[0] as [unknown, { headers: Record<string, string> }];
+    const init = call[1];
+    expect(init.headers['x-api-key']).toBe('sk-ant-test');
+    expect(init.headers['anthropic-version']).toBe('2023-06-01');
+    expect(init.headers.authorization).toBeUndefined();
+  });
 });

--- a/packages/agent-host/src/models.service.ts
+++ b/packages/agent-host/src/models.service.ts
@@ -54,10 +54,7 @@ export class AgentModelsService {
     try {
       res = await fetch(url, {
         method: 'GET',
-        headers: {
-          authorization: `Bearer ${apiKey}`,
-          accept: 'application/json',
-        },
+        headers: authHeaders(baseUrl, apiKey),
       });
     } catch (err) {
       this.logger.warn(`fetch ${url} failed: ${describe(err)}`);
@@ -131,6 +128,20 @@ function parsePerMillion(raw: unknown): number | null {
   const n = typeof raw === 'string' ? Number(raw) : typeof raw === 'number' ? raw : null;
   if (n === null || !Number.isFinite(n)) return null;
   return n * 1_000_000;
+}
+
+function authHeaders(baseUrl: string, apiKey: string): Record<string, string> {
+  if (/api\.anthropic\.com/i.test(baseUrl)) {
+    return {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      accept: 'application/json',
+    };
+  }
+  return {
+    authorization: `Bearer ${apiKey}`,
+    accept: 'application/json',
+  };
 }
 
 function describe(err: unknown): string {


### PR DESCRIPTION
## Summary

The wizard's "Save & test" returned 401 against Anthropic.

Anthropic's OpenAI-compat shim accepts \`Authorization: Bearer ...\` for \`/v1/chat/completions\` (so chat traffic works fine), but \`/v1/models\` falls through to the native auth path which requires \`x-api-key\` + \`anthropic-version\`. We were sending Bearer everywhere.

## Fix

\`AgentModelsService.fetchModels\` branches on provider URL:

| URL matches | Headers |
|---|---|
| \`api.anthropic.com\` | \`x-api-key: <key>\`, \`anthropic-version: 2023-06-01\` |
| anything else | \`Authorization: Bearer <key>\` |

## Verified

- Two new unit tests lock the header-selection behavior in (Bearer vs x-api-key).
- All 15 tests pass; typecheck + lint clean.

Patch changeset attached so this releases as \`0.24.2\` (after #92's \`0.24.1\` lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)