### PR TITLE
refactor!: rename ai-agent → builtin-ai + setup gate hooks

### DIFF
--- a/.changeset/route-alignment-builtin-ai.md
+++ b/.changeset/route-alignment-builtin-ai.md
@@ -1,0 +1,19 @@
+---
+'@getmunin/dashboard-pages': major
+---
+
+refactor!: route alignment + ai-agent → builtin-ai rename + setup gate
+
+Frontend route alignment, the second pass after the API rename. Three things in one diff:
+
+**1. Rename `/dashboard/settings/ai-agent` → `/dashboard/settings/builtin-ai`** in OSS and updates the wizard's hardcoded internal link. The package export `AgentSettingsPage` is renamed to `BuiltinAiSettingsPage` to match the URL.
+
+**2. New gate hooks** for use in dashboard layouts and the setup page:
+
+- `useDashboardGate()` — returns `{ ready, role }`. When the active org's built-in AI is not configured (`providerApiKeySet === false`) and the user is owner/admin, redirects to `/setup`. Members are allowed through (they see the dashboard's per-page empty states). `/dashboard/account` is exempt — escape hatch if onboarding goes sideways.
+- `useSetupGate()` — returns `{ ready }`. Inverse: redirects to `/dashboard` when configuration is already complete.
+- `useAgentConfigStatus()` — small primitive used by both gate hooks.
+
+**3. OSS app wired up.** `apps/web/app/dashboard/layout.tsx` now uses `useDashboardGate`; `apps/web/app/setup/page.tsx` now uses `useSetupGate`.
+
+Companion frontend changes ship in `munin-cloud` once a release of this package is published.

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,21 +1,16 @@
 'use client';
 
-import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { authClient, useActiveRole } from '@getmunin/dashboard-pages';
+import { authClient, useDashboardGate } from '@getmunin/dashboard-pages';
 import { PageSpinner } from '@getmunin/ui';
 import { MuninTopbar } from '@/components/munin-topbar';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
-  const { data: session, isPending } = authClient.useSession();
-  const { role } = useActiveRole();
+  const { data: session } = authClient.useSession();
+  const { ready, role } = useDashboardGate();
 
-  useEffect(() => {
-    if (!isPending && !session) router.push('/login');
-  }, [isPending, session, router]);
-
-  if (isPending || !session) {
+  if (!ready || !session) {
     return <PageSpinner className="min-h-screen bg-bone dark:bg-background" />;
   }
 

--- a/apps/web/app/dashboard/settings/ai-agent/page.tsx
+++ b/apps/web/app/dashboard/settings/ai-agent/page.tsx
@@ -1,1 +1,0 @@
-export { AgentSettingsPage as default } from '@getmunin/dashboard-pages';

--- a/apps/web/app/dashboard/settings/builtin-ai/page.tsx
+++ b/apps/web/app/dashboard/settings/builtin-ai/page.tsx
@@ -1,0 +1,1 @@
+export { BuiltinAiSettingsPage as default } from '@getmunin/dashboard-pages';

--- a/apps/web/app/dashboard/settings/layout.tsx
+++ b/apps/web/app/dashboard/settings/layout.tsx
@@ -38,7 +38,7 @@ const GROUPS: SubNavGroup[] = [
     items: [
       { href: '/dashboard/settings/team', labelKey: 'team' },
       { href: '/dashboard/settings/channels', labelKey: 'channels' },
-      { href: '/dashboard/settings/ai-agent', labelKey: 'builtInAi' },
+      { href: '/dashboard/settings/builtin-ai', labelKey: 'builtInAi' },
       { href: '/dashboard/settings/export', labelKey: 'dataExport' },
     ],
   },

--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -1,19 +1,12 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { AgentSetupWizard, authClient } from '@getmunin/dashboard-pages';
+import { AgentSetupWizard, useSetupGate } from '@getmunin/dashboard-pages';
 import { PageSpinner } from '@getmunin/ui';
 
 export default function SetupRoute() {
-  const router = useRouter();
-  const { data: session, isPending } = authClient.useSession();
+  const { ready } = useSetupGate();
 
-  useEffect(() => {
-    if (!isPending && !session) router.push('/login');
-  }, [isPending, session, router]);
-
-  if (isPending || !session) {
+  if (!ready) {
     return <PageSpinner className="min-h-screen bg-bone dark:bg-background" />;
   }
 

--- a/packages/dashboard-pages/src/auth/use-agent-config-status.ts
+++ b/packages/dashboard-pages/src/auth/use-agent-config-status.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { api } from '../api';
+
+interface AgentConfigStatusDto {
+  providerApiKeySet: boolean;
+}
+
+export function useAgentConfigStatus(): {
+  configured: boolean | null;
+  loading: boolean;
+  error: string | null;
+} {
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api<AgentConfigStatusDto>('/api/v1/agent-config')
+      .then((dto) => {
+        if (cancelled) return;
+        setConfigured(dto.providerApiKeySet);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'unknown error');
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { configured, loading, error };
+}

--- a/packages/dashboard-pages/src/auth/use-dashboard-gate.ts
+++ b/packages/dashboard-pages/src/auth/use-dashboard-gate.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { authClient } from '../auth-client';
+import { isOwnerOrAdmin, useActiveRole, type OrgRole } from './use-active-role';
+import { useAgentConfigStatus } from './use-agent-config-status';
+
+const EXEMPT_PREFIXES = ['/dashboard/account'];
+
+export function useDashboardGate(): { ready: boolean; role: OrgRole | null } {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { data: session, isPending } = authClient.useSession();
+  const { role, loading: roleLoading } = useActiveRole();
+  const { configured, loading: configLoading } = useAgentConfigStatus();
+
+  const exempt = EXEMPT_PREFIXES.some((p) => pathname?.startsWith(p));
+
+  useEffect(() => {
+    if (isPending) return;
+    if (!session) {
+      router.push('/login');
+      return;
+    }
+    if (exempt) return;
+    if (roleLoading || configLoading) return;
+    if (configured === false && isOwnerOrAdmin(role)) {
+      router.push('/setup');
+    }
+  }, [
+    isPending,
+    session,
+    roleLoading,
+    configLoading,
+    configured,
+    role,
+    exempt,
+    router,
+  ]);
+
+  const ready =
+    !isPending &&
+    !!session &&
+    (exempt ||
+      (!roleLoading &&
+        !configLoading &&
+        (configured === true || !isOwnerOrAdmin(role))));
+
+  return { ready, role };
+}

--- a/packages/dashboard-pages/src/auth/use-setup-gate.ts
+++ b/packages/dashboard-pages/src/auth/use-setup-gate.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { authClient } from '../auth-client';
+import { useAgentConfigStatus } from './use-agent-config-status';
+
+export function useSetupGate(): { ready: boolean } {
+  const router = useRouter();
+  const { data: session, isPending } = authClient.useSession();
+  const { configured, loading } = useAgentConfigStatus();
+
+  useEffect(() => {
+    if (isPending) return;
+    if (!session) {
+      router.push('/login');
+      return;
+    }
+    if (loading) return;
+    if (configured === true) {
+      router.push('/dashboard');
+    }
+  }, [isPending, session, loading, configured, router]);
+
+  const ready = !isPending && !!session && !loading && configured === false;
+
+  return { ready };
+}

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -3,9 +3,12 @@ export { authClient } from './auth-client';
 export { OrgSwitcher } from './components/org-switcher';
 export { PageShell, nativeFieldClass } from './components/page-shell';
 export { useActiveRole, isOwnerOrAdmin, type OrgRole } from './auth/use-active-role';
+export { useAgentConfigStatus } from './auth/use-agent-config-status';
+export { useDashboardGate } from './auth/use-dashboard-gate';
+export { useSetupGate } from './auth/use-setup-gate';
 
 export { AcceptInvitePage } from './pages/accept-invite';
-export { AgentSettingsPage } from './pages/agent-settings';
+export { BuiltinAiSettingsPage } from './pages/builtin-ai-settings';
 export { AgentSetupWizard } from './pages/agent-setup-wizard';
 export { AgentsPage } from './pages/agents';
 export { ApiKeysPage } from './pages/api-keys';

--- a/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
@@ -150,7 +150,7 @@ function ReadyCard({ config, onBack }: ReadyCardProps) {
           </Button>
           <Button
             variant="outline"
-            render={<Link href={'/dashboard/settings/ai-agent' satisfies Route} />}
+            render={<Link href={'/dashboard/settings/builtin-ai' satisfies Route} />}
           >
             {t('wizard.cta.tweakSettings')}
           </Button>

--- a/packages/dashboard-pages/src/pages/builtin-ai-settings.tsx
+++ b/packages/dashboard-pages/src/pages/builtin-ai-settings.tsx
@@ -6,7 +6,7 @@ import { useAgentConfig } from '../components/agent-config/use-agent-config';
 import { ProviderCard } from '../components/agent-config/provider-card';
 import { ModelsCard } from '../components/agent-config/models-card';
 
-export function AgentSettingsPage() {
+export function BuiltinAiSettingsPage() {
   const t = useTranslations('agentSetup');
   const tCommon = useTranslations('common');
   const { config, loadError, models, setConfig, setModels } = useAgentConfig();


### PR DESCRIPTION
## Summary

Frontend route alignment, second pass after the API rename. Three things in one diff:

1. **Rename `/dashboard/settings/ai-agent` → `/dashboard/settings/builtin-ai`** in OSS and the wizard's hardcoded link. The package export `AgentSettingsPage` is renamed to `BuiltinAiSettingsPage` (symbol matches URL).
2. **Setup gate hooks** in `@getmunin/dashboard-pages`:
   - `useDashboardGate()` — redirects owners/admins to `/setup` when built-in AI is not configured. Members are allowed through. `/dashboard/account` is exempt.
   - `useSetupGate()` — inverse redirect.
   - `useAgentConfigStatus()` — small primitive used by both.
3. **OSS app wired up** — dashboard layout and `/setup` page now use the gates.

Companion changes ship in `munin-cloud` once a release of this package is published.

## Notes

- Members of an unconfigured org see the dashboard normally. The per-page empty-states handle "no agent / no data" — no need to lock everyone out.
- `/dashboard/account` exempt so a user can fix their email/password even if onboarding goes sideways.
- Inverse redirect on `/setup` so configured users don't accidentally re-enter the wizard.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 325/325 passing
- [ ] Manual: sign up new user → land on `/dashboard` → redirected to `/setup` → complete wizard → returns to `/dashboard`
- [ ] Manual: with built-in AI configured, navigate to `/setup` → redirected to `/dashboard`
- [ ] Manual: sign in as a member of an unconfigured org → dashboard renders, no redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)