### PR TITLE
test(conv): kill conversations.controller integration flake

### DIFF
--- a/packages/backend-core/src/control/conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/conversations.controller.integration.test.ts
@@ -98,19 +98,27 @@ const skipReason = TEST_URL
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
     });
 
+    // Insert the chat channel directly via the service-role connection
+    // (bypasses RLS, commits before app boot). Previously this went through
+    // an MCP tool call after the app started — that path occasionally
+    // flaked under CI: the tool's response was awaited but its result
+    // wasn't validated, so a transient transport error left the channel
+    // missing and every "no active channel configured" assertion below it
+    // failed. Direct insert is one SQL round-trip with deterministic
+    // visibility for the app's separate connection pool.
+    await db.insert(schema.convChannels).values({
+      orgId: orgAId,
+      type: 'chat',
+      name: 'Web chat',
+      config: {},
+    });
+
     app = await NestFactory.create(AppModule, { logger: false });
     await app.listen(0, '127.0.0.1');
     const server = app.getHttpServer() as { address(): AddressInfo | string | null };
     const address = server.address();
     if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
     baseUrl = `http://127.0.0.1:${address.port}`;
-
-    await withClient(adminKeyA, async (c) => {
-      await c.callTool({
-        name: 'conv_create_channel',
-        arguments: { type: 'chat', name: 'Web chat' },
-      });
-    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary

The release-PR workflow on \`main\` flaked twice on the same two assertions in \`conversations.controller.integration.test.ts\` after #102 / #103 merged. Root cause: \`beforeAll\` created the required chat channel via an MCP tool call but never validated the result — when the MCP transport hiccupped under CI load, the channel never landed and every "no active channel configured for this org" assertion below it failed (Test 1 directly, Test 3 as a cascade because no conversation = no events).

Fix: insert the channel directly through the service-role \`db\` connection. One SQL round-trip, deterministic visibility for the app pool, no silent MCP transport failure mode.

Also surfaced a (very minor) latent issue: a tool call that returns an error wouldn't have failed the test — \`callTool\` was awaited but its return value discarded. Direct insert removes the smoke screen.

## Test plan

- [x] Local: \`pnpm --filter @getmunin/backend-core test\` — 365/365.
- [ ] CI green here.
- [ ] Watch the next merge to main; this same workflow should be stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)