### PR TITLE
feat(oauth): MCP resource discovery + WWW-Authenticate (Phase 1/5)

### DIFF
--- a/.changeset/oauth-mcp-resource-discovery.md
+++ b/.changeset/oauth-mcp-resource-discovery.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/backend-core': minor
+---
+
+feat(oauth): MCP resource discovery + WWW-Authenticate (Phase 1)
+
+First step toward MCP-spec OAuth 2.1 compliance:
+
+- New `GET /.well-known/oauth-protected-resource` (RFC 9728) describing the `/mcp` resource: where it lives, which authorization servers can issue tokens for it, supported scopes (`mcp:tools`, `mcp:admin`, `mcp:self_service`, `kb:read`, `conv:write`, …), bearer transport.
+- `AuthGuard` emits `WWW-Authenticate: Bearer resource_metadata="…"` on 401 responses for `/mcp/*` requests, per the MCP authorization spec. Other authenticated routes are unchanged.
+- New `OAuthModule` exported from `@getmunin/backend-core` so cloud picks it up automatically.
+
+This phase publishes the resource-side metadata. The authorization server endpoints (Better-Auth `oidcProvider`, RFC 8707 resource indicators, consent UI) come in subsequent phases. Existing API key + delegated token flows are untouched.

--- a/packages/backend-core/src/app.module.ts
+++ b/packages/backend-core/src/app.module.ts
@@ -19,6 +19,7 @@ import { MailModule } from './common/mail/mail.module.js';
 import { WebhookModule } from './common/webhooks/webhook.module.js';
 import { StorageModule } from './common/storage/storage.module.js';
 import { RealtimeModule } from './realtime/realtime.module.js';
+import { OAuthModule } from './oauth/oauth.module.js';
 
 /**
  * Feature modules. Composed with an AuthModule downstream — auth is
@@ -41,6 +42,7 @@ export const BACKEND_FEATURE_MODULES_NO_AUTH = [
   CrmModule,
   CmsModule,
   RealtimeModule,
+  OAuthModule,
 ];
 
 export const BACKEND_BASE_CONTROLLERS = [HealthController, WhoamiController];

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -3,6 +3,7 @@ import { CredentialResolver, type ResolvedCredential } from '@getmunin/core';
 import type { Db } from '@getmunin/db';
 import { DB } from '../db/db.module.js';
 import { Reflector } from '@nestjs/core';
+import { resourceMetadataUrl } from '../../oauth/oauth.constants.js';
 
 /** Decorator used on routes that should be reachable without auth (signup, oauth discovery). */
 export const ALLOW_ANONYMOUS = Symbol('allowAnonymous');
@@ -90,12 +91,26 @@ export class AuthGuard implements CanActivate {
 
     if (!credential) {
       if (allowAnon) return true;
+      maybeSetMcpResourceMetadataHeader(context, request);
       throw new UnauthorizedException('invalid or expired credential');
     }
 
     request.credential = credential;
     return true;
   }
+}
+
+function maybeSetMcpResourceMetadataHeader(
+  context: ExecutionContext,
+  request: AuthenticatedRequest & { url?: string; path?: string },
+): void {
+  const url = (request.url ?? request.path ?? '').toString();
+  if (!url.startsWith('/mcp')) return;
+  const res = context.switchToHttp().getResponse<{ setHeader?: (n: string, v: string) => void }>();
+  res.setHeader?.(
+    'WWW-Authenticate',
+    `Bearer resource_metadata="${resourceMetadataUrl()}"`,
+  );
 }
 
 const SESSION_COOKIE_NAMES = ['better-auth.session_token', '__Secure-better-auth.session_token'];

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -49,6 +49,15 @@ export { CmsModule } from './modules/cms/cms.module.js';
 export { RateLimitModule } from './common/rate-limit/rate-limit.module.js';
 export { QuotasModule } from './common/quotas/quotas.module.js';
 export { WebhookModule } from './common/webhooks/webhook.module.js';
+export { OAuthModule } from './oauth/oauth.module.js';
+export {
+  MCP_RESOURCE_PATH,
+  SUPPORTED_SCOPES,
+  type SupportedScope,
+  mcpResourceUrl,
+  authorizationServerUrl,
+  resourceMetadataUrl,
+} from './oauth/oauth.constants.js';
 
 export { HealthController } from './common/health.controller.js';
 export { WhoamiController } from './common/whoami.controller.js';

--- a/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { OAuthResourceController } from './oauth-resource.controller.js';
+import { SUPPORTED_SCOPES } from './oauth.constants.js';
+
+describe('OAuthResourceController', () => {
+  let originalUrl: string | undefined;
+
+  beforeEach(() => {
+    originalUrl = process.env.MUNIN_PUBLIC_URL;
+  });
+
+  afterEach(() => {
+    if (originalUrl === undefined) delete process.env.MUNIN_PUBLIC_URL;
+    else process.env.MUNIN_PUBLIC_URL = originalUrl;
+  });
+
+  it('returns RFC 9728 metadata pointing at the configured public URL', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://api.example.test';
+    const meta = new OAuthResourceController().metadata();
+    expect(meta).toEqual({
+      resource: 'https://api.example.test/mcp',
+      authorization_servers: ['https://api.example.test'],
+      scopes_supported: SUPPORTED_SCOPES,
+      bearer_methods_supported: ['header'],
+      resource_documentation: 'https://api.example.test/docs',
+    });
+  });
+
+  it('strips trailing slashes from MUNIN_PUBLIC_URL', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://api.example.test/';
+    const meta = new OAuthResourceController().metadata();
+    expect(meta.resource).toBe('https://api.example.test/mcp');
+    expect(meta.authorization_servers).toEqual(['https://api.example.test']);
+  });
+
+  it('falls back to localhost when MUNIN_PUBLIC_URL is unset', () => {
+    delete process.env.MUNIN_PUBLIC_URL;
+    const meta = new OAuthResourceController().metadata();
+    expect(meta.resource).toBe('http://localhost:3001/mcp');
+  });
+
+  it('exposes the expected scope set', () => {
+    const meta = new OAuthResourceController().metadata();
+    expect(meta.scopes_supported).toContain('mcp:tools');
+    expect(meta.scopes_supported).toContain('kb:read');
+    expect(meta.scopes_supported).toContain('conv:write');
+    expect(meta.bearer_methods_supported).toEqual(['header']);
+  });
+});

--- a/packages/backend-core/src/oauth/oauth-resource.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { AllowAnonymous } from '../common/auth/auth.guard.js';
+import {
+  authorizationServerUrl,
+  mcpResourceUrl,
+  SUPPORTED_SCOPES,
+} from './oauth.constants.js';
+
+interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  scopes_supported: readonly string[];
+  bearer_methods_supported: readonly string[];
+  resource_documentation?: string;
+}
+
+@Controller('.well-known/oauth-protected-resource')
+export class OAuthResourceController {
+  @Get()
+  @AllowAnonymous()
+  @Header('content-type', 'application/json; charset=utf-8')
+  @Header('cache-control', 'public, max-age=3600')
+  metadata(): ProtectedResourceMetadata {
+    return {
+      resource: mcpResourceUrl(),
+      authorization_servers: [authorizationServerUrl()],
+      scopes_supported: SUPPORTED_SCOPES,
+      bearer_methods_supported: ['header'],
+      resource_documentation: `${authorizationServerUrl()}/docs`,
+    };
+  }
+}

--- a/packages/backend-core/src/oauth/oauth.constants.ts
+++ b/packages/backend-core/src/oauth/oauth.constants.ts
@@ -1,0 +1,33 @@
+export const MCP_RESOURCE_PATH = '/mcp';
+
+export const SUPPORTED_SCOPES = [
+  'mcp:tools',
+  'mcp:admin',
+  'mcp:self_service',
+  'kb:read',
+  'kb:write',
+  'conv:read',
+  'conv:write',
+  'crm:read',
+  'crm:write',
+  'cms:read',
+  'cms:write',
+] as const;
+
+export type SupportedScope = (typeof SUPPORTED_SCOPES)[number];
+
+export function readPublicBaseUrl(): string {
+  return (process.env.MUNIN_PUBLIC_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
+}
+
+export function mcpResourceUrl(): string {
+  return `${readPublicBaseUrl()}${MCP_RESOURCE_PATH}`;
+}
+
+export function authorizationServerUrl(): string {
+  return readPublicBaseUrl();
+}
+
+export function resourceMetadataUrl(): string {
+  return `${readPublicBaseUrl()}/.well-known/oauth-protected-resource`;
+}

--- a/packages/backend-core/src/oauth/oauth.module.ts
+++ b/packages/backend-core/src/oauth/oauth.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { OAuthResourceController } from './oauth-resource.controller.js';
+
+@Module({
+  controllers: [OAuthResourceController],
+})
+export class OAuthModule {}


### PR DESCRIPTION
## Summary

Phase 1 of 5 toward MCP-spec OAuth 2.1 compliance. This phase publishes the **resource server** side of the spec (RFC 9728) so MCP clients can *discover* that authentication exists. It does not yet expose authorization server endpoints — that's Phase 2.

### What's new

- **`GET /.well-known/oauth-protected-resource`** (RFC 9728). Returns:
  ```json
  {
    "resource": "https://<host>/mcp",
    "authorization_servers": ["https://<host>"],
    "scopes_supported": ["mcp:tools", "mcp:admin", "mcp:self_service",
                        "kb:read", "kb:write", "conv:read", "conv:write",
                        "crm:read", "crm:write", "cms:read", "cms:write"],
    "bearer_methods_supported": ["header"],
    "resource_documentation": "https://<host>/docs"
  }
  ```
- **`WWW-Authenticate: Bearer resource_metadata="…"`** on 401 responses for `/mcp/*`. Only `/mcp/*`; other authenticated routes are unchanged. This lets compliant MCP clients (Claude Desktop, Cursor, mcp-inspector) discover where to authenticate when they hit the MCP endpoint without credentials.
- New `OAuthModule` registered in `BACKEND_FEATURE_MODULES_NO_AUTH` and re-exported from `@getmunin/backend-core` so cloud picks it up automatically.

### What's *not* yet done (next phases)

| Phase | What |
|---|---|
| 2 | Better-Auth `oidcProvider` plugin: `/auth/authorize`, `/auth/token`, `/auth/register` (DCR), `/auth/revoke`, OIDC discovery |
| 3 | RFC 8707 resource indicators — token endpoint binds `aud` from `resource` |
| 4 | Consent UI at `/dashboard/oauth/consent` |
| 5 | Polish + conformance audit (Authlete / openid-conformance-suite) + Claude Desktop smoke |

Existing `mn_admin_*` API keys and `mn_dlg_*` delegated tokens continue working unchanged. OAuth is additive.

### Verification

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 369/369 passing (added 4 unit tests for the metadata controller)
- [x] Manual:
  - `curl http://localhost:3001/.well-known/oauth-protected-resource` returns the JSON above
  - `curl -X POST http://localhost:3001/mcp` returns 401 with `WWW-Authenticate: Bearer resource_metadata="..."`
  - `curl http://localhost:3001/api/v1/conversations` returns 401 *without* the header (correctly scoped to `/mcp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)