### PR TITLE
fix(oauth): unbreak CI lint after Phase 2 merge

### DIFF
--- a/packages/backend-core/src/oauth/oauth-as-alias.controller.test.ts
+++ b/packages/backend-core/src/oauth/oauth-as-alias.controller.test.ts
@@ -22,12 +22,14 @@ describe('OAuthAsAliasController', () => {
       authorization_endpoint: 'https://api.example.test/auth/oauth2/authorize',
       token_endpoint: 'https://api.example.test/auth/oauth2/token',
     };
-    global.fetch = vi.fn(async () =>
-      new Response(JSON.stringify(fakeMeta), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      }),
-    ) as typeof fetch;
+    global.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(fakeMeta), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
 
     const out = await new OAuthAsAliasController().metadata();
     expect(out).toEqual(fakeMeta);
@@ -38,7 +40,9 @@ describe('OAuthAsAliasController', () => {
   });
 
   it('throws 502 when upstream is unreachable', async () => {
-    global.fetch = vi.fn(async () => new Response('boom', { status: 500 })) as typeof fetch;
+    global.fetch = vi.fn(() =>
+      Promise.resolve(new Response('boom', { status: 500 })),
+    );
     await expect(new OAuthAsAliasController().metadata()).rejects.toMatchObject({
       status: 502,
     });


### PR DESCRIPTION
PR #107 (Phase 2) auto-merged before lint finished and tipped main red. Same diff I pushed to the branch after the merge, applied to main. After this lands the changesets release PR for Phase 1+2 can be cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)