### PR TITLE
feat(oauth): branded consent UI (Phase 4/5)

### DIFF
--- a/.changeset/oauth-mcp-phase4-consent-ui.md
+++ b/.changeset/oauth-mcp-phase4-consent-ui.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/dashboard-pages': minor
+---
+
+feat(oauth): branded consent UI at /dashboard/oauth/consent (Phase 4)
+
+Custom consent page for the OAuth 2.1 authorization flow. Replaces Better-Auth's default `getConsentHTML` fallback with a Munin-styled card showing the client name, requested scopes, and Allow/Deny actions. Submission posts to `/auth/oauth2/consent` with `accept: true|false` and the `consent_code` from the query string; on success the user is redirected back to the OAuth client.
+
+The page is added to `useDashboardGate`'s exempt list so a user can authorize an external app even before completing the built-in-AI setup wizard.
+
+A wrapper at `apps/web/app/dashboard/oauth/consent/page.tsx` re-exports the component; cloud picks it up automatically when it bumps the package.

--- a/apps/web/app/dashboard/oauth/consent/page.tsx
+++ b/apps/web/app/dashboard/oauth/consent/page.tsx
@@ -1,0 +1,1 @@
+export { OAuthConsentPage as default } from '@getmunin/dashboard-pages';

--- a/packages/dashboard-pages/src/auth/use-dashboard-gate.ts
+++ b/packages/dashboard-pages/src/auth/use-dashboard-gate.ts
@@ -6,7 +6,7 @@ import { authClient } from '../auth-client';
 import { isOwnerOrAdmin, useActiveRole, type OrgRole } from './use-active-role';
 import { useAgentConfigStatus } from './use-agent-config-status';
 
-const EXEMPT_PREFIXES = ['/dashboard/account'];
+const EXEMPT_PREFIXES = ['/dashboard/account', '/dashboard/oauth/consent'];
 
 export function useDashboardGate(): { ready: boolean; role: OrgRole | null } {
   const router = useRouter();

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -9,6 +9,7 @@ export { useSetupGate } from './auth/use-setup-gate';
 
 export { AcceptInvitePage } from './pages/accept-invite';
 export { BuiltinAiSettingsPage } from './pages/builtin-ai-settings';
+export { OAuthConsentPage } from './pages/oauth-consent';
 export { AgentSetupWizard } from './pages/agent-setup-wizard';
 export { AgentsPage } from './pages/agents';
 export { ApiKeysPage } from './pages/api-keys';

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Button, Card, CardContent, Hero, PageSpinner } from '@getmunin/ui';
+import { authClient } from '../auth-client';
+import { api, ApiError } from '../api';
+
+interface OAuthConsentResponse {
+  redirect_uri?: string;
+}
+
+export function OAuthConsentPage() {
+  const search = useSearchParams();
+  const { data: session, isPending } = authClient.useSession();
+
+  const consentCode = search?.get('consent_code') ?? '';
+  const clientId = search?.get('client_id') ?? '';
+  const clientName = search?.get('client_name') ?? clientId;
+  const scopeRaw = search?.get('scope') ?? '';
+
+  const scopes = useMemo(
+    () => (scopeRaw ? scopeRaw.split(/\s+/).filter(Boolean) : []),
+    [scopeRaw],
+  );
+
+  const [busy, setBusy] = useState<'allow' | 'deny' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isPending && !session) {
+      const next = encodeURIComponent(window.location.href);
+      window.location.assign(`/login?next=${next}`);
+    }
+  }, [isPending, session]);
+
+  if (isPending || !session) {
+    return <PageSpinner className="min-h-screen bg-bone dark:bg-background" />;
+  }
+
+  if (!consentCode || !clientId) {
+    return (
+      <div className="flex min-h-screen items-center justify-center px-6">
+        <Card className="max-w-md">
+          <CardContent className="py-6 text-sm text-destructive">
+            Missing consent_code or client_id. Return to the application that started the
+            authorization flow.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  async function submit(accept: boolean) {
+    setBusy(accept ? 'allow' : 'deny');
+    setError(null);
+    try {
+      const resp = await api<OAuthConsentResponse>('/auth/oauth2/consent', {
+        method: 'POST',
+        body: JSON.stringify({ accept, consent_code: consentCode }),
+      });
+      if (resp?.redirect_uri) window.location.assign(resp.redirect_uri);
+      else window.history.back();
+    } catch (err) {
+      if (err instanceof ApiError) setError(err.message);
+      else setError('Something went wrong. Please try again.');
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-bone dark:bg-background">
+      <main className="mx-auto max-w-xl px-6 py-16">
+        <Hero
+          title={
+            <>
+              Authorize <em>{clientName}</em>?
+            </>
+          }
+          lede="An external application is asking for access to your Munin account. Review the requested scopes before deciding."
+        />
+
+        <Card className="mt-8">
+          <CardContent className="space-y-5 py-6">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Application
+              </p>
+              <p className="mt-1 font-mono text-sm">{clientName}</p>
+              <p className="font-mono text-xs text-muted-foreground">{clientId}</p>
+            </div>
+
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Requested scopes
+              </p>
+              {scopes.length === 0 ? (
+                <p className="mt-1 text-sm text-muted-foreground">(no scopes requested)</p>
+              ) : (
+                <ul className="mt-2 space-y-1">
+                  {scopes.map((scope) => (
+                    <li key={scope} className="font-mono text-sm">
+                      {scope}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+
+            <div className="flex gap-3 pt-2">
+              <Button onClick={() => void submit(true)} disabled={busy !== null}>
+                {busy === 'allow' ? 'Authorizing…' : 'Authorize'}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => void submit(false)}
+                disabled={busy !== null}
+              >
+                {busy === 'deny' ? 'Denying…' : 'Deny'}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
Phase 4 of MCP-spec OAuth 2.1. Builds on [#110 (Phase 3)](https://github.com/getmunin/munin/pull/110). With this in, a user starting the OAuth flow from an MCP client lands on a Munin-styled consent page instead of Better-Auth's default fallback.

### What's new

- New \`OAuthConsentPage\` component in \`@getmunin/dashboard-pages\`. Reads \`consent_code\`, \`client_id\`, \`client_name\`, \`scope\` from query string. Card-based UI matching the rest of the dashboard. Allow/Deny buttons POST to \`/auth/oauth2/consent\`.
- Wrapper at \`apps/web/app/dashboard/oauth/consent/page.tsx\` re-exports the component.
- \`useDashboardGate\` adds \`/dashboard/oauth/consent\` to \`EXEMPT_PREFIXES\` so authorization works even before the built-in-AI setup wizard is complete.

### Verification

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 371/371
- [x] Manual: \`/dashboard/oauth/consent\` renders 200 with and without query params; missing-params shows a destructive card; with params shows the consent card.
- [ ] Real flow: kicked off from \`mcp-inspector\` after Phase 5

### Phases left

| Phase | What |
|---|---|
| 5 | Conformance audit (Authlete / openid-conformance-suite) + Claude Desktop / mcp-inspector smoke + skill doc for connecting clients |

🤖 Generated with [Claude Code](https://claude.com/claude-code)