### PR TITLE
fix(agent-host): dedupe runner-spawn-failure logs

### DIFF
--- a/.changeset/agent-host-spawn-failure-dedup.md
+++ b/.changeset/agent-host-spawn-failure-dedup.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/agent-host': patch
+---
+
+fix(agent-host): dedupe runner-spawn-failure logs
+
+The runner reconcile loop attempts to spawn a runner for every provisioned `agent_config` row every 30 seconds. When the admin API key in `agent_config.admin_api_key_ct` doesn't resolve to a live `api_keys` row (e.g. after a partial DB reset), every spawn attempt logs an `ERROR` — N error lines per minute, indefinitely.
+
+Now the same `(config_id, error_message)` is only logged at ERROR level once per 10 minutes. Subsequent identical failures during the cooldown emit at DEBUG level. A successful spawn (or a different error) resets the dedup state so the next failure is reported promptly.
+
+The underlying credential mismatch is still surfaced — just not as a stuck error stream that drowns out everything else.

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -61,6 +61,7 @@ interface CuratorWorker {
 export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy {
   private readonly logger = new Logger(AgentHostRunner.name);
   private readonly runners = new Map<string, PerConfigRunner>();
+  private readonly failedSpawns = new Map<string, { error: string; loggedAt: number }>();
   private reconcileTimer: NodeJS.Timeout | null = null;
   private stopped = false;
   private readonly baseUrl: string;
@@ -152,10 +153,11 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
         const runner = await this.spawnRunner(id);
         if (runner) {
           this.runners.set(id, runner);
+          this.failedSpawns.delete(id);
           this.logger.log(`started runner for ${id}`);
         }
       } catch (err) {
-        this.logger.error(`failed to start runner for ${id}: ${describe(err)}`);
+        this.recordSpawnFailure(id, describe(err));
       }
     }
 
@@ -166,6 +168,20 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
           this.logger.log(`acquired chat lock for ${id}`);
         }
       }
+    }
+  }
+
+  private recordSpawnFailure(id: string, error: string): void {
+    const now = Date.now();
+    const RELOG_MS = 10 * 60 * 1000;
+    const prev = this.failedSpawns.get(id);
+    const sameError = prev?.error === error;
+    const dueForRelog = !prev || !sameError || now - prev.loggedAt >= RELOG_MS;
+    if (dueForRelog) {
+      this.logger.error(`failed to start runner for ${id}: ${error}`);
+      this.failedSpawns.set(id, { error, loggedAt: now });
+    } else {
+      this.logger.debug?.(`spawn for ${id} still failing: ${error}`);
     }
   }
 


### PR DESCRIPTION
The reconcile loop spam-logs an ERROR every 30s when the admin API key in \`agent_config.admin_api_key_ct\` doesn't resolve to a live \`api_keys\` row. Now the same \`(config_id, error_message)\` is logged at ERROR once per 10 minutes; identical failures within the cooldown go to DEBUG. A successful spawn or a different error resets the dedup state.

Independent of the OAuth phases — just removes log noise. The underlying credential-mismatch is still surfaced clearly when it first happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)