### PR TITLE
test(oauth): conformance integration tests for Phase 5

### DIFF
--- a/apps/backend/src/auth/oauth-conformance.integration.test.ts
+++ b/apps/backend/src/auth/oauth-conformance.integration.test.ts
@@ -1,0 +1,102 @@
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { createApp } from '@getmunin/backend-core';
+import { runMigrations } from '@getmunin/db';
+import { AppModule } from '../app.module.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run OAuth AS conformance tests.';
+
+const FIXED_PORT = 17345;
+const PRESET_BASE_URL = `http://127.0.0.1:${FIXED_PORT}`;
+
+(skipReason ? describe.skip : describe)('OAuth 2.1 / MCP authorization-server conformance', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod-it-must-be-32-chars';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_STORAGE_PROVIDER = 'local';
+    process.env.MUNIN_STORAGE_LOCAL_PATH = '/tmp/munin-oauth-as-it';
+    process.env.MUNIN_STORAGE_LOCAL_BASE_URL = 'http://127.0.0.1:0/static/assets';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED = '1';
+    process.env.MUNIN_BUILTIN_AGENT = '0';
+    process.env.MUNIN_PUBLIC_URL = PRESET_BASE_URL;
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    app = await createApp(AppModule, { logger: false });
+    await app.listen(FIXED_PORT, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = PRESET_BASE_URL;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    delete process.env.MUNIN_PUBLIC_URL;
+  });
+
+  describe('RFC 8414: Authorization server metadata', () => {
+    it('serves the metadata at /.well-known/oauth-authorization-server', async () => {
+      const res = await fetch(`${baseUrl}/.well-known/oauth-authorization-server`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(typeof body.issuer).toBe('string');
+      expect(typeof body.authorization_endpoint).toBe('string');
+      expect(typeof body.token_endpoint).toBe('string');
+      expect(typeof body.registration_endpoint).toBe('string');
+      expect(Array.isArray(body.response_types_supported)).toBe(true);
+      expect(body.response_types_supported).toContain('code');
+      expect(Array.isArray(body.grant_types_supported)).toBe(true);
+      expect(body.grant_types_supported).toContain('authorization_code');
+      expect(body.grant_types_supported).toContain('refresh_token');
+      expect(Array.isArray(body.scopes_supported)).toBe(true);
+      expect(body.scopes_supported).toContain('mcp:tools');
+      expect(Array.isArray(body.code_challenge_methods_supported)).toBe(true);
+      expect(body.code_challenge_methods_supported).toContain('S256');
+    });
+
+    it('exposes the upstream openid-configuration document', async () => {
+      const res = await fetch(`${baseUrl}/auth/.well-known/openid-configuration`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.issuer).toBe(baseUrl);
+      expect(body.registration_endpoint).toBe(`${baseUrl}/auth/oauth2/register`);
+    });
+  });
+
+  describe('RFC 7591: Dynamic Client Registration', () => {
+    it('mints a public client and persists it', async () => {
+      const res = await fetch(`${baseUrl}/auth/oauth2/register`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          client_name: 'Conformance Test Client',
+          redirect_uris: ['http://localhost:5173/callback'],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          token_endpoint_auth_method: 'none',
+          scope: 'openid mcp:tools',
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(typeof body.client_id).toBe('string');
+      expect((body.client_id as string).length).toBeGreaterThan(8);
+      expect(body.redirect_uris).toEqual(['http://localhost:5173/callback']);
+    });
+  });
+});

--- a/packages/backend-core/src/oauth/oauth-conformance.integration.test.ts
+++ b/packages/backend-core/src/oauth/oauth-conformance.integration.test.ts
@@ -1,0 +1,81 @@
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { NestFactory } from '@nestjs/core';
+import { runMigrations } from '@getmunin/db';
+import { AppModule } from '../app.module.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run OAuth conformance tests.';
+
+(skipReason ? describe.skip : describe)('OAuth 2.1 / MCP resource-server conformance', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod-it-must-be-32-chars';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_STORAGE_PROVIDER = 'local';
+    process.env.MUNIN_STORAGE_LOCAL_PATH = '/tmp/munin-oauth-rs-it';
+    process.env.MUNIN_STORAGE_LOCAL_BASE_URL = 'http://127.0.0.1:0/static/assets';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED = '1';
+    process.env.MUNIN_BUILTIN_AGENT = '0';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+    process.env.MUNIN_PUBLIC_URL = baseUrl;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    delete process.env.MUNIN_PUBLIC_URL;
+  });
+
+  describe('RFC 9728: Protected resource metadata', () => {
+    it('serves the metadata at /.well-known/oauth-protected-resource', async () => {
+      const res = await fetch(`${baseUrl}/.well-known/oauth-protected-resource`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/application\/json/);
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.resource).toBe(`${baseUrl}/mcp`);
+      expect(body.authorization_servers).toEqual([baseUrl]);
+      expect(body.bearer_methods_supported).toEqual(['header']);
+      expect(body.resource_indicators_supported).toBe(true);
+      expect(Array.isArray(body.scopes_supported)).toBe(true);
+      expect(body.scopes_supported).toContain('mcp:tools');
+    });
+  });
+
+  describe('MCP authorization spec: WWW-Authenticate on 401', () => {
+    it('emits Bearer challenge with resource_metadata for /mcp', async () => {
+      const res = await fetch(`${baseUrl}/mcp`, { method: 'POST', body: '{}' });
+      expect(res.status).toBe(401);
+      const challenge = res.headers.get('www-authenticate') ?? '';
+      expect(challenge).toContain('Bearer');
+      expect(challenge).toContain('resource_metadata="');
+      expect(challenge).toContain('/.well-known/oauth-protected-resource');
+    });
+
+    it('does NOT emit the resource_metadata challenge for non-/mcp routes', async () => {
+      const res = await fetch(`${baseUrl}/api/v1/whoami`);
+      expect(res.status).toBe(401);
+      const challenge = res.headers.get('www-authenticate') ?? '';
+      expect(challenge).not.toContain('resource_metadata');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Resource-server conformance test (backend-core): RFC 9728 metadata shape, Bearer challenge with `resource_metadata` on `/mcp` 401s, and that non-/mcp 401s do NOT get the challenge.
- Authorization-server conformance test (apps/backend): RFC 8414 oauth-authorization-server alias, upstream openid-configuration document, and RFC 7591 DCR via `/auth/oauth2/register`.
- Both suites skip when no Postgres URL is available.

## Test plan
- [x] `pnpm --filter @getmunin/backend-core test -- --run oauth-conformance` (3 tests pass against a fresh DB)
- [x] `pnpm --filter @getmunin/backend test -- --run oauth-conformance` (3 tests pass against a fresh DB)
- [x] `pnpm --filter @getmunin/backend-core typecheck && pnpm --filter @getmunin/backend-core lint`
- [x] `pnpm --filter @getmunin/backend typecheck && pnpm --filter @getmunin/backend lint`

## Notes
- Better-Auth surfaced a deprecation warning for the `oidc-provider` plugin (move to `@better-auth/oauth-provider` in a future major). Tracking separately — not changed here.
- Closes the Phase 5 conformance audit work; manual smokes against `mcp-inspector` / Claude Desktop remain optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)