### PR TITLE
feat(dashboard): editorial overview redesign + dev DB/env QoL

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -10,6 +10,7 @@
     "dev": "nest start --watch",
     "start": "node dist/main.js",
     "migrate": "tsx src/migrate.ts",
+    "migrate:test": "tsx src/migrate-test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"

--- a/apps/backend/src/load-env.ts
+++ b/apps/backend/src/load-env.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+function findWorkspaceRoot(start: string): string | null {
+  let dir = start;
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(resolve(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+const root = findWorkspaceRoot(process.cwd());
+if (root) {
+  const envPath = resolve(root, '.env');
+  if (existsSync(envPath) && typeof process.loadEnvFile === 'function') {
+    process.loadEnvFile(envPath);
+  }
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,3 +1,4 @@
+import './load-env.js';
 import './instrument.js';
 import 'reflect-metadata';
 import { createApp } from '@getmunin/backend-core';

--- a/apps/backend/src/migrate-test.ts
+++ b/apps/backend/src/migrate-test.ts
@@ -1,0 +1,54 @@
+import './load-env.js';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { runMigrations } from '@getmunin/db';
+import { AGENT_HOST_SINGLETON_DDL } from '@getmunin/agent-host';
+
+async function main(): Promise<void> {
+  const targetUrl = process.env.MUNIN_TEST_MIGRATE_URL;
+  if (!targetUrl) {
+    console.error('MUNIN_TEST_MIGRATE_URL is required');
+    process.exit(1);
+  }
+
+  const target = new URL(targetUrl);
+  const targetDb = target.pathname.replace(/^\//, '');
+  if (!targetDb) {
+    console.error(`MUNIN_TEST_MIGRATE_URL must include a database name: ${targetUrl}`);
+    process.exit(1);
+  }
+
+  const adminUrl = new URL(targetUrl);
+  adminUrl.pathname = '/postgres';
+
+  const admin = postgres(adminUrl.toString(), { max: 1 });
+  try {
+    const existing = await admin<{ count: string }[]>`
+      SELECT count(*)::text AS count
+      FROM pg_database
+      WHERE datname = ${targetDb}
+    `;
+    if (existing[0]?.count === '0') {
+      await admin.unsafe(`CREATE DATABASE "${targetDb.replace(/"/g, '""')}"`);
+      console.log(`created database ${targetDb}`);
+    } else {
+      console.log(`database ${targetDb} already exists`);
+    }
+  } finally {
+    await admin.end();
+  }
+
+  await runMigrations(targetUrl);
+  console.log('OSS schema applied to test DB');
+
+  const client = postgres(targetUrl, { max: 1 });
+  try {
+    const db = drizzle(client);
+    await db.execute(AGENT_HOST_SINGLETON_DDL);
+    console.log('agent-host singleton DDL applied to test DB');
+  } finally {
+    await client.end();
+  }
+}
+
+void main();

--- a/apps/backend/src/migrate.ts
+++ b/apps/backend/src/migrate.ts
@@ -8,6 +8,7 @@
  * Reads MUNIN_MIGRATE_URL (privileged superuser URL — not the runtime
  * munin_app role). Both halves are idempotent.
  */
+import './load-env.js';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { runMigrations } from '@getmunin/db';

--- a/apps/backend/test-env.ts
+++ b/apps/backend/test-env.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+function findWorkspaceRoot(start: string): string | null {
+  let dir = start;
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(resolve(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+const root = findWorkspaceRoot(process.cwd());
+if (root) {
+  const envPath = resolve(root, '.env');
+  if (existsSync(envPath) && typeof process.loadEnvFile === 'function') {
+    process.loadEnvFile(envPath);
+  }
+}

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,3 +1,4 @@
+import './test-env';
 import { defineConfig } from 'vitest/config';
 import swc from 'unplugin-swc';
 

--- a/apps/web/components/munin-topbar.tsx
+++ b/apps/web/components/munin-topbar.tsx
@@ -10,15 +10,17 @@ import { cn } from '@getmunin/ui';
 import { LocaleSwitcher } from './locale-switcher';
 import { UserMenu } from './user-menu';
 
-type NavLabelKey = 'inbox' | 'settings';
+type NavLabelKey = 'overview' | 'inbox' | 'settings';
 
 interface NavItem {
   href: Route;
   labelKey: NavLabelKey;
   ownerOrAdminOnly?: boolean;
+  exact?: boolean;
 }
 
 const NAV: NavItem[] = [
+  { href: '/dashboard', labelKey: 'overview', exact: true },
   { href: '/dashboard/inbox', labelKey: 'inbox' },
   { href: '/dashboard/settings', labelKey: 'settings', ownerOrAdminOnly: true },
 ];
@@ -60,7 +62,7 @@ export function MuninTopbar({ role, user, onSignOut, inboxCount, status = 'conne
 
       <nav className="absolute inset-y-0 left-1/2 flex -translate-x-1/2 items-stretch">
         {visibleNav.map((item) => {
-          const active = pathname.startsWith(item.href);
+          const active = item.exact ? pathname === item.href : pathname.startsWith(item.href);
           return (
             <Link
               key={item.href}
@@ -69,7 +71,7 @@ export function MuninTopbar({ role, user, onSignOut, inboxCount, status = 'conne
                 'inline-flex items-center gap-1.5 px-5 text-[13px] -mb-px border-b-2 border-transparent transition-colors duration-fast ease-munin',
                 active
                   ? 'border-cobalt bg-paper-deep font-medium text-ink dark:bg-secondary dark:text-foreground dark:border-cobalt-soft'
-                  : 'text-ink-mute hover:bg-paper-deep hover:text-ink dark:hover:bg-secondary dark:hover:text-foreground',
+                  : 'text-ink-mute hover:bg-paper-deep hover:text-ink hover:border-ink dark:hover:bg-secondary dark:hover:text-foreground dark:hover:border-foreground',
               )}
             >
               {tNav(item.labelKey)}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -80,36 +80,6 @@
     "partnerAccess": "Partner access"
   },
   "dashboard": {
-    "overview": {
-      "title": "Welcome to Munin",
-      "subtitle": "Connect your AI agent or build a server-side integration.",
-      "connectCard": {
-        "title": "Connect your AI agent",
-        "description": "Add this URL to Claude Desktop, Cursor, or any MCP client.",
-        "consentNote": "You'll see a consent screen here when an agent connects."
-      },
-      "buildCard": {
-        "title": "Build a server integration",
-        "description": "Voice AI, web chatbot, or mobile app? Mint short-lived end-user tokens server-side.",
-        "cta": "Manage API keys"
-      }
-    },
-    "agentStatus": {
-      "title": "Self-service agent",
-      "connected": "{count, plural, one {1 agent connected} other {# agents connected}} — replies to end-user messages will be handled automatically.",
-      "notConnected": "No self-service agent connected. End-user messages will sit until a human replies from the dashboard or an agent runner is connected.",
-      "staleNotConnected": "No self-service agent connected, and there are unanswered end-user messages. Reply from the dashboard or connect an agent runner.",
-      "hint": "Connect an agent: run @getmunin/agent-runtime against this Munin's MCP, or use the cloud product's auto-replier."
-    },
-    "needsAttention": {
-      "title": "Needs attention",
-      "allClear": "All caught up.",
-      "conversationsLabel": "conversations needing handover",
-      "openConversations": "Open conversations →",
-      "kbCurationLabel": "KB suggestions pending review",
-      "crmMergeProposalsLabel": "CRM merges pending review",
-      "openInbox": "Open inbox →"
-    },
     "agents": {
       "title": "Connected agents",
       "subtitle": "Every OAuth-authorized agent and end-user token issued for this org. Revoke any active token to immediately invalidate further MCP calls.",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -80,36 +80,6 @@
     "partnerAccess": "Partnertilgang"
   },
   "dashboard": {
-    "overview": {
-      "title": "Velkommen til Munin",
-      "subtitle": "Koble til AI-agenten din eller bygg en serverside-integrasjon.",
-      "connectCard": {
-        "title": "Koble til AI-agenten din",
-        "description": "Legg denne URL-en inn i Claude Desktop, Cursor eller en annen MCP-klient.",
-        "consentNote": "Du ser et samtykkebilde her når en agent kobler seg til."
-      },
-      "buildCard": {
-        "title": "Bygg en serverside-integrasjon",
-        "description": "Tale-AI, web-chatbot eller mobilapp? Generer korte sluttbruker-tokens fra serveren.",
-        "cta": "Administrer API-nøkler"
-      }
-    },
-    "agentStatus": {
-      "title": "Selvbetjeningsagent",
-      "connected": "{count, plural, one {1 agent tilkoblet} other {# agenter tilkoblet}} — sluttbrukermeldinger får automatiske svar.",
-      "notConnected": "Ingen selvbetjeningsagent tilkoblet. Sluttbrukermeldinger blir liggende til et menneske svarer fra dashbordet eller en agent-runner kobles til.",
-      "staleNotConnected": "Ingen selvbetjeningsagent tilkoblet, og det finnes ubesvarte sluttbrukermeldinger. Svar fra dashbordet eller koble til en agent-runner.",
-      "hint": "Koble til en agent: kjør @getmunin/agent-runtime mot dette Munin-instansens MCP, eller bruk skytjenesten."
-    },
-    "needsAttention": {
-      "title": "Trenger oppmerksomhet",
-      "allClear": "Alt er ajour.",
-      "conversationsLabel": "samtaler som venter på overlevering",
-      "openConversations": "Åpne samtaler →",
-      "kbCurationLabel": "KB-forslag venter på gjennomgang",
-      "crmMergeProposalsLabel": "CRM-sammenslåinger venter på gjennomgang",
-      "openInbox": "Åpne innboks →"
-    },
     "agents": {
       "title": "Tilkoblede agenter",
       "subtitle": "Alle OAuth-autoriserte agenter og sluttbruker-tokens utstedt for denne organisasjonen. Tilbakekall et aktivt token for å gjøre videre MCP-kall ugyldige umiddelbart.",

--- a/packages/backend-core/test-env.ts
+++ b/packages/backend-core/test-env.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+function findWorkspaceRoot(start: string): string | null {
+  let dir = start;
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(resolve(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+const root = findWorkspaceRoot(process.cwd());
+if (root) {
+  const envPath = resolve(root, '.env');
+  if (existsSync(envPath) && typeof process.loadEnvFile === 'function') {
+    process.loadEnvFile(envPath);
+  }
+}

--- a/packages/backend-core/vitest.config.ts
+++ b/packages/backend-core/vitest.config.ts
@@ -1,3 +1,4 @@
+import './test-env';
 import { defineConfig } from 'vitest/config';
 import swc from 'unplugin-swc';
 

--- a/packages/dashboard-pages/src/components/dashboard/dashboard-hero.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/dashboard-hero.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Hero } from '@getmunin/ui';
+
+interface DashboardHeroProps {
+  orgName: string | null;
+  date: Date;
+  totalCount: number;
+  liveCount: number;
+}
+
+export function DashboardHero({ orgName, date, totalCount, liveCount }: DashboardHeroProps) {
+  const dateLabel = date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const eyebrow = [orgName, dateLabel].filter(Boolean).join(' · ');
+  const lede = composeLede(totalCount, liveCount);
+
+  return (
+    <Hero
+      eyebrow={eyebrow}
+      title={
+        <>
+          The day, <em>from above</em>.
+        </>
+      }
+      lede={lede}
+    />
+  );
+}
+
+function composeLede(totalCount: number, liveCount: number): string {
+  if (totalCount === 0) {
+    return 'Nothing waiting on you. The agents are caught up; the perch is quiet.';
+  }
+  const things =
+    totalCount === 1 ? '1 thing waiting on you' : `${totalCount} things waiting on you`;
+  if (liveCount === 0) {
+    return `${things}. No live conversations — review at your own pace.`;
+  }
+  if (liveCount === 1) {
+    return `${things}, and one live conversation needs a reply.`;
+  }
+  return `${things}, and ${liveCount} live conversations need a reply.`;
+}

--- a/packages/dashboard-pages/src/components/dashboard/get-started.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/get-started.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { cn, Eyebrow } from '@getmunin/ui';
+import { MCP_SETUPS, type McpSetup } from '../../data/mcp-setups';
+import { RECIPES, type Recipe } from '../../data/recipes';
+import { RecipeDrawer } from './recipe-drawer';
+
+export function GetStarted() {
+  const [activeId, setActiveId] = useState<McpSetup['id']>('claude');
+  const [openRecipe, setOpenRecipe] = useState<Recipe | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const setup = MCP_SETUPS.find((s) => s.id === activeId) ?? MCP_SETUPS[0]!;
+
+  function copySnippet() {
+    if (navigator.clipboard) {
+      void navigator.clipboard.writeText(setup.snippet).catch(() => {});
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  }
+
+  return (
+    <section className="border-t border-rule-soft pt-14 dark:border-rule-on-dark">
+      <header className="mb-8 max-w-xl space-y-2">
+        <Eyebrow tone="muted">Get started</Eyebrow>
+        <h2 className="font-serif text-3xl md:text-4xl leading-[1.0] font-normal tracking-tight text-ink dark:text-foreground">
+          Wake the <em className="italic text-cobalt dark:text-cobalt-soft">flock</em>.
+        </h2>
+        <p className="text-sm text-ink-soft max-w-lg leading-[1.55] dark:text-foreground/80">
+          Connect your favourite model to Munin over MCP, then pick a recipe to wire up an agent
+          that drops drafts into this inbox.
+        </p>
+      </header>
+
+      <div className="grid gap-9 md:grid-cols-[1.05fr_1fr] items-start">
+        {/* MCP setup column */}
+        <div>
+          <div className="flex justify-between items-baseline border-b border-ink pb-2.5 mb-4 dark:border-foreground">
+            <Eyebrow tone="ink" size="sm" className="font-medium">
+              01 · Connect MCP
+            </Eyebrow>
+            <Eyebrow tone="muted" size="sm">
+              pick your client
+            </Eyebrow>
+          </div>
+
+          <div className="flex border border-ink mb-3.5 dark:border-foreground">
+            {MCP_SETUPS.map((s) => {
+              const active = s.id === activeId;
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  onClick={() => {
+                    setActiveId(s.id);
+                    setCopied(false);
+                  }}
+                  className={cn(
+                    'flex-1 cursor-pointer px-3.5 py-2.5 flex flex-col items-start gap-0.5 border-r border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
+                    active
+                      ? 'bg-ink text-paper dark:bg-foreground dark:text-background'
+                      : 'bg-paper hover:bg-paper-deep dark:bg-card dark:hover:bg-secondary',
+                  )}
+                >
+                  <span className="text-[13px] font-medium">{s.label}</span>
+                  <span
+                    className={cn(
+                      'font-mono text-[9px] uppercase tracking-eyebrow',
+                      active ? 'text-paper/55' : 'text-ink-mute',
+                    )}
+                  >
+                    {s.sublabel}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="bg-paper-deep border border-ink dark:bg-card dark:border-rule-on-dark">
+            <pre className="m-0 px-4 py-4 overflow-x-auto font-mono text-xs leading-[1.6] text-ink dark:text-foreground">
+              <code>{setup.snippet}</code>
+            </pre>
+            <div className="flex justify-between items-center px-3.5 py-2 border-t border-rule-soft bg-paper dark:bg-secondary dark:border-rule-on-dark">
+              <a
+                href={setup.docsHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute hover:text-cobalt transition-colors duration-fast"
+              >
+                {setup.docsLabel} ↗
+              </a>
+              <button
+                type="button"
+                onClick={copySnippet}
+                className="font-mono text-[10px] uppercase tracking-eyebrow bg-ink text-paper border-0 px-3 py-1.5 cursor-pointer hover:bg-black dark:bg-foreground dark:text-background"
+              >
+                {copied ? 'Copied ✓' : 'Copy'}
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-4 px-4 py-3.5 bg-paper-deep border-l-2 border-cobalt text-[13px] leading-[1.55] text-ink-soft dark:bg-secondary dark:text-foreground/80">
+            <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute mr-2">
+              Then
+            </span>
+            Mint an API key in{' '}
+            <Link
+              href="/dashboard/settings/api-keys"
+              className="text-cobalt no-underline border-b border-current dark:text-cobalt-soft"
+            >
+              Settings · API keys
+            </Link>{' '}
+            and paste it in place of the placeholder. The token scopes the agent to a single org.
+          </div>
+        </div>
+
+        {/* Recipes column */}
+        <div>
+          <div className="flex justify-between items-baseline border-b border-ink pb-2.5 mb-4 dark:border-foreground">
+            <Eyebrow tone="ink" size="sm" className="font-medium">
+              02 · Agent recipes
+            </Eyebrow>
+            <Eyebrow tone="muted" size="sm">
+              {RECIPES.length} starters
+            </Eyebrow>
+          </div>
+
+          <ul className="list-none m-0 p-0 border-t border-rule-soft dark:border-rule-on-dark">
+            {RECIPES.map((r) => (
+              <li
+                key={r.id}
+                tabIndex={0}
+                role="button"
+                onClick={() => setOpenRecipe(r)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setOpenRecipe(r);
+                  }
+                }}
+                className="grid grid-cols-[1fr_auto] gap-5 items-center px-1.5 py-3.5 border-b border-rule-soft cursor-pointer transition-[padding,background] duration-fast ease-munin hover:bg-paper-deep hover:pl-3 focus:outline-none focus:bg-paper-deep dark:border-rule-on-dark dark:hover:bg-secondary dark:focus:bg-secondary"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-ink dark:text-foreground">{r.name}</div>
+                  <div className="text-[13px] text-ink-soft mt-0.5 leading-[1.45] dark:text-foreground/75">
+                    {r.summary}
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-1 whitespace-nowrap">
+                  <span className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+                    {r.cadence}
+                  </span>
+                  <span className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+                    View prompt →
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <RecipeDrawer recipe={openRecipe} onClose={() => setOpenRecipe(null)} />
+    </section>
+  );
+}

--- a/packages/dashboard-pages/src/components/dashboard/inbox-preview.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-preview.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { cn, Eyebrow, Pill } from '@getmunin/ui';
+import {
+  formatRelativeAge,
+  type InboxPreviewKind,
+  type InboxPreviewRow,
+} from '../../lib/inbox-preview';
+
+const PILL_TONE: Record<InboxPreviewKind, 'live' | 'kb' | 'crm' | 'out'> = {
+  conv: 'live',
+  kb: 'kb',
+  crm: 'crm',
+  out: 'out',
+};
+
+interface InboxPreviewProps {
+  rows: InboxPreviewRow[];
+  totalCount: number;
+}
+
+export function InboxPreview({ rows, totalCount }: InboxPreviewProps) {
+  return (
+    <section className="min-w-0">
+      <div className="flex items-baseline justify-between gap-4 border-b border-ink pb-2.5 mb-3.5 dark:border-foreground">
+        <Eyebrow tone="ink" size="sm" className="font-medium">
+          Inbox{' '}
+          <span className="text-cobalt dark:text-cobalt-soft ml-1.5">
+            {String(totalCount).padStart(2, '0')}
+          </span>
+        </Eyebrow>
+        <Link
+          href="/dashboard/inbox"
+          className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute hover:text-cobalt transition-colors duration-fast"
+        >
+          Open inbox →
+        </Link>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="font-serif italic text-base text-ink-mute py-6">
+          Nothing waiting — the perch is quiet.
+        </p>
+      ) : (
+        <ul className="list-none m-0 p-0">
+          {rows.map((row) => (
+            <InboxRow key={row.id} row={row} />
+          ))}
+        </ul>
+      )}
+
+      <Link
+        href="/dashboard/inbox"
+        className="mt-3.5 inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-eyebrow text-cobalt hover:text-cobalt-deep transition-colors duration-fast py-2 dark:text-cobalt-soft"
+      >
+        Open inbox →
+      </Link>
+    </section>
+  );
+}
+
+function InboxRow({ row }: { row: InboxPreviewRow }) {
+  const age = useRelativeAge(row.timestamp);
+  return (
+    <li>
+      <Link
+        href="/dashboard/inbox"
+        className={cn(
+          'grid items-center gap-3.5 px-1.5 py-2.5 border-b border-rule-soft cursor-pointer transition-[padding,background] duration-fast ease-munin hover:bg-paper-deep hover:pl-3 dark:border-rule-on-dark dark:hover:bg-secondary',
+          'grid-cols-[120px_minmax(0,1fr)_auto]',
+        )}
+      >
+        <span className="flex">
+          <Pill tone={PILL_TONE[row.kind]} pulse={row.live}>
+            {row.pillLabel}
+          </Pill>
+        </span>
+        <span className="min-w-0 truncate text-[13px] block">
+          <span
+            className={cn(
+              'font-medium',
+              row.live ? 'text-cobalt dark:text-cobalt-soft' : 'text-ink dark:text-foreground',
+            )}
+          >
+            {row.subject}
+          </span>
+          <span className="text-ink-mute ml-2">· {row.who}</span>
+        </span>
+        <span
+          className={cn(
+            'font-mono text-[10px] text-right min-w-[48px]',
+            row.live ? 'text-cobalt dark:text-cobalt-soft' : 'text-ink-mute',
+          )}
+        >
+          {age}
+        </span>
+      </Link>
+    </li>
+  );
+}
+
+function useRelativeAge(iso: string): string {
+  const [age, setAge] = useState(() => formatRelativeAge(iso));
+  useEffect(() => {
+    setAge(formatRelativeAge(iso));
+    const id = setInterval(() => setAge(formatRelativeAge(iso)), 60_000);
+    return () => clearInterval(id);
+  }, [iso]);
+  return age;
+}

--- a/packages/dashboard-pages/src/components/dashboard/recipe-drawer.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/recipe-drawer.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Button,
+  Eyebrow,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@getmunin/ui';
+import type { Recipe } from '../../data/recipes';
+
+interface RecipeDrawerProps {
+  recipe: Recipe | null;
+  onClose: () => void;
+}
+
+export function RecipeDrawer({ recipe, onClose }: RecipeDrawerProps) {
+  const [copied, setCopied] = useState(false);
+
+  function copyPrompt() {
+    if (!recipe) return;
+    if (navigator.clipboard) {
+      void navigator.clipboard.writeText(recipe.prompt).catch(() => {});
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  }
+
+  return (
+    <Sheet
+      open={recipe !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          setCopied(false);
+          onClose();
+        }
+      }}
+    >
+      <SheetContent side="right" className="w-full max-w-[640px]">
+        {recipe && (
+          <>
+            <SheetHeader>
+              <Eyebrow tone="muted" size="sm">
+                Recipe · {recipe.cadence}
+              </Eyebrow>
+              <SheetTitle>{recipe.name}</SheetTitle>
+              <SheetDescription>{recipe.summary}</SheetDescription>
+            </SheetHeader>
+
+            <div className="flex-1 overflow-y-auto px-6 py-5 space-y-7">
+              <section>
+                <Eyebrow tone="muted" size="sm" className="block mb-2.5">
+                  Tools
+                </Eyebrow>
+                <ul className="list-none m-0 p-0 space-y-1">
+                  {recipe.tools.map((t) => (
+                    <li key={t} className="font-mono text-xs">
+                      <code className="bg-paper-deep border border-rule-soft px-2 py-1 inline-block dark:bg-secondary dark:border-rule-on-dark">
+                        {t}
+                      </code>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              <section>
+                <Eyebrow tone="muted" size="sm" className="block mb-2.5">
+                  System prompt · paste this verbatim
+                </Eyebrow>
+                <pre className="bg-paper-deep border border-ink p-5 m-0 font-mono text-xs leading-[1.65] text-ink whitespace-pre-wrap break-words max-h-[480px] overflow-y-auto dark:bg-card dark:border-rule-on-dark dark:text-foreground">
+                  <code>{recipe.prompt}</code>
+                </pre>
+              </section>
+            </div>
+
+            <footer className="px-6 py-3.5 border-t border-ink flex gap-3 items-center bg-paper dark:bg-card dark:border-rule-on-dark">
+              <Button onClick={copyPrompt}>{copied ? 'Copied ✓' : 'Copy prompt'}</Button>
+              <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+                After pasting, point the agent's MCP at <code className="text-cobalt">munin</code>
+              </span>
+            </footer>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/dashboard-pages/src/components/dashboard/spark.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/spark.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@getmunin/ui';
+
+interface SparkProps {
+  values: number[];
+  className?: string;
+  tone?: 'accent' | 'ink';
+}
+
+export function Spark({ values, className, tone = 'accent' }: SparkProps) {
+  if (values.length < 2) {
+    return <svg className={cn('block w-full h-[22px]', className)} viewBox="0 0 200 22" />;
+  }
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const w = 200;
+  const h = 22;
+  const points = values
+    .map((v, i) => {
+      const x = (i / (values.length - 1)) * w;
+      const y = h - ((v - min) / Math.max(1, max - min)) * h;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+  return (
+    <svg
+      className={cn('block w-full h-[22px]', className)}
+      viewBox={`0 0 ${w} ${h}`}
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <polyline
+        fill="none"
+        strokeWidth={1.2}
+        points={points}
+        className={
+          tone === 'accent'
+            ? 'stroke-cobalt dark:stroke-cobalt-soft'
+            : 'stroke-ink dark:stroke-foreground'
+        }
+      />
+    </svg>
+  );
+}

--- a/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import Link from 'next/link';
+import { Eyebrow } from '@getmunin/ui';
+import { Spark } from './spark';
+
+interface SummaryTile {
+  current: number;
+  previous: number;
+  sparkline: number[];
+}
+
+export interface UsageSummary {
+  mcpCalls: SummaryTile;
+  apiCalls: SummaryTile;
+  conversations: SummaryTile;
+  avgLatencyMs: SummaryTile;
+}
+
+interface UsageKpisProps {
+  summary: UsageSummary | null;
+}
+
+export function UsageKpis({ summary }: UsageKpisProps) {
+  return (
+    <section className="min-w-0">
+      <div className="flex items-baseline justify-between gap-4 border-b border-ink pb-2.5 mb-3.5 dark:border-foreground">
+        <Eyebrow tone="ink" size="sm" className="font-medium">
+          Usage · this month
+        </Eyebrow>
+        <Link
+          href="/dashboard/settings/usage"
+          className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute hover:text-cobalt transition-colors duration-fast"
+        >
+          Full report →
+        </Link>
+      </div>
+
+      <div className="grid gap-3.5 grid-cols-[repeat(auto-fit,minmax(180px,1fr))]">
+        <Kpi
+          label="MCP calls"
+          value={summary?.mcpCalls.current}
+          previous={summary?.mcpCalls.previous}
+          spark={summary?.mcpCalls.sparkline ?? []}
+          format={formatCount}
+        />
+        <Kpi
+          label="API calls"
+          value={summary?.apiCalls.current}
+          previous={summary?.apiCalls.previous}
+          spark={summary?.apiCalls.sparkline ?? []}
+          format={formatCount}
+        />
+        <Kpi
+          label="Conversations"
+          value={summary?.conversations.current}
+          previous={summary?.conversations.previous}
+          spark={summary?.conversations.sparkline ?? []}
+          format={formatCount}
+        />
+        <Kpi
+          label="Avg latency · 7d"
+          value={summary?.avgLatencyMs.current}
+          previous={summary?.avgLatencyMs.previous}
+          spark={summary?.avgLatencyMs.sparkline ?? []}
+          format={formatLatency}
+          lowerIsBetter
+          tone="ink"
+        />
+      </div>
+
+      <Link
+        href="/dashboard/settings/usage"
+        className="mt-3.5 inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-eyebrow text-cobalt hover:text-cobalt-deep transition-colors duration-fast py-2 dark:text-cobalt-soft"
+      >
+        See by-agent breakdown →
+      </Link>
+    </section>
+  );
+}
+
+interface KpiProps {
+  label: string;
+  value: number | undefined;
+  previous: number | undefined;
+  spark: number[];
+  format: (n: number) => string;
+  lowerIsBetter?: boolean;
+  tone?: 'accent' | 'ink';
+}
+
+function Kpi({ label, value, previous, spark, format, lowerIsBetter, tone = 'accent' }: KpiProps) {
+  const delta = formatDelta(value, previous, format, lowerIsBetter);
+  return (
+    <div className="border border-rule-soft bg-paper px-4 py-3.5 dark:bg-card dark:border-rule-on-dark">
+      <div className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">{label}</div>
+      <div className="font-serif text-[28px] leading-none tracking-tight my-1.5 text-ink dark:text-foreground">
+        {value === undefined ? '—' : format(value)}
+      </div>
+      <div
+        className={
+          delta?.tone === 'positive'
+            ? 'font-mono text-[10px] text-emerald-700 dark:text-emerald-400'
+            : 'font-mono text-[10px] text-ink-mute'
+        }
+      >
+        {delta?.label ?? ' '}
+      </div>
+      <Spark className="mt-2" values={spark} tone={tone} />
+    </div>
+  );
+}
+
+function formatCount(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+function formatLatency(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function formatDelta(
+  current: number | undefined,
+  previous: number | undefined,
+  format: (n: number) => string,
+  lowerIsBetter = false,
+): { tone: 'positive' | 'neutral'; label: string } | null {
+  if (current === undefined || previous === undefined || previous === 0) return null;
+  const diff = current - previous;
+  if (diff === 0) return { tone: 'neutral', label: 'flat vs last' };
+  const pct = Math.round((Math.abs(diff) / previous) * 100);
+  const arrow = diff > 0 ? '↑' : '↓';
+  const isImprovement = lowerIsBetter ? diff < 0 : diff > 0;
+  if (lowerIsBetter) {
+    const absDiff = Math.abs(diff);
+    return {
+      tone: isImprovement ? 'positive' : 'neutral',
+      label: `${arrow} ${format(absDiff)}`,
+    };
+  }
+  return {
+    tone: isImprovement ? 'positive' : 'neutral',
+    label: `${arrow} ${pct}% vs last`,
+  };
+}

--- a/packages/dashboard-pages/src/data/mcp-setups.ts
+++ b/packages/dashboard-pages/src/data/mcp-setups.ts
@@ -1,0 +1,67 @@
+export interface McpSetup {
+  id: 'claude' | 'chatgpt' | 'gemini';
+  label: string;
+  sublabel: string;
+  snippet: string;
+  docsHref: string;
+  docsLabel: string;
+}
+
+const HOST = 'https://mcp.getmunin.com';
+const TOKEN_PLACEHOLDER = 'mn_live_••••••••';
+
+export const MCP_SETUPS: McpSetup[] = [
+  {
+    id: 'claude',
+    label: 'Claude',
+    sublabel: 'Desktop & Web',
+    snippet: `// claude_desktop_config.json
+{
+  "mcpServers": {
+    "munin": {
+      "url": "${HOST}",
+      "headers": {
+        "Authorization": "Bearer ${TOKEN_PLACEHOLDER}"
+      }
+    }
+  }
+}`,
+    docsHref: 'https://docs.getmunin.com/mcp/claude',
+    docsLabel: 'docs.getmunin.com/mcp/claude',
+  },
+  {
+    id: 'chatgpt',
+    label: 'ChatGPT',
+    sublabel: 'Custom Connector',
+    snippet: `// Settings → Connectors → New connector → MCP
+{
+  "name": "Munin",
+  "transport": "http",
+  "url":  "${HOST}",
+  "auth": {
+    "type":  "bearer",
+    "token": "${TOKEN_PLACEHOLDER}"
+  }
+}`,
+    docsHref: 'https://docs.getmunin.com/mcp/chatgpt',
+    docsLabel: 'docs.getmunin.com/mcp/chatgpt',
+  },
+  {
+    id: 'gemini',
+    label: 'Gemini',
+    sublabel: 'CLI & Studio',
+    snippet: `// ~/.gemini/mcp.json
+{
+  "servers": {
+    "munin": {
+      "url": "${HOST}",
+      "headers": {
+        "Authorization": "Bearer ${TOKEN_PLACEHOLDER}"
+      }
+    }
+  }
+}`,
+    docsHref: 'https://docs.getmunin.com/mcp/gemini',
+    docsLabel: 'docs.getmunin.com/mcp/gemini',
+  },
+];

--- a/packages/dashboard-pages/src/data/recipes.ts
+++ b/packages/dashboard-pages/src/data/recipes.ts
@@ -1,0 +1,244 @@
+export type RecipeCadence = 'continuous' | 'daily' | 'weekly' | 'event-driven' | 'on-demand';
+
+export interface Recipe {
+  id: string;
+  name: string;
+  summary: string;
+  cadence: RecipeCadence;
+  tools: string[];
+  prompt: string;
+}
+
+export const RECIPES: Recipe[] = [
+  {
+    id: 'kb-curator',
+    name: 'KB Curator',
+    summary: 'Watches conversations for KB gaps, drafts new articles, queues them for review.',
+    cadence: 'daily',
+    tools: [
+      'conv_search_messages',
+      'conv_list_conversations',
+      'kb_search',
+      'kb_propose_curation_candidate',
+      'kb_publish_curation_candidate',
+    ],
+    prompt: `You are the KB curator.
+
+Goal: keep the knowledge base accurate and aligned with what end-users actually
+ask. Drafts go to the curation inbox; never publish directly without review.
+
+Workflow (run daily, 18:00 local):
+1. Call conv_list_conversations(status="closed", since="24h") and pick a sample
+   of resolved conversations.
+2. For each, call conv_search_messages with the user's wording to confirm
+   recurring questions. Group similar phrasings into one theme.
+3. For each theme, call kb_search to check whether we already cover it. If an
+   existing article covers ~70% of the answer, stop and note it for an edit
+   instead of a new draft.
+4. For real gaps (3+ distinct conversations, no good article), call
+   kb_propose_curation_candidate with status="proposed". Title in the user's
+   own words. Body answerable in <300 words. One concrete example with
+   realistic numbers.
+5. Never call kb_publish_curation_candidate yourself — leave that to a human
+   reviewer in the inbox.
+
+Constraints:
+- One article per question. If it's two questions, propose two candidates.
+- No marketing voice. Direct, present-tense.
+- If the answer depends on the customer's plan or setup, say so explicitly.`,
+  },
+  {
+    id: 'content-marketer',
+    name: 'Content Marketer',
+    summary: 'Mines conversations for FAQs and drafts CMS entries that answer them.',
+    cadence: 'weekly',
+    tools: [
+      'conv_search_messages',
+      'kb_search',
+      'cms_list_collections',
+      'cms_create_entry',
+      'cms_publish_entry',
+    ],
+    prompt: `You are a content marketer.
+
+Goal: turn recurring questions in customer conversations into published CMS
+articles that answer them clearly.
+
+Workflow (run weekly, Monday 09:00 local):
+1. Call conv_search_messages on themes that came up repeatedly in the last
+   seven days. Keep the customers' verbatim phrasing.
+2. For each theme, call kb_search to see whether we already have an internal
+   article. If yes, mine it for the answer; if no, draft from the
+   conversations.
+3. Call cms_list_collections to find the right content type (e.g. "blog-post",
+   "help-article"). If unsure, stop and ask.
+4. Call cms_create_entry with status="draft". Title should match how
+   customers phrase the question; H2s should be the sub-questions that came
+   up most. Include one anonymised quote per post.
+5. Never call cms_publish_entry directly — file the draft and let a human
+   review it in the CMS.
+
+Constraints:
+- One post per theme per quarter; if we've covered it, propose an update.
+- No marketing language, no exclamation marks. Plain English.
+- 700-1200 words per post.`,
+  },
+  {
+    id: 'crm-deduper',
+    name: 'CRM Deduper',
+    summary: 'Finds duplicate contacts, files structured merge proposals for review.',
+    cadence: 'daily',
+    tools: [
+      'crm_list_contacts',
+      'crm_search_contacts',
+      'crm_propose_merge_candidate',
+      'crm_list_merge_proposals',
+    ],
+    prompt: `You are the CRM deduper.
+
+Goal: keep the contact list clean by surfacing duplicates as structured merge
+proposals — never merge without HITL approval.
+
+Workflow (run daily, 02:00 local):
+1. Call crm_list_contacts to walk the contact list in pages.
+2. For each contact, call crm_search_contacts on its name and email-local-part
+   to find near-duplicates (same person at a different email, typos, etc.).
+3. Score each candidate pair:
+   - high: identical normalised email OR identical phone OR exact name+domain match.
+   - medium: fuzzy name match + same company.
+   Skip everything below medium.
+4. Call crm_list_merge_proposals(status="pending") to dedupe against open
+   proposals before filing a new one.
+5. Call crm_propose_merge_candidate with confidence, evidence (the matching
+   fields), and recommendedKeeperId (prefer the one with more activities or
+   the verified email).
+
+Constraints:
+- Never call crm_apply_merge_proposal directly. Always propose.
+- Don't propose merges across companies unless there's a phone or email match.
+- One open proposal per pair — don't re-file if one is already pending.`,
+  },
+  {
+    id: 'outreach-drafter',
+    name: 'Outreach Drafter',
+    summary: 'Builds outbound campaigns from a brief, drafts personalised opener emails for review.',
+    cadence: 'on-demand',
+    tools: [
+      'crm_list_segments',
+      'crm_list_contacts_in_segment',
+      'crm_get_contact',
+      'outreach_create_campaign',
+      'outreach_propose_initial',
+    ],
+    prompt: `You are the outreach drafter.
+
+Goal: take a campaign brief from a human, target a CRM segment, and queue
+personalised opener emails for HITL approval.
+
+Brief format the human will give you:
+- offer (e.g. "30-min demo of conversation routing")
+- segment (segment name or natural-language ICP)
+- volume (e.g. "50 contacts")
+- tone (e.g. "warm, peer-to-peer")
+
+Workflow:
+1. Call crm_list_segments and pick the matching one. If no segment fits, stop
+   and ask the human to create one — never invent ad-hoc filters.
+2. Call crm_list_contacts_in_segment. The result already enforces suppression
+   and consent floors, so trust it. If the count is more than 2x the
+   requested volume, ask the human to narrow.
+3. Call outreach_create_campaign with enabled=false. Name it after the
+   offer + date.
+4. For each contact (up to volume), call crm_get_contact and pick one
+   specific hook from their profile or recent activity. If you can't find
+   one, drop the contact.
+5. Call outreach_propose_initial per contact. Subject: six words or fewer,
+   lowercase. Body: hook, one-line value prop, soft CTA, sign-off — four
+   lines total.
+
+Constraints:
+- Never enable the campaign or auto-send. HITL only.
+- One personalisation hook per email. If you can't find one, drop them.
+- No "I hope this finds you well". No "circling back". No "quick question".`,
+  },
+  {
+    id: 'bug-spotter',
+    name: 'Bug Spotter',
+    summary: 'Spots repeated themes in conversations and flags real product issues for engineering.',
+    cadence: 'daily',
+    tools: [
+      'conv_list_conversations',
+      'conv_search_messages',
+      'conv_get_conversation',
+      'conv_send_message',
+    ],
+    prompt: `You are the bug spotter.
+
+Goal: catch real product issues hiding in conversations and flag them as
+internal notes — not noise.
+
+Workflow (run daily, 10:00 local):
+1. Call conv_list_conversations(status="open", needsHumanAttention=true) plus
+   conversations closed in the last seven days.
+2. Call conv_search_messages for repeated phrases that suggest broken
+   behaviour: "doesn't work", "stopped working", "error", "blank screen",
+   etc. Cluster results that share a verb and an object.
+3. For each cluster of 4+ conversations, classify:
+   - bug: multiple users describing the same broken behaviour.
+   - confusion: users misreading something that works as designed.
+   - request: a feature that doesn't exist.
+   Only proceed with bugs.
+4. For each bug cluster, pick a representative conversation and call
+   conv_send_message with internal=true. Body must include:
+   - what the user did
+   - what they expected
+   - what happened
+   - the conversation IDs of the cluster
+   Prefix the body with "[bug-spotter] " so reviewers can filter.
+
+Constraints:
+- Never reply to the end-user. Internal notes only.
+- Never flag from a single conversation. Wait for the cluster.
+- If you're not sure it's a bug, classify confusion and stop.`,
+  },
+  {
+    id: 'renewal-watcher',
+    name: 'Renewal Watcher',
+    summary: 'Watches deals for upcoming renewals and drafts outreach when contracts approach end.',
+    cadence: 'daily',
+    tools: [
+      'crm_list_deals',
+      'crm_get_contact',
+      'crm_set_ai_summary',
+      'outreach_propose_initial',
+    ],
+    prompt: `You are the renewal watcher.
+
+Goal: surface every renewal early enough that an account manager has time to
+act — with enough context to act well.
+
+Workflow (run daily, 07:00 local):
+1. Call crm_list_deals(stage="active") and filter client-side for deals
+   closing within 60 days.
+2. For each deal, call crm_get_contact for the primary contact. Read their
+   tags, notes, and AI summary if present.
+3. Compute a health signal:
+   - red: low engagement signals (no recent activity, negative tags).
+   - yellow: mixed signals.
+   - green: positive recent activity.
+   Roll this up and call crm_set_ai_summary on the deal with a 2-3 sentence
+   summary including the colour.
+4. For yellow and red deals, call outreach_propose_initial drafting an
+   account-management email:
+   - red: direct check-in, name the concern, propose a working session.
+   - yellow: lighter touch, lead with a usage observation, ask one question.
+   File the draft against the existing deal owner's outreach campaign — or
+   stop and ask the human if no campaign exists.
+5. Green deals get a one-line AI summary and no draft.
+
+Constraints:
+- Never auto-send. Always HITL via the outreach proposal.
+- No "just checking in". Lead with a fact from the account.
+- Don't draft for an account that already has an open conversation thread.`,
+  },
+];

--- a/packages/dashboard-pages/src/lib/inbox-preview.ts
+++ b/packages/dashboard-pages/src/lib/inbox-preview.ts
@@ -1,0 +1,145 @@
+export type InboxPreviewKind = 'conv' | 'kb' | 'crm' | 'out';
+
+export interface InboxPreviewRow {
+  id: string;
+  kind: InboxPreviewKind;
+  pillLabel: string;
+  who: string;
+  subject: string;
+  timestamp: string;
+  live: boolean;
+}
+
+interface LiveSummary {
+  id: string;
+  subject: string | null;
+  endUserId: string | null;
+  needsHumanAttention: boolean;
+  needsHumanAttentionAt: string | null;
+  lastMessageAt: string | null;
+  updatedAt: string;
+  latestEndUserMessage: { body: string; createdAt: string } | null;
+}
+
+interface KbCandidate {
+  id: string;
+  title: string;
+  proposedTargetSpaceSlug: string | null;
+  updatedAt: string;
+}
+
+interface CrmContactSummary {
+  id: string;
+  name: string | null;
+  email: string | null;
+}
+
+interface CrmMergeProposal {
+  id: string;
+  contactA: CrmContactSummary;
+  contactB: CrmContactSummary;
+  confidence: 'high' | 'medium';
+  createdAt: string;
+}
+
+interface OutreachProposal {
+  id: string;
+  draftSubject: string | null;
+  campaign?: { name: string } | null;
+  contact?: { name: string | null; email: string | null } | null;
+  createdAt: string;
+}
+
+export interface InboxQueueShape {
+  live: LiveSummary[];
+  queue: {
+    kb: KbCandidate[];
+    crm: CrmMergeProposal[];
+    outreach: OutreachProposal[];
+  };
+}
+
+const contactLabel = (c: CrmContactSummary) => c.name ?? c.email ?? c.id;
+
+const liveToRow = (c: LiveSummary): InboxPreviewRow => ({
+  id: `live:${c.id}`,
+  kind: 'conv',
+  pillLabel: 'conversation',
+  who: c.endUserId ?? 'end-user',
+  subject: c.subject ?? c.latestEndUserMessage?.body.slice(0, 80) ?? 'New conversation',
+  timestamp: c.needsHumanAttentionAt ?? c.lastMessageAt ?? c.updatedAt,
+  live: true,
+});
+
+const kbToRow = (k: KbCandidate): InboxPreviewRow => ({
+  id: `kb:${k.id}`,
+  kind: 'kb',
+  pillLabel: 'kb',
+  who: k.proposedTargetSpaceSlug ? `for ${k.proposedTargetSpaceSlug}` : 'kb candidate',
+  subject: k.title,
+  timestamp: k.updatedAt,
+  live: false,
+});
+
+const crmToRow = (c: CrmMergeProposal): InboxPreviewRow => ({
+  id: `crm:${c.id}`,
+  kind: 'crm',
+  pillLabel: 'crm',
+  who: `${c.confidence} confidence`,
+  subject: `${contactLabel(c.contactA)} ↔ ${contactLabel(c.contactB)}`,
+  timestamp: c.createdAt,
+  live: false,
+});
+
+const outreachToRow = (o: OutreachProposal): InboxPreviewRow => ({
+  id: `out:${o.id}`,
+  kind: 'out',
+  pillLabel: 'outreach',
+  who: o.contact?.email ?? o.contact?.name ?? o.campaign?.name ?? 'draft',
+  subject: o.draftSubject ?? o.campaign?.name ?? 'Outreach draft',
+  timestamp: o.createdAt,
+  live: false,
+});
+
+export function mergeInboxPreview(
+  inbox: InboxQueueShape | null,
+  limit: number,
+): InboxPreviewRow[] {
+  if (!inbox) return [];
+  const rows: InboxPreviewRow[] = [
+    ...inbox.live.map(liveToRow),
+    ...inbox.queue.kb.map(kbToRow),
+    ...inbox.queue.crm.map(crmToRow),
+    ...inbox.queue.outreach.map(outreachToRow),
+  ];
+  rows.sort((a, b) => {
+    if (a.live !== b.live) return a.live ? -1 : 1;
+    return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+  });
+  return rows.slice(0, limit);
+}
+
+export function totalInboxCount(inbox: InboxQueueShape | null): number {
+  if (!inbox) return 0;
+  return (
+    inbox.live.length +
+    inbox.queue.kb.length +
+    inbox.queue.crm.length +
+    inbox.queue.outreach.length
+  );
+}
+
+export function formatRelativeAge(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const seconds = Math.max(0, Math.floor((now.getTime() - then) / 1000));
+  if (seconds < 60) return 'now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  const weeks = Math.floor(days / 7);
+  return `${weeks}w`;
+}

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -1,227 +1,91 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import Link from 'next/link';
-import { AlertCircle, Bot, CheckCircle2, Code2, KeyRound } from 'lucide-react';
-import { useTranslations } from 'next-intl';
-import { Button } from '@getmunin/ui';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@getmunin/ui';
 import { api } from '../api';
 import { useRealtime } from '../realtime';
+import { DashboardHero } from '../components/dashboard/dashboard-hero';
+import { GetStarted } from '../components/dashboard/get-started';
+import { InboxPreview } from '../components/dashboard/inbox-preview';
+import { UsageKpis, type UsageSummary } from '../components/dashboard/usage-kpis';
+import {
+  mergeInboxPreview,
+  totalInboxCount,
+  type InboxQueueShape,
+} from '../lib/inbox-preview';
 
-interface BacklogDto {
-  conversationsNeedingAttention: number;
-  kbCurationPending: number;
-  crmMergeProposalsPending: number;
-}
-
-interface AgentStatusDto {
-  selfServiceAgentSubscriberCount: number;
-  lastInboundEndUserMessageAt: string | null;
-  lastAgentMessageAt: string | null;
+interface MembershipDto {
+  orgId: string;
+  orgName: string;
+  orgSlug: string;
+  isDefault: boolean;
 }
 
 export function DashboardPage() {
-  const t = useTranslations('dashboard.overview');
-  const tBacklog = useTranslations('dashboard.needsAttention');
-  const tAgent = useTranslations('dashboard.agentStatus');
+  const [inbox, setInbox] = useState<InboxQueueShape | null>(null);
+  const [summary, setSummary] = useState<UsageSummary | null>(null);
+  const [orgName, setOrgName] = useState<string | null>(null);
 
-  const [backlog, setBacklog] = useState<BacklogDto | null>(null);
-  const [agentStatus, setAgentStatus] = useState<AgentStatusDto | null>(null);
-
-  const loadBacklog = useCallback(() => {
-    void api<BacklogDto>('/api/v1/overview/backlog')
-      .then(setBacklog)
-      .catch(() => setBacklog(null));
+  const loadInbox = useCallback(() => {
+    void api<InboxQueueShape>('/api/v1/inbox')
+      .then(setInbox)
+      .catch(() => setInbox(null));
   }, []);
-  const loadStatus = useCallback(() => {
-    void api<AgentStatusDto>('/api/v1/overview/agent-status')
-      .then(setAgentStatus)
-      .catch(() => setAgentStatus(null));
+  const loadSummary = useCallback(() => {
+    void api<UsageSummary>('/api/v1/usage/summary')
+      .then(setSummary)
+      .catch(() => setSummary(null));
+  }, []);
+  const loadOrg = useCallback(() => {
+    void api<MembershipDto[]>('/api/v1/me/memberships')
+      .then((memberships) => {
+        const m = memberships.find((x) => x.isDefault) ?? memberships[0];
+        setOrgName(m?.orgName ?? null);
+      })
+      .catch(() => setOrgName(null));
   }, []);
 
   useEffect(() => {
-    loadBacklog();
-    loadStatus();
-  }, [loadBacklog, loadStatus]);
+    loadInbox();
+    loadSummary();
+    loadOrg();
+  }, [loadInbox, loadSummary, loadOrg]);
 
   useRealtime([{ channel: 'org' }], (event) => {
     if (
       event.type.startsWith('conversation.') ||
       event.type.startsWith('kb.document.') ||
-      event.type.startsWith('crm.merge_proposal.')
+      event.type.startsWith('kb.curation.') ||
+      event.type.startsWith('crm.merge_proposal.') ||
+      event.type.startsWith('outreach.')
     ) {
-      loadBacklog();
-      loadStatus();
+      loadInbox();
+      loadSummary();
     }
   });
 
-  const allClear =
-    backlog !== null &&
-    backlog.conversationsNeedingAttention === 0 &&
-    backlog.kbCurationPending === 0 &&
-    backlog.crmMergeProposalsPending === 0;
+  const rows = mergeInboxPreview(inbox, 5);
+  const totalCount = totalInboxCount(inbox);
+  const liveCount = inbox?.live.length ?? 0;
 
   return (
-    <>
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
-        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
-      </div>
+    <div className="px-10 py-10 max-w-7xl mx-auto space-y-10">
+      <DashboardHero
+        orgName={orgName}
+        date={new Date()}
+        totalCount={totalCount}
+        liveCount={liveCount}
+      />
 
-      {backlog !== null && (
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              {allClear ? (
-                <CheckCircle2 className="size-5 text-muted-foreground" />
-              ) : (
-                <AlertCircle className="size-5 text-amber-600 dark:text-amber-400" />
-              )}
-              <CardTitle>{tBacklog('title')}</CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            {allClear ? (
-              <p className="text-muted-foreground">{tBacklog('allClear')}</p>
-            ) : (
-              <ul className="space-y-2">
-                {backlog.conversationsNeedingAttention > 0 && (
-                  <li className="flex items-center justify-between gap-3">
-                    <span>
-                      <strong className="font-medium">
-                        {backlog.conversationsNeedingAttention}
-                      </strong>{' '}
-                      {tBacklog('conversationsLabel')}
-                    </span>
-                    <Link
-                      href="/dashboard/inbox"
-                      className="text-xs text-muted-foreground hover:underline"
-                    >
-                      {tBacklog('openConversations')}
-                    </Link>
-                  </li>
-                )}
-                {backlog.kbCurationPending > 0 && (
-                  <li className="flex items-center justify-between gap-3">
-                    <span>
-                      <strong className="font-medium">{backlog.kbCurationPending}</strong>{' '}
-                      {tBacklog('kbCurationLabel')}
-                    </span>
-                    <Link
-                      href="/dashboard/inbox"
-                      className="text-xs text-muted-foreground hover:underline"
-                    >
-                      {tBacklog('openInbox')}
-                    </Link>
-                  </li>
-                )}
-                {backlog.crmMergeProposalsPending > 0 && (
-                  <li className="flex items-center justify-between gap-3">
-                    <span>
-                      <strong className="font-medium">{backlog.crmMergeProposalsPending}</strong>{' '}
-                      {tBacklog('crmMergeProposalsLabel')}
-                    </span>
-                    <Link
-                      href="/dashboard/inbox"
-                      className="text-xs text-muted-foreground hover:underline"
-                    >
-                      {tBacklog('openInbox')}
-                    </Link>
-                  </li>
-                )}
-              </ul>
-            )}
-          </CardContent>
-        </Card>
-      )}
-
-      {agentStatus !== null && <AgentStatusCard status={agentStatus} t={tAgent} />}
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <Bot className="size-5 text-muted-foreground" />
-              <CardTitle>{t('connectCard.title')}</CardTitle>
-            </div>
-            <CardDescription>{t('connectCard.description')}</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <code className="block rounded-md border bg-muted px-3 py-2 font-mono text-sm">
-              https://mcp.getmunin.com
-            </code>
-            <p className="text-xs text-muted-foreground">{t('connectCard.consentNote')}</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <Code2 className="size-5 text-muted-foreground" />
-              <CardTitle>{t('buildCard.title')}</CardTitle>
-            </div>
-            <CardDescription>{t('buildCard.description')}</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button className="w-full" render={<Link href="/dashboard/settings/api-keys" />}>
-              <KeyRound className="size-4" />
-              {t('buildCard.cta')}
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    </>
-  );
-}
-
-function AgentStatusCard({
-  status,
-  t,
-}: {
-  status: AgentStatusDto;
-  t: ReturnType<typeof useTranslations>;
-}) {
-  const connected = status.selfServiceAgentSubscriberCount > 0;
-  const lastInbound = status.lastInboundEndUserMessageAt
-    ? new Date(status.lastInboundEndUserMessageAt)
-    : null;
-  const lastAgent = status.lastAgentMessageAt ? new Date(status.lastAgentMessageAt) : null;
-  const inboundAheadOfAgent =
-    lastInbound !== null && (lastAgent === null || lastInbound > lastAgent);
-  const stale = !connected && inboundAheadOfAgent;
-  return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center gap-2">
-          {connected ? (
-            <CheckCircle2 className="size-5 text-emerald-600 dark:text-emerald-400" />
-          ) : stale ? (
-            <AlertCircle className="size-5 text-amber-600 dark:text-amber-400" />
-          ) : (
-            <Bot className="size-5 text-muted-foreground" />
-          )}
-          <CardTitle>{t('title')}</CardTitle>
+      {totalCount > 0 ? (
+        <div className="grid gap-8 md:grid-cols-[1.4fr_1fr]">
+          <InboxPreview rows={rows} totalCount={totalCount} />
+          <UsageKpis summary={summary} />
         </div>
-        <CardDescription>
-          {connected
-            ? t('connected', { count: status.selfServiceAgentSubscriberCount })
-            : stale
-              ? t('staleNotConnected')
-              : t('notConnected')}
-        </CardDescription>
-      </CardHeader>
-      {!connected && (
-        <CardContent>
-          <p className="text-xs text-muted-foreground">{t('hint')}</p>
-        </CardContent>
+      ) : (
+        <UsageKpis summary={summary} />
       )}
-    </Card>
+
+      <GetStarted />
+    </div>
   );
 }

--- a/packages/db/test-env.ts
+++ b/packages/db/test-env.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+function findWorkspaceRoot(start: string): string | null {
+  let dir = start;
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(resolve(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+const root = findWorkspaceRoot(process.cwd());
+if (root) {
+  const envPath = resolve(root, '.env');
+  if (existsSync(envPath) && typeof process.loadEnvFile === 'function') {
+    process.loadEnvFile(envPath);
+  }
+}

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,9 @@
+import './test-env';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+    testTimeout: 30_000,
+  },
+});

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "concurrency": "20",
   "globalDependencies": ["**/.env.*local", "**/.env"],
   "globalEnv": ["NODE_ENV", "DATABASE_URL", "TEST_DATABASE_URL", "MUNIN_*"],
   "tasks": {


### PR DESCRIPTION
## Summary

Two cleanly separated commits:

**1. `feat(dashboard)` — editorial overview redesign**

Replaces the 3-card welcome page with the editorial dashboard from the design mockups:

- **Hero** — eyebrow (`Org · Date`), big serif headline with italic accent, dynamic lede composed from real backlog/live counts. Shows "Nothing waiting…" when the inbox is empty.
- **Inbox preview** — top 5 items merged from `/api/v1/inbox` (live conversations + KB / CRM / outreach queue), pill kinds match design, live rows pulse with cobalt. Hidden entirely when the inbox is empty (usage section then stretches full-width).
- **Usage KPIs** — 4 cards (MCP calls, API calls, Conversations, Avg latency) with sparklines, fed by `/api/v1/usage/summary`. `auto-fit` grid: 2 cols when nested with inbox, 4 cols when stretched.
- **Get Started** — left column: tabbed MCP setup snippets (Claude/ChatGPT/Gemini) pointed at `https://mcp.getmunin.com` with copy-to-clipboard; right column: 6 agent recipes (KB Curator, Content Marketer, CRM Deduper, Outreach Drafter, Bug Spotter, Renewal Watcher), each opening a `Sheet` drawer with tools + system prompt. Recipes use only real OSS MCP tools (`conv_*`, `kb_*`, `crm_*`, `cms_*`, `outreach_*`).
- **Topbar** — adds **Overview** tab pointing at `/dashboard` with `exact: true` matching, plus a hover underline for inactive tabs that aligns with the navbar's bottom border.
- Drops `agentStatus` + `needsAttention` i18n trees and the old card components.

Reuses existing `@getmunin/ui` primitives throughout (`Hero`, `Pill`, `Eyebrow`, `Sheet*`, `Button`). Realtime updates via `useRealtime(['org'])` reload backlog + usage + inbox on `conversation.*` / `kb.*` / `crm.merge_proposal.*` / `outreach.*` events.

**2. `chore(dev)` — local-dev QoL**

- Auto-load root `.env` via Node 24's `process.loadEnvFile` for backend dev/migrate + vitest configs. No more `set -a; source .env`.
- Add `pnpm --filter @getmunin/backend migrate:test` that creates and migrates a dedicated `munin_test` Postgres DB. Tests already preferred `TEST_DATABASE_URL` but it was unset — now they don't share state with manual dev.
- Bump turbo concurrency to 20 so `pnpm dev` doesn't trip on the 12 persistent dev tasks vs the default of 10.

## Test plan

- [ ] `pnpm typecheck` (already green locally for all touched packages)
- [ ] `pnpm lint`
- [ ] `pnpm test` — verify TEST_DATABASE_URL routes tests to `munin_test`
- [ ] Browser: load `/dashboard` with populated inbox + usage data — hero, KPIs, inbox preview render
- [ ] Browser: empty inbox state — preview hides, usage stretches full-width, hero falls back to "Nothing waiting"
- [ ] Browser: open a recipe drawer, copy prompt, ESC closes
- [ ] Browser: tab switching for MCP snippets, copy-to-clipboard shows "Copied ✓"
- [ ] Browser: hover Inbox tab while on Settings — underline aligns with navbar border
- [ ] Browser: dark mode + `<980px` width (cols collapse)