### PR TITLE
feat(oss)!: drop Google sign-in from OSS edition

### DIFF
--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -37,7 +37,6 @@ export interface MuninAuthOptions {
   baseUrl: string;
   authSecret: string;
   trustedOrigins?: string[];
-  google?: { clientId: string; clientSecret: string };
   mailer?: Mailer;
   /** URL of the dashboard, used to build verification + reset links. */
   webBaseUrl?: string;
@@ -54,7 +53,6 @@ export function createMuninAuth({
   baseUrl,
   authSecret,
   trustedOrigins,
-  google,
   mailer,
   webBaseUrl,
   allowedEmailDomains = [],
@@ -118,14 +116,6 @@ export function createMuninAuth({
             });
           },
           sendOnSignUp: true,
-        }
-      : undefined,
-    socialProviders: google
-      ? {
-          google: {
-            clientId: google.clientId,
-            clientSecret: google.clientSecret,
-          },
         }
       : undefined,
     trustedOrigins: origins,

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -5,7 +5,6 @@ import { readMailerFromEnv } from '@getmunin/core';
 import {
   DB,
   handleAuthRequest,
-  readGoogleProviderFromEnv,
   readTrustedOriginsFromEnv,
   requireAuthSecret,
 } from '@getmunin/backend-core';
@@ -28,7 +27,6 @@ export class AuthController {
       baseUrl: process.env.MUNIN_PUBLIC_URL ?? PUBLIC_URL_FALLBACK,
       authSecret: requireAuthSecret(),
       trustedOrigins: readTrustedOriginsFromEnv(),
-      google: readGoogleProviderFromEnv(),
       mailer,
       webBaseUrl: process.env.MUNIN_WEB_URL,
       allowedEmailDomains: readAllowedEmailDomainsFromEnv(),

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -5,12 +5,10 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { authClient } from '@getmunin/dashboard-pages';
-import { GoogleButton } from '@getmunin/ui';
 import { Button } from '@getmunin/ui';
 import { Input } from '@getmunin/ui';
 import { Label } from '@getmunin/ui';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@getmunin/ui';
-import { Separator } from '@getmunin/ui';
 import { useTranslateError } from '@/lib/translate-error';
 
 function safeRedirect(raw: string | null): string {
@@ -22,7 +20,6 @@ function LoginForm() {
   const t = useTranslations('auth.signIn');
   const tFields = useTranslations('auth.fields');
   const tCommon = useTranslations('common');
-  const tUi = useTranslations('ui.googleButton');
   const translateError = useTranslateError();
   const router = useRouter();
   const params = useSearchParams();
@@ -63,15 +60,6 @@ function LoginForm() {
         <CardDescription>{t('subtitle')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <GoogleButton
-          label={tUi('signIn')}
-          onSignIn={() => {
-            void authClient.signIn.social({ provider: 'google', callbackURL: redirectTo });
-          }}
-        />
-
-        <DividerWithLabel label={tCommon('or')} />
-
         <form
           onSubmit={(event) => {
             void onSubmit(event);
@@ -122,15 +110,5 @@ export default function LoginPage() {
     <Suspense fallback={null}>
       <LoginForm />
     </Suspense>
-  );
-}
-
-function DividerWithLabel({ label }: { label: string }) {
-  return (
-    <div className="flex items-center gap-3 text-xs text-muted-foreground">
-      <Separator className="flex-1" />
-      {label}
-      <Separator className="flex-1" />
-    </div>
   );
 }

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -5,12 +5,10 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { api, ApiError, authClient } from '@getmunin/dashboard-pages';
-import { GoogleButton } from '@getmunin/ui';
 import { Button } from '@getmunin/ui';
 import { Input } from '@getmunin/ui';
 import { Label } from '@getmunin/ui';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@getmunin/ui';
-import { Separator } from '@getmunin/ui';
 import { useTranslateError } from '@/lib/translate-error';
 
 function safeRedirect(raw: string | null): string {
@@ -33,7 +31,6 @@ function SignupForm() {
   const t = useTranslations('auth.signUp');
   const tFields = useTranslations('auth.fields');
   const tCommon = useTranslations('common');
-  const tUi = useTranslations('ui.googleButton');
   const translateError = useTranslateError();
   const router = useRouter();
   const params = useSearchParams();
@@ -95,15 +92,6 @@ function SignupForm() {
       </CardHeader>
       <CardContent className="space-y-4">
         {inviteError && <p className="text-sm text-destructive">{inviteError}</p>}
-        <GoogleButton
-          label={tUi('signUp')}
-          onSignIn={() => {
-            void authClient.signIn.social({ provider: 'google', callbackURL: redirectTo });
-          }}
-        />
-
-        <DividerWithLabel label={tCommon('or')} />
-
         <form
           onSubmit={(event) => {
             void onSubmit(event);
@@ -161,16 +149,6 @@ function SignupForm() {
         </p>
       </CardContent>
     </Card>
-  );
-}
-
-function DividerWithLabel({ label }: { label: string }) {
-  return (
-    <div className="flex items-center gap-3 text-xs text-muted-foreground">
-      <Separator className="flex-1" />
-      {label}
-      <Separator className="flex-1" />
-    </div>
   );
 }
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5,7 +5,6 @@
   },
   "common": {
     "loading": "Loading…",
-    "or": "or",
     "signOut": "Sign out",
     "revoke": "Revoke",
     "save": "Save",
@@ -34,7 +33,6 @@
     "signIn": {
       "title": "Sign in",
       "subtitle": "Welcome back to Munin.",
-      "googleButton": "Sign in with Google",
       "submit": "Sign in",
       "submitting": "Signing in…",
       "noAccount": "New here?",
@@ -45,7 +43,6 @@
       "title": "Create your account",
       "subtitle": "Munin — agent-native business apps.",
       "invitationSubtitle": "You're accepting an invitation for {email}.",
-      "googleButton": "Sign up with Google",
       "submit": "Create account",
       "submitting": "Creating account…",
       "haveAccount": "Already have an account?",
@@ -483,12 +480,6 @@
     "CONV_INVALID": "Conversation entry is invalid.",
     "FEEDBACK_RATE_LIMIT": "Too many suggestions created in the last hour. Try again later.",
     "FEEDBACK_NOT_FOUND": "Suggestion not found."
-  },
-  "ui": {
-    "googleButton": {
-      "signIn": "Sign in with Google",
-      "signUp": "Sign up with Google"
-    }
   },
   "footer": {
     "privacy": "Privacy",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -5,7 +5,6 @@
   },
   "common": {
     "loading": "Laster…",
-    "or": "eller",
     "signOut": "Logg ut",
     "revoke": "Tilbakekall",
     "save": "Lagre",
@@ -34,7 +33,6 @@
     "signIn": {
       "title": "Logg inn",
       "subtitle": "Velkommen tilbake til Munin.",
-      "googleButton": "Logg inn med Google",
       "submit": "Logg inn",
       "submitting": "Logger inn…",
       "noAccount": "Ny her?",
@@ -45,7 +43,6 @@
       "title": "Opprett konto",
       "subtitle": "Munin — agent-native forretningsapper.",
       "invitationSubtitle": "Du aksepterer en invitasjon for {email}.",
-      "googleButton": "Registrer deg med Google",
       "submit": "Opprett konto",
       "submitting": "Oppretter konto…",
       "haveAccount": "Har du allerede konto?",
@@ -483,12 +480,6 @@
     "CONV_INVALID": "Samtaleoppføringen er ugyldig.",
     "FEEDBACK_RATE_LIMIT": "For mange forslag opprettet siste time. Prøv igjen senere.",
     "FEEDBACK_NOT_FOUND": "Forslaget ble ikke funnet."
-  },
-  "ui": {
-    "googleButton": {
-      "signIn": "Logg inn med Google",
-      "signUp": "Registrer deg med Google"
-    }
   },
   "footer": {
     "privacy": "Personvern",


### PR DESCRIPTION
## Summary

Email/password becomes the only auth path on OSS. Google OAuth is reserved for Cloud, where it's a real differentiator. This is a deliberate product decision — adding *reasons to choose Cloud* without taking anything away from a self-hoster who's happy with email/password.

## Changes

**`apps/backend/src/auth/`**
- `auth.config.ts` — drop `google?` from `MuninAuthOptions`; remove the `socialProviders` block.
- `auth.controller.ts` — stop importing/passing `readGoogleProviderFromEnv`.

**`apps/web/app/(auth)/`**
- `login/page.tsx` — remove `<GoogleButton>`, divider, and `Separator` import.
- `signup/page.tsx` — same.

**`apps/web/messages/{en,nb}.json`**
- Drop `auth.signIn.googleButton`, `auth.signUp.googleButton`, `ui.googleButton.*`, and the now-unused `common.or` key.

**Untouched**
- `packages/backend-core/src/auth-env.ts:readGoogleProviderFromEnv` — Cloud's `cloud-auth.controller.ts` still imports it from `@getmunin/backend-core`.
- `packages/ui/src/components/google-button.tsx` — Cloud's `web-cloud` still uses it.

## Breaking change

`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` are no longer read by `apps/backend`. Self-hosters relying on Google sign-in must drop back to email/password (or roll their own provider wiring downstream). Documented in the commit footer.

## Test plan

- [x] `pnpm -F @getmunin/backend typecheck` / `lint` clean
- [x] `pnpm -F @getmunin/web typecheck` / `lint` clean
- [x] `pnpm -F @getmunin/web build` — auth pages compile, no GoogleButton refs in the bundle
- [ ] backend integration tests (skipped locally — need a provisioned `munin_test` DB; will run in CI)
- [ ] visual review of `/login` and `/signup` (single email/password card, no divider)

## Related

Cloud companion PR adds GitHub OAuth on Cloud: getmunin/munin-cloud#TBD

🤖 Generated with [Claude Code](https://claude.com/claude-code)