### PR TITLE
chore(oss): scrub stale Cloud-edition references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,12 +83,6 @@ OPENAI_API_KEY=
 # OPENAI_BASE_URL=http://localhost:11434/v1
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 
-# --- Google Sign-in (optional) -----------------------------------------
-# https://console.cloud.google.com/apis/credentials → OAuth 2.0 Client ID
-# Authorized redirect URI: <MUNIN_PUBLIC_URL>/auth/callback/google
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-
 # --- Curator scheduler (backend-side cron) ------------------------------
 # The backend enqueues curator sweep jobs on these cadences via
 # @nestjs/schedule. Standard cron expressions (minute hour dom mon dow).

--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ Once you've signed up (hosted) or run `docker compose up` (self-host), point you
 {
   "mcpServers": {
     "munin": {
-      "url": "https://mcp.getmunin.com"
+      "url": "http://localhost:3001/mcp"
     }
   }
 }
 ```
 
-For self-host, swap in `http://localhost:3001/mcp`. The first call triggers an OAuth consent screen in your browser, then your agent has the full tool surface (KB, conversations, CRM, CMS, suggestions).
+(For the hosted version, swap in `https://mcp.getmunin.com`.) The first call triggers an OAuth consent screen in your browser, then your agent has the full tool surface (KB, conversations, CRM, CMS, suggestions).
 
 ## Two trust contexts, one MCP endpoint
 
-The same `mcp.getmunin.com` URL serves two distinct callers, audience-aware:
+The same `/mcp` endpoint serves two distinct callers, audience-aware:
 
 - **Admin agents** (Claude Desktop, Cursor, internal automation) — OAuth-authorized by you. Full tool surface.
 - **End-user agents** (your voice AI, web chatbot, mobile app helper) — short-lived delegated tokens minted server-side from your backend, scoped to one of your end-users. Only self-service tools (read your own contact, send a message in your own conversation).

--- a/packages/backend-core/src/modules/cms/skills/stale-content-review.md
+++ b/packages/backend-core/src/modules/cms/skills/stale-content-review.md
@@ -19,7 +19,7 @@ Run periodically. Quarterly is a good default for content-stable orgs; monthly f
 3. **Find stale published entries** — `cms_list_entries({ status: "published" })`, filter to `updatedAt > N months ago` per collection's velocity. For each, run `cms_list_inbound_references` to see if the entry is still load-bearing or has been superseded.
 4. **Find orphaned assets** — `cms_list_assets`, cross-reference against entry bodies (search for asset IDs in entries' `data` payloads) to find uploads no entry points to.
 5. **Compose a structured report** grouped by recommended action: `archive`, `refresh`, `delete-asset`, `keep`. Include enough evidence per item that a reviewer can decide without re-querying.
-6. **Stop.** The operator reviews the report (curator-runner log on the cloud product, or your reply-to-the-user output for ad-hoc runs) and acts on it manually using the existing `cms_*` tools.
+6. **Stop.** The operator reviews the report (your reply-to-the-user output for ad-hoc runs, or the scheduled-runner log if you're invoked from a cron) and acts on it manually using the existing `cms_*` tools.
 
 ## Step 1 — collections inventory
 

--- a/packages/backend-core/src/modules/crm/skills/hygiene.md
+++ b/packages/backend-core/src/modules/crm/skills/hygiene.md
@@ -10,7 +10,7 @@ CRM data drifts. Imports re-add contacts under a slightly different email. Human
 
 This skill walks an admin agent through one periodic hygiene pass: pull contacts, find suspect pairs, judge each pair, and file high-confidence pairs as **structured merge proposals** via `crm_propose_merge_candidate`. A human (or trusted admin agent) then reviews each pending proposal and resolves it with `crm_apply_merge_proposal` (atomic patch + archive) or `crm_dismiss_merge_proposal` (records the rejection so the next curator pass skips the pair).
 
-Run periodically. Don't run inline per CRM mutation — batching is cheaper and the suspect-pair signal is much stronger when you can see the whole population at once. The cloud product has a curator runner that schedules this weekly per enabled org.
+Run periodically. Don't run inline per CRM mutation — batching is cheaper and the suspect-pair signal is much stronger when you can see the whole population at once. A weekly cadence is a good default; wire it up via your scheduler of choice.
 
 ## TL;DR
 
@@ -124,7 +124,7 @@ The dashboard "Needs attention" backlog card surfaces the count of pending propo
 - **Don't auto-apply.** v1 is propose-only. The cost of a wrong merge (lost activity history, wrong `endUserId` link) is much higher than the cost of one extra human review per pair.
 - **Don't propose pairs the operator already dismissed.** Step 1 exists for a reason. If you skip it, you'll churn the operator's review queue with noise.
 - **Don't include private end-user data in `evidence` beyond what's needed to decide.** No payment info, no internal account states, no health/legal/financial details. The matched email, the matched phone, the names, the companyId — that's enough.
-- **Don't run on every conversation.** This is a periodic batch pass. The cloud curator runner schedules it. If you're being asked to do it inline as part of a chat reply, push back — that's the wrong shape.
+- **Don't run on every conversation.** This is a periodic batch pass — your scheduler triggers it. If you're being asked to do it inline as part of a chat reply, push back — that's the wrong shape.
 - **Don't use `crm_update_contact` to "manually merge" instead of proposing.** The proposals table is the audit trail and the operator's review queue. Bypassing it loses both.
 
 ## Future work

--- a/packages/backend-core/src/modules/kb/skills/curation.md
+++ b/packages/backend-core/src/modules/kb/skills/curation.md
@@ -105,7 +105,7 @@ Behavior:
 
 - The first call ever materializes the `kb-curation-inbox` KB space (admin audience). Subsequent calls reuse it.
 - The candidate is created as a regular `kb_documents` row inside that space, tagged `curation` + `candidate`, audience `admin` only. It is **not** visible to end-user agents — they keep getting handovers for the same gap until the operator promotes the candidate.
-- A `kb.curation_candidate.proposed` realtime event fires for any subscribed agent / cloud runner.
+- A `kb.curation_candidate.proposed` realtime event fires for any subscribed agent or scheduled runner.
 
 ## Step 6 — review and promote (the operator's loop)
 


### PR DESCRIPTION
## Summary

Three small cleanups after #122 dropped Google sign-in, so OSS docs and runtime guidance don't keep leaning on the hosted edition.

## Changes

**`.env.example`**
- Remove the `# --- Google Sign-in (optional) ---` block + `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`. Dead config — `apps/backend` no longer reads them.

**`README.md`**
- Flip the MCP-URL example: `http://localhost:3001/mcp` is now the default in the `claude_desktop_config.json` snippet; hosted is shown as the swap-in. (Previously the polarity was the other way around, which read oddly in an OSS repo.)
- Section header / lede: `The same \`/mcp\` endpoint serves two distinct callers` instead of naming `mcp.getmunin.com`.

**Skill markdown** — three files mention a "curator runner on the cloud product"; OSS agents read these at runtime and the references confused the picture for self-hosters. Reframed generically:
- `packages/backend-core/src/modules/kb/skills/curation.md` — "subscribed agent / cloud runner" → "subscribed agent or scheduled runner".
- `packages/backend-core/src/modules/crm/skills/hygiene.md` — drop "the cloud product has a curator runner that schedules this weekly per enabled org" (× 2 occurrences) in favor of "wire it up via your scheduler of choice" / "your scheduler triggers it".
- `packages/backend-core/src/modules/cms/skills/stale-content-review.md` — "curator-runner log on the cloud product" → "scheduled-runner log if you're invoked from a cron".

## What I deliberately left alone

- `README.md`'s "Two ways to run" section (Self-host vs Hosted at https://getmunin.com) — useful signposting, doesn't oversell.
- `README.md`'s "Cloud composes the same modules with multi-tenant auth" architecture pointer — useful contributor context.
- `@getmunin.com` email aliases (security, conduct, mail-from) — real maintainer addresses.
- All `CHANGELOG.md` cloud mentions — history; rewriting is worse than leaving.
- `Cloudflare R2` / `s3.fr-par.scw.cloud` in storage env comments — generic backend names.

## Test plan

- [x] `git diff` shows only the listed lines (5 files, +7 −13)
- [ ] CI lint/typecheck/build (pure docs + skill-markdown change, no code paths touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)