### PR TITLE
refactor(backend): load TS source directly in dev — drop 9 tsc watchers

### DIFF
--- a/.changeset/backend-loads-ts.md
+++ b/.changeset/backend-loads-ts.md
@@ -1,0 +1,13 @@
+---
+"@getmunin/core": patch
+"@getmunin/db": patch
+"@getmunin/types": patch
+"@getmunin/sdk": patch
+"@getmunin/mcp-toolkit": patch
+"@getmunin/bootstrap": patch
+"@getmunin/backend-core": patch
+"@getmunin/agent-host": patch
+"@getmunin/agent-runtime": patch
+---
+
+Add a `development` package-export condition pointing at `./src/index.ts` (and `./src/schema.ts` for `@getmunin/db`). Loaders that resolve with `--conditions=development` (e.g. the OSS backend's new `node --import @swc-node/register/esm-register --watch --conditions=development src/main.ts` dev script) see the TypeScript source directly; the existing `types` → `dist/*.d.ts` and `default` → `dist/*.js` resolution paths are unchanged, so production runtime, typecheck, and downstream consumers that don't opt into the condition keep their current behavior.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "prebuild": "node scripts/copy-widget.mjs",
     "build": "nest build",
-    "dev": "nest start --watch",
+    "dev": "node --import @swc-node/register/esm-register --watch --conditions=development src/main.ts",
     "start": "node dist/main.js",
-    "migrate": "tsx src/migrate.ts",
-    "migrate:test": "tsx src/migrate-test.ts",
+    "migrate": "node --import @swc-node/register/esm-register --conditions=development src/migrate.ts",
+    "migrate:test": "node --import @swc-node/register/esm-register --conditions=development src/migrate-test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"
@@ -39,6 +39,7 @@
     "@getmunin/tsconfig": "workspace:*",
     "@nestjs/cli": "^11.0.21",
     "@nestjs/testing": "^11.1.19",
+    "@swc-node/register": "^1.11.1",
     "@swc/core": "^1.15.32",
     "@types/express": "^5.0.0",
     "@types/node": "^22.7.0",

--- a/packages/agent-host/package.json
+++ b/packages/agent-host/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -26,7 +27,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@getmunin/agent-runtime",
   "version": "3.1.0",
   "license": "MIT",
-  "description": "LLM agent loop — given a config, conversation history, and an MCP tool handle, produce a reply.",
+  "description": "LLM agent loop \u2014 given a config, conversation history, and an MCP tool handle, produce a reply.",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "restricted"
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -28,7 +29,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -26,7 +27,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node ./scripts/copy-skills.mjs",
-    "dev": "tsc -p tsconfig.build.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -26,7 +27,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -26,7 +27,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,10 +17,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./schema": {
+      "development": "./src/schema.ts",
       "types": "./dist/schema.d.ts",
       "default": "./dist/schema.js"
     }
@@ -31,7 +33,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && mkdir -p dist/sql && cp src/sql/*.sql dist/sql/",
-    "dev": "tsc -p tsconfig.build.json --watch",
     "typecheck": "tsc -p tsconfig.json",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/packages/mcp-toolkit/package.json
+++ b/packages/mcp-toolkit/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -26,7 +27,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -27,7 +28,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -26,7 +27,6 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@nestjs/testing':
         specifier: ^11.1.19
         version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.19)
+      '@swc-node/register':
+        specifier: ^1.11.1
+        version: 1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.32)(@swc/types@0.1.26)(typescript@5.9.3)
       '@swc/core':
         specifier: ^1.15.32
         version: 1.15.32
@@ -196,7 +199,7 @@ importers:
         version: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl:
         specifier: ^4.11.0
-        version: 4.11.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.11.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -553,7 +556,7 @@ importers:
         version: 1.14.0(react@19.2.5)
       next-intl:
         specifier: ^4.0.0
-        version: 4.11.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.11.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -10563,7 +10566,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.11.0: {}
 
-  next-intl@4.11.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+  next-intl@4.11.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.5
       '@parcel/watcher': 2.5.6


### PR DESCRIPTION
Switch the backend's dev mode to import package source TS at runtime via `@swc-node/register`, eliminating the need for nine `tsc --watch` processes that kept each shared package's `dist/` in sync. `pnpm dev` goes from twelve processes to three.

## How it works

Each shared package — `core`, `db`, `types`, `sdk`, `mcp-toolkit`, `bootstrap`, `backend-core`, `agent-host`, `agent-runtime` — gains a `development` export condition pointing at `./src/index.ts` (plus `./schema` for `@getmunin/db`):

```jsonc
{
  "exports": {
    ".": {
      "development": "./src/index.ts",   // new — opt-in via --conditions=development
      "types": "./dist/index.d.ts",       // unchanged
      "default": "./dist/index.js"        // unchanged
    }
  }
}
```

The backend's dev script changes from `nest start --watch` to:

```
node --import @swc-node/register/esm-register --watch --conditions=development src/main.ts
```

- Node's built-in `--watch` handles file watching
- `@swc-node/register` compiles TS on the fly with full NestJS decorator metadata (esbuild was tried first but fell short on `emitDecoratorMetadata` for type-only imports — Reflector got elided and DI broke)
- `--conditions=development` flips Node's module resolution to the new `development` exports condition, so imports of `@getmunin/core` resolve to `packages/core/src/index.ts` instead of `dist/`

The `migrate` and `migrate:test` scripts use the same pipeline, so they no longer require packages to be pre-built.

Each shared package's `dev` script (`tsc --watch`) is removed, so `turbo run dev` no longer spins them up.

## What changes for production / CI / consumers

Nothing. The `default` and `types` conditions are unchanged. Without `--conditions=development`, Node and `tsc` see the same `./dist/*` paths they always did. So:

- Prod runtime (`node dist/main.js`) — unchanged
- `pnpm build`, `pnpm typecheck`, `pnpm test` — unchanged (turbo's `^build` chain still builds packages first)
- The published `@getmunin/dashboard-pages` consumed by `munin-cloud` — unchanged
- CI workflow — unchanged

## Why swc-node over tsx

I prototyped tsx first because it was already a dep and has a built-in watcher. Three problems hit:

1. tsx auto-discovers a single tsconfig from cwd and uses its `include` glob to decide which files get TS options. Files outside the entry's `include` (i.e. everything in `packages/*/src/`) fall through to default options.
2. Working around (1) with a wide root tsconfig got Nest to start, but esbuild's `emitDecoratorMetadata` quietly skipped types referenced only via `import { X } from 'pkg'` where `X` was used solely as a constructor parameter type. Nest's DI then saw `undefined` for those constructor params and refused to instantiate `AuthGuard`.
3. swc handles both per-file tsconfig discovery and decorator metadata correctly. It's already in the codebase for `pnpm openapi:generate`, so we're not adding a new tool.

## Test plan

- [ ] `pnpm dev` from repo root: three processes (web, backend, chat-widget) come up, no tsc watchers
- [ ] Edit `packages/backend-core/src/control/whoami.controller.ts`: backend restarts within ~1s and serves the change
- [ ] `curl localhost:3001/healthz` after first boot returns 200
- [ ] `pnpm --filter @getmunin/backend migrate` (run against a real DB) — should work without `pnpm build` first
- [ ] CI green: typecheck, lint, test, build, e2e
- [ ] After merge + release, downstream `munin-cloud` `pnpm install` picks up the new minor without surprises (the new condition is opt-in)

## Changeset

Patch bump for the nine packages — purely additive; consumers without `--conditions=development` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)