### PR TITLE
fix(packaging): include src/ in published tarballs

### DIFF
--- a/.changeset/include-src-in-published-tarballs.md
+++ b/.changeset/include-src-in-published-tarballs.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Include `src/` in the published tarballs for every package that declares a `development` export condition (`@getmunin/types`, `core`, `db`, `sdk`, `mcp-toolkit`, `bootstrap`, `backend-core`, `agent-runtime`, `agent-host`).
+
+The `development` condition resolves to `./src/index.ts`, which is the right path in the OSS workspace (pnpm-linked) but didn't exist in the published tarball — `files: ["dist"]` excluded it. Downstream consumers whose toolchain activates the `development` condition (e.g. vitest 2.x in cloud) hit `Cannot find module '.../src/index.ts'` errors at runtime. Shipping `src/` alongside `dist/` makes the condition resolve in both environments.

--- a/packages/agent-host/package.json
+++ b/packages/agent-host/package.json
@@ -23,7 +23,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@getmunin/agent-runtime",
   "version": "3.2.1",
   "license": "MIT",
-  "description": "LLM agent loop — given a config, conversation history, and an MCP tool handle, produce a reply.",
+  "description": "LLM agent loop \u2014 given a config, conversation history, and an MCP tool handle, produce a reply.",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "restricted"
@@ -23,9 +23,10 @@
     }
   },
   "files": [
+    "README.md",
     "dist",
     "prompts",
-    "README.md"
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -23,7 +23,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node ./scripts/copy-skills.mjs",

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -23,7 +23,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -29,7 +29,8 @@
   },
   "files": [
     "dist",
-    "drizzle"
+    "drizzle",
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && mkdir -p dist/sql && cp src/sql/*.sql dist/sql/",

--- a/packages/mcp-toolkit/package.json
+++ b/packages/mcp-toolkit/package.json
@@ -23,7 +23,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,8 +23,9 @@
     }
   },
   "files": [
+    "README.md",
     "dist",
-    "README.md"
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,7 +23,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Summary

The `exports` map of every workspace package declares a `development` condition pointing at `./src/index.ts` so the OSS monorepo can consume packages without a build step. Cloud's vitest 2.x also activates that condition, but the published tarballs only ship `files: [\"dist\", ...]` — so resolution to `./src/index.ts` fails downstream:

\`\`\`
Cannot find module '.../node_modules/@getmunin/db/src/index.ts'
  imported from '.../node_modules/@getmunin/core/dist/audit.js'
\`\`\`

Adding `src` to the `files` array of every affected package makes the condition resolve in both the OSS workspace and the published tarball. No code path changes; this is purely a packaging fix.

Packages updated: `agent-host`, `backend-core`, `agent-runtime`, `bootstrap`, `core`, `db`, `mcp-toolkit`, `types`, `sdk` (the 9 packages with `development → ./src/index.ts` in their exports map; `ui` and `dashboard-pages` already ship `src/`).

This unblocks getmunin/munin-cloud#37.

## Test plan

- [ ] CI green
- [ ] After release publishes, cloud's CI passes against the patched packages