### PR TITLE
feat(dashboard): operator-side 'Seen HH:MM' badge (re-apply of #138)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -219,6 +219,7 @@
         "crmMergeBody": "Merge <strong>{loser}</strong> into <strong>{keeper}</strong>.",
         "crmMergeExplain": "Keeps the primary; rewrites foreign keys; archives the loser. No conversations are lost.",
         "internalLabel": "internal · {author}",
+        "seenAt": "Seen {time}",
         "activityConv": "Conversation activity",
         "activityContact": "Contact activity",
         "activityEmpty": "No activity yet.",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -219,6 +219,7 @@
         "crmMergeBody": "Slå sammen <strong>{loser}</strong> inn i <strong>{keeper}</strong>.",
         "crmMergeExplain": "Beholder hovedoppføringen; flytter referanser; arkiverer den andre. Ingen samtaler går tapt.",
         "internalLabel": "intern · {author}",
+        "seenAt": "Sett {time}",
         "activityConv": "Samtaleaktivitet",
         "activityContact": "Kontaktaktivitet",
         "activityEmpty": "Ingen aktivitet ennå.",

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -66,6 +66,7 @@ export interface MessageDto {
   attachments: unknown[];
   metadata: Record<string, unknown>;
   createdAt: string;
+  seenAt: string | null;
 }
 
 export interface ConversationSummary {
@@ -339,16 +340,31 @@ export class ConvService {
     const row = conversations[0];
     if (!row) throw new NotFoundException(`conv_not_found: conversation ${id}`);
 
-    const messages = await ctx.db
-      .select()
+    const reads = ctx.db
+      .select({
+        messageId: schema.convMessageReads.messageId,
+        seenAt: sql<Date | null>`MIN(${schema.convMessageReads.readAt})`.as('seen_at'),
+      })
+      .from(schema.convMessageReads)
+      .where(eq(schema.convMessageReads.conversationId, id))
+      .groupBy(schema.convMessageReads.messageId)
+      .as('reads');
+
+    const rows = await ctx.db
+      .select({
+        msg: schema.convMessages,
+        seenAt: reads.seenAt,
+      })
       .from(schema.convMessages)
+      .leftJoin(reads, eq(reads.messageId, schema.convMessages.id))
       .where(eq(schema.convMessages.conversationId, id))
       .orderBy(asc(schema.convMessages.createdAt));
 
+    const messages = rows.map((r) => r.msg);
     const authorNames = await this.loadAuthorNames(messages);
     return {
       ...toConversationSummary(row.conv, row.channelType),
-      messages: messages.map((m) => toMessageDto(m, authorNames)),
+      messages: rows.map((r) => toMessageDto(r.msg, authorNames, r.seenAt)),
     };
   }
 
@@ -1013,6 +1029,7 @@ function toConversationSummary(
 function toMessageDto(
   row: typeof schema.convMessages.$inferSelect,
   authorNames: Map<string, string> = new Map(),
+  seenAt: Date | null = null,
 ): MessageDto {
   return {
     id: row.id,
@@ -1026,6 +1043,7 @@ function toMessageDto(
     attachments: row.attachments,
     metadata: row.metadata,
     createdAt: row.createdAt.toISOString(),
+    seenAt: seenAt ? seenAt.toISOString() : null,
   };
 }
 

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -46,6 +46,7 @@ interface MessageDto {
   attachments: unknown[];
   metadata: Record<string, unknown>;
   createdAt: string;
+  seenAt?: string | null;
 }
 
 interface ConversationDetail extends ConversationSummary {
@@ -1365,31 +1366,46 @@ function MessageBubble({ message }: { message: MessageDto }) {
     );
   }
   return (
-    <div
-      className={cn(
-        'max-w-[85%] px-3 py-2 text-sm',
-        isStaff
-          ? 'ml-auto rounded-bubble rounded-tr-[2px] bg-cobalt text-paper'
-          : isAgent
-            ? 'ml-auto rounded-bubble rounded-tr-[2px] bg-ink text-paper dark:bg-paper dark:text-ink'
-            : 'mr-auto rounded-bubble rounded-tl-[2px] bg-paper-deep text-ink dark:bg-secondary dark:text-foreground',
-      )}
-    >
+    <div className={cn('flex flex-col gap-1', isOutbound ? 'items-end' : 'items-start')}>
       <div
         className={cn(
-          'mb-0.5 font-mono text-[9px] uppercase tracking-eyebrow',
+          'max-w-[85%] px-3 py-2 text-sm',
           isStaff
-            ? 'text-paper/70'
+            ? 'rounded-bubble rounded-tr-[2px] bg-cobalt text-paper'
             : isAgent
-              ? 'text-paper/70 dark:text-ink/70'
-              : 'text-ink-mute',
+              ? 'rounded-bubble rounded-tr-[2px] bg-ink text-paper dark:bg-paper dark:text-ink'
+              : 'rounded-bubble rounded-tl-[2px] bg-paper-deep text-ink dark:bg-secondary dark:text-foreground',
         )}
       >
-        {bubbleLabel(message, t)}
+        <div
+          className={cn(
+            'mb-0.5 font-mono text-[9px] uppercase tracking-eyebrow',
+            isStaff
+              ? 'text-paper/70'
+              : isAgent
+                ? 'text-paper/70 dark:text-ink/70'
+                : 'text-ink-mute',
+          )}
+        >
+          {bubbleLabel(message, t)}
+        </div>
+        <div className="whitespace-pre-wrap">{message.body}</div>
       </div>
-      <div className="whitespace-pre-wrap">{message.body}</div>
+      {isOutbound && message.seenAt && (
+        <div className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+          {t('seenAt', { time: formatSeenAt(message.seenAt) })}
+        </div>
+      )}
     </div>
   );
+}
+
+function formatSeenAt(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
 }
 
 function bubbleLabel(


### PR DESCRIPTION
## Re-apply of #138

PR #138 was marked merged in GitHub on 2026-05-13 at 08:00:48 UTC — 22
seconds after #137 (08:00:26). GitHub squashed #138 onto its recorded
base \`feat/read-tracking\`, but that branch was auto-deleted moments
earlier when #137 merged. The squash commit \`71e5b959\` was created
but never reached \`main\`. Result: PR shows \"merged\" but the diff
never landed.

This PR re-applies the same 4-file diff against current \`main\` via
\`git cherry-pick 71e5b959\`. No content changes vs the original.

## Summary (unchanged from #138)

Surfaces the read-tracking data persisted by #137 in the operator's
conversation drawer.

- **Backend (\`conv.service.ts\`):** \`MessageDto\` gains
  \`seenAt: string | null\`. \`getConversation()\` LEFT JOINs a subquery
  on \`conv_message_reads\` aggregated by \`MIN(read_at)\` per message.
  Other \`toMessageDto\` callers default to \`null\`.
- **Frontend (\`inbox-sections.tsx\`):** \`MessageBubble\` wrapped in a
  flex column so the bubble keeps its own background while a small
  \`font-mono text-[9px] uppercase\` "Seen 14:02" caption sits flush
  under outbound bubbles when \`seenAt\` is present.
- **i18n:** \`dashboard.overview.drawer.seenAt\` (en + nb).

## Test plan

- [x] \`pnpm typecheck\` clean across all 24 packages
- [x] \`pnpm lint\` clean
- [ ] CI test suite green
- [ ] Manual: open the dashboard drawer for a conv with an agent
  message; open the widget on another browser, scroll until the
  message is in view; confirm "Seen HH:MM" caption appears under the
  bubble without refresh.
- [ ] Manual: no caption renders under the visitor's own messages.
- [ ] Manual: messages that have never been opened render unchanged.

## Notes for next time

When merging stacked PRs, wait for the base PR's merge to fully
complete (and its branch to be deleted) before merging the dependent
PR. GitHub's auto-retarget on merged stacks is racy in the same-second
window. Alternative: change #138's base from \`feat/read-tracking\` to
\`main\` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)