### PR TITLE
feat(email): strip signatures from inbound bodies

### DIFF
--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -29,6 +29,8 @@ import {
   formatQuotedHistory,
   stripQuotedReplyHtml,
   stripQuotedReplyText,
+  stripSignatureHtml,
+  stripSignatureText,
   type QuotedPriorMessage,
 } from './reply-history.js';
 import type {
@@ -342,8 +344,8 @@ export class EmailAdapter implements ChannelAdapter {
           conversationId = newConv!.id;
         }
 
-        const cleanText = stripQuotedReplyText(parsed.bodyText);
-        const cleanHtml = stripQuotedReplyHtml(parsed.bodyHtml);
+        const cleanText = stripSignatureText(stripQuotedReplyText(parsed.bodyText));
+        const cleanHtml = stripSignatureHtml(stripQuotedReplyHtml(parsed.bodyHtml));
         const [msg] = await tx
           .insert(schema.convMessages)
           .values({

--- a/packages/backend-core/src/modules/conv/email/reply-history.ts
+++ b/packages/backend-core/src/modules/conv/email/reply-history.ts
@@ -67,6 +67,62 @@ export function stripQuotedReplyHtml(html: string | null): string | null {
   return out.replace(/\s+$/, '');
 }
 
+const SIGNATURE_OPENERS: RegExp[] = [
+  /^--\s?$/,
+  /^_{5,}$/,
+  /^sent from my (iphone|ipad|ipod|android|.+\bphone|.+\btablet)\b/i,
+  /^sent from outlook( for ios| for android| mobile)?\b/i,
+  /^get outlook for (ios|android)\b/i,
+  /^sent via samsung\b/i,
+  /^sendt fra (min )?(iphone|ipad|outlook|mobil|android)\b/i,
+  /^envoyé de mon (iphone|ipad)\b/i,
+  /^enviado desde mi (iphone|ipad)\b/i,
+  /^verzonden vanaf mijn (iphone|ipad)\b/i,
+  /^von meinem (iphone|ipad) gesendet\b/i,
+];
+
+/**
+ * Strip an email signature off the end of an already-quote-stripped body.
+ * Cuts at the first line that matches a known signature opener (RFC 3676
+ * `-- `, mobile-client patterns across a few languages, or an underscore
+ * separator). Always conservative — if cutting would leave the body empty
+ * or near-empty, returns the input unchanged.
+ *
+ * Run AFTER `stripQuotedReplyText` so the openers aren't fighting the
+ * quoted reply for the cut point.
+ */
+export function stripSignatureText(body: string): string {
+  if (!body) return body;
+  const lines = body.split(/\r?\n/);
+  let cut = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!.trim();
+    if (SIGNATURE_OPENERS.some((re) => re.test(line))) {
+      cut = i;
+      break;
+    }
+  }
+  if (cut < 0) return body;
+  const kept = lines.slice(0, cut);
+  let nonEmpty = 0;
+  for (const l of kept) if (l.trim() !== '') nonEmpty += 1;
+  if (nonEmpty === 0) return body;
+  return kept.join('\n').replace(/\s+$/g, '').trim();
+}
+
+/**
+ * HTML signature strip — narrowly targets containers mail clients reliably
+ * mark up as signatures. Gmail's `<div class="gmail_signature">` is the
+ * canonical case. Outlook leaves no class hook so we don't try to guess.
+ */
+export function stripSignatureHtml(html: string | null): string | null {
+  if (!html) return html;
+  let out = html;
+  out = out.replace(/<div[^>]*class="[^"]*gmail_signature[^"]*"[^>]*>[\s\S]*?<\/div>/gi, '');
+  out = out.replace(/<div[^>]*data-smartmail="gmail_signature"[^>]*>[\s\S]*?<\/div>/gi, '');
+  return out.replace(/\s+$/, '');
+}
+
 /** Prefix the subject with `Re: ` unless it already starts with one. */
 export function ensureReSubject(subject: string | null | undefined): string {
   const s = (subject ?? '').trim();


### PR DESCRIPTION
## Summary

Inbound mail is already stripped for quoted replies (the threaded
history mail clients tack on under your message). This adds a second
pass for the **sender's signature** so the agent and dashboard see only
the new content the sender actually typed.

Heuristic, conservative — no new deps, no Python sidecar, no ML
model. Lives next to the existing strippers in
\`packages/backend-core/src/modules/conv/email/reply-history.ts\`.

## What it cuts

**Text body** — first line matching:
- \`-- \` (RFC 3676 standard signature delimiter)
- \`_____\` (5+ underscores; some Outlook variants)
- Mobile-client openers, across the languages we currently see:
  - \`Sent from my iPhone / iPad / iPod / Android / *phone / *tablet\`
  - \`Sent from Outlook (for iOS|for Android|Mobile)?\`
  - \`Get Outlook for (iOS|Android)\`
  - \`Sent via Samsung\`
  - \`Sendt fra min iPhone / iPad / Outlook / mobil / Android\`
  - \`Envoyé de mon iPhone\` / \`Enviado desde mi iPhone\` /
    \`Verzonden vanaf mijn iPhone\` / \`Von meinem iPhone gesendet\`

**HTML body** — narrow:
- \`<div class="gmail_signature">…</div>\`
- \`<div data-smartmail="gmail_signature">…</div>\`

Outlook leaves no class hook, so for HTML we don't guess. The text
side still catches Outlook via the \`Sent from Outlook…\` opener and
the underscore separator.

## Safety rails

- The text stripper **never returns an empty body**. If the cut would
  remove every non-empty line (signature-only message — rare but
  possible from a noreply: address) it returns the input unchanged.
- Runs **after** \`stripQuotedReplyText\` so the existing thread-
  separator (\`_____\` / multi-language "wrote:" markers) gets the
  first shot. That ordering matters because both passes look at the
  same separator character.

## Known misses (intentional)

- Long corporate signatures with no \`-- \` delimiter and no opener —
  the \`Best, Name\\nTitle\\nCompany\\n+1 555…\` style. These leak
  through to the agent. False negatives are cosmetic; we'd rather miss
  a signature than chew a real sentence.
- Outlook HTML signatures (mass of \`<div class="MsoNormal">\` blocks
  with no marker). Same reasoning.

If accuracy starts mattering enough, the next step is a CRM-aware
pass that strips trailing lines matching the sender's known
\`conv_contacts.name\` / phone / address. We already have that data;
worth the engineering only if the heuristic ceiling actually bites.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean apart from one pre-existing warning
- [ ] CI test suite green
- [ ] Manual: send an inbound message from iPhone Mail — confirm
  "Sent from my iPhone" disappears from \`conv_messages.body\`.
- [ ] Manual: send an inbound message with \`-- \\nName\\nTitle\\nCo.\` —
  confirm the dashed delimiter and everything after it disappear.
- [ ] Manual: send a one-line message **with** "Sent from my iPhone"
  as the only content — confirm the body comes through unchanged
  (no-cut safety rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)