### PR TITLE
refactor(agent-host): chatModel/curatorModel → fastModel/smartModel

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -692,8 +692,8 @@
       "saveAndContinue": "Save & continue",
       "checklist": {
         "provider": "Provider configured ({url})",
-        "chat": "Chat model — {model}",
-        "curator": "Curator model — {model}"
+        "fast": "Fast model — {model}",
+        "smart": "Smart model — {model}"
       },
       "cta": {
         "goToDashboard": "Go to dashboard",
@@ -727,12 +727,14 @@
     },
     "models": {
       "title": "Models",
-      "curatorHint": "Curation runs less often but reasons over more text. Pick a stronger model than chat.",
+      "smartHint": "Munin runs two models. Pick a fast, cheap one for chat-bot replies and quick cleanup; pick a stronger one for jobs that need judgment.",
       "needKey": "Save an API key to load the model list.",
       "unsupported": "Provider didn't return a model list. Enter model ids manually (e.g. anthropic/claude-haiku-4.5).",
-      "chat": "Chat model",
-      "curator": "Curator model",
-      "curatorSameAsChat": "Same as chat"
+      "fast": "Fast model",
+      "fastHint": "Used for: chat-bot replies, signature stripping, classification, short summarization. Latency and cost matter more than smarts here.",
+      "smart": "Smart model",
+      "smartUseHint": "Used for: KB curation, CRM hygiene, outreach drafts — anywhere the agent needs to weigh judgment over many messages.",
+      "smartSameAsFast": "Same as fast model"
     }
   },
   "acceptInvite": {

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -692,8 +692,8 @@
       "saveAndContinue": "Lagre og fortsett",
       "checklist": {
         "provider": "Leverandør konfigurert ({url})",
-        "chat": "Chat-modell — {model}",
-        "curator": "Kurator-modell — {model}"
+        "fast": "Rask modell — {model}",
+        "smart": "Smart modell — {model}"
       },
       "cta": {
         "goToDashboard": "Gå til dashbord",
@@ -727,12 +727,14 @@
     },
     "models": {
       "title": "Modeller",
-      "curatorHint": "Kurering kjører sjeldnere, men resonnerer over mer tekst. Velg en sterkere modell enn for chat.",
+      "smartHint": "Munin bruker to modeller. Velg én rask og rimelig for chat-bot-svar og lett rydding; velg en sterkere for jobber som krever skjønn.",
       "needKey": "Lagre en API-nøkkel for å hente modell-listen.",
       "unsupported": "Leverandøren returnerte ingen modell-liste. Skriv inn modell-ID-er manuelt (f.eks. anthropic/claude-haiku-4.5).",
-      "chat": "Chat-modell",
-      "curator": "Kurator-modell",
-      "curatorSameAsChat": "Samme som chat"
+      "fast": "Rask modell",
+      "fastHint": "Brukes til: chat-bot-svar, signaturfjerning, klassifisering, korte oppsummeringer. Latens og kostnad veier tyngre enn intelligens her.",
+      "smart": "Smart modell",
+      "smartUseHint": "Brukes til: KB-kurering, CRM-hygiene, utgående utkast — overalt der agenten må vurdere på tvers av mange meldinger.",
+      "smartSameAsFast": "Samme som rask modell"
     }
   },
   "acceptInvite": {

--- a/packages/agent-host/src/config.controller.ts
+++ b/packages/agent-host/src/config.controller.ts
@@ -16,8 +16,8 @@ import { AgentConfigService, type AgentConfigDto } from './config.service.js';
 import { AgentModelsService, type ListModelsResult } from './models.service.js';
 
 const UpsertDto = z.object({
-  chatModel: z.string().min(1).optional(),
-  curatorModel: z.string().min(1).nullable().optional(),
+  fastModel: z.string().min(1).optional(),
+  smartModel: z.string().min(1).nullable().optional(),
   providerBaseUrl: z.string().url().optional(),
   providerApiKey: z.string().min(1).nullable().optional(),
   maxHistoryChars: z.number().int().positive().optional(),

--- a/packages/agent-host/src/config.repository.ts
+++ b/packages/agent-host/src/config.repository.ts
@@ -1,7 +1,7 @@
 export interface AgentConfigRow {
   id: string;
-  chatModel: string;
-  curatorModel: string | null;
+  fastModel: string;
+  smartModel: string | null;
   providerBaseUrl: string;
   providerApiKeySet: boolean;
   maxHistoryChars: number;
@@ -13,8 +13,8 @@ export interface AgentConfigRow {
 }
 
 export interface AgentConfigPatch {
-  chatModel?: string;
-  curatorModel?: string | null;
+  fastModel?: string;
+  smartModel?: string | null;
   providerBaseUrl?: string;
   providerApiKey?: string | null;
   maxHistoryChars?: number;

--- a/packages/agent-host/src/config.service.test.ts
+++ b/packages/agent-host/src/config.service.test.ts
@@ -9,8 +9,8 @@ import type { AdminKeyProvider } from './admin-key-provider.js';
 
 const baseRow: AgentConfigRow = {
   id: 'singleton',
-  chatModel: 'anthropic/claude-haiku-4.5',
-  curatorModel: null,
+  fastModel: 'anthropic/claude-haiku-4.5',
+  smartModel: null,
   providerBaseUrl: 'https://provider.example/v1',
   providerApiKeySet: false,
   maxHistoryChars: 32_000,
@@ -103,7 +103,7 @@ describe('AgentConfigService', () => {
     const adminKey = makeAdminKey();
     const svc = new AgentConfigService(repo, adminKey);
 
-    await svc.upsertForCurrentActor({ chatModel: 'anthropic/claude-sonnet-4-6' });
+    await svc.upsertForCurrentActor({ fastModel: 'anthropic/claude-sonnet-4-6' });
 
     expect(adminKey.mint).not.toHaveBeenCalled();
     expect(adminKey.revoke).not.toHaveBeenCalled();
@@ -114,8 +114,8 @@ describe('AgentConfigService', () => {
     const svc = new AgentConfigService(repo, makeAdminKey());
 
     const patch: AgentConfigPatch = {
-      chatModel: 'a',
-      curatorModel: 'b',
+      fastModel: 'a',
+      smartModel: 'b',
       providerBaseUrl: 'https://x',
       maxHistoryChars: 64_000,
     };

--- a/packages/agent-host/src/config.service.ts
+++ b/packages/agent-host/src/config.service.ts
@@ -9,8 +9,8 @@ import type { AdminKeyProvider } from './admin-key-provider.js';
 
 export interface AgentConfigDto {
   id: string;
-  chatModel: string;
-  curatorModel: string | null;
+  fastModel: string;
+  smartModel: string | null;
   providerBaseUrl: string;
   providerApiKeySet: boolean;
   maxHistoryChars: number;
@@ -54,8 +54,8 @@ export class AgentConfigService {
 function toDto(row: AgentConfigRow): AgentConfigDto {
   return {
     id: row.id,
-    chatModel: row.chatModel,
-    curatorModel: row.curatorModel,
+    fastModel: row.fastModel,
+    smartModel: row.smartModel,
     providerBaseUrl: row.providerBaseUrl,
     providerApiKeySet: row.providerApiKeySet,
     maxHistoryChars: row.maxHistoryChars,

--- a/packages/agent-host/src/models.service.test.ts
+++ b/packages/agent-host/src/models.service.test.ts
@@ -4,8 +4,8 @@ import type { AgentConfigRepository, AgentConfigRow } from './config.repository.
 
 const baseRow: AgentConfigRow = {
   id: 'singleton',
-  chatModel: 'anthropic/claude-haiku-4.5',
-  curatorModel: null,
+  fastModel: 'anthropic/claude-haiku-4.5',
+  smartModel: null,
   providerBaseUrl: 'https://provider.example/v1',
   providerApiKeySet: true,
   maxHistoryChars: 32_000,

--- a/packages/agent-host/src/per-org-config.repository.ts
+++ b/packages/agent-host/src/per-org-config.repository.ts
@@ -8,7 +8,7 @@ import type {
   AgentConfigRow,
 } from './config.repository.js';
 
-const DEFAULT_CHAT_MODEL = 'anthropic/claude-haiku-4.5';
+const DEFAULT_FAST_MODEL = 'anthropic/claude-haiku-4.5';
 const DEFAULT_PROVIDER_BASE_URL = 'https://openrouter.ai/api/v1';
 
 @Injectable()
@@ -52,8 +52,8 @@ async function readOrMaterialize(id: string): Promise<AgentConfigRow> {
   const rows = await ctx.db
     .select({
       id: agentConfig.id,
-      chatModel: agentConfig.chatModel,
-      curatorModel: agentConfig.curatorModel,
+      fastModel: agentConfig.fastModel,
+      smartModel: agentConfig.smartModel,
       providerBaseUrl: agentConfig.providerBaseUrl,
       providerKeySet: sql<boolean>`(${agentConfig.providerApiKeyCt} IS NOT NULL)`,
       maxHistoryChars: agentConfig.maxHistoryChars,
@@ -70,8 +70,8 @@ async function readOrMaterialize(id: string): Promise<AgentConfigRow> {
   if (row) {
     return {
       id: row.id,
-      chatModel: row.chatModel,
-      curatorModel: row.curatorModel,
+      fastModel: row.fastModel,
+      smartModel: row.smartModel,
       providerBaseUrl: row.providerBaseUrl,
       providerApiKeySet: row.providerKeySet,
       maxHistoryChars: row.maxHistoryChars,
@@ -86,15 +86,15 @@ async function readOrMaterialize(id: string): Promise<AgentConfigRow> {
     .insert(agentConfig)
     .values({
       id,
-      chatModel: DEFAULT_CHAT_MODEL,
+      fastModel: DEFAULT_FAST_MODEL,
       providerBaseUrl: DEFAULT_PROVIDER_BASE_URL,
     })
     .returning();
   if (!created) throw new Error(`failed to materialize agent_config row for id=${id}`);
   return {
     id: created.id,
-    chatModel: created.chatModel,
-    curatorModel: created.curatorModel,
+    fastModel: created.fastModel,
+    smartModel: created.smartModel,
     providerBaseUrl: created.providerBaseUrl,
     providerApiKeySet: false,
     maxHistoryChars: created.maxHistoryChars,
@@ -109,8 +109,8 @@ async function readOrMaterialize(id: string): Promise<AgentConfigRow> {
 async function applyPatch(id: string, patch: AgentConfigPatch): Promise<void> {
   const ctx = getCurrentContext();
   const setClauses: Record<string, unknown> = {};
-  if (patch.chatModel !== undefined) setClauses['chatModel'] = patch.chatModel;
-  if (patch.curatorModel !== undefined) setClauses['curatorModel'] = patch.curatorModel;
+  if (patch.fastModel !== undefined) setClauses['fastModel'] = patch.fastModel;
+  if (patch.smartModel !== undefined) setClauses['smartModel'] = patch.smartModel;
   if (patch.providerBaseUrl !== undefined) setClauses['providerBaseUrl'] = patch.providerBaseUrl;
   if (patch.maxHistoryChars !== undefined) setClauses['maxHistoryChars'] = patch.maxHistoryChars;
   if (patch.maxToolIterations !== undefined) setClauses['maxToolIterations'] = patch.maxToolIterations;

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -222,7 +222,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     const handlerConfig: HandlerConfig = {
       providerBaseUrl: config.providerBaseUrl,
       providerApiKey,
-      model: config.chatModel,
+      model: config.fastModel,
       maxToolIterations: config.maxToolIterations,
       maxHistoryChars: config.maxHistoryChars,
       debounceMs: config.debounceMs,
@@ -291,7 +291,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       return p;
     };
 
-    const curatorModel = opts.config.curatorModel ?? opts.config.chatModel;
+    const smartModel = opts.config.smartModel ?? opts.config.fastModel;
 
     const executeOne = async (job: CuratorJob): Promise<void> => {
       log.info(`running ${job.skillUri} for ${job.id} (attempt ${job.attempts}/${job.maxAttempts})`);
@@ -304,7 +304,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
           )) ?? this.fallbackAdminApiKey ?? '',
           providerBaseUrl: opts.config.providerBaseUrl,
           providerApiKey: opts.providerApiKey,
-          model: curatorModel,
+          model: smartModel,
           skillUri: job.skillUri,
           userPrompt: job.userPrompt,
           maxToolIterations: 24,

--- a/packages/agent-host/src/schema.ts
+++ b/packages/agent-host/src/schema.ts
@@ -6,8 +6,8 @@ const updatedAt = timestamp('updated_at', { withTimezone: true }).notNull().defa
 
 export const agentConfig = pgTable('agent_config', {
   id: text('id').primaryKey(),
-  chatModel: text('chat_model').notNull(),
-  curatorModel: text('curator_model'),
+  fastModel: text('fast_model').notNull(),
+  smartModel: text('smart_model'),
   providerBaseUrl: text('provider_base_url').notNull(),
   providerApiKeyCt: text('provider_api_key_ct'),
   adminApiKeyCt: text('admin_api_key_ct'),
@@ -22,10 +22,26 @@ export const agentConfig = pgTable('agent_config', {
 export const SINGLETON_ID = 'singleton' as const;
 
 export const AGENT_HOST_SINGLETON_DDL = sql`
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'agent_config' AND column_name = 'chat_model'
+    ) THEN
+      ALTER TABLE agent_config RENAME COLUMN chat_model TO fast_model;
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'agent_config' AND column_name = 'curator_model'
+    ) THEN
+      ALTER TABLE agent_config RENAME COLUMN curator_model TO smart_model;
+    END IF;
+  END $$;
+
   CREATE TABLE IF NOT EXISTS agent_config (
     id text PRIMARY KEY DEFAULT 'singleton',
-    chat_model text NOT NULL DEFAULT 'anthropic/claude-haiku-4.5',
-    curator_model text,
+    fast_model text NOT NULL DEFAULT 'anthropic/claude-haiku-4.5',
+    smart_model text,
     provider_base_url text NOT NULL DEFAULT 'https://openrouter.ai/api/v1',
     provider_api_key_ct text,
     admin_api_key_ct text,
@@ -49,10 +65,26 @@ export const AGENT_HOST_SINGLETON_DDL = sql`
 `;
 
 export const AGENT_HOST_MULTI_TENANT_DDL = sql`
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'agent_config' AND column_name = 'chat_model'
+    ) THEN
+      ALTER TABLE agent_config RENAME COLUMN chat_model TO fast_model;
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'agent_config' AND column_name = 'curator_model'
+    ) THEN
+      ALTER TABLE agent_config RENAME COLUMN curator_model TO smart_model;
+    END IF;
+  END $$;
+
   CREATE TABLE IF NOT EXISTS agent_config (
     id text PRIMARY KEY REFERENCES orgs(id) ON DELETE CASCADE,
-    chat_model text NOT NULL,
-    curator_model text,
+    fast_model text NOT NULL,
+    smart_model text,
     provider_base_url text NOT NULL,
     provider_api_key_ct text,
     admin_api_key_ct text,
@@ -64,7 +96,7 @@ export const AGENT_HOST_MULTI_TENANT_DDL = sql`
     updated_at timestamptz NOT NULL DEFAULT now()
   );
 
-  ALTER TABLE agent_config ADD COLUMN IF NOT EXISTS curator_model text;
+  ALTER TABLE agent_config ADD COLUMN IF NOT EXISTS smart_model text;
 
   DROP INDEX IF EXISTS agent_config_enabled_idx;
 

--- a/packages/agent-host/src/singleton-config.repository.ts
+++ b/packages/agent-host/src/singleton-config.repository.ts
@@ -55,8 +55,8 @@ async function readRow(id: string, createIfMissing: boolean): Promise<AgentConfi
   const rows = await ctx.db
     .select({
       id: agentConfig.id,
-      chatModel: agentConfig.chatModel,
-      curatorModel: agentConfig.curatorModel,
+      fastModel: agentConfig.fastModel,
+      smartModel: agentConfig.smartModel,
       providerBaseUrl: agentConfig.providerBaseUrl,
       providerKeySet: sql<boolean>`(${agentConfig.providerApiKeyCt} IS NOT NULL)`,
       maxHistoryChars: agentConfig.maxHistoryChars,
@@ -73,8 +73,8 @@ async function readRow(id: string, createIfMissing: boolean): Promise<AgentConfi
   if (row) {
     return {
       id: row.id,
-      chatModel: row.chatModel,
-      curatorModel: row.curatorModel,
+      fastModel: row.fastModel,
+      smartModel: row.smartModel,
       providerBaseUrl: row.providerBaseUrl,
       providerApiKeySet: row.providerKeySet,
       maxHistoryChars: row.maxHistoryChars,
@@ -97,8 +97,8 @@ async function readRow(id: string, createIfMissing: boolean): Promise<AgentConfi
 async function applyPatch(id: string, patch: AgentConfigPatch): Promise<void> {
   const ctx = getCurrentContext();
   const setClauses: Record<string, unknown> = {};
-  if (patch.chatModel !== undefined) setClauses['chatModel'] = patch.chatModel;
-  if (patch.curatorModel !== undefined) setClauses['curatorModel'] = patch.curatorModel;
+  if (patch.fastModel !== undefined) setClauses['fastModel'] = patch.fastModel;
+  if (patch.smartModel !== undefined) setClauses['smartModel'] = patch.smartModel;
   if (patch.providerBaseUrl !== undefined) setClauses['providerBaseUrl'] = patch.providerBaseUrl;
   if (patch.maxHistoryChars !== undefined) setClauses['maxHistoryChars'] = patch.maxHistoryChars;
   if (patch.maxToolIterations !== undefined) setClauses['maxToolIterations'] = patch.maxToolIterations;

--- a/packages/dashboard-pages/src/components/agent-config/models-card.tsx
+++ b/packages/dashboard-pages/src/components/agent-config/models-card.tsx
@@ -35,8 +35,8 @@ export function ModelsCard({ config, models, saveLabel, extraActions, onSaved }:
   const tCommon = useTranslations('common');
   const translate = useTranslateError();
 
-  const [chatModel, setChatModel] = useState(config.chatModel);
-  const [curatorModel, setCuratorModel] = useState(config.curatorModel ?? '');
+  const [fastModel, setFastModel] = useState(config.fastModel);
+  const [smartModel, setSmartModel] = useState(config.smartModel ?? '');
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -54,8 +54,8 @@ export function ModelsCard({ config, models, saveLabel, extraActions, onSaved }:
       const updated = await api<AgentConfigDto>('/api/v1/agent-config', {
         method: 'PUT',
         body: JSON.stringify({
-          chatModel,
-          curatorModel: curatorModel || null,
+          fastModel,
+          smartModel: smartModel || null,
         }),
       });
       setMessage(t('saved'));
@@ -67,14 +67,14 @@ export function ModelsCard({ config, models, saveLabel, extraActions, onSaved }:
     }
   }
 
-  const canSave = config.providerApiKeySet && chatModel.length > 0 && !saving;
+  const canSave = config.providerApiKeySet && fastModel.length > 0 && !saving;
   const label = saveLabel ?? tCommon('save');
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>{t('models.title')}</CardTitle>
-        <CardDescription>{t('models.curatorHint')}</CardDescription>
+        <CardDescription>{t('models.smartHint')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {!config.providerApiKeySet ? (
@@ -82,11 +82,12 @@ export function ModelsCard({ config, models, saveLabel, extraActions, onSaved }:
         ) : models?.supported ? (
           <>
             <div className="space-y-1.5">
-              <Label htmlFor="chatModel">{t('models.chat')}</Label>
+              <Label htmlFor="fastModel">{t('models.fast')}</Label>
+              <p className="text-xs text-muted-foreground">{t('models.fastHint')}</p>
               <NativeSelect
-                id="chatModel"
-                value={chatModel}
-                onChange={(e) => setChatModel(e.target.value)}
+                id="fastModel"
+                value={fastModel}
+                onChange={(e) => setFastModel(e.target.value)}
               >
                 {sortedModels.map((m) => (
                   <option key={m.id} value={m.id}>
@@ -96,13 +97,14 @@ export function ModelsCard({ config, models, saveLabel, extraActions, onSaved }:
               </NativeSelect>
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="curatorModel">{t('models.curator')}</Label>
+              <Label htmlFor="smartModel">{t('models.smart')}</Label>
+              <p className="text-xs text-muted-foreground">{t('models.smartUseHint')}</p>
               <NativeSelect
-                id="curatorModel"
-                value={curatorModel}
-                onChange={(e) => setCuratorModel(e.target.value)}
+                id="smartModel"
+                value={smartModel}
+                onChange={(e) => setSmartModel(e.target.value)}
               >
-                <option value="">{t('models.curatorSameAsChat')}</option>
+                <option value="">{t('models.smartSameAsFast')}</option>
                 {sortedModels.map((m) => (
                   <option key={m.id} value={m.id}>
                     {formatModel(m)}
@@ -115,21 +117,23 @@ export function ModelsCard({ config, models, saveLabel, extraActions, onSaved }:
           <>
             <p className="text-sm text-muted-foreground">{t('models.unsupported')}</p>
             <div className="space-y-1.5">
-              <Label htmlFor="chatModelText">{t('models.chat')}</Label>
+              <Label htmlFor="fastModelText">{t('models.fast')}</Label>
+              <p className="text-xs text-muted-foreground">{t('models.fastHint')}</p>
               <Input
-                id="chatModelText"
-                value={chatModel}
-                onChange={(e) => setChatModel(e.target.value)}
+                id="fastModelText"
+                value={fastModel}
+                onChange={(e) => setFastModel(e.target.value)}
                 placeholder="provider/model-name"
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="curatorModelText">{t('models.curator')}</Label>
+              <Label htmlFor="smartModelText">{t('models.smart')}</Label>
+              <p className="text-xs text-muted-foreground">{t('models.smartUseHint')}</p>
               <Input
-                id="curatorModelText"
-                value={curatorModel}
-                onChange={(e) => setCuratorModel(e.target.value)}
-                placeholder={t('models.curatorSameAsChat')}
+                id="smartModelText"
+                value={smartModel}
+                onChange={(e) => setSmartModel(e.target.value)}
+                placeholder={t('models.smartSameAsFast')}
               />
             </div>
           </>

--- a/packages/dashboard-pages/src/components/agent-config/types.ts
+++ b/packages/dashboard-pages/src/components/agent-config/types.ts
@@ -1,7 +1,7 @@
 export interface AgentConfigDto {
   id: string;
-  chatModel: string;
-  curatorModel: string | null;
+  fastModel: string;
+  smartModel: string | null;
   providerBaseUrl: string;
   providerApiKeySet: boolean;
   maxHistoryChars: number;
@@ -24,8 +24,8 @@ export interface ListModelsResult {
 export interface UpsertBody {
   providerBaseUrl?: string;
   providerApiKey?: string | null;
-  chatModel?: string;
-  curatorModel?: string | null;
+  fastModel?: string;
+  smartModel?: string | null;
 }
 
 export const PROVIDER_PRESETS = [

--- a/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
@@ -136,8 +136,8 @@ function ReadyCard({ config, onBack }: ReadyCardProps) {
 
   const lines: string[] = [
     t('wizard.checklist.provider', { url: shortHost(config.providerBaseUrl) }),
-    t('wizard.checklist.chat', { model: config.chatModel }),
-    t('wizard.checklist.curator', { model: config.curatorModel ?? config.chatModel }),
+    t('wizard.checklist.fast', { model: config.fastModel }),
+    t('wizard.checklist.smart', { model: config.smartModel ?? config.fastModel }),
   ];
 
   return (


### PR DESCRIPTION
## Why

The current \`chatModel\` / \`curatorModel\` config bakes in a use-case
assumption ("there's one model for chat and one for curator"). Every
new feature that wants an LLM call has to either reuse one of those
buckets (paying its model price even if the task is simpler) or add
yet another config column.

Renaming to capability tiers — **fast** (latency + cost-sensitive)
and **smart** (judgment-sensitive) — lets every code path pick the
appropriate tier without adding new columns. It's also how teams
actually talk about their LLM setup.

## Behavior — unchanged

| Path | Before | After |
|---|---|---|
| Conversational chat replies | \`chatModel\` | \`fastModel\` |
| Skill passes (KB curation, CRM hygiene, outreach drafts, etc.) | \`curatorModel ?? chatModel\` | \`smartModel ?? fastModel\` |

The fallback semantics are preserved verbatim — a customer with only
one model set continues to get every job routed to it.

## Migration

Idempotent rename inside both DDL strings in \`packages/agent-host/src/schema.ts\`:

\`\`\`sql
DO $$
BEGIN
  IF EXISTS (… chat_model …) THEN
    ALTER TABLE agent_config RENAME COLUMN chat_model TO fast_model;
  END IF;
  IF EXISTS (… curator_model …) THEN
    ALTER TABLE agent_config RENAME COLUMN curator_model TO smart_model;
  END IF;
END $$;
\`\`\`

- **Fresh DBs**: \`CREATE TABLE\` creates \`fast_model\` / \`smart_model\` from the start.
- **Existing DBs**: the guarded RENAME flips the legacy names on first boot after upgrade.
- **Already-renamed DBs**: the IF EXISTS check makes the rename a no-op.

Verified locally — the SQL runs cleanly on both fresh and already-renamed schemas.

## UI

The agent-config form now shows example use-cases under each field so
operators have a concrete mental anchor when picking models:

- **Fast model** — "Used for: chat-bot replies, signature stripping,
  classification, short summarization. Latency and cost matter more
  than smarts here."
- **Smart model** — "Used for: KB curation, CRM hygiene, outreach
  drafts — anywhere the agent needs to weigh judgment over many
  messages."

en + nb strings updated.

## Files touched

- \`packages/agent-host/src/schema.ts\` — column names + both DDL strings
- \`packages/agent-host/src/config.repository.ts\` — types
- \`packages/agent-host/src/config.controller.ts\` — Zod schema
- \`packages/agent-host/src/config.service.ts\` — types + DTO mapper
- \`packages/agent-host/src/singleton-config.repository.ts\` — select/insert/update
- \`packages/agent-host/src/per-org-config.repository.ts\` — same shape + DEFAULT_FAST_MODEL constant
- \`packages/agent-host/src/runner.service.ts\` — picks \`fastModel\` for chat handler, \`smartModel ?? fastModel\` for curator worker
- \`packages/agent-host/src/{config,models}.service.test.ts\` — test fixtures
- \`packages/dashboard-pages/src/components/agent-config/types.ts\` — DTO + UpsertBody types
- \`packages/dashboard-pages/src/components/agent-config/models-card.tsx\` — form fields + DOM ids + new hint text
- \`packages/dashboard-pages/src/pages/agent-setup-wizard.tsx\` — wizard checklist labels
- \`apps/web/messages/{en,nb}.json\` — translation keys

## Test plan

- [x] \`pnpm typecheck\` clean across 24 packages
- [x] \`pnpm lint\` clean (one pre-existing warning)
- [x] Local migration verified idempotent (ran the RENAME block twice against my dev DB)
- [ ] CI test suite green
- [ ] Manual: dashboard's agent-config form loads, shows hints, saves correctly
- [ ] Manual: existing org with only \`chat_model\` set continues to work — chat handler uses it for both chat and skill passes (fallback)

## Cloud follow-up

\`munin-cloud/apps/backend-cloud/src/migrate.ts\` has a legacy backfill
INSERT that references \`chat_model\`. It's dead code on modern
deployments (the source table \`org_agent_configs\` is gone), but
should be updated for hygiene when cloud bumps the
\`@getmunin/agent-host\` dep to the next release. Not included here
because it lives in a separate repo with unrelated pending edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)