### PR TITLE
Dashboard inbox: fix trigger-message quote, inline error states, drawer flicker

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -232,6 +232,19 @@
           "release": "Couldn't release",
           "close": "Couldn't close the conversation"
         },
+        "actionFailedShort": {
+          "send": "Send failed",
+          "takeOver": "Take over failed",
+          "release": "Release failed",
+          "close": "Close failed"
+        },
+        "actionFailedReasonConnection": "Check connection",
+        "retryAction": {
+          "send": "Retry send",
+          "takeOver": "Retry",
+          "release": "Retry",
+          "close": "Retry"
+        },
         "retry": "Retry",
         "activityConv": "Conversation activity",
         "activityContact": "Contact activity",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -11,6 +11,7 @@
     "saveChanges": "Save changes",
     "saving": "Saving…",
     "creating": "Creating…",
+    "retry": "Retry",
     "retrying": "Retrying…",
     "apply": "Apply",
     "loadMore": "Load more",
@@ -127,6 +128,9 @@
     "organization": "Organization"
   },
   "dashboard": {
+    "connectionBanner": {
+      "offline": "Connection lost. Reconnecting…"
+    },
     "saveFailed": {
       "title": "Save failed",
       "sub": "Nothing was saved · safe to retry",
@@ -220,6 +224,15 @@
         "crmMergeExplain": "Keeps the primary; rewrites foreign keys; archives the loser. No conversations are lost.",
         "internalLabel": "internal · {author}",
         "seenAt": "Seen {time}",
+        "loadFailedEyebrow": "Couldn't load",
+        "loadFailedTitle": "This conversation didn't load.",
+        "actionFailed": {
+          "send": "Couldn't send your reply",
+          "takeOver": "Couldn't take over",
+          "release": "Couldn't release",
+          "close": "Couldn't close the conversation"
+        },
+        "retry": "Retry",
         "activityConv": "Conversation activity",
         "activityContact": "Contact activity",
         "activityEmpty": "No activity yet.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -238,7 +238,7 @@
           "release": "Release failed",
           "close": "Close failed"
         },
-        "actionFailedReasonConnection": "Check connection",
+        "actionFailedReasonConnection": "check connection",
         "retryAction": {
           "send": "Retry send",
           "takeOver": "Retry",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -232,6 +232,19 @@
           "release": "Kunne ikke slippe",
           "close": "Kunne ikke lukke samtalen"
         },
+        "actionFailedShort": {
+          "send": "Sending feilet",
+          "takeOver": "Overtakelse feilet",
+          "release": "Slipp feilet",
+          "close": "Lukking feilet"
+        },
+        "actionFailedReasonConnection": "Sjekk tilkoblingen",
+        "retryAction": {
+          "send": "Send på nytt",
+          "takeOver": "Prøv igjen",
+          "release": "Prøv igjen",
+          "close": "Prøv igjen"
+        },
         "retry": "Prøv igjen",
         "activityConv": "Samtaleaktivitet",
         "activityContact": "Kontaktaktivitet",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -238,7 +238,7 @@
           "release": "Slipp feilet",
           "close": "Lukking feilet"
         },
-        "actionFailedReasonConnection": "Sjekk tilkoblingen",
+        "actionFailedReasonConnection": "sjekk tilkoblingen",
         "retryAction": {
           "send": "Send på nytt",
           "takeOver": "Prøv igjen",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -11,6 +11,7 @@
     "saveChanges": "Lagre endringer",
     "saving": "Lagrer…",
     "creating": "Oppretter…",
+    "retry": "Prøv igjen",
     "retrying": "Prøver igjen…",
     "apply": "Bruk",
     "loadMore": "Last flere",
@@ -127,6 +128,9 @@
     "organization": "Organisasjon"
   },
   "dashboard": {
+    "connectionBanner": {
+      "offline": "Tilkoblingen er borte. Kobler til igjen…"
+    },
     "saveFailed": {
       "title": "Lagring feilet",
       "sub": "Ingenting ble lagret · trygt å prøve igjen",
@@ -220,6 +224,15 @@
         "crmMergeExplain": "Beholder hovedoppføringen; flytter referanser; arkiverer den andre. Ingen samtaler går tapt.",
         "internalLabel": "intern · {author}",
         "seenAt": "Sett {time}",
+        "loadFailedEyebrow": "Kunne ikke laste",
+        "loadFailedTitle": "Denne samtalen lot seg ikke laste.",
+        "actionFailed": {
+          "send": "Kunne ikke sende svaret ditt",
+          "takeOver": "Kunne ikke overta",
+          "release": "Kunne ikke slippe",
+          "close": "Kunne ikke lukke samtalen"
+        },
+        "retry": "Prøv igjen",
         "activityConv": "Samtaleaktivitet",
         "activityContact": "Kontaktaktivitet",
         "activityEmpty": "Ingen aktivitet ennå.",

--- a/packages/dashboard-pages/src/api.ts
+++ b/packages/dashboard-pages/src/api.ts
@@ -45,13 +45,16 @@ export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
       },
     });
   } catch (err) {
+    if (typeof console !== 'undefined') {
+      console.debug('[munin/api] network error', { path, method, err });
+    }
     throw new ApiError({
       status: 0,
       statusText: 'network error',
       endpoint: path,
       method,
       requestId: null,
-      message: err instanceof Error ? err.message : 'Network request failed',
+      message: "Couldn't reach Munin. Check your connection.",
     });
   }
   if (!res.ok) {

--- a/packages/dashboard-pages/src/components/connection-banner.tsx
+++ b/packages/dashboard-pages/src/components/connection-banner.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import type { RealtimeStatus } from '../realtime';
+
+export function ConnectionBanner({ status }: { status: RealtimeStatus }) {
+  const t = useTranslations('dashboard.connectionBanner');
+  if (status !== 'offline') return null;
+  return (
+    <div
+      role="status"
+      className="sticky top-0 z-40 border-b-[0.5px] border-amber-300 bg-amber-50 px-4 py-2 text-center font-mono text-[11px] uppercase tracking-eyebrow text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200"
+    >
+      {t('offline')}
+    </div>
+  );
+}

--- a/packages/dashboard-pages/src/components/connection-banner.tsx
+++ b/packages/dashboard-pages/src/components/connection-banner.tsx
@@ -9,7 +9,7 @@ export function ConnectionBanner({ status }: { status: RealtimeStatus }) {
   return (
     <div
       role="status"
-      className="sticky top-0 z-40 border-b-[0.5px] border-amber-300 bg-amber-50 px-4 py-2 text-center font-mono text-[11px] uppercase tracking-eyebrow text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200"
+      className="border-b-[0.5px] border-amber-300 bg-amber-50 px-4 py-2 text-center text-sm font-sans text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200"
     >
       {t('offline')}
     </div>

--- a/packages/dashboard-pages/src/components/connection-banner.tsx
+++ b/packages/dashboard-pages/src/components/connection-banner.tsx
@@ -1,11 +1,16 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { RealtimeStatus } from '../realtime';
 
 export function ConnectionBanner({ status }: { status: RealtimeStatus }) {
   const t = useTranslations('dashboard.connectionBanner');
-  if (status !== 'offline') return null;
+  const [hasBeenConnected, setHasBeenConnected] = useState(false);
+  useEffect(() => {
+    if (status === 'connected') setHasBeenConnected(true);
+  }, [status]);
+  if (!hasBeenConnected || status === 'connected') return null;
   return (
     <div
       role="status"

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -264,7 +264,6 @@ export function useInboxData(): InboxController {
       setHasLoadedOnce(true);
     } catch (err) {
       if (err instanceof ApiError) setLoadError(err);
-      notify.error(messageOf(err));
     }
   }, [buildQueue]);
 
@@ -346,6 +345,21 @@ export function useInboxData(): InboxController {
       if (typeof eventConvId === 'string') void loadDetail(eventConvId);
     }
   });
+
+  const wasOfflineRef = useRef(false);
+  useEffect(() => {
+    if (connectionStatus === 'offline') {
+      wasOfflineRef.current = true;
+      return;
+    }
+    if (connectionStatus === 'connected' && wasOfflineRef.current) {
+      wasOfflineRef.current = false;
+      setActionError(null);
+      setDetailErrors({});
+      void loadInbox();
+      if (convDrawer) void loadDetail(convDrawer.id);
+    }
+  }, [connectionStatus, convDrawer, loadDetail, loadInbox]);
 
   const takeOver = useCallback(
     async (id: string, openFullAfter = true) => {
@@ -577,7 +591,6 @@ export function LiveNowSection({ controller }: { controller: InboxController }) 
     details,
     pending,
     actionError,
-    clearActionError,
     setConvDrawer,
     setReply,
     setDraftEdit,
@@ -609,7 +622,6 @@ export function LiveNowSection({ controller }: { controller: InboxController }) 
             detail={details[c.id]}
             pending={pending}
             actionError={actionError?.conversationId === c.id ? actionError : null}
-            onDismissError={clearActionError}
             onOpen={(mode) => {
               setReply('');
               setDraftEdit(null);
@@ -763,7 +775,6 @@ function LiveCard({
   detail,
   pending,
   actionError,
-  onDismissError,
   onOpen,
   onTakeOver,
 }: {
@@ -771,7 +782,6 @@ function LiveCard({
   detail: ConversationDetail | undefined;
   pending: boolean;
   actionError: ConvActionError;
-  onDismissError: () => void;
   onOpen: (mode: 'simplified' | 'full') => void;
   onTakeOver: () => void;
 }) {
@@ -844,7 +854,6 @@ function LiveCard({
               action={actionError.type}
               message={actionError.message}
               onRetry={retryAction}
-              onDismiss={onDismissError}
             />
           ) : claimed ? (
             <Button variant="accent" size="sm" onClick={() => onOpen('full')}>
@@ -875,43 +884,32 @@ function InlineActionError({
   action,
   message,
   onRetry,
-  onDismiss,
 }: {
   action: NonNullable<ConvActionError>['type'];
   message: string;
   onRetry: (() => void) | null;
-  onDismiss: () => void;
 }) {
   const t = useTranslations('dashboard.overview.drawer');
   const reason = isConnectionMessage(message) ? t('actionFailedReasonConnection') : message;
   return (
     <div
-      className="flex items-center gap-3 border-[0.5px] border-cobalt/30 bg-destructive/5 px-3 py-2 dark:border-cobalt-soft/40"
+      className="flex items-center gap-[14px] whitespace-nowrap border-[0.5px] border-cobalt bg-[oklch(0.98_0.025_25)] px-3 py-1.5 text-[13px] font-medium text-cobalt dark:border-cobalt-soft dark:bg-cobalt-soft/10 dark:text-cobalt-soft"
       role="alert"
     >
       <span
-        className="size-1.5 rounded-full bg-cobalt dark:bg-cobalt-soft"
+        className="size-1.5 rounded-full bg-cobalt animate-pulse dark:bg-cobalt-soft"
         aria-hidden
       />
-      <span className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+      <span>
         {t(`actionFailedShort.${action}`)} · {reason}
       </span>
-      {onRetry ? (
+      {onRetry && (
         <button
           type="button"
-          className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt underline underline-offset-2 hover:no-underline dark:text-cobalt-soft"
+          className="cursor-pointer text-[13px] font-medium text-cobalt underline underline-offset-[3px] hover:text-cobalt-deep dark:text-cobalt-soft"
           onClick={onRetry}
         >
-          {t('retry')} <span aria-hidden>↵</span>
-        </button>
-      ) : (
-        <button
-          type="button"
-          className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt/70 hover:text-cobalt dark:text-cobalt-soft/70 dark:hover:text-cobalt-soft"
-          onClick={onDismiss}
-          aria-label="Dismiss"
-        >
-          ×
+          {t('retry')} <span aria-hidden>↻</span>
         </button>
       )}
     </div>
@@ -1122,43 +1120,52 @@ function SimplifiedConvDrawer({
         </section>
       </div>
 
-      {actionError && (
-        <div
-          className="flex items-center gap-3 border-t-[0.5px] border-cobalt/30 bg-destructive/5 px-6 py-2 dark:border-cobalt-soft/40"
-          role="alert"
-        >
-          <span
-            className="size-1.5 rounded-full bg-cobalt dark:bg-cobalt-soft"
-            aria-hidden
-          />
-          <span className="flex-1 font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
-            {t(`actionFailedShort.${actionError.type}`)} ·{' '}
-            {isConnectionMessage(actionError.message)
-              ? t('actionFailedReasonConnection')
-              : actionError.message}
-          </span>
-        </div>
-      )}
+      <div
+        className={
+          actionError
+            ? 'border-t-[0.5px] border-cobalt dark:border-cobalt-soft'
+            : undefined
+        }
+      >
+        {actionError && (
+          <div
+            className="flex items-center gap-3 border-b-[0.5px] border-rule-soft bg-[oklch(0.98_0.025_25)] px-[26px] py-3 text-[13px] font-medium text-cobalt dark:border-rule-on-dark dark:bg-cobalt-soft/10 dark:text-cobalt-soft"
+            role="alert"
+          >
+            <span
+              className="size-1.5 rounded-full bg-cobalt animate-pulse dark:bg-cobalt-soft"
+              aria-hidden
+            />
+            <span className="flex-1">
+              {t(`actionFailedShort.${actionError.type}`)} ·{' '}
+              {isConnectionMessage(actionError.message)
+                ? t('actionFailedReasonConnection')
+                : actionError.message}
+            </span>
+          </div>
+        )}
 
-      <DrawerFooter
-        primary={{
-          label: actionError?.type === 'send' ? t('retryAction.send') : t('sendDraft'),
-          onClick: () => onSendDraft(draftBody),
-          disabled: pending || !draftBody.trim(),
-        }}
-        secondary={[
-          draft
-            ? isEditing
-              ? { label: t('cancel'), onClick: () => setDraftEdit(null) }
-              : {
-                  label: t('edit'),
-                  onClick: () => setDraftEdit(draft.body),
-                }
-            : null,
-          { label: t('takeOver'), onClick: onTakeOver, disabled: pending },
-        ].filter((a): a is { label: string; onClick: () => void } => a !== null)}
-        shortcut={t('shortcutSend')}
-      />
+        <DrawerFooter
+          bordered={!actionError}
+          primary={{
+            label: actionError?.type === 'send' ? t('retryAction.send') : t('sendDraft'),
+            onClick: () => onSendDraft(draftBody),
+            disabled: pending || !draftBody.trim(),
+          }}
+          secondary={[
+            draft
+              ? isEditing
+                ? { label: t('cancel'), onClick: () => setDraftEdit(null) }
+                : {
+                    label: t('edit'),
+                    onClick: () => setDraftEdit(draft.body),
+                  }
+              : null,
+            { label: t('takeOver'), onClick: onTakeOver, disabled: pending },
+          ].filter((a): a is { label: string; onClick: () => void } => a !== null)}
+          shortcut={t('shortcutSend')}
+        />
+      </div>
     </>
   );
 }
@@ -1230,17 +1237,23 @@ function FullConvDrawer({
 
       <ActivityRail contactId={detail.contactId} conversationId={detail.id} />
 
-      <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+      <div
+        className={
+          actionError
+            ? 'border-t-[0.5px] border-cobalt dark:border-cobalt-soft'
+            : 'border-t-[0.5px] border-rule-soft dark:border-rule-on-dark'
+        }
+      >
         {actionError && (
           <div
-            className="flex items-center gap-3 border-b-[0.5px] border-cobalt/30 bg-destructive/5 px-4 py-2 dark:border-cobalt-soft/40"
+            className="flex items-center gap-3 border-b-[0.5px] border-rule-soft bg-[oklch(0.98_0.025_25)] px-[26px] py-3 text-[13px] font-medium text-cobalt dark:border-rule-on-dark dark:bg-cobalt-soft/10 dark:text-cobalt-soft"
             role="alert"
           >
             <span
-              className="size-1.5 rounded-full bg-cobalt dark:bg-cobalt-soft"
+              className="size-1.5 rounded-full bg-cobalt animate-pulse dark:bg-cobalt-soft"
               aria-hidden
             />
-            <span className="flex-1 font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+            <span className="flex-1">
               {t(`actionFailedShort.${actionError.type}`)} ·{' '}
               {isConnectionMessage(actionError.message)
                 ? t('actionFailedReasonConnection')
@@ -1249,7 +1262,7 @@ function FullConvDrawer({
             {retryHandler(actionError, onSend, onTakeOver, onRelease, onCloseConv) ? (
               <button
                 type="button"
-                className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt underline underline-offset-2 hover:no-underline dark:text-cobalt-soft"
+                className="cursor-pointer text-[13px] font-medium text-cobalt underline underline-offset-[3px] hover:text-cobalt-deep dark:text-cobalt-soft"
                 onClick={retryHandler(actionError, onSend, onTakeOver, onRelease, onCloseConv)!}
                 disabled={pending}
               >
@@ -1555,13 +1568,20 @@ function DrawerFooter({
   primary,
   secondary,
   shortcut,
+  bordered = true,
 }: {
   primary: { label: string; onClick: () => void; disabled?: boolean };
   secondary: Array<{ label: string; onClick: () => void; disabled?: boolean }>;
   shortcut?: string;
+  bordered?: boolean;
 }) {
   return (
-    <div className="flex items-center justify-between gap-2 border-t-[0.5px] border-rule-soft px-6 py-3 dark:border-rule-on-dark">
+    <div
+      className={cn(
+        'flex items-center justify-between gap-2 px-6 py-3',
+        bordered && 'border-t-[0.5px] border-rule-soft dark:border-rule-on-dark',
+      )}
+    >
       <div className="flex items-center gap-2">
         <Button variant="accent" size="sm" onClick={primary.onClick} disabled={primary.disabled}>
           {primary.label}

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -13,7 +13,7 @@ import {
 } from '@getmunin/ui';
 import { api, ApiError } from '../../api';
 import { notify } from '../../lib/notify';
-import { useRealtime, type SubscriptionChannel } from '../../realtime';
+import { useRealtime, type RealtimeStatus, type SubscriptionChannel } from '../../realtime';
 
 type Status = 'open' | 'snoozed' | 'closed' | 'spam';
 
@@ -201,6 +201,10 @@ function mergeLive(
   return next;
 }
 
+export type ConvActionError =
+  | { type: 'send' | 'takeOver' | 'release' | 'close'; conversationId: string; message: string }
+  | null;
+
 export interface InboxController {
   items: LiveSummary[];
   details: Record<string, ConversationDetail>;
@@ -219,6 +223,11 @@ export interface InboxController {
   draftEdit: string | null;
   setDraftEdit: (next: string | null) => void;
   kbBodies: Record<string, string>;
+  detailErrors: Record<string, string>;
+  reloadDetail: (id: string) => Promise<void>;
+  actionError: ConvActionError;
+  clearActionError: () => void;
+  connectionStatus: RealtimeStatus;
   takeOver: (id: string, openFullAfter?: boolean) => Promise<void>;
   release: (id: string) => Promise<void>;
   closeConv: (id: string) => Promise<void>;
@@ -242,6 +251,8 @@ export function useInboxData(): InboxController {
   const [loadError, setLoadError] = useState<ApiError | null>(null);
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [retrying, setRetrying] = useState(false);
+  const [detailErrors, setDetailErrors] = useState<Record<string, string>>({});
+  const [actionError, setActionError] = useState<ConvActionError>(null);
 
   const loadInbox = useCallback(async () => {
     try {
@@ -278,10 +289,25 @@ export function useInboxData(): InboxController {
     try {
       const d = await api<ConversationDetail>(`/api/v1/conversations/${id}`);
       setDetails((prev) => ({ ...prev, [id]: d }));
+      setDetailErrors((prev) => {
+        if (!prev[id]) return prev;
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
     } catch (err) {
-      notify.error(messageOf(err));
+      setDetailErrors((prev) => ({ ...prev, [id]: messageOf(err) }));
     }
   }, []);
+
+  const reloadDetail = useCallback(
+    async (id: string) => {
+      await loadDetail(id);
+    },
+    [loadDetail],
+  );
+
+  const clearActionError = useCallback(() => setActionError(null), []);
 
   useEffect(() => {
     void loadInbox();
@@ -308,7 +334,7 @@ export function useInboxData(): InboxController {
     return subs;
   }, [convDrawer]);
 
-  useRealtime(subscriptions, (event) => {
+  const { status: connectionStatus } = useRealtime(subscriptions, (event) => {
     const matches =
       event.type.startsWith('conversation.') ||
       event.type.startsWith('kb.') ||
@@ -324,12 +350,13 @@ export function useInboxData(): InboxController {
   const takeOver = useCallback(
     async (id: string, openFullAfter = true) => {
       setPending(true);
+      setActionError(null);
       try {
         await api(`/api/v1/conversations/${id}/take-over`, { method: 'POST', body: '{}' });
         await Promise.all([loadDetail(id), loadInbox()]);
         if (openFullAfter) setConvDrawer({ id, mode: 'full' });
       } catch (err) {
-        notify.error(messageOf(err));
+        setActionError({ type: 'takeOver', conversationId: id, message: messageOf(err) });
       } finally {
         setPending(false);
       }
@@ -340,11 +367,12 @@ export function useInboxData(): InboxController {
   const release = useCallback(
     async (id: string) => {
       setPending(true);
+      setActionError(null);
       try {
         await api(`/api/v1/conversations/${id}/release`, { method: 'POST', body: '{}' });
         await Promise.all([loadDetail(id), loadInbox()]);
       } catch (err) {
-        notify.error(messageOf(err));
+        setActionError({ type: 'release', conversationId: id, message: messageOf(err) });
       } finally {
         setPending(false);
       }
@@ -355,6 +383,7 @@ export function useInboxData(): InboxController {
   const closeConv = useCallback(
     async (id: string) => {
       setPending(true);
+      setActionError(null);
       try {
         await api(`/api/v1/conversations/${id}/status`, {
           method: 'POST',
@@ -364,7 +393,7 @@ export function useInboxData(): InboxController {
         setItems((prev) => prev.filter((it) => it.id !== id));
         await loadInbox();
       } catch (err) {
-        notify.error(messageOf(err));
+        setActionError({ type: 'close', conversationId: id, message: messageOf(err) });
       } finally {
         setPending(false);
       }
@@ -390,6 +419,7 @@ export function useInboxData(): InboxController {
         createdAt: new Date().toISOString(),
       };
       setReply('');
+      setActionError(null);
       setDetails((prev) => {
         const d = prev[id];
         if (!d) return prev;
@@ -412,7 +442,7 @@ export function useInboxData(): InboxController {
           await loadDetail(id);
         }
       } catch (err) {
-        notify.error(messageOf(err));
+        setActionError({ type: 'send', conversationId: id, message: messageOf(err) });
         setDetails((prev) => {
           const d = prev[id];
           if (!d) return prev;
@@ -525,6 +555,11 @@ export function useInboxData(): InboxController {
     draftEdit,
     setDraftEdit,
     kbBodies,
+    detailErrors,
+    reloadDetail,
+    actionError,
+    clearActionError,
+    connectionStatus,
     takeOver,
     release,
     closeConv,
@@ -621,6 +656,10 @@ export function InboxDrawers({ controller }: { controller: InboxController }) {
     draftEdit,
     setDraftEdit,
     kbBodies,
+    detailErrors,
+    reloadDetail,
+    actionError,
+    clearActionError,
     send,
     takeOver,
     release,
@@ -630,6 +669,9 @@ export function InboxDrawers({ controller }: { controller: InboxController }) {
     dismissQueue,
   } = controller;
   const selectedConv = convDrawer ? details[convDrawer.id] : null;
+  const convError = convDrawer ? detailErrors[convDrawer.id] : null;
+  const drawerActionError =
+    convDrawer && actionError?.conversationId === convDrawer.id ? actionError : null;
 
   return (
     <>
@@ -650,6 +692,7 @@ export function InboxDrawers({ controller }: { controller: InboxController }) {
                 pending={pending}
                 draftEdit={draftEdit}
                 setDraftEdit={setDraftEdit}
+                actionError={drawerActionError}
                 onSendDraft={(body) => void send(selectedConv.id, body, { claim: false, closeDrawer: true })}
                 onTakeOver={() => void takeOver(selectedConv.id, true)}
                 onClose={() => setConvDrawer(null)}
@@ -660,13 +703,22 @@ export function InboxDrawers({ controller }: { controller: InboxController }) {
                 reply={reply}
                 setReply={setReply}
                 pending={pending}
+                actionError={drawerActionError}
                 onSend={() => void send(selectedConv.id, reply)}
                 onTakeOver={() => void takeOver(selectedConv.id, false)}
                 onRelease={() => void release(selectedConv.id)}
                 onCloseConv={() => void closeConv(selectedConv.id)}
                 onClose={() => setConvDrawer(null)}
+                onClearActionError={clearActionError}
               />
             )
+          ) : convDrawer && convError ? (
+            <DrawerLoadFailed
+              message={convError}
+              retrying={pending}
+              onRetry={() => void reloadDetail(convDrawer.id)}
+              onClose={() => setConvDrawer(null)}
+            />
           ) : (
             <div className="flex flex-1 items-center justify-center text-sm text-ink-mute">
               <MessageSquare className="mr-2 size-4" /> {t('loading')}
@@ -850,11 +902,46 @@ function QueueRow({
   );
 }
 
+function DrawerLoadFailed({
+  message,
+  retrying,
+  onRetry,
+  onClose,
+}: {
+  message: string;
+  retrying: boolean;
+  onRetry: () => void;
+  onClose: () => void;
+}) {
+  const t = useTranslations('dashboard.overview.drawer');
+  const tCommon = useTranslations('common');
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <div className="font-mono text-[10px] uppercase tracking-eyebrow text-destructive">
+        {t('loadFailedEyebrow')}
+      </div>
+      <h2 className="font-serif text-xl leading-tight text-ink dark:text-foreground">
+        {t('loadFailedTitle')}
+      </h2>
+      <p className="text-sm text-ink-mute">{message}</p>
+      <div className="mt-2 flex items-center gap-3">
+        <Button type="button" variant="accent" onClick={onRetry} disabled={retrying}>
+          {retrying ? tCommon('retrying') : tCommon('retry')}
+        </Button>
+        <Button type="button" variant="outline" onClick={onClose}>
+          {tCommon('close')}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 function SimplifiedConvDrawer({
   detail,
   pending,
   draftEdit,
   setDraftEdit,
+  actionError,
   onSendDraft,
   onTakeOver,
   onClose,
@@ -863,6 +950,7 @@ function SimplifiedConvDrawer({
   pending: boolean;
   draftEdit: string | null;
   setDraftEdit: (v: string | null) => void;
+  actionError: ConvActionError;
   onSendDraft: (body: string) => void;
   onTakeOver: () => void;
   onClose: () => void;
@@ -942,6 +1030,12 @@ function SimplifiedConvDrawer({
         </section>
       </div>
 
+      {actionError && (
+        <div className="border-t-[0.5px] border-destructive/40 bg-destructive/5 px-6 py-3 text-xs text-destructive">
+          {t(`actionFailed.${actionError.type}`)} — {actionError.message}
+        </div>
+      )}
+
       <DrawerFooter
         primary={{
           label: t('sendDraft'),
@@ -970,21 +1064,25 @@ function FullConvDrawer({
   reply,
   setReply,
   pending,
+  actionError,
   onSend,
   onTakeOver,
   onRelease,
   onCloseConv,
   onClose,
+  onClearActionError,
 }: {
   detail: ConversationDetail;
   reply: string;
   setReply: (v: string) => void;
   pending: boolean;
+  actionError: ConvActionError;
   onSend: () => void;
   onTakeOver: () => void;
   onRelease: () => void;
   onCloseConv: () => void;
   onClose: () => void;
+  onClearActionError: () => void;
 }) {
   const t = useTranslations('dashboard.overview.drawer');
   const claimed = detail.claim !== null;
@@ -1031,11 +1129,31 @@ function FullConvDrawer({
       <div className="border-t-[0.5px] border-rule-soft p-4 dark:border-rule-on-dark">
         <textarea
           value={reply}
-          onChange={(e) => setReply(e.target.value)}
+          onChange={(e) => {
+            setReply(e.target.value);
+            if (actionError) onClearActionError();
+          }}
           rows={3}
           placeholder={t('replyPlaceholder')}
           className="w-full rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-2 text-sm outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark"
         />
+        {actionError && (
+          <div className="mt-2 flex items-start gap-2 rounded-input border-[0.5px] border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            <span className="flex-1">
+              {t(`actionFailed.${actionError.type}`)} — {actionError.message}
+            </span>
+            {actionError.type === 'send' && (
+              <button
+                type="button"
+                className="font-mono uppercase tracking-eyebrow underline-offset-2 hover:underline"
+                onClick={onSend}
+                disabled={pending || !reply.trim()}
+              >
+                {t('retry')}
+              </button>
+            )}
+          </div>
+        )}
         <div className="mt-3 flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">
             {!claimed ? (

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -711,10 +711,17 @@ function LiveCard({
   const tDrawer = useTranslations('dashboard.overview.drawer');
   const age = useRelative();
   const claimed = detail?.claim != null;
+  const flaggedAtMs = conv.needsHumanAttentionAt
+    ? Date.parse(conv.needsHumanAttentionAt)
+    : null;
   const lastEndUserMsg = detail?.messages
     .slice()
     .reverse()
-    .find((m) => m.authorType === 'end_user');
+    .find((m) => {
+      if (m.authorType !== 'end_user') return false;
+      if (flaggedAtMs == null) return true;
+      return Date.parse(m.createdAt) <= flaggedAtMs;
+    });
   const who = conv.endUserId ?? tDrawer('conversationFallback', { id: conv.displayId });
   const subject = conv.subject ?? tDrawer('conversationFallback', { id: conv.displayId });
   const waiting = conv.needsHumanAttentionAt

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -799,6 +799,10 @@ function LiveCard({
       : '';
 
   const handleCardClick = () => onOpen(claimed ? 'full' : 'simplified');
+  const retryAction =
+    actionError?.type === 'takeOver'
+      ? onTakeOver
+      : null;
 
   return (
     <li className="space-y-0">
@@ -835,7 +839,14 @@ function LiveCard({
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2" onClick={(e) => e.stopPropagation()}>
-          {claimed ? (
+          {actionError ? (
+            <InlineActionError
+              action={actionError.type}
+              message={actionError.message}
+              onRetry={retryAction}
+              onDismiss={onDismissError}
+            />
+          ) : claimed ? (
             <Button variant="accent" size="sm" onClick={() => onOpen('full')}>
               {t('chat')}
             </Button>
@@ -849,32 +860,80 @@ function LiveCard({
               >
                 {t('reply')}
               </Button>
-              <Button size="sm" onClick={onTakeOver} disabled={pending}>
+              <Button size="sm" onClick={onTakeOver} disabled={pending} pending={pending}>
                 {t('takeOver')}
               </Button>
             </>
           )}
         </div>
       </div>
-      {actionError && (
-        <div
-          className="flex items-start gap-3 border-x-[0.5px] border-b-[0.5px] border-ink border-t-0 bg-destructive/5 px-5 py-2 text-sm text-destructive dark:border-rule-on-dark"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <span className="flex-1">
-            {tDrawer(`actionFailed.${actionError.type}`)} — {actionError.message}
-          </span>
-          <button
-            type="button"
-            className="underline-offset-2 hover:underline"
-            onClick={onDismissError}
-          >
-            {tDrawer('close')}
-          </button>
-        </div>
-      )}
     </li>
   );
+}
+
+function InlineActionError({
+  action,
+  message,
+  onRetry,
+  onDismiss,
+}: {
+  action: NonNullable<ConvActionError>['type'];
+  message: string;
+  onRetry: (() => void) | null;
+  onDismiss: () => void;
+}) {
+  const t = useTranslations('dashboard.overview.drawer');
+  const reason = isConnectionMessage(message) ? t('actionFailedReasonConnection') : message;
+  return (
+    <div
+      className="flex items-center gap-3 border-[0.5px] border-cobalt/30 bg-destructive/5 px-3 py-2 dark:border-cobalt-soft/40"
+      role="alert"
+    >
+      <span
+        className="size-1.5 rounded-full bg-cobalt dark:bg-cobalt-soft"
+        aria-hidden
+      />
+      <span className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+        {t(`actionFailedShort.${action}`)} · {reason}
+      </span>
+      {onRetry ? (
+        <button
+          type="button"
+          className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt underline underline-offset-2 hover:no-underline dark:text-cobalt-soft"
+          onClick={onRetry}
+        >
+          {t('retry')} <span aria-hidden>↵</span>
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt/70 hover:text-cobalt dark:text-cobalt-soft/70 dark:hover:text-cobalt-soft"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}
+
+function isConnectionMessage(msg: string): boolean {
+  return /reach munin|check your connection|network/i.test(msg);
+}
+
+function retryHandler(
+  err: NonNullable<ConvActionError>,
+  onSend: () => void,
+  onTakeOver: () => void,
+  onRelease: () => void,
+  onCloseConv: () => void,
+): (() => void) | null {
+  if (err.type === 'send') return onSend;
+  if (err.type === 'takeOver') return onTakeOver;
+  if (err.type === 'release') return onRelease;
+  if (err.type === 'close') return onCloseConv;
+  return null;
 }
 
 function QueueRow({
@@ -1064,14 +1123,26 @@ function SimplifiedConvDrawer({
       </div>
 
       {actionError && (
-        <div className="border-t-[0.5px] border-destructive/40 bg-destructive/5 px-6 py-3 text-xs text-destructive">
-          {t(`actionFailed.${actionError.type}`)} — {actionError.message}
+        <div
+          className="flex items-center gap-3 border-t-[0.5px] border-cobalt/30 bg-destructive/5 px-6 py-2 dark:border-cobalt-soft/40"
+          role="alert"
+        >
+          <span
+            className="size-1.5 rounded-full bg-cobalt dark:bg-cobalt-soft"
+            aria-hidden
+          />
+          <span className="flex-1 font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+            {t(`actionFailedShort.${actionError.type}`)} ·{' '}
+            {isConnectionMessage(actionError.message)
+              ? t('actionFailedReasonConnection')
+              : actionError.message}
+          </span>
         </div>
       )}
 
       <DrawerFooter
         primary={{
-          label: t('sendDraft'),
+          label: actionError?.type === 'send' ? t('retryAction.send') : t('sendDraft'),
           onClick: () => onSendDraft(draftBody),
           disabled: pending || !draftBody.trim(),
         }}
@@ -1159,52 +1230,69 @@ function FullConvDrawer({
 
       <ActivityRail contactId={detail.contactId} conversationId={detail.id} />
 
-      <div className="border-t-[0.5px] border-rule-soft p-4 dark:border-rule-on-dark">
-        <textarea
-          value={reply}
-          onChange={(e) => {
-            setReply(e.target.value);
-            if (actionError) onClearActionError();
-          }}
-          rows={3}
-          placeholder={t('replyPlaceholder')}
-          className="w-full rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-2 text-sm outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark"
-        />
+      <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
         {actionError && (
-          <div className="mt-2 flex items-start gap-2 rounded-input border-[0.5px] border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-            <span className="flex-1">
-              {t(`actionFailed.${actionError.type}`)} — {actionError.message}
+          <div
+            className="flex items-center gap-3 border-b-[0.5px] border-cobalt/30 bg-destructive/5 px-4 py-2 dark:border-cobalt-soft/40"
+            role="alert"
+          >
+            <span
+              className="size-1.5 rounded-full bg-cobalt dark:bg-cobalt-soft"
+              aria-hidden
+            />
+            <span className="flex-1 font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+              {t(`actionFailedShort.${actionError.type}`)} ·{' '}
+              {isConnectionMessage(actionError.message)
+                ? t('actionFailedReasonConnection')
+                : actionError.message}
             </span>
-            {actionError.type === 'send' && (
+            {retryHandler(actionError, onSend, onTakeOver, onRelease, onCloseConv) ? (
               <button
                 type="button"
-                className="font-mono uppercase tracking-eyebrow underline-offset-2 hover:underline"
-                onClick={onSend}
-                disabled={pending || !reply.trim()}
+                className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt underline underline-offset-2 hover:no-underline dark:text-cobalt-soft"
+                onClick={retryHandler(actionError, onSend, onTakeOver, onRelease, onCloseConv)!}
+                disabled={pending}
               >
-                {t('retry')}
+                {t(`retryAction.${actionError.type}`)} <span aria-hidden>↵</span>
               </button>
-            )}
+            ) : null}
           </div>
         )}
-        <div className="mt-3 flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            {!claimed ? (
-              <Button size="sm" onClick={onTakeOver} disabled={pending}>
-                {t('takeOver')}
+        <div className="p-4">
+          <textarea
+            value={reply}
+            onChange={(e) => {
+              setReply(e.target.value);
+              if (actionError) onClearActionError();
+            }}
+            rows={3}
+            placeholder={t('replyPlaceholder')}
+            className="w-full rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-2 text-sm outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark"
+          />
+          <div className="mt-3 flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              {!claimed ? (
+                <Button size="sm" onClick={onTakeOver} disabled={pending} pending={pending}>
+                  {t('takeOver')}
+                </Button>
+              ) : (
+                <Button size="sm" variant="outline" onClick={onRelease} disabled={pending}>
+                  <Unplug className="size-3.5" /> {t('release')}
+                </Button>
+              )}
+              <Button size="sm" variant="ghost" onClick={onCloseConv} disabled={pending}>
+                {t('closeConv')}
               </Button>
-            ) : (
-              <Button size="sm" variant="outline" onClick={onRelease} disabled={pending}>
-                <Unplug className="size-3.5" /> {t('release')}
-              </Button>
-            )}
-            <Button size="sm" variant="ghost" onClick={onCloseConv} disabled={pending}>
-              {t('closeConv')}
+            </div>
+            <Button
+              variant="accent"
+              onClick={onSend}
+              disabled={pending || !reply.trim()}
+              pending={pending}
+            >
+              {actionError?.type === 'send' ? t('retryAction.send') : t('send')}
             </Button>
           </div>
-          <Button variant="accent" onClick={onSend} disabled={pending || !reply.trim()}>
-            {t('send')}
-          </Button>
         </div>
       </div>
     </>

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -572,7 +572,17 @@ export function useInboxData(): InboxController {
 
 export function LiveNowSection({ controller }: { controller: InboxController }) {
   const t = useTranslations('dashboard.overview.liveNow');
-  const { items, details, pending, setConvDrawer, setReply, setDraftEdit, takeOver } = controller;
+  const {
+    items,
+    details,
+    pending,
+    actionError,
+    clearActionError,
+    setConvDrawer,
+    setReply,
+    setDraftEdit,
+    takeOver,
+  } = controller;
   if (items.length === 0) return null;
 
   return (
@@ -598,6 +608,8 @@ export function LiveNowSection({ controller }: { controller: InboxController }) 
             conv={c}
             detail={details[c.id]}
             pending={pending}
+            actionError={actionError?.conversationId === c.id ? actionError : null}
+            onDismissError={clearActionError}
             onOpen={(mode) => {
               setReply('');
               setDraftEdit(null);
@@ -750,12 +762,16 @@ function LiveCard({
   conv,
   detail,
   pending,
+  actionError,
+  onDismissError,
   onOpen,
   onTakeOver,
 }: {
   conv: ConversationSummary;
   detail: ConversationDetail | undefined;
   pending: boolean;
+  actionError: ConvActionError;
+  onDismissError: () => void;
   onOpen: (mode: 'simplified' | 'full') => void;
   onTakeOver: () => void;
 }) {
@@ -785,7 +801,7 @@ function LiveCard({
   const handleCardClick = () => onOpen(claimed ? 'full' : 'simplified');
 
   return (
-    <li>
+    <li className="space-y-0">
       <div
         className="group/livecard flex items-stretch gap-4 border-[0.5px] border-ink bg-paper px-5 py-4 cursor-pointer transition-colors duration-fast ease-munin hover:border-cobalt dark:border-rule-on-dark dark:bg-card dark:hover:border-cobalt-soft"
         onClick={handleCardClick}
@@ -840,6 +856,23 @@ function LiveCard({
           )}
         </div>
       </div>
+      {actionError && (
+        <div
+          className="flex items-start gap-3 border-x-[0.5px] border-b-[0.5px] border-ink border-t-0 bg-destructive/5 px-5 py-2 text-sm text-destructive dark:border-rule-on-dark"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <span className="flex-1">
+            {tDrawer(`actionFailed.${actionError.type}`)} — {actionError.message}
+          </span>
+          <button
+            type="button"
+            className="underline-offset-2 hover:underline"
+            onClick={onDismissError}
+          >
+            {tDrawer('close')}
+          </button>
+        </div>
+      )}
     </li>
   );
 }

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -869,10 +869,17 @@ function SimplifiedConvDrawer({
 }) {
   const t = useTranslations('dashboard.overview.drawer');
   const age = useRelative();
+  const flaggedAtMs = detail.needsHumanAttentionAt
+    ? Date.parse(detail.needsHumanAttentionAt)
+    : null;
   const customer = detail.messages
     .slice()
     .reverse()
-    .find((m) => m.authorType === 'end_user' && !m.internal);
+    .find((m) => {
+      if (m.authorType !== 'end_user' || m.internal) return false;
+      if (flaggedAtMs == null) return true;
+      return Date.parse(m.createdAt) <= flaggedAtMs;
+    });
   const draft = detail.messages
     .slice()
     .reverse()

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { api } from '../api';
 import { useActiveMembership } from '../auth/use-active-role';
 import { useRealtime } from '../realtime';
+import { ConnectionBanner } from '../components/connection-banner';
 import { DashboardHero } from '../components/dashboard/dashboard-hero';
 import { GetStarted } from '../components/dashboard/get-started';
 import { UsageKpis, type UsageSummary } from '../components/dashboard/usage-kpis';
@@ -56,6 +57,7 @@ export function DashboardPage() {
 
   return (
     <div className="px-10 py-10 max-w-7xl mx-auto space-y-10">
+      <ConnectionBanner status={inbox.connectionStatus} />
       <DashboardHero
         orgName={orgName}
         date={new Date()}

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -47,18 +47,22 @@ export function DashboardPage() {
 
   if (inbox.loadError && !inbox.hasLoadedOnce) {
     return (
-      <div className="px-10 py-10 max-w-7xl mx-auto">
-        <LoadFailed
-          {...buildLoadFailedProps(inbox.loadError, () => void inbox.retryLoad(), inbox.retrying)}
-        />
-      </div>
+      <>
+        <ConnectionBanner status={inbox.connectionStatus} />
+        <div className="px-10 py-10 max-w-7xl mx-auto">
+          <LoadFailed
+            {...buildLoadFailedProps(inbox.loadError, () => void inbox.retryLoad(), inbox.retrying)}
+          />
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="px-10 py-10 max-w-7xl mx-auto space-y-10">
+    <>
       <ConnectionBanner status={inbox.connectionStatus} />
-      <DashboardHero
+      <div className="px-10 py-10 max-w-7xl mx-auto space-y-10">
+        <DashboardHero
         orgName={orgName}
         date={new Date()}
         liveCount={inbox.items.length}
@@ -73,6 +77,7 @@ export function DashboardPage() {
       <GetStarted />
 
       <InboxDrawers controller={inbox} />
-    </div>
+      </div>
+    </>
   );
 }

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -49,7 +49,7 @@ export function DashboardPage() {
     return (
       <>
         <ConnectionBanner status={inbox.connectionStatus} />
-        <div className="px-10 py-10 max-w-7xl mx-auto">
+        <div className="px-10 pt-11 pb-6 max-w-7xl mx-auto">
           <LoadFailed
             {...buildLoadFailedProps(inbox.loadError, () => void inbox.retryLoad(), inbox.retrying)}
           />
@@ -61,7 +61,7 @@ export function DashboardPage() {
   return (
     <>
       <ConnectionBanner status={inbox.connectionStatus} />
-      <div className="px-10 py-10 max-w-7xl mx-auto space-y-10">
+      <div className="px-10 pt-11 pb-6 max-w-7xl mx-auto space-y-9">
         <DashboardHero
         orgName={orgName}
         date={new Date()}

--- a/packages/dashboard-pages/src/realtime.ts
+++ b/packages/dashboard-pages/src/realtime.ts
@@ -26,13 +26,11 @@ interface IncomingFrame {
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
-/**
- * Single WebSocket per hook instance. Each hook re-subscribes on mount
- * and closes on unmount. Auto-reconnects with capped exponential backoff
- * while the component is mounted. Fires `onEvent` for every matching
- * incoming event; the caller decides what to do with it.
- */
 export type RealtimeStatus = 'connecting' | 'connected' | 'offline';
+
+function subKey(sub: SubscriptionChannel): string {
+  return 'id' in sub ? `${sub.channel}:${sub.id}` : sub.channel;
+}
 
 export function useRealtime(
   subscriptions: readonly SubscriptionChannel[],
@@ -43,15 +41,14 @@ export function useRealtime(
   const onEventRef = useRef(onEvent);
   onEventRef.current = onEvent;
 
-  const subsRef = useRef<readonly SubscriptionChannel[]>(subscriptions);
-  subsRef.current = subscriptions;
-  const subsKey = subscriptions
-    .map((s) => ('id' in s ? `${s.channel}:${s.id}` : s.channel))
-    .sort()
-    .join(',');
+  const wsRef = useRef<WebSocket | null>(null);
+  const activeSubsRef = useRef<Map<string, SubscriptionChannel>>(new Map());
+
+  const subsKey = subscriptions.map(subKey).sort().join(',');
+  const desiredSubsRef = useRef<readonly SubscriptionChannel[]>(subscriptions);
+  desiredSubsRef.current = subscriptions;
 
   useEffect(() => {
-    let ws: WebSocket | null = null;
     let backoffMs = 500;
     let cancelled = false;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -62,16 +59,20 @@ export function useRealtime(
     const connect = () => {
       if (cancelled) return;
       setStatus('connecting');
-      ws = new WebSocket(url);
+      const ws = new WebSocket(url);
+      wsRef.current = ws;
       ws.onopen = () => {
-        if (cancelled || !ws) return;
+        if (cancelled || wsRef.current !== ws) return;
         backoffMs = 500;
         setStatus('connected');
-        for (const sub of subsRef.current) {
+        activeSubsRef.current = new Map();
+        for (const sub of desiredSubsRef.current) {
+          const key = subKey(sub);
           ws.send(JSON.stringify({ type: 'subscribe', ...sub }));
+          activeSubsRef.current.set(key, sub);
         }
         pingInterval = setInterval(() => {
-          if (ws && ws.readyState === ws.OPEN) ws.send(JSON.stringify({ type: 'ping' }));
+          if (ws.readyState === ws.OPEN) ws.send(JSON.stringify({ type: 'ping' }));
         }, 30_000);
       };
       ws.onmessage = (msg) => {
@@ -91,6 +92,8 @@ export function useRealtime(
         if (pingInterval) clearInterval(pingInterval);
         pingInterval = null;
         if (cancelled) return;
+        wsRef.current = null;
+        activeSubsRef.current = new Map();
         setStatus('offline');
         const delay = backoffMs;
         backoffMs = Math.min(backoffMs * 2, 30_000);
@@ -104,6 +107,9 @@ export function useRealtime(
       cancelled = true;
       if (reconnectTimer) clearTimeout(reconnectTimer);
       if (pingInterval) clearInterval(pingInterval);
+      const ws = wsRef.current;
+      wsRef.current = null;
+      activeSubsRef.current = new Map();
       if (ws) {
         ws.onopen = null;
         ws.onmessage = null;
@@ -117,6 +123,26 @@ export function useRealtime(
         }
       }
     };
+  }, []);
+
+  useEffect(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== ws.OPEN) return;
+    const desired = new Map<string, SubscriptionChannel>();
+    for (const sub of desiredSubsRef.current) desired.set(subKey(sub), sub);
+    const active = activeSubsRef.current;
+    for (const [key, sub] of active) {
+      if (!desired.has(key)) {
+        ws.send(JSON.stringify({ type: 'unsubscribe', ...sub }));
+        active.delete(key);
+      }
+    }
+    for (const [key, sub] of desired) {
+      if (!active.has(key)) {
+        ws.send(JSON.stringify({ type: 'subscribe', ...sub }));
+        active.set(key, sub);
+      }
+    }
   }, [subsKey]);
 
   return { connected, status };


### PR DESCRIPTION
## Summary

- **Trigger-message quote**: Live now snippet and drawer "Customer" quote now show the message that triggered handover (latest end-user message at-or-before `needsHumanAttentionAt`), not the latest message overall.
- **Inline error states**: Replaced action-error toasts (send / takeOver / release / close) with inline error strips on Live now cards and inside the conversation drawers. Network errors map to a friendly "Couldn't reach Munin. Check your connection." string. Errors auto-clear on WS reconnect.
- **Connection banner**: Global amber banner driven by WebSocket status, mounted above the dashboard container (full-width, hugs topbar). Anti-flicker guard so the banner only appears after first successful connect, and the WS is no longer recycled on subscription changes — so opening a drawer no longer briefly flips status to `connecting`.
- **Drawer border fix**: Stacked 0.5px borders (cobalt error strip top + reply-area top) were rendering as a thick line. Wrapped strip + footer in a single conditional-border parent in both drawers.
- **Cleanup**: Removed the redundant load-error toast in `useInboxData` (inline `LoadFailed` already covers it).

## Test plan
- [ ] Open a drawer — page does not flicker / shift on open or close
- [ ] Kill the backend → open a closed conversation → drawer shows inline load-error with retry, no toast
- [ ] Send a reply with backend down → inline error strip appears, network message reads "check connection"
- [ ] Reconnect backend → inline errors clear automatically
- [ ] Connection banner appears only after first successful connect, stable through reconnect retries
- [ ] Live now card and drawer "Customer" quote show the trigger message, not the latest