### PR TITLE
feat(email): capture Authentication-Results headers on inbound

### DIFF
--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -360,7 +360,7 @@ export class EmailAdapter implements ChannelAdapter {
             body: cleanText || '(no body)',
             bodyHtml: cleanHtml,
             internal: false,
-            metadata: parsed.messageId ? { inboundMessageId: parsed.messageId } : {},
+            metadata: buildInboundMetadata(parsed),
           })
           .returning();
         await tx
@@ -460,6 +460,11 @@ export async function parseMessage(source: Buffer | string): Promise<ParsedInbou
   const text = (parsed.text ?? '').trim() || stripHtml(html ?? '');
   const refs = parsed.references;
   const referencesText = Array.isArray(refs) ? refs.join(' ') : refs;
+  const authenticationResults = extractHeaderValues(parsed.headerLines, 'authentication-results');
+  const arcAuthenticationResults = extractHeaderValues(
+    parsed.headerLines,
+    'arc-authentication-results',
+  );
   return {
     recipients,
     fromAddress,
@@ -470,7 +475,35 @@ export async function parseMessage(source: Buffer | string): Promise<ParsedInbou
     references: parseMessageIdHeader(referencesText),
     bodyText: text,
     bodyHtml: html,
+    authenticationResults,
+    arcAuthenticationResults,
   };
+}
+
+function extractHeaderValues(
+  headerLines: ReadonlyArray<{ key: string; line: string }>,
+  name: string,
+): string[] {
+  const lower = name.toLowerCase();
+  const out: string[] = [];
+  for (const h of headerLines) {
+    if (h.key.toLowerCase() !== lower) continue;
+    const value = h.line.split(':').slice(1).join(':').trim();
+    if (value) out.push(value);
+  }
+  return out;
+}
+
+function buildInboundMetadata(parsed: ParsedInboundEmail): Record<string, unknown> {
+  const meta: Record<string, unknown> = {};
+  if (parsed.messageId) meta.inboundMessageId = parsed.messageId;
+  if (parsed.authenticationResults.length > 0) {
+    meta.authenticationResults = parsed.authenticationResults;
+  }
+  if (parsed.arcAuthenticationResults.length > 0) {
+    meta.arcAuthenticationResults = parsed.arcAuthenticationResults;
+  }
+  return meta;
 }
 
 function collectAddresses(field: AddressObject | AddressObject[] | undefined): string[] {

--- a/packages/backend-core/src/modules/conv/email/threading.ts
+++ b/packages/backend-core/src/modules/conv/email/threading.ts
@@ -24,6 +24,10 @@ export interface ParsedInboundEmail {
   bodyText: string;
   /** HTML body, when the message had one. */
   bodyHtml: string | null;
+  /** Raw `Authentication-Results` header lines (one per header, value only — key prefix stripped). */
+  authenticationResults: string[];
+  /** Raw `ARC-Authentication-Results` header lines (one per header, value only). */
+  arcAuthenticationResults: string[];
 }
 
 export interface ThreadResolution {


### PR DESCRIPTION
## Summary
- Captures `Authentication-Results` and `ARC-Authentication-Results` headers from inbound email (mailparser already exposes them via `headerLines`; previously we read them, then discarded them).
- Stored as string arrays on `conv_messages.metadata` (`authenticationResults`, `arcAuthenticationResults`). Empty arrays are omitted, so existing rows and synthetic test fixtures keep the same metadata shape.
- No trust decisions are made on these values yet — this is phase zero of the email-signature → CRM enrichment work. We want to sample real production data before designing the SPF/DKIM/DMARC trust gate (which needs to handle Gmail, M365, IMAP hosts, and ARC-on-forward all formatting these slightly differently).

## Why arrays
RFC 8601 allows multiple `Authentication-Results` headers (one per MTA traversed). Only the outermost — from our own receiving provider — is trustworthy; everything below it can be forged by the sender. `mailparser`'s `headerLines` preserves order, so the first entry in the array is the trusted one.

## Sampling query (after this has been deployed for a bit)
```sql
SELECT metadata->'authenticationResults',
       metadata->'arcAuthenticationResults',
       created_at
  FROM conv_messages
 WHERE metadata ? 'authenticationResults'
 ORDER BY created_at DESC
 LIMIT 100;
```

That sample drives the parser choice for the next phase (likely `mailauth` — reliable Authentication-Results parsing across providers is a known hard problem) and the trust gate for CRM enrichment: `dmarc=pass && DKIM aligned to From domain && not (mailing list || role account)`.

## Test plan
- [x] `pnpm typecheck` in `packages/backend-core` — clean.
- [ ] Email integration test (`email.integration.test.ts`) — could not run locally; pre-existing `permission denied for database munin_test` on `CREATE SCHEMA "drizzle"` skipped every test in `conv/`. Unrelated to this change. CI will exercise it.
- [ ] After deploy: run the sampling query above against prod inbound mail and confirm header strings land in `metadata` as expected, across at least Gmail- and M365-originated mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)