### PR TITLE
feat(email): per-channel send limits with auto-defer

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -401,7 +401,12 @@
         "enableInbound": "Enable inbound (poll an IMAP mailbox)",
         "create": "Create email channel",
         "editTitle": "Edit email channel",
-        "editDescription": "Update the channel's name or transport. Leave a password blank to keep the stored credential — type a new one to replace it."
+        "editDescription": "Update the channel's name or transport. Leave a password blank to keep the stored credential — type a new one to replace it.",
+        "sendLimitsLabel": "Send limits",
+        "sendLimitsHelp": "Optional caps on outbound email volume to protect domain reputation. Messages over the limit stay queued and send automatically when capacity opens. Leave blank for no limit.",
+        "sendLimitsPlaceholder": "no limit",
+        "perDayMax": "Max per day (rolling 24h)",
+        "perHourMax": "Max per hour (rolling 60min)"
       },
       "errors": {
         "load": "Could not load channels.",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -401,7 +401,12 @@
         "enableInbound": "Aktiver innkommende (poll en IMAP-postboks)",
         "create": "Opprett e-postkanal",
         "editTitle": "Rediger e-postkanal",
-        "editDescription": "Oppdater kanalens navn eller transport. La et passord stå tomt for å beholde det lagrede — skriv et nytt for å erstatte det."
+        "editDescription": "Oppdater kanalens navn eller transport. La et passord stå tomt for å beholde det lagrede — skriv et nytt for å erstatte det.",
+        "sendLimitsLabel": "Sendegrenser",
+        "sendLimitsHelp": "Valgfrie tak på utgående e-post for å beskytte domenets omdømme. Meldinger over grensen forblir i køen og sendes automatisk når kapasiteten åpner seg. La feltet stå tomt for ingen grense.",
+        "sendLimitsPlaceholder": "ingen grense",
+        "perDayMax": "Maks per dag (rullende 24 t)",
+        "perHourMax": "Maks per time (rullende 60 min)"
       },
       "errors": {
         "load": "Kunne ikke laste kanaler.",

--- a/packages/backend-core/src/modules/conv/channels/outbound-delivery.worker.ts
+++ b/packages/backend-core/src/modules/conv/channels/outbound-delivery.worker.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, isNotNull, lt, lte, sql } from 'drizzle-orm';
 import {
@@ -7,6 +7,7 @@ import {
   withContext,
   type RequestContext,
 } from '@getmunin/core';
+import type { SendLimits } from '@getmunin/types';
 import { randomUUID } from 'node:crypto';
 import { DB } from '../../../common/db/db.module.js';
 import {
@@ -15,6 +16,11 @@ import {
   type ChannelAdapter,
   type SendContext,
 } from './adapter.js';
+import {
+  decideRateLimit,
+  rateLimitDeferralError,
+  type SendCounts,
+} from './send-rate-limit.js';
 
 const POLL_INTERVAL_MS = Number(
   process.env.MUNIN_OUTBOUND_DELIVERY_WORKER_INTERVAL_MS ??
@@ -34,8 +40,11 @@ const BACKOFF_BASE_MS = 30_000;
  * Disabled in tests via `MUNIN_OUTBOUND_DELIVERY_WORKER_DISABLED=1` (or
  * legacy `MUNIN_EMAIL_OUTBOUND_WORKER_DISABLED=1`) or `NODE_ENV=test`.
  */
+type AttemptOutcome = 'sent' | 'deferred' | 'failed';
+
 @Injectable()
 export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(OutboundDeliveryWorker.name);
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private disabled =
@@ -65,8 +74,8 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
     this.timer = null;
   }
 
-  async tick(): Promise<{ attempted: number; sent: number; failed: number }> {
-    if (this.running) return { attempted: 0, sent: 0, failed: 0 };
+  async tick(): Promise<{ attempted: number; sent: number; deferred: number; failed: number }> {
+    if (this.running) return { attempted: 0, sent: 0, deferred: 0, failed: 0 };
     this.running = true;
     try {
       return await this.drain();
@@ -75,7 +84,7 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  private async drain(): Promise<{ attempted: number; sent: number; failed: number }> {
+  private async drain(): Promise<{ attempted: number; sent: number; deferred: number; failed: number }> {
     const now = new Date();
     const rows = await this.db
       .select({ id: schema.convMessageDeliveries.id })
@@ -91,23 +100,38 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
       .limit(BATCH_SIZE);
 
     let sent = 0;
+    let deferred = 0;
     let failed = 0;
     for (const row of rows) {
-      const ok = await this.attemptOne(row.id);
-      if (ok) sent += 1;
+      const outcome = await this.attemptOne(row.id);
+      if (outcome === 'sent') sent += 1;
+      else if (outcome === 'deferred') deferred += 1;
       else failed += 1;
     }
-    return { attempted: rows.length, sent, failed };
+    return { attempted: rows.length, sent, deferred, failed };
   }
 
-  private async attemptOne(deliveryId: string): Promise<boolean> {
+  private async attemptOne(deliveryId: string): Promise<AttemptOutcome> {
     const ctx = await this.loadContext(deliveryId);
-    if (!ctx) return false;
+    if (!ctx) return 'failed';
 
     const adapter = this.registry.get(ctx.channel.type);
     if (!adapter) {
       await this.recordFailure(deliveryId, ctx.attempt, `no adapter registered for channel type '${ctx.channel.type}'`);
-      return false;
+      return 'failed';
+    }
+
+    const limits = extractSendLimits(ctx.channel.config);
+    if (limits) {
+      const counts = await this.countRecentSends(ctx.channel.id);
+      const decision = decideRateLimit(limits, counts, new Date());
+      if (decision.kind === 'deferred') {
+        await this.recordDeferral(deliveryId, decision.nextAttemptAt, rateLimitDeferralError(decision));
+        this.logger.log(
+          `delivery ${deliveryId} on channel ${ctx.channel.id} deferred (${decision.reason}) until ${decision.nextAttemptAt.toISOString()}`,
+        );
+        return 'deferred';
+      }
     }
 
     let result;
@@ -123,7 +147,7 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
       result = await adapter.send(sendCtx);
     } catch (err) {
       await this.recordFailure(deliveryId, ctx.attempt, errorMessage(err));
-      return false;
+      return 'failed';
     }
 
     await this.db
@@ -145,7 +169,65 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
       messageId: ctx.message.id,
       channelId: ctx.channel.id,
     });
-    return true;
+    return 'sent';
+  }
+
+  private async recordDeferral(
+    deliveryId: string,
+    nextAttemptAt: Date,
+    encodedReason: string,
+  ): Promise<void> {
+    await this.db
+      .update(schema.convMessageDeliveries)
+      .set({
+        status: 'queued',
+        nextAttemptAt,
+        error: encodedReason,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.convMessageDeliveries.id, deliveryId));
+  }
+
+  private async countRecentSends(channelId: string): Promise<SendCounts> {
+    const now = new Date();
+    const hourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+    const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const rows = await this.db.execute<{
+      hour_count: string | number;
+      hour_oldest: Date | string | null;
+      day_count: string | number;
+      day_oldest: Date | string | null;
+    }>(sql`
+      SELECT
+        COUNT(*) FILTER (WHERE sent_at >= ${hourAgo.toISOString()}::timestamptz) AS hour_count,
+        MIN(sent_at) FILTER (WHERE sent_at >= ${hourAgo.toISOString()}::timestamptz) AS hour_oldest,
+        COUNT(*) AS day_count,
+        MIN(sent_at) AS day_oldest
+      FROM conv_message_deliveries
+      WHERE channel_id = ${channelId}
+        AND status = 'sent'
+        AND sent_at IS NOT NULL
+        AND sent_at >= ${dayAgo.toISOString()}::timestamptz
+    `);
+    const row = Array.isArray(rows)
+      ? rows[0]
+      : ((rows as { rows?: unknown[] }).rows?.[0] as
+          | { hour_count: string | number; hour_oldest: Date | string | null; day_count: string | number; day_oldest: Date | string | null }
+          | undefined);
+    if (!row) {
+      return {
+        lastHourSentCount: 0,
+        oldestSentAtInLastHour: null,
+        lastDaySentCount: 0,
+        oldestSentAtInLastDay: null,
+      };
+    }
+    return {
+      lastHourSentCount: Number(row.hour_count),
+      oldestSentAtInLastHour: toDate(row.hour_oldest),
+      lastDaySentCount: Number(row.day_count),
+      oldestSentAtInLastDay: toDate(row.day_oldest),
+    };
   }
 
   private async recordFailure(deliveryId: string, priorAttempts: number, error: string): Promise<void> {
@@ -252,4 +334,26 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function extractSendLimits(config: unknown): SendLimits | null {
+  if (!config || typeof config !== 'object') return null;
+  const limits = (config as { sendLimits?: unknown }).sendLimits;
+  if (!limits || typeof limits !== 'object') return null;
+  const out: SendLimits = {};
+  const candidate = limits as { perHourMax?: unknown; perDayMax?: unknown };
+  if (typeof candidate.perHourMax === 'number' && candidate.perHourMax > 0) {
+    out.perHourMax = candidate.perHourMax;
+  }
+  if (typeof candidate.perDayMax === 'number' && candidate.perDayMax > 0) {
+    out.perDayMax = candidate.perDayMax;
+  }
+  return out.perHourMax === undefined && out.perDayMax === undefined ? null : out;
+}
+
+function toDate(value: Date | string | null): Date | null {
+  if (value === null) return null;
+  if (value instanceof Date) return value;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }

--- a/packages/backend-core/src/modules/conv/channels/send-rate-limit.test.ts
+++ b/packages/backend-core/src/modules/conv/channels/send-rate-limit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideRateLimit,
+  parseRateLimitDeferral,
+  rateLimitDeferralError,
+  type SendCounts,
+} from './send-rate-limit.js';
+
+const NOW = new Date('2026-05-14T12:00:00.000Z');
+
+function counts(partial: Partial<SendCounts> = {}): SendCounts {
+  return {
+    lastHourSentCount: 0,
+    oldestSentAtInLastHour: null,
+    lastDaySentCount: 0,
+    oldestSentAtInLastDay: null,
+    ...partial,
+  };
+}
+
+describe('decideRateLimit', () => {
+  it('allows when limits are undefined', () => {
+    expect(decideRateLimit(undefined, counts(), NOW)).toEqual({ kind: 'allowed' });
+  });
+
+  it('allows when limits exist but are all unset', () => {
+    expect(decideRateLimit({}, counts({ lastDaySentCount: 99 }), NOW)).toEqual({ kind: 'allowed' });
+  });
+
+  it('allows when under both limits', () => {
+    expect(
+      decideRateLimit(
+        { perHourMax: 10, perDayMax: 100 },
+        counts({ lastHourSentCount: 5, lastDaySentCount: 50 }),
+        NOW,
+      ),
+    ).toEqual({ kind: 'allowed' });
+  });
+
+  it('defers when at per-hour limit and emits per_hour reason', () => {
+    const oldest = new Date(NOW.getTime() - 30 * 60 * 1000);
+    const decision = decideRateLimit(
+      { perHourMax: 5 },
+      counts({ lastHourSentCount: 5, oldestSentAtInLastHour: oldest }),
+      NOW,
+    );
+    expect(decision.kind).toBe('deferred');
+    if (decision.kind === 'deferred') {
+      expect(decision.reason).toBe('per_hour');
+      expect(decision.nextAttemptAt.getTime()).toBe(
+        oldest.getTime() + 60 * 60 * 1000 + 1_000,
+      );
+    }
+  });
+
+  it('defers when at per-day limit and emits per_day reason', () => {
+    const oldest = new Date(NOW.getTime() - 6 * 60 * 60 * 1000);
+    const decision = decideRateLimit(
+      { perDayMax: 100 },
+      counts({ lastDaySentCount: 100, oldestSentAtInLastDay: oldest }),
+      NOW,
+    );
+    expect(decision.kind).toBe('deferred');
+    if (decision.kind === 'deferred') {
+      expect(decision.reason).toBe('per_day');
+      expect(decision.nextAttemptAt.getTime()).toBe(
+        oldest.getTime() + 24 * 60 * 60 * 1000 + 1_000,
+      );
+    }
+  });
+
+  it('picks the later unblock time when both limits exceeded', () => {
+    const oldestHour = new Date(NOW.getTime() - 30 * 60 * 1000);
+    const oldestDay = new Date(NOW.getTime() - 2 * 60 * 60 * 1000);
+    const decision = decideRateLimit(
+      { perHourMax: 5, perDayMax: 50 },
+      counts({
+        lastHourSentCount: 5,
+        oldestSentAtInLastHour: oldestHour,
+        lastDaySentCount: 50,
+        oldestSentAtInLastDay: oldestDay,
+      }),
+      NOW,
+    );
+    expect(decision.kind).toBe('deferred');
+    if (decision.kind === 'deferred') {
+      const dayUnblock = oldestDay.getTime() + 24 * 60 * 60 * 1000 + 1_000;
+      expect(decision.nextAttemptAt.getTime()).toBe(dayUnblock);
+      expect(decision.reason).toBe('per_day');
+    }
+  });
+
+  it('floors unblock time to now if computed value is in the past', () => {
+    const oldest = new Date(NOW.getTime() - 2 * 60 * 60 * 1000);
+    const decision = decideRateLimit(
+      { perHourMax: 1 },
+      counts({ lastHourSentCount: 1, oldestSentAtInLastHour: oldest }),
+      NOW,
+    );
+    expect(decision.kind).toBe('deferred');
+    if (decision.kind === 'deferred') {
+      expect(decision.nextAttemptAt.getTime()).toBe(NOW.getTime() + 1_000);
+    }
+  });
+});
+
+describe('rateLimitDeferralError / parseRateLimitDeferral', () => {
+  it('round-trips', () => {
+    const until = new Date('2026-05-15T08:00:00.000Z');
+    const encoded = rateLimitDeferralError({
+      kind: 'deferred',
+      nextAttemptAt: until,
+      reason: 'per_day',
+    });
+    expect(encoded).toBe('rate_limited:per_day:until=2026-05-15T08:00:00.000Z');
+    expect(parseRateLimitDeferral(encoded)).toEqual({ reason: 'per_day', until });
+  });
+
+  it('returns null for unrelated errors', () => {
+    expect(parseRateLimitDeferral(null)).toBeNull();
+    expect(parseRateLimitDeferral('SMTP refused')).toBeNull();
+    expect(parseRateLimitDeferral('rate_limited:bad')).toBeNull();
+  });
+});

--- a/packages/backend-core/src/modules/conv/channels/send-rate-limit.ts
+++ b/packages/backend-core/src/modules/conv/channels/send-rate-limit.ts
@@ -1,0 +1,70 @@
+import type { SendLimits } from '@getmunin/types';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const REOPEN_BUFFER_MS = 1_000;
+
+export interface SendCounts {
+  lastHourSentCount: number;
+  oldestSentAtInLastHour: Date | null;
+  lastDaySentCount: number;
+  oldestSentAtInLastDay: Date | null;
+}
+
+export type RateLimitDecision =
+  | { kind: 'allowed' }
+  | { kind: 'deferred'; nextAttemptAt: Date; reason: 'per_hour' | 'per_day' };
+
+export function decideRateLimit(
+  limits: SendLimits | undefined,
+  counts: SendCounts,
+  now: Date,
+): RateLimitDecision {
+  if (!limits) return { kind: 'allowed' };
+  const perHour = limits.perHourMax;
+  const perDay = limits.perDayMax;
+  if (!perHour && !perDay) return { kind: 'allowed' };
+
+  const hourBlocked =
+    perHour !== undefined && counts.lastHourSentCount >= perHour && counts.oldestSentAtInLastHour;
+  const dayBlocked =
+    perDay !== undefined && counts.lastDaySentCount >= perDay && counts.oldestSentAtInLastDay;
+
+  if (!hourBlocked && !dayBlocked) return { kind: 'allowed' };
+
+  const hourUnblockAt = hourBlocked
+    ? new Date(counts.oldestSentAtInLastHour!.getTime() + HOUR_MS + REOPEN_BUFFER_MS)
+    : null;
+  const dayUnblockAt = dayBlocked
+    ? new Date(counts.oldestSentAtInLastDay!.getTime() + DAY_MS + REOPEN_BUFFER_MS)
+    : null;
+
+  let nextMs = Number.NEGATIVE_INFINITY;
+  let reason: 'per_hour' | 'per_day' = 'per_day';
+  if (hourUnblockAt) {
+    nextMs = hourUnblockAt.getTime();
+    reason = 'per_hour';
+  }
+  if (dayUnblockAt && dayUnblockAt.getTime() >= nextMs) {
+    nextMs = dayUnblockAt.getTime();
+    reason = 'per_day';
+  }
+
+  const floored = nextMs < now.getTime() ? now.getTime() + REOPEN_BUFFER_MS : nextMs;
+  return { kind: 'deferred', nextAttemptAt: new Date(floored), reason };
+}
+
+export function rateLimitDeferralError(decision: Extract<RateLimitDecision, { kind: 'deferred' }>): string {
+  return `rate_limited:${decision.reason}:until=${decision.nextAttemptAt.toISOString()}`;
+}
+
+export function parseRateLimitDeferral(
+  error: string | null,
+): { reason: 'per_hour' | 'per_day'; until: Date } | null {
+  if (!error) return null;
+  const m = /^rate_limited:(per_hour|per_day):until=(.+)$/.exec(error);
+  if (!m) return null;
+  const date = new Date(m[2]!);
+  if (Number.isNaN(date.getTime())) return null;
+  return { reason: m[1] as 'per_hour' | 'per_day', until: date };
+}

--- a/packages/backend-core/src/modules/conv/email/email.service.ts
+++ b/packages/backend-core/src/modules/conv/email/email.service.ts
@@ -15,7 +15,9 @@ import {
 import { z } from 'zod';
 import {
   EmailChannelConfigInput,
+  SendLimitsSchema,
   type EmailChannelConfigInputT,
+  type SendLimits,
 } from '@getmunin/types';
 
 export { EmailChannelConfigInput };
@@ -49,6 +51,7 @@ export interface EmailChannelConfigDto {
     password: typeof REDACTED_PASSWORD;
     mailbox?: string;
   };
+  sendLimits?: SendLimits;
 }
 
 const StoredSmtpOutboundSchema = z.object({
@@ -87,6 +90,7 @@ export const StoredEmailChannelConfigSchema = z.object({
     StoredMailerOutboundSchema,
   ]),
   inbound: StoredImapInboundSchema.optional(),
+  sendLimits: SendLimitsSchema.optional(),
 });
 
 export type StoredEmailChannelConfig = z.infer<typeof StoredEmailChannelConfigSchema>;
@@ -131,6 +135,12 @@ export class EmailService {
         mailbox: input.inbound.mailbox,
       };
     }
+    if (input.sendLimits) {
+      const trimmed: SendLimits = {};
+      if (input.sendLimits.perDayMax !== undefined) trimmed.perDayMax = input.sendLimits.perDayMax;
+      if (input.sendLimits.perHourMax !== undefined) trimmed.perHourMax = input.sendLimits.perHourMax;
+      if (Object.keys(trimmed).length > 0) out.sendLimits = trimmed;
+    }
     return out;
   }
 
@@ -168,6 +178,7 @@ export class EmailService {
         mailbox: stored.inbound.mailbox,
       };
     }
+    if (stored.sendLimits) out.sendLimits = { ...stored.sendLimits };
     return out;
   }
 

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -76,6 +76,7 @@ interface EmailChannelDto extends ChannelDto {
       username?: string;
       mailbox?: string;
     };
+    sendLimits?: { perDayMax?: number; perHourMax?: number };
   };
 }
 
@@ -688,6 +689,14 @@ function toSaveErrorDetail(
   };
 }
 
+function parsePositiveInt(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
 function EmailChannelDialog({
   open,
   onOpenChange,
@@ -719,6 +728,8 @@ function EmailChannelDialog({
   const [imapUsername, setImapUsername] = useState('');
   const [imapPassword, setImapPassword] = useState('');
   const [imapMailbox, setImapMailbox] = useState('');
+  const [perDayMax, setPerDayMax] = useState('');
+  const [perHourMax, setPerHourMax] = useState('');
   const [creating, setCreating] = useState(false);
   const [submitError, setSubmitError] = useState<SaveErrorDetail | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -750,6 +761,12 @@ function EmailChannelDialog({
     setImapUsername(cfg?.inbound?.username ?? '');
     setImapPassword('');
     setImapMailbox(cfg?.inbound?.mailbox ?? '');
+    setPerDayMax(
+      cfg?.sendLimits?.perDayMax != null ? String(cfg.sendLimits.perDayMax) : '',
+    );
+    setPerHourMax(
+      cfg?.sendLimits?.perHourMax != null ? String(cfg.sendLimits.perHourMax) : '',
+    );
     setSubmitError(null);
     setFieldErrors({});
     setCreating(false);
@@ -788,6 +805,14 @@ function EmailChannelDialog({
               },
             }
           : {}),
+        ...(() => {
+          const sendLimits: { perDayMax?: number; perHourMax?: number } = {};
+          const day = parsePositiveInt(perDayMax);
+          const hour = parsePositiveInt(perHourMax);
+          if (day !== null) sendLimits.perDayMax = day;
+          if (hour !== null) sendLimits.perHourMax = hour;
+          return Object.keys(sendLimits).length > 0 ? { sendLimits } : {};
+        })(),
       },
     };
     const parsed = SetupEmailBody.safeParse(payload);
@@ -1017,6 +1042,37 @@ function EmailChannelDialog({
                 </label>
               </div>
             )}
+          </fieldset>
+
+          <fieldset className="rounded-md border border-rule-soft px-4 pb-4 pt-3">
+            <legend className="px-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+              {t('email.sendLimitsLabel')}
+            </legend>
+            <p className="text-xs text-muted-foreground">{t('email.sendLimitsHelp')}</p>
+            <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <FormField label={t('email.perDayMax')}>
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  step={1}
+                  value={perDayMax}
+                  onChange={(e) => setPerDayMax(e.target.value)}
+                  placeholder={t('email.sendLimitsPlaceholder')}
+                />
+              </FormField>
+              <FormField label={t('email.perHourMax')}>
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  step={1}
+                  value={perHourMax}
+                  onChange={(e) => setPerHourMax(e.target.value)}
+                  placeholder={t('email.sendLimitsPlaceholder')}
+                />
+              </FormField>
+            </div>
           </fieldset>
 
           <DialogFooter className={dialogFooterClass}>

--- a/packages/types/src/channels.ts
+++ b/packages/types/src/channels.ts
@@ -35,6 +35,13 @@ export const ImapInboundSchema = z.object({
   mailbox: z.string().max(120).optional(),
 });
 
+export const SendLimitsSchema = z.object({
+  perDayMax: z.number().int().positive().max(1_000_000).optional(),
+  perHourMax: z.number().int().positive().max(1_000_000).optional(),
+});
+
+export type SendLimits = z.infer<typeof SendLimitsSchema>;
+
 export const EmailChannelConfigInput = z.object({
   addressing: z.object({
     fromAddress: z.string().email(),
@@ -43,6 +50,7 @@ export const EmailChannelConfigInput = z.object({
   }),
   outbound: OutboundConfigSchema,
   inbound: ImapInboundSchema.optional(),
+  sendLimits: SendLimitsSchema.optional(),
 });
 
 export type EmailChannelConfigInputT = z.infer<typeof EmailChannelConfigInput>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,8 @@ export {
   MailerOutboundSchema,
   OutboundConfigSchema,
   ImapInboundSchema,
+  SendLimitsSchema,
+  type SendLimits,
   EmailChannelConfigInput,
   type EmailChannelConfigInputT,
   CreateWidgetBody,


### PR DESCRIPTION
## Summary

- Two optional caps per email channel: **`perDayMax`** (rolling 24h) and **`perHourMax`** (rolling 60min). Configurable in the channel setup modal. Blank = no limit (no behavior change).
- When a delivery hits the limit, it **stays queued** with `next_attempt_at = oldest_sent_at_in_window + window_length + 1s`. The existing 10s poll picks it up when capacity opens. `attempt` is not incremented, so deferrals don't burn the 5-attempt budget.
- The check sits in the generic `OutboundDeliveryWorker`, so any future channel kind can opt in by adding `sendLimits` to its config.
- Transactional emails (invites, password reset) bypass the worker entirely — inherently exempt, which is the right UX.

## How it works

1. Channel admin sets a cap in the email modal (\"Send limits\" fieldset).
2. Stored as `sendLimits: { perDayMax?, perHourMax? }` in the channel's existing JSONB config — no schema migration.
3. `OutboundDeliveryWorker.attemptOne` runs one combined SQL query against `conv_message_deliveries` (last-hour + last-day sent counts + their oldest `sent_at`) before calling the adapter.
4. `decideRateLimit(limits, counts, now)` returns `{ kind: 'allowed' } | { kind: 'deferred', nextAttemptAt, reason }`. When both windows are over, picks the **later** unblock time so the next attempt clears both.
5. Deferral is recorded as `error = 'rate_limited:<per_hour|per_day>:until=<iso>'` — machine-parseable for future inbox surfacing.

## Affects

- Agent replies, human-staff replies, outreach drafts — anything routed through `conv_message_deliveries`.
- Per-channel granularity (limits are about a single sending identity's reputation).

## Tests

- 9 unit tests on `decideRateLimit` and the marker round-trip: under-limit allow, at per-hour, at per-day, both over (picks later unblock), past-window flooring, marker encode/parse, unrelated-error handling.
- Local typecheck + lint clean on every touched package.

## Deliberately out of scope

- **No new index** on `(channel_id, status, sent_at)`. Existing indexes are fine at expected channel-level volume; add if pg slow-log flags the query.
- **No inbox surface** for \"deferred — will send at HH:MM\". The marker is parseable; UI follow-up can land later.
- **No max-age cap** on deferrals. Aggressive limits will pile up rows that keep deferring. Add a 7-day hard fail if real customers hit this.

## Test plan

- [x] Unit tests pass (9/9).
- [x] Typecheck + lint across `types`, `backend-core`, `dashboard-pages`, `agent-host`, OSS web.
- [ ] Manual: create an email channel with `perHourMax = 2`, send 3 messages from the inbox, confirm rows 1–2 send and row 3 is deferred with `next_attempt_at` ~1h out and `error` set to the marker. Wait or fast-forward and confirm it sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)