### PR TITLE
feat(agent): derive brand-voice prompt from website import

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -401,7 +401,12 @@
         "enableInbound": "Enable inbound (poll an IMAP mailbox)",
         "create": "Create email channel",
         "editTitle": "Edit email channel",
-        "editDescription": "Update the channel's name or transport. Leave a password blank to keep the stored credential — type a new one to replace it."
+        "editDescription": "Update the channel's name or transport. Leave a password blank to keep the stored credential — type a new one to replace it.",
+        "sendLimitsLabel": "Send limits",
+        "sendLimitsHelp": "Optional caps on outbound email volume to protect domain reputation. Messages over the limit stay queued and send automatically when capacity opens. Leave blank for no limit.",
+        "sendLimitsPlaceholder": "no limit",
+        "perDayMax": "Max per day (rolling 24h)",
+        "perHourMax": "Max per hour (rolling 60min)"
       },
       "errors": {
         "load": "Could not load channels.",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -401,7 +401,12 @@
         "enableInbound": "Aktiver innkommende (poll en IMAP-postboks)",
         "create": "Opprett e-postkanal",
         "editTitle": "Rediger e-postkanal",
-        "editDescription": "Oppdater kanalens navn eller transport. La et passord stå tomt for å beholde det lagrede — skriv et nytt for å erstatte det."
+        "editDescription": "Oppdater kanalens navn eller transport. La et passord stå tomt for å beholde det lagrede — skriv et nytt for å erstatte det.",
+        "sendLimitsLabel": "Sendegrenser",
+        "sendLimitsHelp": "Valgfrie tak på utgående e-post for å beskytte domenets omdømme. Meldinger over grensen forblir i køen og sendes automatisk når kapasiteten åpner seg. La feltet stå tomt for ingen grense.",
+        "sendLimitsPlaceholder": "ingen grense",
+        "perDayMax": "Maks per dag (rullende 24 t)",
+        "perHourMax": "Maks per time (rullende 60 min)"
       },
       "errors": {
         "load": "Kunne ikke laste kanaler.",

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -249,7 +249,6 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       onCuratorJobPending: (event) => curatorWorker.onPending(event),
       onConnected: () => curatorWorker.onConnected(),
       onKbDocumentChanged: (event: KbDocumentChangedEvent) => {
-        if (event.type === 'deleted') return;
         if (!event.slug || !prompts.isPromptDocument(event.slug)) return;
         void prompts.refresh(event.slug);
       },

--- a/packages/agent-host/src/web-import.handler.ts
+++ b/packages/agent-host/src/web-import.handler.ts
@@ -1,4 +1,6 @@
 import {
+  BRAND_VOICE_SLUG,
+  PROMPT_SPACE_SLUG,
   WebCrawler,
   openAiCompatibleProvider,
   openMcpClient,
@@ -15,6 +17,7 @@ const TARGET_SPACE_SLUG = 'website-import';
 const MAX_PAGES_TO_INSERT = 30;
 const PROFILE_CONTEXT_PAGES = 8;
 const PROFILE_MAX_TOKENS = 1200;
+const BRAND_VOICE_MAX_TOKENS = 600;
 
 export interface WebImportHandlerOpts {
   job: CuratorJob;
@@ -77,6 +80,7 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
     }
 
     let profileTokens = 0;
+    let brandVoiceWritten = false;
     if (crawl.pages.length > 0) {
       const profile = await generateCompanyProfile({
         provider: { baseUrl: opts.providerBaseUrl, apiKey: opts.providerApiKey },
@@ -90,10 +94,23 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
         profileTokens = profile.totalTokens;
         const ok = await createProfileDocument(mcp, spaceId, profile.markdown, opts.logger);
         if (ok) created++;
+
+        const brandVoice = await generateBrandVoice({
+          provider: { baseUrl: opts.providerBaseUrl, apiKey: opts.providerApiKey },
+          model: opts.model,
+          profileMarkdown: profile.markdown,
+          logger: opts.logger,
+        });
+        if (brandVoice) {
+          profileTokens += brandVoice.totalTokens;
+          brandVoiceWritten = await upsertBrandVoiceDocument(mcp, brandVoice.markdown, opts.logger);
+          if (brandVoiceWritten) created++;
+        }
       }
     }
 
-    const replyText = `Imported ${created} document(s) from ${crawl.siteUrl}; ${crawl.skipped.length} URL(s) skipped.`;
+    const suffix = brandVoiceWritten ? ' Brand voice applied to agent prompt.' : '';
+    const replyText = `Imported ${created} document(s) from ${crawl.siteUrl}; ${crawl.skipped.length} URL(s) skipped.${suffix}`;
     return {
       ok: true,
       toolCalls: created,
@@ -232,6 +249,128 @@ async function generateCompanyProfile(opts: {
     opts.logger.warn(`company profile generation failed: ${describe(err)}`);
     return null;
   }
+}
+
+interface BrandVoiceResult {
+  markdown: string;
+  totalTokens: number;
+}
+
+async function generateBrandVoice(opts: {
+  provider: { baseUrl: string; apiKey: string };
+  model: string;
+  profileMarkdown: string;
+  logger: WebImportHandlerOpts['logger'];
+}): Promise<BrandVoiceResult | null> {
+  const systemPrompt = [
+    "You produce a short brand-voice instruction that gets appended to a chat assistant's system prompt.",
+    'It tells the assistant how to write as this specific company across every channel (chat widget, email, voice).',
+    'Read the company profile and produce 100-200 words of plain markdown. Cover:',
+    '- The company in one short sentence (without naming the company explicitly — the assistant already speaks for them).',
+    '- Tone, voice, vocabulary cues. Concrete: short sentences? technical jargon ok? warm and informal? formal and precise?',
+    '- Who the assistant is speaking with (audience).',
+    '- What to avoid: phrasings or claims that are off-brand or unsupported.',
+    'Write in the imperative ("Be direct.", "Avoid jargon.", etc.) — instructions to the assistant, not a description of the company.',
+    'Output markdown only. No headings, no preamble, no closing remark.',
+  ].join('\n');
+
+  try {
+    const response = await openAiCompatibleProvider({
+      config: {
+        provider: { baseUrl: opts.provider.baseUrl, apiKey: opts.provider.apiKey },
+        model: opts.model,
+        systemPrompt,
+        maxTokens: BRAND_VOICE_MAX_TOKENS,
+      },
+      messages: [
+        { role: 'system', content: systemPrompt },
+        {
+          role: 'user',
+          content: `Company profile:\n\n${truncate(opts.profileMarkdown, 6000)}`,
+        },
+      ],
+      tools: [],
+    });
+    const text = (response.message.content ?? '').toString().trim();
+    if (!text) return null;
+    return { markdown: text, totalTokens: response.usage?.total_tokens ?? 0 };
+  } catch (err) {
+    opts.logger.warn(`brand voice generation failed: ${describe(err)}`);
+    return null;
+  }
+}
+
+async function upsertBrandVoiceDocument(
+  mcp: McpToolHandle,
+  body: string,
+  logger: WebImportHandlerOpts['logger'],
+): Promise<boolean> {
+  const listed = await mcp.callTool('kb_list_spaces', {}).catch((err: unknown) => toolError(err));
+  if (listed.isError) {
+    logger.warn(`brand-voice kb_list_spaces failed: ${stringifyToolResult(listed)}`);
+    return false;
+  }
+  const spaceId = findSpaceIdInResult(listed, PROMPT_SPACE_SLUG);
+  if (!spaceId) {
+    logger.warn(`brand-voice skipped: KB space '${PROMPT_SPACE_SLUG}' not found yet`);
+    return false;
+  }
+
+  const existing = await mcp
+    .callTool('kb_get_document_by_slug', {
+      spaceSlug: PROMPT_SPACE_SLUG,
+      slug: BRAND_VOICE_SLUG,
+    })
+    .catch((err: unknown) => toolError(err));
+  const current = existing.isError ? null : parseExistingDocument(existing);
+
+  if (!current) {
+    const created = await mcp
+      .callTool('kb_create_document', {
+        spaceId,
+        slug: BRAND_VOICE_SLUG,
+        title: 'Brand voice',
+        body,
+        audiences: ['admin'],
+        tags: ['agent-runtime', 'generated', 'brand-voice'],
+      })
+      .catch((err: unknown) => toolError(err));
+    if (created.isError) {
+      logger.warn(`brand-voice kb_create_document failed: ${stringifyToolResult(created)}`);
+      return false;
+    }
+    return true;
+  }
+
+  const updated = await mcp
+    .callTool('kb_update_document', {
+      id: current.id,
+      ifVersion: current.version,
+      body,
+    })
+    .catch((err: unknown) => toolError(err));
+  if (updated.isError) {
+    logger.warn(`brand-voice kb_update_document failed: ${stringifyToolResult(updated)}`);
+    return false;
+  }
+  return true;
+}
+
+function parseExistingDocument(res: McpToolResult): { id: string; version: number } | null {
+  for (const item of res.content) {
+    if (item.type !== 'text') continue;
+    const text = (item as { text?: string }).text;
+    if (!text || text === 'null') continue;
+    try {
+      const parsed = JSON.parse(text) as { id?: string; version?: number } | null;
+      if (parsed && typeof parsed.id === 'string' && typeof parsed.version === 'number') {
+        return { id: parsed.id, version: parsed.version };
+      }
+    } catch {
+      // fall through to next content block
+    }
+  }
+  return null;
 }
 
 function buildProfileUserPrompt(

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -3,6 +3,7 @@ export { openAiCompatibleProvider, ProviderError } from './providers/openai-comp
 export { createStubProvider, type StubProviderHandle, type StubScript } from './providers/stub.js';
 export { mcpToolsToChatTools, flattenToolResult } from './mcp-tool-translation.js';
 export {
+  BRAND_VOICE_SLUG,
   CHANNEL_PROMPT_PREFIX,
   PROMPT_SPACE_SLUG,
   SYSTEM_PROMPT_SLUG,

--- a/packages/agent-runtime/src/prompt-resolver.test.ts
+++ b/packages/agent-runtime/src/prompt-resolver.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  BRAND_VOICE_SLUG,
   CHANNEL_PROMPT_PREFIX,
   PROMPT_SPACE_SLUG,
   SYSTEM_PROMPT_SLUG,
@@ -171,10 +172,65 @@ describe('createPromptResolver', () => {
     const mcp = fakeMcp();
     const resolver = await createPromptResolver({ promptsDir: dir, mcp, logger: silentLogger });
     expect(resolver.isPromptDocument(SYSTEM_PROMPT_SLUG)).toBe(true);
+    expect(resolver.isPromptDocument(BRAND_VOICE_SLUG)).toBe(true);
     expect(resolver.isPromptDocument(`${CHANNEL_PROMPT_PREFIX}email`)).toBe(true);
     expect(resolver.isPromptDocument('some-other-doc')).toBe(false);
     expect(resolver.isPromptDocument(null)).toBe(false);
     expect(resolver.isPromptDocument(undefined)).toBe(false);
+  });
+
+  it('system() returns the base prompt when no brand-voice doc exists', async () => {
+    const dir = writePrompts({ system: 'SYS_BASE' });
+    const mcp = fakeMcp();
+    const resolver = await createPromptResolver({ promptsDir: dir, mcp, logger: silentLogger });
+    expect(resolver.system()).toBe('SYS_BASE');
+  });
+
+  it('system() appends a Brand voice section when the doc is present at boot', async () => {
+    const dir = writePrompts({ system: 'SYS_BASE' });
+    const mcp = fakeMcp({ existingDocs: { [BRAND_VOICE_SLUG]: 'Be warm.\nUse short sentences.' } });
+    const resolver = await createPromptResolver({ promptsDir: dir, mcp, logger: silentLogger });
+    const out = resolver.system();
+    expect(out.startsWith('SYS_BASE')).toBe(true);
+    expect(out).toContain('## Brand voice');
+    expect(out).toContain('Be warm.');
+    expect(out).toContain('Use short sentences.');
+  });
+
+  it('system() updates after refresh when brand-voice is added to the KB', async () => {
+    const dir = writePrompts({ system: 'SYS' });
+    const mcp = fakeMcp();
+    const resolver = await createPromptResolver({ promptsDir: dir, mcp, logger: silentLogger });
+    expect(resolver.system()).toBe('SYS');
+
+    const callTool = vi.spyOn(mcp, 'callTool');
+    callTool.mockImplementationOnce(() =>
+      Promise.resolve({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ slug: BRAND_VOICE_SLUG, body: 'Be direct.' }),
+          },
+        ],
+      }),
+    );
+    await resolver.refresh(BRAND_VOICE_SLUG);
+    expect(resolver.system()).toContain('## Brand voice');
+    expect(resolver.system()).toContain('Be direct.');
+  });
+
+  it('refresh() clears brand-voice from system() when the doc is deleted', async () => {
+    const dir = writePrompts({ system: 'SYS' });
+    const mcp = fakeMcp({ existingDocs: { [BRAND_VOICE_SLUG]: 'Be playful.' } });
+    const resolver = await createPromptResolver({ promptsDir: dir, mcp, logger: silentLogger });
+    expect(resolver.system()).toContain('Be playful.');
+
+    const callTool = vi.spyOn(mcp, 'callTool');
+    callTool.mockImplementationOnce(() =>
+      Promise.resolve({ content: [{ type: 'text', text: 'null' }] }),
+    );
+    await resolver.refresh(BRAND_VOICE_SLUG);
+    expect(resolver.system()).toBe('SYS');
   });
 
   it('throws when system.md is missing from disk', async () => {

--- a/packages/agent-runtime/src/prompt-resolver.ts
+++ b/packages/agent-runtime/src/prompt-resolver.ts
@@ -6,6 +6,9 @@ import type { McpToolHandle, McpToolResult } from './types.js';
 export const PROMPT_SPACE_SLUG = 'agent-runtime';
 export const SYSTEM_PROMPT_SLUG = 'system-prompt';
 export const CHANNEL_PROMPT_PREFIX = 'channel-';
+export const BRAND_VOICE_SLUG = 'brand-voice';
+
+const BRAND_VOICE_HEADER = '\n\n## Brand voice\n\n';
 
 export function defaultPromptsDir(): string {
   const here = dirname(fileURLToPath(import.meta.url));
@@ -63,9 +66,15 @@ export async function createPromptResolver(
     cache.set(p.slug, seeded);
   }
 
+  // brand-voice is not seeded from disk — it's generated at onboarding by
+  // the website-import job. Read it lazily; absent is the common case.
+  const initialBrandVoice = await readBySlug(opts.mcp, BRAND_VOICE_SLUG);
+  if (initialBrandVoice) cache.set(BRAND_VOICE_SLUG, initialBrandVoice);
+
   function isPromptSlug(slug: string | null | undefined): boolean {
     if (!slug) return false;
     if (slug === SYSTEM_PROMPT_SLUG) return true;
+    if (slug === BRAND_VOICE_SLUG) return true;
     return slug.startsWith(CHANNEL_PROMPT_PREFIX);
   }
 
@@ -74,6 +83,16 @@ export async function createPromptResolver(
     if (body !== null) {
       cache.set(slug, body);
       log.info(`refreshed ${slug} from KB`);
+      return;
+    }
+    // Doc deleted in KB. For brand-voice this is meaningful — admins
+    // remove it to disable customization. For seeded prompts the on-disk
+    // fallback still lives in cache (untouched here), so a deletion
+    // simply leaves the runner with the body we had at boot until it
+    // restarts and re-seeds.
+    if (slug === BRAND_VOICE_SLUG) {
+      cache.delete(slug);
+      log.info(`cleared ${slug} (deleted in KB)`);
     }
   }
 
@@ -83,7 +102,10 @@ export async function createPromptResolver(
 
   return {
     system(): string {
-      return cache.get(SYSTEM_PROMPT_SLUG) ?? '';
+      const base = cache.get(SYSTEM_PROMPT_SLUG) ?? '';
+      const voice = cache.get(BRAND_VOICE_SLUG)?.trim();
+      if (!voice) return base;
+      return `${base}${BRAND_VOICE_HEADER}${voice}`;
     },
     channel(kind: string): string {
       const slug = `${CHANNEL_PROMPT_PREFIX}${kind}`;

--- a/packages/backend-core/src/modules/conv/channels/outbound-delivery.worker.ts
+++ b/packages/backend-core/src/modules/conv/channels/outbound-delivery.worker.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, isNotNull, lt, lte, sql } from 'drizzle-orm';
 import {
@@ -7,6 +7,7 @@ import {
   withContext,
   type RequestContext,
 } from '@getmunin/core';
+import type { SendLimits } from '@getmunin/types';
 import { randomUUID } from 'node:crypto';
 import { DB } from '../../../common/db/db.module.js';
 import {
@@ -15,6 +16,11 @@ import {
   type ChannelAdapter,
   type SendContext,
 } from './adapter.js';
+import {
+  decideRateLimit,
+  rateLimitDeferralError,
+  type SendCounts,
+} from './send-rate-limit.js';
 
 const POLL_INTERVAL_MS = Number(
   process.env.MUNIN_OUTBOUND_DELIVERY_WORKER_INTERVAL_MS ??
@@ -34,8 +40,11 @@ const BACKOFF_BASE_MS = 30_000;
  * Disabled in tests via `MUNIN_OUTBOUND_DELIVERY_WORKER_DISABLED=1` (or
  * legacy `MUNIN_EMAIL_OUTBOUND_WORKER_DISABLED=1`) or `NODE_ENV=test`.
  */
+type AttemptOutcome = 'sent' | 'deferred' | 'failed';
+
 @Injectable()
 export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(OutboundDeliveryWorker.name);
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private disabled =
@@ -65,8 +74,8 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
     this.timer = null;
   }
 
-  async tick(): Promise<{ attempted: number; sent: number; failed: number }> {
-    if (this.running) return { attempted: 0, sent: 0, failed: 0 };
+  async tick(): Promise<{ attempted: number; sent: number; deferred: number; failed: number }> {
+    if (this.running) return { attempted: 0, sent: 0, deferred: 0, failed: 0 };
     this.running = true;
     try {
       return await this.drain();
@@ -75,7 +84,7 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  private async drain(): Promise<{ attempted: number; sent: number; failed: number }> {
+  private async drain(): Promise<{ attempted: number; sent: number; deferred: number; failed: number }> {
     const now = new Date();
     const rows = await this.db
       .select({ id: schema.convMessageDeliveries.id })
@@ -91,23 +100,38 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
       .limit(BATCH_SIZE);
 
     let sent = 0;
+    let deferred = 0;
     let failed = 0;
     for (const row of rows) {
-      const ok = await this.attemptOne(row.id);
-      if (ok) sent += 1;
+      const outcome = await this.attemptOne(row.id);
+      if (outcome === 'sent') sent += 1;
+      else if (outcome === 'deferred') deferred += 1;
       else failed += 1;
     }
-    return { attempted: rows.length, sent, failed };
+    return { attempted: rows.length, sent, deferred, failed };
   }
 
-  private async attemptOne(deliveryId: string): Promise<boolean> {
+  private async attemptOne(deliveryId: string): Promise<AttemptOutcome> {
     const ctx = await this.loadContext(deliveryId);
-    if (!ctx) return false;
+    if (!ctx) return 'failed';
 
     const adapter = this.registry.get(ctx.channel.type);
     if (!adapter) {
       await this.recordFailure(deliveryId, ctx.attempt, `no adapter registered for channel type '${ctx.channel.type}'`);
-      return false;
+      return 'failed';
+    }
+
+    const limits = extractSendLimits(ctx.channel.config);
+    if (limits) {
+      const counts = await this.countRecentSends(ctx.channel.id);
+      const decision = decideRateLimit(limits, counts, new Date());
+      if (decision.kind === 'deferred') {
+        await this.recordDeferral(deliveryId, decision.nextAttemptAt, rateLimitDeferralError(decision));
+        this.logger.log(
+          `delivery ${deliveryId} on channel ${ctx.channel.id} deferred (${decision.reason}) until ${decision.nextAttemptAt.toISOString()}`,
+        );
+        return 'deferred';
+      }
     }
 
     let result;
@@ -123,7 +147,7 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
       result = await adapter.send(sendCtx);
     } catch (err) {
       await this.recordFailure(deliveryId, ctx.attempt, errorMessage(err));
-      return false;
+      return 'failed';
     }
 
     await this.db
@@ -145,7 +169,65 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
       messageId: ctx.message.id,
       channelId: ctx.channel.id,
     });
-    return true;
+    return 'sent';
+  }
+
+  private async recordDeferral(
+    deliveryId: string,
+    nextAttemptAt: Date,
+    encodedReason: string,
+  ): Promise<void> {
+    await this.db
+      .update(schema.convMessageDeliveries)
+      .set({
+        status: 'queued',
+        nextAttemptAt,
+        error: encodedReason,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.convMessageDeliveries.id, deliveryId));
+  }
+
+  private async countRecentSends(channelId: string): Promise<SendCounts> {
+    const now = new Date();
+    const hourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+    const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const rows = await this.db.execute<{
+      hour_count: string | number;
+      hour_oldest: Date | string | null;
+      day_count: string | number;
+      day_oldest: Date | string | null;
+    }>(sql`
+      SELECT
+        COUNT(*) FILTER (WHERE sent_at >= ${hourAgo.toISOString()}::timestamptz) AS hour_count,
+        MIN(sent_at) FILTER (WHERE sent_at >= ${hourAgo.toISOString()}::timestamptz) AS hour_oldest,
+        COUNT(*) AS day_count,
+        MIN(sent_at) AS day_oldest
+      FROM conv_message_deliveries
+      WHERE channel_id = ${channelId}
+        AND status = 'sent'
+        AND sent_at IS NOT NULL
+        AND sent_at >= ${dayAgo.toISOString()}::timestamptz
+    `);
+    const row = Array.isArray(rows)
+      ? rows[0]
+      : ((rows as { rows?: unknown[] }).rows?.[0] as
+          | { hour_count: string | number; hour_oldest: Date | string | null; day_count: string | number; day_oldest: Date | string | null }
+          | undefined);
+    if (!row) {
+      return {
+        lastHourSentCount: 0,
+        oldestSentAtInLastHour: null,
+        lastDaySentCount: 0,
+        oldestSentAtInLastDay: null,
+      };
+    }
+    return {
+      lastHourSentCount: Number(row.hour_count),
+      oldestSentAtInLastHour: toDate(row.hour_oldest),
+      lastDaySentCount: Number(row.day_count),
+      oldestSentAtInLastDay: toDate(row.day_oldest),
+    };
   }
 
   private async recordFailure(deliveryId: string, priorAttempts: number, error: string): Promise<void> {
@@ -252,4 +334,26 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function extractSendLimits(config: unknown): SendLimits | null {
+  if (!config || typeof config !== 'object') return null;
+  const limits = (config as { sendLimits?: unknown }).sendLimits;
+  if (!limits || typeof limits !== 'object') return null;
+  const out: SendLimits = {};
+  const candidate = limits as { perHourMax?: unknown; perDayMax?: unknown };
+  if (typeof candidate.perHourMax === 'number' && candidate.perHourMax > 0) {
+    out.perHourMax = candidate.perHourMax;
+  }
+  if (typeof candidate.perDayMax === 'number' && candidate.perDayMax > 0) {
+    out.perDayMax = candidate.perDayMax;
+  }
+  return out.perHourMax === undefined && out.perDayMax === undefined ? null : out;
+}
+
+function toDate(value: Date | string | null): Date | null {
+  if (value === null) return null;
+  if (value instanceof Date) return value;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }

--- a/packages/backend-core/src/modules/conv/channels/send-rate-limit.test.ts
+++ b/packages/backend-core/src/modules/conv/channels/send-rate-limit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideRateLimit,
+  parseRateLimitDeferral,
+  rateLimitDeferralError,
+  type SendCounts,
+} from './send-rate-limit.js';
+
+const NOW = new Date('2026-05-14T12:00:00.000Z');
+
+function counts(partial: Partial<SendCounts> = {}): SendCounts {
+  return {
+    lastHourSentCount: 0,
+    oldestSentAtInLastHour: null,
+    lastDaySentCount: 0,
+    oldestSentAtInLastDay: null,
+    ...partial,
+  };
+}
+
+describe('decideRateLimit', () => {
+  it('allows when limits are undefined', () => {
+    expect(decideRateLimit(undefined, counts(), NOW)).toEqual({ kind: 'allowed' });
+  });
+
+  it('allows when limits exist but are all unset', () => {
+    expect(decideRateLimit({}, counts({ lastDaySentCount: 99 }), NOW)).toEqual({ kind: 'allowed' });
+  });
+
+  it('allows when under both limits', () => {
+    expect(
+      decideRateLimit(
+        { perHourMax: 10, perDayMax: 100 },
+        counts({ lastHourSentCount: 5, lastDaySentCount: 50 }),
+        NOW,
+      ),
+    ).toEqual({ kind: 'allowed' });
+  });
+
+  it('defers when at per-hour limit and emits per_hour reason', () => {
+    const oldest = new Date(NOW.getTime() - 30 * 60 * 1000);
+    const decision = decideRateLimit(
+      { perHourMax: 5 },
+      counts({ lastHourSentCount: 5, oldestSentAtInLastHour: oldest }),
+      NOW,
+    );
+    expect(decision.kind).toBe('deferred');
+    if (decision.kind === 'deferred') {
+      expect(decision.reason).toBe('per_hour');
+      expect(decision.nextAttemptAt.getTime()).toBe(
+        oldest.getTime() + 60 * 60 * 1000 + 1_000,
+      );
+    }
+  });
+
+  it('defers when at per-day limit and emits per_day reason', () => {
+    const oldest = new Date(NOW.getTime() - 6 * 60 * 60 * 1000);
+    const decision = decideRateLimit(
+      { perDayMax: 100 },
+      counts({ lastDaySentCount: 100, oldestSentAtInLastDay: oldest }),
+      NOW,
+    );
+    expect(decision.kind).toBe('deferred');
+    if (decision.kind === 'deferred') {
+      expect(decision.reason).toBe('per_day');
+      expect(decision.nextAttemptAt.getTime()).toBe(
+        oldest.getTime() + 24 * 60 * 60 * 1000 + 1_000,
+      );
+    }
+  });
+
+  it('picks the later unblock time when both limits exceeded', () => {
+    const oldestHour = new Date(NOW.getTime() - 30 * 60 * 1000);
+    const oldestDay = new Date(NOW.getTime() - 2 * 60 * 60 * 1000);
+    const decision = decideRateLimit(
+      { perHourMax: 5, perDayMax: 50 },
+      counts({
+        lastHourSentCount: 5,
+        oldestSentAtInLastHour: oldestHour,
+        lastDaySentCount: 50,
+        oldestSentAtInLastDay: oldestDay,
+      }),
+      NOW,
+    );
+    expect(decision.kind).toBe('deferred');
+    if (decision.kind === 'deferred') {
+      const dayUnblock = oldestDay.getTime() + 24 * 60 * 60 * 1000 + 1_000;
+      expect(decision.nextAttemptAt.getTime()).toBe(dayUnblock);
+      expect(decision.reason).toBe('per_day');
+    }
+  });
+
+  it('floors unblock time to now if computed value is in the past', () => {
+    const oldest = new Date(NOW.getTime() - 2 * 60 * 60 * 1000);
+    const decision = decideRateLimit(
+      { perHourMax: 1 },
+      counts({ lastHourSentCount: 1, oldestSentAtInLastHour: oldest }),
+      NOW,
+    );
+    expect(decision.kind).toBe('deferred');
+    if (decision.kind === 'deferred') {
+      expect(decision.nextAttemptAt.getTime()).toBe(NOW.getTime() + 1_000);
+    }
+  });
+});
+
+describe('rateLimitDeferralError / parseRateLimitDeferral', () => {
+  it('round-trips', () => {
+    const until = new Date('2026-05-15T08:00:00.000Z');
+    const encoded = rateLimitDeferralError({
+      kind: 'deferred',
+      nextAttemptAt: until,
+      reason: 'per_day',
+    });
+    expect(encoded).toBe('rate_limited:per_day:until=2026-05-15T08:00:00.000Z');
+    expect(parseRateLimitDeferral(encoded)).toEqual({ reason: 'per_day', until });
+  });
+
+  it('returns null for unrelated errors', () => {
+    expect(parseRateLimitDeferral(null)).toBeNull();
+    expect(parseRateLimitDeferral('SMTP refused')).toBeNull();
+    expect(parseRateLimitDeferral('rate_limited:bad')).toBeNull();
+  });
+});

--- a/packages/backend-core/src/modules/conv/channels/send-rate-limit.ts
+++ b/packages/backend-core/src/modules/conv/channels/send-rate-limit.ts
@@ -1,0 +1,70 @@
+import type { SendLimits } from '@getmunin/types';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const REOPEN_BUFFER_MS = 1_000;
+
+export interface SendCounts {
+  lastHourSentCount: number;
+  oldestSentAtInLastHour: Date | null;
+  lastDaySentCount: number;
+  oldestSentAtInLastDay: Date | null;
+}
+
+export type RateLimitDecision =
+  | { kind: 'allowed' }
+  | { kind: 'deferred'; nextAttemptAt: Date; reason: 'per_hour' | 'per_day' };
+
+export function decideRateLimit(
+  limits: SendLimits | undefined,
+  counts: SendCounts,
+  now: Date,
+): RateLimitDecision {
+  if (!limits) return { kind: 'allowed' };
+  const perHour = limits.perHourMax;
+  const perDay = limits.perDayMax;
+  if (!perHour && !perDay) return { kind: 'allowed' };
+
+  const hourBlocked =
+    perHour !== undefined && counts.lastHourSentCount >= perHour && counts.oldestSentAtInLastHour;
+  const dayBlocked =
+    perDay !== undefined && counts.lastDaySentCount >= perDay && counts.oldestSentAtInLastDay;
+
+  if (!hourBlocked && !dayBlocked) return { kind: 'allowed' };
+
+  const hourUnblockAt = hourBlocked
+    ? new Date(counts.oldestSentAtInLastHour!.getTime() + HOUR_MS + REOPEN_BUFFER_MS)
+    : null;
+  const dayUnblockAt = dayBlocked
+    ? new Date(counts.oldestSentAtInLastDay!.getTime() + DAY_MS + REOPEN_BUFFER_MS)
+    : null;
+
+  let nextMs = Number.NEGATIVE_INFINITY;
+  let reason: 'per_hour' | 'per_day' = 'per_day';
+  if (hourUnblockAt) {
+    nextMs = hourUnblockAt.getTime();
+    reason = 'per_hour';
+  }
+  if (dayUnblockAt && dayUnblockAt.getTime() >= nextMs) {
+    nextMs = dayUnblockAt.getTime();
+    reason = 'per_day';
+  }
+
+  const floored = nextMs < now.getTime() ? now.getTime() + REOPEN_BUFFER_MS : nextMs;
+  return { kind: 'deferred', nextAttemptAt: new Date(floored), reason };
+}
+
+export function rateLimitDeferralError(decision: Extract<RateLimitDecision, { kind: 'deferred' }>): string {
+  return `rate_limited:${decision.reason}:until=${decision.nextAttemptAt.toISOString()}`;
+}
+
+export function parseRateLimitDeferral(
+  error: string | null,
+): { reason: 'per_hour' | 'per_day'; until: Date } | null {
+  if (!error) return null;
+  const m = /^rate_limited:(per_hour|per_day):until=(.+)$/.exec(error);
+  if (!m) return null;
+  const date = new Date(m[2]!);
+  if (Number.isNaN(date.getTime())) return null;
+  return { reason: m[1] as 'per_hour' | 'per_day', until: date };
+}

--- a/packages/backend-core/src/modules/conv/email/email.service.ts
+++ b/packages/backend-core/src/modules/conv/email/email.service.ts
@@ -15,7 +15,9 @@ import {
 import { z } from 'zod';
 import {
   EmailChannelConfigInput,
+  SendLimitsSchema,
   type EmailChannelConfigInputT,
+  type SendLimits,
 } from '@getmunin/types';
 
 export { EmailChannelConfigInput };
@@ -49,6 +51,7 @@ export interface EmailChannelConfigDto {
     password: typeof REDACTED_PASSWORD;
     mailbox?: string;
   };
+  sendLimits?: SendLimits;
 }
 
 const StoredSmtpOutboundSchema = z.object({
@@ -87,6 +90,7 @@ export const StoredEmailChannelConfigSchema = z.object({
     StoredMailerOutboundSchema,
   ]),
   inbound: StoredImapInboundSchema.optional(),
+  sendLimits: SendLimitsSchema.optional(),
 });
 
 export type StoredEmailChannelConfig = z.infer<typeof StoredEmailChannelConfigSchema>;
@@ -131,6 +135,12 @@ export class EmailService {
         mailbox: input.inbound.mailbox,
       };
     }
+    if (input.sendLimits) {
+      const trimmed: SendLimits = {};
+      if (input.sendLimits.perDayMax !== undefined) trimmed.perDayMax = input.sendLimits.perDayMax;
+      if (input.sendLimits.perHourMax !== undefined) trimmed.perHourMax = input.sendLimits.perHourMax;
+      if (Object.keys(trimmed).length > 0) out.sendLimits = trimmed;
+    }
     return out;
   }
 
@@ -168,6 +178,7 @@ export class EmailService {
         mailbox: stored.inbound.mailbox,
       };
     }
+    if (stored.sendLimits) out.sendLimits = { ...stored.sendLimits };
     return out;
   }
 

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -76,6 +76,7 @@ interface EmailChannelDto extends ChannelDto {
       username?: string;
       mailbox?: string;
     };
+    sendLimits?: { perDayMax?: number; perHourMax?: number };
   };
 }
 
@@ -688,6 +689,14 @@ function toSaveErrorDetail(
   };
 }
 
+function parsePositiveInt(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
 function EmailChannelDialog({
   open,
   onOpenChange,
@@ -719,6 +728,8 @@ function EmailChannelDialog({
   const [imapUsername, setImapUsername] = useState('');
   const [imapPassword, setImapPassword] = useState('');
   const [imapMailbox, setImapMailbox] = useState('');
+  const [perDayMax, setPerDayMax] = useState('');
+  const [perHourMax, setPerHourMax] = useState('');
   const [creating, setCreating] = useState(false);
   const [submitError, setSubmitError] = useState<SaveErrorDetail | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -750,6 +761,12 @@ function EmailChannelDialog({
     setImapUsername(cfg?.inbound?.username ?? '');
     setImapPassword('');
     setImapMailbox(cfg?.inbound?.mailbox ?? '');
+    setPerDayMax(
+      cfg?.sendLimits?.perDayMax != null ? String(cfg.sendLimits.perDayMax) : '',
+    );
+    setPerHourMax(
+      cfg?.sendLimits?.perHourMax != null ? String(cfg.sendLimits.perHourMax) : '',
+    );
     setSubmitError(null);
     setFieldErrors({});
     setCreating(false);
@@ -788,6 +805,14 @@ function EmailChannelDialog({
               },
             }
           : {}),
+        ...(() => {
+          const sendLimits: { perDayMax?: number; perHourMax?: number } = {};
+          const day = parsePositiveInt(perDayMax);
+          const hour = parsePositiveInt(perHourMax);
+          if (day !== null) sendLimits.perDayMax = day;
+          if (hour !== null) sendLimits.perHourMax = hour;
+          return Object.keys(sendLimits).length > 0 ? { sendLimits } : {};
+        })(),
       },
     };
     const parsed = SetupEmailBody.safeParse(payload);
@@ -1017,6 +1042,37 @@ function EmailChannelDialog({
                 </label>
               </div>
             )}
+          </fieldset>
+
+          <fieldset className="rounded-md border border-rule-soft px-4 pb-4 pt-3">
+            <legend className="px-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+              {t('email.sendLimitsLabel')}
+            </legend>
+            <p className="text-xs text-muted-foreground">{t('email.sendLimitsHelp')}</p>
+            <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <FormField label={t('email.perDayMax')}>
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  step={1}
+                  value={perDayMax}
+                  onChange={(e) => setPerDayMax(e.target.value)}
+                  placeholder={t('email.sendLimitsPlaceholder')}
+                />
+              </FormField>
+              <FormField label={t('email.perHourMax')}>
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  step={1}
+                  value={perHourMax}
+                  onChange={(e) => setPerHourMax(e.target.value)}
+                  placeholder={t('email.sendLimitsPlaceholder')}
+                />
+              </FormField>
+            </div>
           </fieldset>
 
           <DialogFooter className={dialogFooterClass}>

--- a/packages/types/src/channels.ts
+++ b/packages/types/src/channels.ts
@@ -35,6 +35,13 @@ export const ImapInboundSchema = z.object({
   mailbox: z.string().max(120).optional(),
 });
 
+export const SendLimitsSchema = z.object({
+  perDayMax: z.number().int().positive().max(1_000_000).optional(),
+  perHourMax: z.number().int().positive().max(1_000_000).optional(),
+});
+
+export type SendLimits = z.infer<typeof SendLimitsSchema>;
+
 export const EmailChannelConfigInput = z.object({
   addressing: z.object({
     fromAddress: z.string().email(),
@@ -43,6 +50,7 @@ export const EmailChannelConfigInput = z.object({
   }),
   outbound: OutboundConfigSchema,
   inbound: ImapInboundSchema.optional(),
+  sendLimits: SendLimitsSchema.optional(),
 });
 
 export type EmailChannelConfigInputT = z.infer<typeof EmailChannelConfigInput>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,8 @@ export {
   MailerOutboundSchema,
   OutboundConfigSchema,
   ImapInboundSchema,
+  SendLimitsSchema,
+  type SendLimits,
   EmailChannelConfigInput,
   type EmailChannelConfigInputT,
   CreateWidgetBody,


### PR DESCRIPTION
## Summary

The website-import job already crawls a customer's public site and synthesizes a Company Profile KB document. This adds a second LLM step that derives a short, prompt-shaped **Brand voice** instruction from that profile and stores it as a new KB doc `agent-runtime/brand-voice`. The agent-runtime resolver appends it to the system prompt at runtime so the chat widget answers on-brand across **all channels** (chat, email, voice) from the first reply.

## How it composes

\`\`\`
<system prompt — shared, generic, shipped default>

## Brand voice

<imperative voice instructions derived from the customer's site>
\`\`\`

Generated once at onboarding. Admins edit via MCP (`kb_update_document` with `ifVersion`) — same path as the existing system-prompt doc. The runner picks up changes within seconds via the existing realtime `kb_document_changed` event. Delete the doc → reverts to the generic system prompt.

## Editing — important note

There is **no dashboard editor** for either prompt. Admins edit through MCP today (same as the system-prompt doc). For non-MCP-fluent admins, a small inline editor in Settings → AI is a sensible follow-up (~80 LOC); not included here.

## Implementation

- `prompt-resolver.ts`:
  - `BRAND_VOICE_SLUG = 'brand-voice'`. Lazily read at boot — absent is the common case, no error.
  - `system()` returns `<system>\\n\\n## Brand voice\\n\\n<body>` when cached and non-empty.
  - `isPromptDocument()` recognizes the slug → realtime updates trigger refresh.
  - `refresh()` clears the cache when the KB doc is deleted (brand-voice only). Seeded system/channel docs keep their previous "fallback if KB read fails" semantics.
- `runner.service.ts`: KB realtime handler no longer short-circuits on `event.type === 'deleted'`. Prompt-doc deletions now flow through `resolver.refresh()`.
- `web-import.handler.ts`: after writing the Company Profile, one focused 100-200-word LLM call (`generateBrandVoice`) produces imperative voice instructions ("Be direct.", "Avoid jargon."). Distinct prompt from the verbose Company Profile (which feeds RAG). `upsertBrandVoiceDocument` creates or updates the doc by version. Audience `['admin']` — internal prompt, not citable content.
- Reply text now appends "Brand voice applied to agent prompt." when written, so onboarding's poll surface reflects it.

## Tests

- 4 new resolver tests covering: base prompt without doc, append at boot when doc exists, append after refresh adds the doc, clear-on-delete.
- All 95 agent-runtime tests pass; lint + typecheck clean on every touched package.

## Out of scope (follow-up)

- **Inline editor** in Settings → AI for brand-voice (and system-prompt — same gap exists for it).
- **Discoverability hint** in the onboarding wizard's completion card pointing admins at the doc.
- **"Regenerate brand voice"** button. Re-running the website import re-derives it via the same path.

## Test plan

- [x] Resolver unit tests pass (11/11) covering the brand-voice paths.
- [x] Typecheck + lint clean across `agent-runtime`, `agent-host`.
- [ ] Manual: complete onboarding with a real URL, confirm `agent-runtime/brand-voice` appears in the KB and that the next chat widget reply reflects the tone. Then `kb_update_document` via MCP, confirm subsequent replies pick up the edit. Then delete the doc, confirm the agent reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)