### PR TITLE
feat(assistants): assistants table + name plumbed into the runtime system prompt

### DIFF
--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -224,6 +224,10 @@ async function ensureSingletonOrgMembershipFor(
         .insert(schema.orgs)
         .values({ name: SINGLETON_ORG_NAME, slug: SINGLETON_ORG_SLUG })
         .returning({ id: schema.orgs.id });
+      await tx
+        .insert(schema.assistants)
+        .values({ orgId: orgRow!.id })
+        .onConflictDoNothing({ target: schema.assistants.orgId });
     }
     const memberCount = await tx
       .select({ c: sql<number>`count(*)::int` })

--- a/packages/agent-runtime/src/assistant-name-preamble.test.ts
+++ b/packages/agent-runtime/src/assistant-name-preamble.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { assistantNamePreamble } from './conversation-handler.js';
+
+describe('assistantNamePreamble', () => {
+  it('emits a one-line preamble when a name is set', () => {
+    expect(assistantNamePreamble('Munin')).toBe('Your name is Munin.\n\n');
+  });
+
+  it('returns empty string when name is null', () => {
+    expect(assistantNamePreamble(null)).toBe('');
+  });
+
+  it('returns empty string when name is undefined', () => {
+    expect(assistantNamePreamble(undefined)).toBe('');
+  });
+
+  it('returns empty string for whitespace-only name', () => {
+    expect(assistantNamePreamble('   ')).toBe('');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(assistantNamePreamble('  Munin  ')).toBe('Your name is Munin.\n\n');
+  });
+});

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -212,9 +212,11 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
       ? deps.prompts.channel(detail.channelType)
       : '';
     const conversationContext = `\n\n[Conversation context]\nYou are replying in conversationId: ${conversationId}. Pass this exact value to any tool that asks for \`conversationId\` — never substitute placeholders like "current" or "this".`;
-    const systemPrompt = channelDescriptor
+    const namePreamble = assistantNamePreamble(detail.assistantName);
+    const systemBody = channelDescriptor
       ? `${baseSystem}\n\n${channelDescriptor}${conversationContext}`
       : `${baseSystem}${conversationContext}`;
+    const systemPrompt = `${namePreamble}${systemBody}`;
 
     let lastError: Error | null = null;
     for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
@@ -468,6 +470,13 @@ function lastInbound(detail: ConversationDetail): ConversationMessage | null {
     }
   }
   return null;
+}
+
+export function assistantNamePreamble(name: string | null | undefined): string {
+  if (!name) return '';
+  const trimmed = name.trim();
+  if (trimmed === '') return '';
+  return `Your name is ${trimmed}.\n\n`;
 }
 
 const defaultScheduler = {

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -13,6 +13,11 @@ export interface ConversationDetail {
   } | null;
   agentMode?: 'auto' | 'draft_only' | 'off';
   outreachCampaignId?: string | null;
+  /**
+   * Configured assistant name for the owning org (from the `assistants` table).
+   * Null when unset; the runtime omits the name preamble in that case.
+   */
+  assistantName?: string | null;
   messages: Array<{
     id: string;
     authorType: 'user' | 'agent' | 'end_user' | 'system';

--- a/packages/backend-core/src/control/assistants.controller.ts
+++ b/packages/backend-core/src/control/assistants.controller.ts
@@ -1,0 +1,99 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Patch,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { z } from 'zod';
+import { schema } from '@getmunin/db';
+import { eq } from 'drizzle-orm';
+import { getCurrentContext } from '@getmunin/core';
+import { AuthGuard } from '../common/auth/auth.guard.js';
+import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.js';
+import { AuditInterceptor } from '../common/audit/audit.interceptor.js';
+
+const PatchDto = z.object({
+  name: z.string().max(64).nullable().optional(),
+  greeting: z.string().max(500).nullable().optional(),
+});
+
+interface AssistantDto {
+  id: string;
+  orgId: string;
+  name: string | null;
+  greeting: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+@Controller('api/v1/assistants/me')
+@UseGuards(AuthGuard)
+@UseInterceptors(TenancyInterceptor, AuditInterceptor)
+export class AssistantsController {
+  @Get()
+  async me(): Promise<AssistantDto> {
+    return toDto(await getOrCreate());
+  }
+
+  @Patch()
+  async update(@Body() body: unknown): Promise<AssistantDto> {
+    const parsed = PatchDto.safeParse(body);
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+
+    const existing = await getOrCreate();
+    const set: Record<string, unknown> = { updatedAt: new Date() };
+    if (parsed.data.name !== undefined) set.name = emptyToNull(parsed.data.name);
+    if (parsed.data.greeting !== undefined) set.greeting = emptyToNull(parsed.data.greeting);
+
+    const ctx = getCurrentContext();
+    const [updated] = await ctx.db
+      .update(schema.assistants)
+      .set(set)
+      .where(eq(schema.assistants.id, existing.id))
+      .returning();
+    return toDto(updated!);
+  }
+}
+
+async function getOrCreate(): Promise<typeof schema.assistants.$inferSelect> {
+  const ctx = getCurrentContext();
+  const actor = ctx.actor!;
+  const rows = await ctx.db
+    .select()
+    .from(schema.assistants)
+    .where(eq(schema.assistants.orgId, actor.orgId))
+    .limit(1);
+  if (rows[0]) return rows[0];
+  const [created] = await ctx.db
+    .insert(schema.assistants)
+    .values({ orgId: actor.orgId })
+    .onConflictDoNothing({ target: schema.assistants.orgId })
+    .returning();
+  if (created) return created;
+  const retry = await ctx.db
+    .select()
+    .from(schema.assistants)
+    .where(eq(schema.assistants.orgId, actor.orgId))
+    .limit(1);
+  return retry[0]!;
+}
+
+function toDto(row: typeof schema.assistants.$inferSelect): AssistantDto {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    name: row.name,
+    greeting: row.greeting,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function emptyToNull(v: string | null): string | null {
+  if (v === null) return null;
+  const trimmed = v.trim();
+  return trimmed === '' ? null : trimmed;
+}

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -4,6 +4,7 @@ import { EndUsersController } from './end-users.controller.js';
 import { DelegatedTokenController } from './delegated-token.controller.js';
 import { TokensController } from './tokens.controller.js';
 import { OrgsController } from './orgs.controller.js';
+import { AssistantsController } from './assistants.controller.js';
 import { AuditLogController } from './audit-log.controller.js';
 import { UsageController } from './usage.controller.js';
 import { UsageStatsController } from './usage-stats.controller.js';
@@ -64,6 +65,7 @@ import { InboxController } from './inbox.controller.js';
     DelegatedTokenController,
     TokensController,
     OrgsController,
+    AssistantsController,
     AuditLogController,
     UsageController,
     UsageStatsController,

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -97,6 +97,13 @@ export interface ConversationSummary {
 
 export interface ConversationDetail extends ConversationSummary {
   messages: MessageDto[];
+  /**
+   * The assistant's configured name (`assistants.name`) for the owning org,
+   * or null if unset. Runtime consumers fall back to no name preamble when
+   * null; the wire format carries the configured value verbatim so each
+   * caller controls its own fallback policy.
+   */
+  assistantName: string | null;
 }
 
 @Injectable()
@@ -332,9 +339,11 @@ export class ConvService {
       .select({
         conv: schema.convConversations,
         channelType: schema.convChannels.type,
+        assistantName: schema.assistants.name,
       })
       .from(schema.convConversations)
       .innerJoin(schema.convChannels, eq(schema.convChannels.id, schema.convConversations.channelId))
+      .leftJoin(schema.assistants, eq(schema.assistants.orgId, schema.convConversations.orgId))
       .where(eq(schema.convConversations.id, id))
       .limit(1);
     const row = conversations[0];
@@ -365,6 +374,7 @@ export class ConvService {
     return {
       ...toConversationSummary(row.conv, row.channelType),
       messages: rows.map((r) => toMessageDto(r.msg, authorNames, r.seenAt)),
+      assistantName: row.assistantName ?? null,
     };
   }
 

--- a/packages/db/drizzle/0021_assistants.sql
+++ b/packages/db/drizzle/0021_assistants.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS "assistants" (
+  "id" text PRIMARY KEY NOT NULL,
+  "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+  "name" text,
+  "greeting" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "assistants_org_uq"
+  ON "assistants" ("org_id");
+
+ALTER TABLE "assistants" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "assistants" FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "tenant_isolation" ON "assistants";
+CREATE POLICY "tenant_isolation" ON "assistants"
+  USING (app_bypass_rls() OR org_id = app_org_id())
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
+-- Backfill: one assistant row per existing org (name/greeting null = use defaults).
+INSERT INTO "assistants" ("id", "org_id")
+SELECT 'ast_' || substr(md5(random()::text || o.id), 1, 16), o.id
+FROM "orgs" o
+WHERE NOT EXISTS (SELECT 1 FROM "assistants" a WHERE a.org_id = o.id);

--- a/packages/db/drizzle/0021_assistants.sql
+++ b/packages/db/drizzle/0021_assistants.sql
@@ -10,12 +10,10 @@ CREATE TABLE IF NOT EXISTS "assistants" (
 CREATE UNIQUE INDEX IF NOT EXISTS "assistants_org_uq"
   ON "assistants" ("org_id");
 
-ALTER TABLE "assistants" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "assistants" FORCE ROW LEVEL SECURITY;
-DROP POLICY IF EXISTS "tenant_isolation" ON "assistants";
-CREATE POLICY "tenant_isolation" ON "assistants"
-  USING (app_bypass_rls() OR org_id = app_org_id())
-  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+-- RLS enable + tenant_isolation policy are applied by src/sql/rls.sql,
+-- which runs AFTER drizzle migrations and is the only place the
+-- app_bypass_rls() / app_org_id() helpers are defined. Don't inline the
+-- policy here — the helpers don't exist yet at migration time.
 
 -- Backfill: one assistant row per existing org (name/greeting null = use defaults).
 INSERT INTO "assistants" ("id", "org_id")

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1779100000000,
       "tag": "0020_conv_read_and_open_tracking",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1779200000000,
+      "tag": "0021_assistants",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -46,6 +46,23 @@ export const orgs = pgTable('orgs', {
   updatedAt,
 });
 
+export const assistants = pgTable(
+  'assistants',
+  {
+    id: id('ast'),
+    orgId: text('org_id')
+      .notNull()
+      .references((): AnyPgColumn => orgs.id, { onDelete: 'cascade' }),
+    name: text('name'),
+    greeting: text('greeting'),
+    createdAt,
+    updatedAt,
+  },
+  (t) => ({
+    orgUnique: uniqueIndex('assistants_org_uq').on(t.orgId),
+  }),
+);
+
 // Identity tables managed by BetterAuth (email/password + Google OAuth in M0).
 // Names match BetterAuth's default schema; the auth adapter is wired in
 // apps/backend/src/auth/.

--- a/packages/db/src/sql/rls.sql
+++ b/packages/db/src/sql/rls.sql
@@ -80,6 +80,14 @@ CREATE POLICY tenant_isolation ON agents
   USING (app_bypass_rls() OR org_id = app_org_id())
   WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
 
+-- ───────────────────────── assistants ──────────────────────────────────────
+ALTER TABLE assistants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE assistants FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON assistants;
+CREATE POLICY tenant_isolation ON assistants
+  USING (app_bypass_rls() OR org_id = app_org_id())
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
 -- ───────────────────────── oauth_clients ───────────────────────────────────
 -- oauth_clients can be either org-scoped (after consent links them) or
 -- nullable-org (during pre-consent registration). Allow null org reads


### PR DESCRIPTION
## Summary

First slice of the `/settings/assistants` feature. Introduces a new first-class `assistants` table, wires the configured name into the agent's system prompt, and ships the REST surface that the upcoming settings UI will consume. The `greeting` column ships at the same time so the next slice (widget greeting + UI) doesn't need another migration.

### Why a separate table, not columns on `orgs`

The settings UI is `/settings/assistants` (plural) — the chatbot is one configurable thing among potential others (additional bots, curators surfaced as cards). Putting `name` / `greeting` on `orgs` worked for one bot but turns `orgs` into a junk drawer as the surface grows and forecloses the natural shape for the rest of the feature. A separate table reads cleanly and is trivially extensible.

### Schema

```sql
CREATE TABLE assistants (
  id text PRIMARY KEY,
  org_id text NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
  name text,
  greeting text,
  created_at timestamptz NOT NULL DEFAULT now(),
  updated_at timestamptz NOT NULL DEFAULT now()
);
CREATE UNIQUE INDEX assistants_org_uq ON assistants(org_id);
```

Synthetic `id` + unique on `org_id` (not `org_id` as PK), so multi-assistant later just drops the uniqueness constraint without restructuring. CASCADE on org delete keeps tenancy/GDPR clean. RLS mirrors the standard `tenant_isolation` policy.

**Eager seeding.** Migration backfills one row per existing org. `auth.config.ts` (the only production org-INSERT path) also creates an assistant row at signup time. Runtime reads always find the row.

### API surface

- `GET /api/v1/assistants/me` — returns the row.
- `PATCH /api/v1/assistants/me` — accepts `name` (≤64 chars) and `greeting` (≤500), both nullable. Empty strings normalise to `null` server-side so the UI can treat `""` as "unset" without a separate affordance. Both endpoints have a `getOrCreate` safety net so a missing row never 500s.

No service module — controller talks to the DB directly, matching `orgs.controller.ts`. Refactor into a service if we later need events/audit.

### Runtime plumbing

- `ConversationDetail` (both backend + agent-runtime) gains `assistantName: string | null`. `getConversation` LEFT JOINs `assistants` (so a missing row degrades gracefully rather than 404ing). `ConversationSummary` deliberately unchanged — list endpoints stay lean.
- `conversation-handler.ts` prepends `"Your name is X.\n\n"` to the system prompt when `assistantName` is set; nothing when null. New exported `assistantNamePreamble()` helper, unit-tested.

The choice not to fall back to `org.name` when `assistantName` is null is deliberate — current behavior (no name) is preserved until the user configures one. One-line flip if you'd prefer the fallback.

### What ships unwired

- `greeting` column. Wiring it requires non-trivial widget channel work for proactive opener delivery. Adding the column now means no follow-up migration when that lands.

### Tests + checks

- 5/5 unit tests pass on `assistantNamePreamble` (set / null / undefined / whitespace-only / trim).
- `pnpm typecheck` clean across `@getmunin/db`, `@getmunin/backend-core`, `@getmunin/agent-runtime`, `@getmunin/dashboard-pages`, `@getmunin/backend`.
- `pnpm lint` clean on the touched packages (one pre-existing unused-import warning in `inbox.controller.ts`, unrelated).
- Pre-existing local-DB perms still block the integration suite (every test in the repo skips on the same error); pure unit tests run fine. CI will exercise the integration path.

## Test plan

- [x] Typecheck across all touched packages — clean.
- [x] Lint — clean (no new warnings or errors).
- [x] `assistantNamePreamble` unit tests — 5/5 pass.
- [ ] CI integration tests — could not run locally due to the pre-existing `permission denied for database munin_test`.
- [ ] After deploy: existing orgs backfilled with one assistant row each (migration is idempotent).
- [ ] After deploy: signup of a new org creates an assistant row.
- [ ] After deploy: `PATCH /api/v1/assistants/me` with `name: "Foo"` propagates to the next chat reply's system prompt (you can verify by inspecting the conversation transcript or having the agent introduce itself).
- [ ] After deploy: setting `name: null` removes the preamble; setting to `""` is treated as null.

## Follow-ups

- **PR 2: Settings UI.** `/settings/assistants` list page (Engine + Chat assistant + curator-visibility cards), `/settings/assistants/chat` detail page (Identity + Voice cards). Rename of `/settings/builtin-ai` to a section within the new page.
- **PR 3: Onboarding tweak.** Optional name field on `OrgNameCard`; `ReadyCard` deep-links to `/settings/assistants/chat`.
- **PR 4: Greeting wiring.** Widget reads `assistant.greeting` and delivers it on conversation creation. Has its own conversation-handler integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)