### PR TITLE
fix: web-import upsert, audit-in-aborted-txn, realtime crash, defuddle noise

### DIFF
--- a/packages/agent-host/src/web-import.handler.ts
+++ b/packages/agent-host/src/web-import.handler.ts
@@ -72,7 +72,7 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
     let created = 0;
     const pagesToInsert = crawl.pages.slice(0, MAX_PAGES_TO_INSERT);
     for (const page of pagesToInsert) {
-      const ok = await createPageDocument(mcp, spaceId, page, opts.logger);
+      const ok = await upsertPageDocument(mcp, spaceId, page, opts.logger);
       if (ok) created++;
     }
 
@@ -88,7 +88,7 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
       });
       if (profile) {
         profileTokens = profile.totalTokens;
-        const ok = await createProfileDocument(mcp, spaceId, profile.markdown, opts.logger);
+        const ok = await upsertProfileDocument(mcp, spaceId, profile.markdown, opts.logger);
         if (ok) created++;
       }
     }
@@ -125,60 +125,98 @@ async function ensureSpace(mcp: McpToolHandle): Promise<string> {
   return id;
 }
 
-async function createPageDocument(
+interface KbDocFields {
+  spaceId: string;
+  title: string;
+  body: string;
+  audiences: string[];
+  tags: string[];
+}
+
+async function upsertKbDocumentBySlug(
+  mcp: McpToolHandle,
+  spaceSlug: string,
+  slug: string,
+  fields: KbDocFields,
+  label: string,
+  logger: WebImportHandlerOpts['logger'],
+): Promise<boolean> {
+  const existing = await mcp
+    .callTool('kb_get_document_by_slug', { spaceSlug, slug })
+    .catch((err: unknown) => toolError(err));
+  const current = existing.isError ? null : parseExistingDocument(existing);
+
+  if (!current) {
+    const created = await mcp
+      .callTool('kb_create_document', { ...fields, slug })
+      .catch((err: unknown) => toolError(err));
+    if (!created.isError) return true;
+    logger.warn(`${label}: kb_create_document failed: ${stringifyToolResult(created)}`);
+    return false;
+  }
+
+  const updated = await mcp
+    .callTool('kb_update_document', {
+      id: current.id,
+      ifVersion: current.version,
+      title: fields.title,
+      body: fields.body,
+      audiences: fields.audiences,
+      tags: fields.tags,
+    })
+    .catch((err: unknown) => toolError(err));
+  if (!updated.isError) return true;
+  logger.warn(`${label}: kb_update_document failed: ${stringifyToolResult(updated)}`);
+  return false;
+}
+
+async function upsertPageDocument(
   mcp: McpToolHandle,
   spaceId: string,
   page: CrawledPage,
   logger: WebImportHandlerOpts['logger'],
 ): Promise<boolean> {
   const slug = slugifyUrl(page.url);
-  const baseArgs = {
-    spaceId,
-    title: page.title,
-    body: page.markdown,
-    audiences: ['admin', 'self_service'],
-    tags: ['imported-from-website'],
-  };
-  const first = await mcp
-    .callTool('kb_create_document', slug ? { ...baseArgs, slug } : baseArgs)
-    .catch((err: unknown) => toolError(err));
-  if (!first.isError) return true;
-
-  if (slug) {
-    const second = await mcp
-      .callTool('kb_create_document', baseArgs)
-      .catch((err: unknown) => toolError(err));
-    if (!second.isError) return true;
-    logger.warn(`kb_create_document failed for ${page.url}: ${stringifyToolResult(second)}`);
-  } else {
-    logger.warn(`kb_create_document failed for ${page.url}: ${stringifyToolResult(first)}`);
+  if (!slug) {
+    logger.warn(`skipping ${page.url}: no valid slug`);
+    return false;
   }
-  return false;
+  return upsertKbDocumentBySlug(
+    mcp,
+    TARGET_SPACE_SLUG,
+    slug,
+    {
+      spaceId,
+      title: page.title,
+      body: page.markdown,
+      audiences: ['admin', 'self_service'],
+      tags: ['imported-from-website'],
+    },
+    `page ${page.url}`,
+    logger,
+  );
 }
 
-async function createProfileDocument(
+async function upsertProfileDocument(
   mcp: McpToolHandle,
   spaceId: string,
   body: string,
   logger: WebImportHandlerOpts['logger'],
 ): Promise<boolean> {
-  const baseArgs = {
-    spaceId,
-    title: 'Company profile',
-    body,
-    audiences: ['admin', 'self_service'],
-    tags: ['imported-from-website', 'company-profile'],
-  };
-  const first = await mcp
-    .callTool('kb_create_document', { ...baseArgs, slug: 'company-profile' })
-    .catch((err: unknown) => toolError(err));
-  if (!first.isError) return true;
-  const second = await mcp
-    .callTool('kb_create_document', baseArgs)
-    .catch((err: unknown) => toolError(err));
-  if (!second.isError) return true;
-  logger.warn(`company-profile kb_create_document failed: ${stringifyToolResult(second)}`);
-  return false;
+  return upsertKbDocumentBySlug(
+    mcp,
+    TARGET_SPACE_SLUG,
+    'company-profile',
+    {
+      spaceId,
+      title: 'Company profile',
+      body,
+      audiences: ['admin', 'self_service'],
+      tags: ['imported-from-website', 'company-profile'],
+    },
+    'company profile',
+    logger,
+  );
 }
 
 interface ProfileResult {
@@ -260,8 +298,9 @@ function slugifyUrl(url: string): string | undefined {
       .replace(/[^a-z0-9]+/gi, '-')
       .toLowerCase()
       .replace(/^-+|-+$/g, '');
-    if (!raw || raw.length > 64) return undefined;
-    return raw;
+    if (!raw) return 'home';
+    const truncated = raw.length > 64 ? raw.slice(0, 64).replace(/-+$/g, '') : raw;
+    return truncated || undefined;
   } catch (err) {
     console.debug(`[web-import] slugify failed for ${url}: ${describe(err)}`);
     return undefined;
@@ -328,6 +367,22 @@ function tryParseJson(s: string): unknown {
   } catch {
     return s;
   }
+}
+
+function parseExistingDocument(res: McpToolResult): { id: string; version: number } | null {
+  for (const item of res.content) {
+    if (item.type !== 'text') continue;
+    const text = (item as { text?: string }).text;
+    if (!text || text === 'null') continue;
+    const parsed = tryParseJson(text);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const obj = parsed as { id?: unknown; version?: unknown };
+      if (typeof obj.id === 'string' && typeof obj.version === 'number') {
+        return { id: obj.id, version: obj.version };
+      }
+    }
+  }
+  return null;
 }
 
 function toolError(err: unknown): McpToolResult {

--- a/packages/agent-runtime/src/web-crawl.ts
+++ b/packages/agent-runtime/src/web-crawl.ts
@@ -524,11 +524,13 @@ const defaultFetcher: HtmlFetcher = async (url) => {
   }
 };
 
+const DEFUDDLE_NOISE = /^Initial parse returned very little content/;
+
 const defaultExtractor: Extractor = async (html, url) => {
   const fn = await loadDefuddle();
   if (!fn) return extractBasic(html);
   try {
-    const result = await fn(html, url, { markdown: true });
+    const result = await withSilencedDefuddleLogs(() => fn(html, url, { markdown: true }));
     const md = (result?.content ?? '').toString().trim();
     if (!md) return null;
     return { title: (result?.title ?? '').toString().trim(), markdown: md };
@@ -539,6 +541,20 @@ const defaultExtractor: Extractor = async (html, url) => {
     return extractBasic(html);
   }
 };
+
+async function withSilencedDefuddleLogs<T>(fn: () => Promise<T>): Promise<T> {
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    const first = args[0];
+    if (typeof first === 'string' && DEFUDDLE_NOISE.test(first)) return;
+    original(...args);
+  };
+  try {
+    return await fn();
+  } finally {
+    console.log = original;
+  }
+}
 
 type DefuddleFn = (
   html: string,

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -114,7 +114,14 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     });
     const listener = (req: IncomingMessage, socket: Duplex, head: Buffer) => {
       if (!req.url || !req.url.startsWith(PATH)) return;
-      void this.handleUpgrade(req, socket, head);
+      this.handleUpgrade(req, socket, head).catch((err: unknown) => {
+        this.logger.warn(`handleUpgrade failed: ${describeError(err)}`);
+        try {
+          socket.destroy();
+        } catch (destroyErr) {
+          this.logger.debug?.(`socket destroy after upgrade failure raised: ${describeError(destroyErr)}`);
+        }
+      });
     };
     this.upgradeListener = listener;
     httpServer.on('upgrade', listener);
@@ -315,11 +322,15 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
         return;
       }
       if (msg.type === 'typing') {
-        void this.handleTyping(entry, msg);
+        this.handleTyping(entry, msg).catch((err: unknown) =>
+          this.logger.warn(`handleTyping failed: ${describeError(err)}`),
+        );
         return;
       }
       if (msg.type === 'read') {
-        void this.handleRead(entry, msg);
+        this.handleRead(entry, msg).catch((err: unknown) =>
+          this.logger.warn(`handleRead failed: ${describeError(err)}`),
+        );
         return;
       }
       const key = encodeChannel(msg);
@@ -744,4 +755,8 @@ function ownsEvent(event: EventRow, endUserId: string): boolean {
   const owner = event.payload?.['endUserId'];
   if (typeof owner === 'string') return owner === endUserId;
   return event.type.startsWith('conversation.');
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/mcp-toolkit/src/server.ts
+++ b/packages/mcp-toolkit/src/server.ts
@@ -5,7 +5,7 @@ import {
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { AuditLogger, ActorIdentity, Audience } from '@getmunin/core';
+import { getCurrentContext, type AuditLogger, type ActorIdentity, type Audience } from '@getmunin/core';
 import type { McpToolRegistry } from './registry.js';
 import type { SkillRegistry } from './skill-registry.js';
 
@@ -94,19 +94,21 @@ export function createMcpServer(opts: CreateMcpServerOptions): Server {
     }
 
     const startedAt = Date.now();
+    let value: unknown;
+    let thrown: unknown = null;
     try {
-      const value = await tool.handler(parseResult.data);
-      await audit.record({
-        tool: tool.meta.name,
-        args: parseResult.data,
-        result: 'ok',
-        durationMs: Date.now() - startedAt,
-      });
-      return {
-        content: [{ type: 'text' as const, text: typeof value === 'string' ? value : JSON.stringify(value) }],
-      };
+      const ctx = getCurrentContext();
+      value = await ctx.db.transaction(() => Promise.resolve(tool.handler(parseResult.data)));
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      thrown = err;
+    }
+    if (thrown !== null) {
+      const message =
+        thrown instanceof Error
+          ? thrown.message
+          : typeof thrown === 'string'
+            ? thrown
+            : JSON.stringify(thrown);
       await audit.record({
         tool: tool.meta.name,
         result: 'error',
@@ -115,6 +117,15 @@ export function createMcpServer(opts: CreateMcpServerOptions): Server {
       });
       return errorResult(message);
     }
+    await audit.record({
+      tool: tool.meta.name,
+      args: parseResult.data,
+      result: 'ok',
+      durationMs: Date.now() - startedAt,
+    });
+    return {
+      content: [{ type: 'text' as const, text: typeof value === 'string' ? value : JSON.stringify(value) }],
+    };
   });
 
   if (skills) {


### PR DESCRIPTION
Four issues surfaced in a single dev session while re-running the onboarding website import. Bundling because they form a coherent reliability story: a UX bug triggered a cascade of latent error-handling problems.

## 1. Web-import duplicates KB docs on re-run

`createPageDocument` / `createProfileDocument` in `web-import.handler.ts` were "create-with-slug → retry-without-slug". Second import of the same site:

- First call hits `kb_documents_space_slug_uq` on slug `home`.
- Retry without slug succeeds with an auto-generated slug → **second copy of every page** in the KB.

Refactored to upsert via a new shared `upsertKbDocumentBySlug` helper: `kb_get_document_by_slug` → `kb_update_document(ifVersion)` if present, else `kb_create_document(slug)`. Page slugs are deterministic from URL, so re-runs cleanly refresh content in place. `slugifyUrl` also truncates >64-char paths instead of returning `undefined`.

## 2. Audit records for failed tool calls silently lost

When a tool method threw (e.g. the slug collision above), `audit.record({ result: 'error' })` ran inside the request transaction Postgres had marked aborted (`25P02`). The audit insert failed; AuditLogger's soft-fail logger swallowed it; the row never landed. **Audit logs for exactly the calls that matter most were being dropped.**

Wrapped the tool dispatch in `ctx.db.transaction(...)`. drizzle-orm's postgres-js driver maps nested `transaction` to a `SAVEPOINT` — on handler throw, the savepoint rolls back but the outer transaction stays live, so the error-path audit insert commits. Success-path audit was already fine but now flows through the same path for consistency.

## 3. RealtimeGateway crashed the process on any DB error

```
DrizzleQueryError: Failed query: INSERT INTO conv_message_reads …
at async RealtimeGateway.handleRead (…realtime.gateway.ts:353:26)
Restarting 'src/main.ts'
```

`void this.handleRead(...)`, `void this.handleTyping(...)`, and `void this.handleUpgrade(...)` let promise rejections escape to the process-level unhandled-rejection handler — dev: tsx restart; prod: container crash. All three now `.catch` and `logger.warn`. `handleUpgrade` also calls `socket.destroy()` on failure so we don't leak the half-open socket.

## 4. Defuddle stdout spam

```
Initial parse returned very little content, trying again
Initial parse returned very little content, trying again
...
```

10+ lines per crawl, no opt-out in defuddle. Added a small `withSilencedDefuddleLogs` wrapper in `web-crawl.ts` that no-ops only this specific log line while invoking Defuddle, restoring `console.log` in `finally`. Surgical — other log output is untouched.

## Files touched

- `packages/agent-host/src/web-import.handler.ts` — upsert refactor, `slugifyUrl` truncation.
- `packages/mcp-toolkit/src/server.ts` — savepoint wrap around `tool.handler`.
- `packages/backend-core/src/realtime/realtime.gateway.ts` — `.catch` on the three WS-message dispatches.
- `packages/agent-runtime/src/web-crawl.ts` — `withSilencedDefuddleLogs`.

## Validation

- [x] Typecheck clean: `agent-runtime`, `mcp-toolkit`, `agent-host`, `backend-core`.
- [x] Lint clean (modulo a pre-existing `or` unused-import warning in `inbox.controller.ts` on main).
- [x] Unit tests: `agent-runtime` web-crawl 23/23, `backend-core` reply-history 15/15, `mcp-toolkit` registry 5/5.
- [ ] Manual: run a website import twice against the same URL, confirm KB shows one set of pages updated (not duplicated). Trigger a slug collision via MCP, confirm `audit_log` now has a row with `result='error'`. Send a malformed WS read message, confirm process stays alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)