### PR TITLE
fix: seenAt string from raw-SQL aggregate + realtime read RLS

### DIFF
--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -352,7 +352,7 @@ export class ConvService {
     const reads = ctx.db
       .select({
         messageId: schema.convMessageReads.messageId,
-        seenAt: sql<Date | null>`MIN(${schema.convMessageReads.readAt})`.as('seen_at'),
+        seenAt: sql<string | null>`MIN(${schema.convMessageReads.readAt})`.as('seen_at'),
       })
       .from(schema.convMessageReads)
       .where(eq(schema.convMessageReads.conversationId, id))
@@ -1084,7 +1084,7 @@ function toConversationSummary(
 function toMessageDto(
   row: typeof schema.convMessages.$inferSelect,
   authorNames: Map<string, string> = new Map(),
-  seenAt: Date | null = null,
+  seenAt: Date | string | null = null,
 ): MessageDto {
   return {
     id: row.id,
@@ -1097,9 +1097,16 @@ function toMessageDto(
     inReplyToId: row.inReplyToId,
     attachments: row.attachments,
     metadata: row.metadata,
-    createdAt: row.createdAt.toISOString(),
-    seenAt: seenAt ? seenAt.toISOString() : null,
+    createdAt: toIsoString(row.createdAt) ?? new Date(0).toISOString(),
+    seenAt: toIsoString(seenAt),
   };
+}
+
+function toIsoString(value: Date | string | null | undefined): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString();
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
 }
 
 function isValidSlug(slug: string): boolean {

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -460,25 +460,25 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     if (!convRow || !convRow.endUserId) return;
     if (convRow.orgId !== entry.orgId) return;
 
-    const inserted = await this.db.execute<{
-      message_id: string;
-      read_at: Date;
-    }>(sql`
-      INSERT INTO conv_message_reads (id, org_id, conversation_id, message_id, end_user_id, read_at)
-      SELECT
-        'cmr_' || encode(gen_random_bytes(16), 'hex'),
-        ${convRow.orgId},
-        ${conversationId},
-        m.id,
-        ${convRow.endUserId},
-        NOW()
-      FROM conv_messages m
-      WHERE m.id = ANY(${messageIds}::text[])
-        AND m.conversation_id = ${conversationId}
-        AND m.author_type <> 'end_user'
-      ON CONFLICT (message_id, end_user_id) DO NOTHING
-      RETURNING message_id, read_at
-    `);
+    const inserted = await this.db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.org_id', ${convRow.orgId}, true)`);
+      return tx.execute<{ message_id: string; read_at: Date }>(sql`
+        INSERT INTO conv_message_reads (id, org_id, conversation_id, message_id, end_user_id, read_at)
+        SELECT
+          'cmr_' || encode(gen_random_bytes(16), 'hex'),
+          ${convRow.orgId},
+          ${conversationId},
+          m.id,
+          ${convRow.endUserId},
+          NOW()
+        FROM conv_messages m
+        WHERE m.id = ANY(${messageIds}::text[])
+          AND m.conversation_id = ${conversationId}
+          AND m.author_type <> 'end_user'
+        ON CONFLICT (message_id, end_user_id) DO NOTHING
+        RETURNING message_id, read_at
+      `);
+    });
 
     const rows: { message_id: string; read_at: Date }[] = Array.isArray(inserted)
       ? (inserted as { message_id: string; read_at: Date }[])
@@ -758,5 +758,10 @@ function ownsEvent(event: EventRow, endUserId: string): boolean {
 }
 
 function describeError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  if (!(err instanceof Error)) return String(err);
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause instanceof Error && cause.message && cause.message !== err.message) {
+    return `${err.message} (cause: ${cause.message})`;
+  }
+  return err.message;
 }


### PR DESCRIPTION
Two backend bugs from the same dev session, found while testing the website-import + chat-widget flow against a live DB.

## 1. \`seenAt.toISOString is not a function\` on GET /api/v1/conversations/:id

\`getConversation\` uses a raw \`sql<Date | null>\\\`MIN(\${readAt})\\\`\` aggregate to fold per-message read timestamps. Postgres-js does **not** run the Drizzle column type-mapper on raw-SQL aggregates — the value comes back as an ISO string, not a Date, despite the type assertion. \`toMessageDto\` then crashes calling \`.toISOString()\` on a string.

Fix:
- Type assertion made honest: \`sql<string | null>\` on the aggregate so callers see the truth.
- \`toMessageDto\` made tolerant: \`seenAt: Date | string | null\`, normalized through a small \`toIsoString()\` helper. Applied to \`createdAt\` too for defense (typed-column path is currently Date, but the same trap waits for any future raw-SQL date that bypasses Drizzle's column mapper).

## 2. RealtimeGateway.handleRead silently failing on RLS

\`handleRead\` writes to \`conv_message_reads\` via \`this.db.execute(sql\\\`INSERT...\\\`)\`. That uses the service-role pool **without** setting any per-request tenancy GUCs, so the RLS policy on \`conv_message_reads\` rejects every insert (\`org_id = app_org_id()\`, and \`app_org_id\` is unset). We saw it as repeating \`[RealtimeGateway] handleRead failed: …\` warnings on every read receipt the chat widget tried to record.

Fix: wrap the INSERT in a transaction that calls \`set_config('app.org_id', \${convRow.orgId}, true)\` first.

**Deliberately NOT bypassing RLS** — the surrounding code already validates that the conversation belongs to the WS connection's authenticated org (line 461: \`if (convRow.orgId !== entry.orgId) return;\`). Setting \`app.org_id\` to that verified value lets RLS continue to catch any future code-path bug that would write to the wrong tenant. \`bypass_rls=on\` is genuinely needed for cross-org workers (outbound delivery, curator schedule); this path is single-org per call, so the narrower \`set_config('app.org_id', …)\` is strictly better defense-in-depth.

## 3. \`describeError\` now includes the underlying cause

When a \`DrizzleQueryError\` wraps a postgres error, \`err.message\` is the \"Failed query: …\" template — not the actual reason. The previous \`describeError\` returned only the top message, which meant the warn log hid the diagnostic (postgres code, severity, column/constraint name). Now it appends \`(cause: …)\` when the wrapped error has a distinct message. This is how I found #2 above.

## Tests

Backend integration tests need \`TEST_DATABASE_URL\`; not runnable locally without it. Typecheck + lint clean. The behavioral test plan:

- [ ] Open a conversation in the dashboard, confirm the GET succeeds (no \`seenAt.toISOString\` 500).
- [ ] Open the chat widget, send a message, confirm \`conv_message_reads\` gains rows when the agent's reply is scrolled into view.
- [ ] Check the \`audit_log\` / process logs no longer show \`handleRead failed\` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)