### PR TITLE
fix: coerce raw-SQL date results through a shared toIsoString helper

### DIFF
--- a/packages/backend-core/src/common/iso.ts
+++ b/packages/backend-core/src/common/iso.ts
@@ -1,0 +1,6 @@
+export function toIsoString(value: Date | string | null | undefined): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString();
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}

--- a/packages/backend-core/src/control/overview.controller.ts
+++ b/packages/backend-core/src/control/overview.controller.ts
@@ -7,6 +7,7 @@ import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.js';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.js';
 import { CURATION_INBOX_SLUG } from '../modules/kb/kb.service.js';
 import { RealtimeGateway } from '../realtime/realtime.gateway.js';
+import { toIsoString } from '../common/iso.js';
 
 export interface OverviewBacklog {
   conversationsNeedingAttention: number;
@@ -62,22 +63,17 @@ export class OverviewController {
     const ctx = getCurrentContext();
     const orgId = ctx.actor!.orgId;
     const [lastInbound] = await ctx.db
-      .select({ at: sql<Date | null>`max(${schema.convMessages.createdAt})` })
+      .select({ at: sql<Date | string | null>`max(${schema.convMessages.createdAt})` })
       .from(schema.convMessages)
       .where(eq(schema.convMessages.authorType, 'end_user'));
     const [lastAgent] = await ctx.db
-      .select({ at: sql<Date | null>`max(${schema.convMessages.createdAt})` })
+      .select({ at: sql<Date | string | null>`max(${schema.convMessages.createdAt})` })
       .from(schema.convMessages)
       .where(eq(schema.convMessages.authorType, 'agent'));
     return {
       selfServiceAgentSubscriberCount: this.realtime.selfServiceSubscriberCount(orgId),
-      lastInboundEndUserMessageAt: lastInbound?.at ? toIso(lastInbound.at) : null,
-      lastAgentMessageAt: lastAgent?.at ? toIso(lastAgent.at) : null,
+      lastInboundEndUserMessageAt: toIsoString(lastInbound?.at ?? null),
+      lastAgentMessageAt: toIsoString(lastAgent?.at ?? null),
     };
   }
-}
-
-function toIso(value: Date | string): string {
-  if (value instanceof Date) return value.toISOString();
-  return new Date(value).toISOString();
 }

--- a/packages/backend-core/src/control/skills.controller.ts
+++ b/packages/backend-core/src/control/skills.controller.ts
@@ -12,6 +12,7 @@ import { AuthGuard } from '../common/auth/auth.guard.js';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.js';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.js';
 import { McpSkillRegistryService } from '../mcp/mcp.skill-registry.service.js';
+import { toIsoString } from '../common/iso.js';
 
 export type SkillTier = 'fast' | 'smart';
 
@@ -40,18 +41,18 @@ export class SkillsController {
     const rows = await ctx.db.execute<{
       skill_uri: string;
       status: string;
-      done_at: Date | null;
-      updated_at: Date;
+      done_at: Date | string | null;
+      updated_at: Date | string;
     }>(sql`
       SELECT DISTINCT ON (skill_uri) skill_uri, status, done_at, updated_at
       FROM ${schema.curatorJobs}
       WHERE org_id = ${actor.orgId}
       ORDER BY skill_uri, updated_at DESC
     `);
-    const latestByUri = new Map<string, { lastRunAt: Date; status: string }>();
+    const latestByUri = new Map<string, { lastRunAt: string | null; status: string }>();
     for (const r of rows) {
       latestByUri.set(r.skill_uri, {
-        lastRunAt: r.done_at ?? r.updated_at,
+        lastRunAt: toIsoString(r.done_at ?? r.updated_at),
         status: r.status,
       });
     }
@@ -64,7 +65,7 @@ export class SkillsController {
         description: skill.description,
         audiences: skill.audiences,
         tier: tierFor(skill.uri),
-        lastRunAt: latest?.lastRunAt.toISOString() ?? null,
+        lastRunAt: latest?.lastRunAt ?? null,
         lastRunStatus: latest ? normalizeStatus(latest.status) : null,
       };
     });
@@ -95,3 +96,4 @@ function normalizeStatus(s: string): SkillDto['lastRunStatus'] {
       return null;
   }
 }
+

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -4,6 +4,7 @@ import { and, asc, desc, eq, ilike, inArray, isNotNull, isNull, notInArray, or, 
 import { getCurrentContext, WebhookDispatcher } from '@getmunin/core';
 import { CuratorJobsService } from '../curator/curator-jobs.service.js';
 import { ConversationClaimsService } from './conv.claims.service.js';
+import { toIsoString } from '../../common/iso.js';
 
 export class ConvInvalidError extends Error {
   readonly code = 'conv_invalid';
@@ -1102,12 +1103,6 @@ function toMessageDto(
   };
 }
 
-function toIsoString(value: Date | string | null | undefined): string | null {
-  if (value == null) return null;
-  if (value instanceof Date) return value.toISOString();
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
-}
 
 function isValidSlug(slug: string): boolean {
   return /^[a-z0-9][a-z0-9-]{0,63}$/.test(slug);

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -22,6 +22,7 @@ import {
 } from '@getmunin/core';
 import { randomUUID } from 'node:crypto';
 import { DB } from '../common/db/db.module.js';
+import { toIsoString } from '../common/iso.js';
 import {
   ADDITIONAL_CREDENTIAL_RESOLVERS,
   type AdditionalCredentialResolver,
@@ -462,7 +463,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
 
     const inserted = await this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.org_id', ${convRow.orgId}, true)`);
-      return tx.execute<{ message_id: string; read_at: Date }>(sql`
+      return tx.execute<{ message_id: string; read_at: Date | string }>(sql`
         INSERT INTO conv_message_reads (id, org_id, conversation_id, message_id, end_user_id, read_at)
         SELECT
           'cmr_' || encode(gen_random_bytes(16), 'hex'),
@@ -480,9 +481,9 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       `);
     });
 
-    const rows: { message_id: string; read_at: Date }[] = Array.isArray(inserted)
-      ? (inserted as { message_id: string; read_at: Date }[])
-      : ((inserted as { rows?: { message_id: string; read_at: Date }[] }).rows ?? []);
+    const rows: { message_id: string; read_at: Date | string }[] = Array.isArray(inserted)
+      ? (inserted as { message_id: string; read_at: Date | string }[])
+      : ((inserted as { rows?: { message_id: string; read_at: Date | string }[] }).rows ?? []);
     if (rows.length === 0) return;
 
     const actor = new ActorIdentity(
@@ -506,7 +507,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
               conversationId,
               messageId: row.message_id,
               endUserId: convRow.endUserId,
-              readAt: row.read_at instanceof Date ? row.read_at.toISOString() : String(row.read_at),
+              readAt: toIsoString(row.read_at),
             },
           });
         } catch (err) {


### PR DESCRIPTION
## Summary

postgres-js returns timestamp columns as strings when accessed via raw \`db.execute<{...: Date}>(sql\`...\`)\` or \`select({ at: sql<Date | null>\`max(...)\` })\` — the Drizzle column-type mapper does not run on raw SQL fragments, so the \`Date\` assertion is a runtime lie. Calling \`.toISOString()\` on the result throws \`TypeError: x.toISOString is not a function\`.

This bit us in #158 (\`seenAt\` in conversation list) and again in skills.controller (\`lastRunAt\` — Curator section spinning forever). Sweep + fix the remaining sites before they manifest.

- New shared helper \`packages/backend-core/src/common/iso.ts\` — accepts \`Date | string | null | undefined\`, returns ISO string or null.
- Honest types: \`sql<Date | string | null>\` instead of \`sql<Date | null>\` at every raw-SQL aggregate / execute site.
- Three controllers/services converted: \`skills.controller\` (was crashing), \`realtime.gateway\` (read_at webhook payload — latent), \`overview.controller\` (×2 aggregates — latent). \`conv.service\` already had a local copy from #158; hoisted to the shared helper.

## Test plan

- [x] \`pnpm -w typecheck\`
- [x] \`pnpm -w lint\`
- [ ] GET /api/v1/skills no longer 500s with \`lastRunAt.toISOString is not a function\`
- [ ] GET /api/v1/overview/agent-status returns valid ISO strings
- [ ] Conversation read-receipt webhook payload \`readAt\` serializes correctly

## Future audits

\`\`\`
rg -n 'sql<(Date|Date \\| null)>' packages
rg -n 'db\\.execute<\\{[^}]*: Date' packages
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)