### PR TITLE
refactor(curator): rename column skill_uri → job_uri

### DIFF
--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -318,14 +318,14 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     const fastModel = opts.config.fastModel;
 
     const executeOne = async (job: CuratorJob): Promise<void> => {
-      log.info(`running ${job.skillUri} for ${job.id} (attempt ${job.attempts}/${job.maxAttempts})`);
+      log.info(`running ${job.jobUri} for ${job.id} (attempt ${job.attempts}/${job.maxAttempts})`);
       let result: SkillPassResult;
       try {
         const adminKey =
           (await runWithServiceContext(this.db, opts.id, () =>
             this.repo.readDecryptedAdminKey(opts.id),
           )) ?? this.fallbackAdminApiKey ?? '';
-        const tier = tierFor(job.skillUri);
+        const tier = tierFor(job.jobUri);
         const model = tier === 'fast' ? fastModel : smartModel;
         const ctx: TaskHandlerContext = {
           job,
@@ -336,23 +336,23 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
           model,
           logger: log,
         };
-        const kind = jobKindOf(job.skillUri);
+        const kind = jobKindOf(job.jobUri);
         if (kind === 'task') {
-          const handler = TASK_HANDLERS.get(job.skillUri);
+          const handler = TASK_HANDLERS.get(job.jobUri);
           if (!handler) {
-            result = { ok: false, skipped: 'agent_error', error: `no handler for ${job.skillUri}` };
+            result = { ok: false, skipped: 'agent_error', error: `no handler for ${job.jobUri}` };
           } else {
             result = await handler(ctx);
           }
         } else if (kind === 'skill') {
-          const prefixes = toolPrefixesFor(job.skillUri);
+          const prefixes = toolPrefixesFor(job.jobUri);
           result = await runSkillPass({
             baseUrl: this.baseUrl,
             adminApiKey: adminKey,
             providerBaseUrl: opts.config.providerBaseUrl,
             providerApiKey: opts.providerApiKey,
             model,
-            skillUri: job.skillUri,
+            skillUri: job.jobUri,
             userPrompt: job.userPrompt,
             maxToolIterations: 24,
             maxHistoryChars: opts.config.maxHistoryChars,
@@ -361,7 +361,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
             logger: log,
           });
         } else {
-          result = { ok: false, skipped: 'agent_error', error: `unknown job uri scheme: ${job.skillUri}` };
+          result = { ok: false, skipped: 'agent_error', error: `unknown job uri scheme: ${job.jobUri}` };
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -47,7 +47,7 @@ export type CuratorJobStatus = 'pending' | 'done' | 'failed' | 'dead';
 export interface CuratorJob {
   id: string;
   orgId: string;
-  skillUri: string;
+  jobUri: string;
   userPrompt: string;
   sourceEventType: string | null;
   sourceEventPayload: unknown;
@@ -68,7 +68,7 @@ export interface CuratorJob {
 }
 
 export interface EnqueueCuratorJobInput {
-  skillUri: string;
+  jobUri: string;
   userPrompt: string;
   sourceEventType?: string;
   sourceEventPayload?: unknown;

--- a/packages/agent-runtime/src/realtime.test.ts
+++ b/packages/agent-runtime/src/realtime.test.ts
@@ -137,7 +137,7 @@ describe('createRealtimeClient', () => {
     const nextAttemptAt = new Date().toISOString();
     send('curator_job.pending', {
       jobId: 'cjob_xyz',
-      skillUri: 'skill://kb/curation',
+      jobUri: 'skill://kb/curation',
       dedupeKey: 'kb-curation:msg:cvm_1',
       nextAttemptAt,
     });
@@ -146,7 +146,7 @@ describe('createRealtimeClient', () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toEqual({
       jobId: 'cjob_xyz',
-      skillUri: 'skill://kb/curation',
+      jobUri: 'skill://kb/curation',
       dedupeKey: 'kb-curation:msg:cvm_1',
       nextAttemptAt,
     });

--- a/packages/agent-runtime/src/realtime.ts
+++ b/packages/agent-runtime/src/realtime.ts
@@ -23,7 +23,7 @@ export interface HandoverResolvedEvent {
 
 export interface CuratorJobPendingEvent {
   jobId: string;
-  skillUri: string;
+  jobUri: string;
   dedupeKey: string | null;
   nextAttemptAt: string;
 }
@@ -174,12 +174,12 @@ export function createRealtimeClient(opts: RealtimeClientOptions): RealtimeClien
 
         if (opts.onCuratorJobPending && eventType === 'curator_job.pending') {
           const jobId = payload['jobId'];
-          const skillUri = payload['skillUri'];
+          const jobUri = payload['jobUri'];
           const nextAttemptAt = payload['nextAttemptAt'];
-          if (typeof jobId !== 'string' || typeof skillUri !== 'string') return;
+          if (typeof jobId !== 'string' || typeof jobUri !== 'string') return;
           opts.onCuratorJobPending({
             jobId,
-            skillUri,
+            jobUri,
             dedupeKey: typeof payload['dedupeKey'] === 'string' ? payload['dedupeKey'] : null,
             nextAttemptAt: typeof nextAttemptAt === 'string' ? nextAttemptAt : new Date().toISOString(),
           });

--- a/packages/backend-core/src/control/curator-jobs.controller.ts
+++ b/packages/backend-core/src/control/curator-jobs.controller.ts
@@ -23,7 +23,7 @@ import {
 const StatusSchema = z.enum(CURATOR_JOB_STATUSES);
 
 const EnqueueBody = z.object({
-  skillUri: z.string().min(1),
+  jobUri: z.string().min(1),
   userPrompt: z.string().min(1),
   sourceEventType: z.string().optional(),
   sourceEventPayload: z.unknown().optional(),

--- a/packages/backend-core/src/control/skills.controller.ts
+++ b/packages/backend-core/src/control/skills.controller.ts
@@ -45,19 +45,19 @@ export class SkillsController {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     const rows = await ctx.db.execute<{
-      skill_uri: string;
+      job_uri: string;
       status: string;
       done_at: Date | string | null;
       updated_at: Date | string;
     }>(sql`
-      SELECT DISTINCT ON (skill_uri) skill_uri, status, done_at, updated_at
+      SELECT DISTINCT ON (job_uri) job_uri, status, done_at, updated_at
       FROM ${schema.curatorJobs}
       WHERE org_id = ${actor.orgId}
-      ORDER BY skill_uri, updated_at DESC
+      ORDER BY job_uri, updated_at DESC
     `);
     const latestByUri = new Map<string, { lastRunAt: string | null; status: string }>();
     for (const r of rows) {
-      latestByUri.set(r.skill_uri, {
+      latestByUri.set(r.job_uri, {
         lastRunAt: toIsoString(r.done_at ?? r.updated_at),
         status: r.status,
       });

--- a/packages/backend-core/src/modules/conv/conv.service.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.test.ts
@@ -416,10 +416,10 @@ const skipReason = TEST_URL
     it('changeStatus to closed enqueues a CRM contact-extract curator job', async () => {
       const conv = await seedConv();
       await run(() => svc.changeStatus({ id: conv.id, status: 'closed' }));
-      const rows = await db.execute<{ skill_uri: string; dedupe_key: string | null }>(
-        sql`SELECT skill_uri, dedupe_key FROM curator_jobs WHERE org_id = ${orgId}`,
+      const rows = await db.execute<{ job_uri: string; dedupe_key: string | null }>(
+        sql`SELECT job_uri, dedupe_key FROM curator_jobs WHERE org_id = ${orgId}`,
       );
-      const extractJob = rows.find((r) => r.skill_uri === 'skill://crm/contact-extract');
+      const extractJob = rows.find((r) => r.job_uri === 'skill://crm/contact-extract');
       expect(extractJob).toBeDefined();
       expect(extractJob!.dedupe_key).toBe(`crm-contact-extract:conv:${conv.id}`);
     });
@@ -468,8 +468,8 @@ const skipReason = TEST_URL
           authorId: 'eu_test',
         }),
       );
-      const rows = await db.execute<{ skill_uri: string; dedupe_key: string | null }>(
-        sql`SELECT skill_uri, dedupe_key FROM curator_jobs WHERE org_id = ${orgId} AND skill_uri = 'skill://outreach/draft-reply'`,
+      const rows = await db.execute<{ job_uri: string; dedupe_key: string | null }>(
+        sql`SELECT job_uri, dedupe_key FROM curator_jobs WHERE org_id = ${orgId} AND job_uri = 'skill://outreach/draft-reply'`,
       );
       expect(rows.length).toBe(1);
       expect(rows[0]!.dedupe_key).toMatch(/^outreach-draft-reply:msg:cvm_/);
@@ -485,8 +485,8 @@ const skipReason = TEST_URL
           authorId: 'eu_test',
         }),
       );
-      const rows = await db.execute<{ skill_uri: string }>(
-        sql`SELECT skill_uri FROM curator_jobs WHERE org_id = ${orgId} AND skill_uri = 'skill://outreach/draft-reply'`,
+      const rows = await db.execute<{ job_uri: string }>(
+        sql`SELECT job_uri FROM curator_jobs WHERE org_id = ${orgId} AND job_uri = 'skill://outreach/draft-reply'`,
       );
       expect(rows.length).toBe(0);
     });
@@ -500,10 +500,10 @@ const skipReason = TEST_URL
           snoozeUntil: new Date(Date.now() + 60_000).toISOString(),
         }),
       );
-      const rows = await db.execute<{ skill_uri: string }>(
-        sql`SELECT skill_uri FROM curator_jobs WHERE org_id = ${orgId}`,
+      const rows = await db.execute<{ job_uri: string }>(
+        sql`SELECT job_uri FROM curator_jobs WHERE org_id = ${orgId}`,
       );
-      expect(rows.find((r) => r.skill_uri === 'skill://crm/contact-extract')).toBeUndefined();
+      expect(rows.find((r) => r.job_uri === 'skill://crm/contact-extract')).toBeUndefined();
     });
 
     it('changeStatus snoozed requires snoozeUntil', async () => {

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -617,7 +617,7 @@ export class ConvService {
         conv.agentMode === 'draft_only'
       ) {
         await this.curatorJobs.enqueue({
-          skillUri: 'skill://outreach/draft-reply',
+          jobUri: 'skill://outreach/draft-reply',
           userPrompt:
             `Run an outreach reply-draft pass for conversation ${input.conversationId}. ` +
             `Follow skill://outreach/draft-reply exactly. Read the thread, identify the prospect's ` +
@@ -643,7 +643,7 @@ export class ConvService {
           },
         });
         await this.curatorJobs.enqueue({
-          skillUri: 'skill://kb/curation',
+          jobUri: 'skill://kb/curation',
           userPrompt:
             `Run a KB curation pass for conversation ${input.conversationId}. ` +
             `Follow the skill exactly. Per-conversation mode: skip the conv_list_conversations ` +
@@ -834,7 +834,7 @@ export class ConvService {
     });
     if (input.status === 'closed') {
       await this.curatorJobs.enqueue({
-        skillUri: 'skill://crm/contact-extract',
+        jobUri: 'skill://crm/contact-extract',
         userPrompt:
           `Run a CRM contact-extraction pass for conversation ${input.id}. ` +
           `Follow the skill exactly: read the conversation, extract identifying info ` +

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -387,7 +387,7 @@ export class EmailAdapter implements ChannelAdapter {
 
         if (!regexCutSignature && cleanText && cleanText.length >= 80) {
           await this.curatorJobs.enqueue({
-            skillUri: 'skill://conv/strip-email-signature',
+            jobUri: 'skill://conv/strip-email-signature',
             userPrompt:
               `Run the signature-stripping skill on this inbound email message.\n\n` +
               `Message ID: ${msg!.id}\n` +

--- a/packages/backend-core/src/modules/curator/curator-jobs.service.ts
+++ b/packages/backend-core/src/modules/curator/curator-jobs.service.ts
@@ -11,7 +11,7 @@ const BACKOFF_BASE_MS = 30_000;
 export interface CuratorJobDto {
   id: string;
   orgId: string;
-  skillUri: string;
+  jobUri: string;
   userPrompt: string;
   sourceEventType: string | null;
   sourceEventPayload: unknown;
@@ -32,7 +32,7 @@ export interface CuratorJobDto {
 }
 
 export interface EnqueueInput {
-  skillUri: string;
+  jobUri: string;
   userPrompt: string;
   sourceEventType?: string;
   sourceEventPayload?: unknown;
@@ -72,8 +72,8 @@ export class CuratorJobsService {
   ) {}
 
   async enqueue(input: EnqueueInput): Promise<EnqueueResult> {
-    if (!input.skillUri.startsWith('skill://') && !input.skillUri.startsWith('task://')) {
-      throw new BadRequestException('skillUri must start with skill:// or task://');
+    if (!input.jobUri.startsWith('skill://') && !input.jobUri.startsWith('task://')) {
+      throw new BadRequestException('jobUri must start with skill:// or task://');
     }
     if (!input.userPrompt.trim()) {
       throw new BadRequestException('userPrompt is required');
@@ -89,7 +89,7 @@ export class CuratorJobsService {
           .insert(schema.curatorJobs)
           .values({
             orgId: ctx.actor!.orgId,
-            skillUri: input.skillUri,
+            jobUri: input.jobUri,
             userPrompt: input.userPrompt,
             sourceEventType: input.sourceEventType ?? null,
             sourceEventPayload: input.sourceEventPayload ?? null,
@@ -128,7 +128,7 @@ export class CuratorJobsService {
       type: 'curator_job.pending',
       payload: {
         jobId: row.id,
-        skillUri: row.skillUri,
+        jobUri: row.jobUri,
         dedupeKey: row.dedupeKey,
         nextAttemptAt: toIso(row.nextAttemptAt),
       },
@@ -221,7 +221,7 @@ export class CuratorJobsService {
         type: 'curator_job.pending',
         payload: {
           jobId: row.id,
-          skillUri: row.skillUri,
+          jobUri: row.jobUri,
           dedupeKey: row.dedupeKey,
           nextAttemptAt: toIso(row.nextAttemptAt),
         },
@@ -280,7 +280,7 @@ function toDto(row: Row): CuratorJobDto {
   return {
     id: row.id,
     orgId: row.orgId,
-    skillUri: row.skillUri,
+    jobUri: row.jobUri,
     userPrompt: row.userPrompt,
     sourceEventType: row.sourceEventType,
     sourceEventPayload: row.sourceEventPayload ?? null,
@@ -319,7 +319,7 @@ function rowFromSql(raw: Record<string, unknown>): Row {
   return {
     id: raw.id as string,
     orgId: raw.org_id as string,
-    skillUri: raw.skill_uri as string,
+    jobUri: raw.job_uri as string,
     userPrompt: raw.user_prompt as string,
     sourceEventType: (raw.source_event_type as string | null) ?? null,
     sourceEventPayload: raw.source_event_payload ?? null,

--- a/packages/backend-core/src/modules/curator/curator-scheduler.service.ts
+++ b/packages/backend-core/src/modules/curator/curator-scheduler.service.ts
@@ -21,7 +21,7 @@ interface SweepDef {
   name: string;
   envCron: string | undefined;
   defaultCron: string;
-  skillUri: string;
+  jobUri: string;
   userPrompt: string;
   dedupeKey: string;
 }
@@ -50,7 +50,7 @@ export class CuratorSchedulerService implements OnModuleInit {
         name: 'curator-kb-sweep',
         envCron: process.env.MUNIN_CURATOR_KB_SWEEP_CRON,
         defaultCron: CronExpression.EVERY_WEEK,
-        skillUri: 'skill://kb/curation',
+        jobUri: 'skill://kb/curation',
         userPrompt: KB_SWEEP_PROMPT,
         dedupeKey: 'kb-sweep:scheduled',
       },
@@ -58,7 +58,7 @@ export class CuratorSchedulerService implements OnModuleInit {
         name: 'curator-crm-hygiene',
         envCron: process.env.MUNIN_CURATOR_CRM_HYGIENE_CRON,
         defaultCron: CronExpression.EVERY_WEEK,
-        skillUri: 'skill://crm/hygiene',
+        jobUri: 'skill://crm/hygiene',
         userPrompt: CRM_HYGIENE_PROMPT,
         dedupeKey: 'crm-hygiene:scheduled',
       },
@@ -66,7 +66,7 @@ export class CuratorSchedulerService implements OnModuleInit {
         name: 'curator-cms-stale',
         envCron: process.env.MUNIN_CURATOR_CMS_STALE_CRON,
         defaultCron: CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT,
-        skillUri: 'skill://cms/stale-content-review',
+        jobUri: 'skill://cms/stale-content-review',
         userPrompt: CMS_STALE_PROMPT,
         dedupeKey: 'cms-stale:scheduled',
       },
@@ -74,7 +74,7 @@ export class CuratorSchedulerService implements OnModuleInit {
         name: 'curator-outreach-draft-initial',
         envCron: process.env.MUNIN_CURATOR_OUTREACH_INITIAL_CRON,
         defaultCron: CronExpression.EVERY_WEEK,
-        skillUri: 'skill://outreach/draft-initial',
+        jobUri: 'skill://outreach/draft-initial',
         userPrompt: OUTREACH_DRAFT_INITIAL_PROMPT,
         dedupeKey: 'outreach-draft-initial:scheduled',
       },
@@ -121,7 +121,7 @@ export class CuratorSchedulerService implements OnModuleInit {
       const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
       await RequestContextStore.run(ctx, async () => {
         const result = await this.jobs.enqueue({
-          skillUri: sweep.skillUri,
+          jobUri: sweep.jobUri,
           userPrompt: sweep.userPrompt,
           sourceEventType: `scheduler.${sweep.name}`,
           dedupeKey: sweep.dedupeKey,

--- a/packages/dashboard-pages/src/components/agent-config/website-import-card.tsx
+++ b/packages/dashboard-pages/src/components/agent-config/website-import-card.tsx
@@ -52,7 +52,7 @@ export function WebsiteImportCard({ onEnqueued, onSkip, onBack }: WebsiteImportC
       const res = await api<EnqueueResponse>('/api/v1/curation/jobs', {
         method: 'POST',
         body: JSON.stringify({
-          skillUri: JOB_URI,
+          jobUri: JOB_URI,
           userPrompt: normalized,
           dedupeKey: `onboarding-import:${normalized}`,
           maxAttempts: 3,

--- a/packages/db/drizzle/0023_curator_jobs_rename_skill_uri.sql
+++ b/packages/db/drizzle/0023_curator_jobs_rename_skill_uri.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "curator_jobs" RENAME COLUMN "skill_uri" TO "job_uri";

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1779300000000,
       "tag": "0022_curator_jobs_web_task_uri",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1779400000000,
+      "tag": "0023_curator_jobs_rename_skill_uri",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1434,12 +1434,11 @@ export const cmsReferences = pgTable(
 );
 
 // ───────────────────────────── Curator jobs ──────────────────────────
-// Persistent queue for curator skill passes. The bundled in-process
+// Persistent queue for curator background jobs. The bundled in-process
 // runner (or any admin-authenticated runner) claims pending rows via
-// SELECT … FOR UPDATE SKIP LOCKED, runs the skill, and acks/fails.
-// Survives restarts; provides at-least-once delivery of (skillUri,
-// userPrompt) work that originated from a backend event
-// (handover_resolved → KB curation) or a scheduled sweep enqueue.
+// SELECT … FOR UPDATE SKIP LOCKED, runs the job, and acks/fails.
+// `job_uri` is the dispatch key — `skill://...` for LLM-driven
+// markdown skills, `task://...` for code-defined deterministic tasks.
 export const curatorJobs = pgTable(
   'curator_jobs',
   {
@@ -1447,7 +1446,7 @@ export const curatorJobs = pgTable(
     orgId: text('org_id')
       .notNull()
       .references(() => orgs.id, { onDelete: 'cascade' }),
-    skillUri: text('skill_uri').notNull(),
+    jobUri: text('job_uri').notNull(),
     userPrompt: text('user_prompt').notNull(),
     sourceEventType: text('source_event_type'),
     sourceEventPayload: jsonb('source_event_payload'),


### PR DESCRIPTION
## Why

Follow-up to #160. That PR added a \`task://\` scheme so \`curator_jobs\` can dispatch both LLM-driven markdown skills and code-defined deterministic tasks. But the column was still named \`skill_uri\`, holding values like \`task://web/scrape-site\`. This rename completes the cleanup so the schema matches the concept: the column is a *dispatch key*, not necessarily a skill URI.

## What

- \`packages/db/src/schema.ts\` — column renamed.
- **Migration 0023** — \`ALTER TABLE curator_jobs RENAME COLUMN skill_uri TO job_uri\`.
- TS field renamed at every enqueue / dispatch site:
  - \`CuratorJobDto\` / \`EnqueueInput\` / \`EnqueueCuratorJobInput\` / \`CuratorJob\`
  - \`CuratorJobPendingEvent\` webhook payload (incl. realtime client parser)
  - \`SweepDef\` in \`curator-scheduler.service.ts\`
  - Raw-SQL column aliases in \`skills.controller.ts\` + \`conv.service.test.ts\`
  - REST POST body field (\`curator-jobs.controller.ts\` zod schema + dashboard \`website-import-card.tsx\`)

## What stays \`skillUri\`

\`SkillPassOptions.skillUri\` in \`@getmunin/agent-runtime\`. That function loads a markdown skill from the MCP server and only accepts \`skill://\` URIs — renaming it would conflate the dispatch key (any URI) with the skill-loader input (strictly \`skill://\`).

## Stacked on

This branch is based on #160 (\`refactor/curator-job-vs-skill\`). When that merges, retarget to \`main\`.

## Test plan

- [x] \`pnpm -w typecheck\` (24/24)
- [x] \`pnpm -w lint\` (only pre-existing warning in \`inbox.controller.ts\`)
- [x] Unit tests across \`@getmunin/types\`, \`@getmunin/agent-runtime\`, \`@getmunin/agent-host\` — all pass
- [x] Applied \`ALTER TABLE\` locally. Confirmed the SkillsController-shaped query returns 4 rows against the renamed column.
- [ ] After merge: end-to-end via \`/dashboard/settings/assistants\` — the Background section should load with last-run timestamps unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)