### PR TITLE
refactor(skills): unify job registry; tasks come from .md too

### DIFF
--- a/packages/backend-core/src/control/skills.controller.ts
+++ b/packages/backend-core/src/control/skills.controller.ts
@@ -10,7 +10,7 @@ import { sql } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
 import {
   KNOWN_SKILL_URIS,
-  KNOWN_TASK_URIS,
+  jobKindOf,
   tierFor,
   type JobKind,
   type ModelTier,
@@ -64,46 +64,33 @@ export class SkillsController {
     }
 
     const dtos: SkillDto[] = [];
-    for (const skill of this.registry.list('admin')) {
-      if (!KNOWN_SKILL_URIS.has(skill.uri)) continue;
-      const latest = latestByUri.get(skill.uri);
+    for (const entry of this.registry.list('admin')) {
+      const kind = jobKindOf(entry.uri);
+      if (kind === 'skill' && !KNOWN_SKILL_URIS.has(entry.uri)) continue;
+      if (!kind) continue;
+      const latest = latestByUri.get(entry.uri);
       dtos.push({
-        uri: skill.uri,
-        kind: 'skill',
-        name: skill.name,
-        description: skill.description,
-        audiences: skill.audiences,
-        tier: tierFor(skill.uri),
+        uri: entry.uri,
+        kind,
+        name: entry.name,
+        description: firstSentence(entry.description),
+        audiences: entry.audiences,
+        tier: tierFor(entry.uri),
         lastRunAt: latest?.lastRunAt ?? null,
         lastRunStatus: latest ? normalizeStatus(latest.status) : null,
       });
     }
-    for (const uri of KNOWN_TASK_URIS) {
-      const meta = TASK_METADATA[uri];
-      if (!meta) continue;
-      const latest = latestByUri.get(uri);
-      dtos.push({
-        uri,
-        kind: 'task',
-        name: meta.name,
-        description: meta.description,
-        audiences: ['admin'],
-        tier: tierFor(uri),
-        lastRunAt: latest?.lastRunAt ?? null,
-        lastRunStatus: latest ? normalizeStatus(latest.status) : null,
-      });
-    }
+    dtos.sort((a, b) => a.name.localeCompare(b.name));
     return dtos;
   }
 }
 
-const TASK_METADATA: Record<string, { name: string; description: string }> = {
-  'task://web/scrape-site': {
-    name: 'Website import',
-    description:
-      "Crawl a customer's public website, populate the KB with per-page docs, and synthesize a company-profile document.",
-  },
-};
+function firstSentence(description: string): string {
+  const trimmed = description.trim();
+  if (!trimmed) return '';
+  const match = /^.+?[.!?](?=\s|$)/.exec(trimmed);
+  return (match ? match[0] : trimmed).trim();
+}
 
 function normalizeStatus(s: string): SkillDto['lastRunStatus'] {
   switch (s) {

--- a/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
+++ b/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
@@ -16,7 +16,9 @@ export class McpSkillRegistryService extends SkillRegistry implements OnModuleIn
     for (const skill of loadSkills(sources)) {
       this.register(skill);
     }
-    this.cachedInstructions = buildInstructions(this.list('admin'));
+    this.cachedInstructions = buildInstructions(
+      this.list('admin').filter((s) => s.uri.startsWith('skill://')),
+    );
   }
 
   instructions(): string {

--- a/packages/backend-core/src/mcp/skill-loader.ts
+++ b/packages/backend-core/src/mcp/skill-loader.ts
@@ -81,8 +81,10 @@ function parseSkill(file: string, src: SkillSource): RegisteredSkill | null {
   const body = raw.slice(match[0].length);
   const slug = basename(file, '.md');
   const moduleSegment = deriveModule(file, src);
-  const uri = `skill://${moduleSegment}/${slug}`;
+  const scheme = fm.kind === 'task' ? 'task' : 'skill';
+  const uri = `${scheme}://${moduleSegment}/${slug}`;
   const audiences = normalizeAudiences(fm.audiences ?? fm.audience);
+  const publicDefault = scheme === 'skill';
   return {
     uri,
     name: typeof fm.title === 'string' && fm.title ? fm.title : slug,
@@ -90,7 +92,10 @@ function parseSkill(file: string, src: SkillSource): RegisteredSkill | null {
     audiences,
     mimeType: typeof fm.mimeType === 'string' ? fm.mimeType : 'text/markdown',
     content: body.trimStart(),
-    public: fm.public === undefined ? true : fm.public !== false && fm.public !== 'false',
+    public:
+      fm.public === undefined
+        ? publicDefault
+        : fm.public !== false && fm.public !== 'false',
   };
 }
 

--- a/packages/backend-core/src/modules/web/skills/scrape-site.md
+++ b/packages/backend-core/src/modules/web/skills/scrape-site.md
@@ -1,0 +1,6 @@
+---
+kind: task
+title: Website import
+description: Crawls a customer's public website, populates the KB with one document per page, and synthesizes a company-profile document for the chat widget. Runs on a deterministic crawl pipeline with a single LLM call at the end for the profile.
+audiences: [admin]
+---

--- a/packages/dashboard-pages/src/components/assistants/chat-assistant-card.tsx
+++ b/packages/dashboard-pages/src/components/assistants/chat-assistant-card.tsx
@@ -33,7 +33,7 @@ export function ChatAssistantCard({ assistant }: ChatAssistantCardProps) {
               <CardDescription className="mt-1">{t('description')}</CardDescription>
             </div>
             <span className="font-mono text-xs uppercase tracking-eyebrow text-muted-foreground">
-              {t('tierLabel', { tier: 'smart' })}
+              {t('tierLabel', { tier: 'fast' })}
             </span>
           </div>
         </CardHeader>

--- a/packages/mcp-toolkit/src/server.ts
+++ b/packages/mcp-toolkit/src/server.ts
@@ -130,13 +130,16 @@ export function createMcpServer(opts: CreateMcpServerOptions): Server {
 
   if (skills) {
     server.setRequestHandler(ListResourcesRequestSchema, () => ({
-      resources: skills.list(audience).map((s) => ({
-        uri: s.uri,
-        name: s.name,
-        description: s.description,
-        mimeType: s.mimeType,
-        annotations: { audience: ['assistant'] as const, priority: 0.9 },
-      })),
+      resources: skills
+        .list(audience)
+        .filter((s) => s.uri.startsWith('skill://'))
+        .map((s) => ({
+          uri: s.uri,
+          name: s.name,
+          description: s.description,
+          mimeType: s.mimeType,
+          annotations: { audience: ['assistant'] as const, priority: 0.9 },
+        })),
     }));
 
     server.setRequestHandler(ReadResourceRequestSchema, (req) => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -20,7 +20,6 @@ export {
 } from './channels.js';
 export {
   KNOWN_SKILL_URIS,
-  KNOWN_TASK_URIS,
   WEB_SCRAPE_SITE_TASK_URI,
   jobKindOf,
   tierFor,

--- a/packages/types/src/job-catalog.test.ts
+++ b/packages/types/src/job-catalog.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
   KNOWN_SKILL_URIS,
-  KNOWN_TASK_URIS,
   jobKindOf,
   tierFor,
   toolPrefixesFor,
@@ -43,9 +42,8 @@ describe('toolPrefixesFor', () => {
   });
 });
 
-describe('known URI sets', () => {
-  it('separates skill vs task URIs by scheme', () => {
+describe('KNOWN_SKILL_URIS', () => {
+  it('only contains skill:// URIs', () => {
     for (const uri of KNOWN_SKILL_URIS) expect(uri.startsWith('skill://')).toBe(true);
-    for (const uri of KNOWN_TASK_URIS) expect(uri.startsWith('task://')).toBe(true);
   });
 });

--- a/packages/types/src/job-catalog.ts
+++ b/packages/types/src/job-catalog.ts
@@ -17,10 +17,6 @@ export const KNOWN_SKILL_URIS: ReadonlySet<string> = new Set([
   'skill://conv/strip-email-signature',
 ]);
 
-export const KNOWN_TASK_URIS: ReadonlySet<string> = new Set([
-  'task://web/scrape-site',
-]);
-
 export const WEB_SCRAPE_SITE_TASK_URI = 'task://web/scrape-site';
 
 const TIER_BY_URI: ReadonlyMap<string, ModelTier> = new Map([


### PR DESCRIPTION
## Why

\`SkillsController\` was carrying two registries: skills (from \`.md\` frontmatter, loaded by \`skill-loader.ts\`) and tasks (a hardcoded \`TASK_METADATA\` map in the controller). Same shape of data, two sources of truth. Adding a new task meant editing TS + the allowlist; adding a skill was just a file. Asymmetric.

## What

Unified onto the .md-loader path:

- **\`skill-loader.ts\`** now parses a \`kind:\` frontmatter field. \`kind: task\` → URI scheme \`task://\`, and \`public: false\` by default so the entry never appears in MCP \`resources/list\`.
- **\`packages/backend-core/src/modules/web/skills/scrape-site.md\`** (new) — frontmatter only, no body. The task's metadata now lives next to skills.
- **\`mcp-toolkit/server.ts\` + \`mcp.skill-registry.service.ts\`** — both filter by \`uri.startsWith('skill://')\` when listing resources/instructions for the LLM. Tasks are invisible to agents (they can't invoke them anyway — they're code-driven).
- **\`SkillsController\`** — dropped the separate task loop and \`TASK_METADATA\`. Single iteration over \`registry.list('admin')\`, partitioned by \`jobKindOf(uri)\`. Description trimmed to first sentence server-side, so the UI shows tight one-liners while the full text stays in the \`.md\` for the LLM.
- **\`@getmunin/types/job-catalog.ts\`** — \`KNOWN_TASK_URIS\` dropped (registry is the source). \`WEB_SCRAPE_SITE_TASK_URI\` stays (handler dispatch key + dashboard payload).
- **\`chat-assistant-card.tsx\`** — fix hardcoded \"smart\" → \"fast\". \`runner.service.ts:248\` always passes \`config.fastModel\` to the chat handler; the card was lying.
- **Sort** — cards now alphabetical by name in both UI sections.

## Adding future tasks

Drop a \`.md\` with \`kind: task\` frontmatter, register the handler in agent-host's \`TASK_HANDLERS\` map. No controller changes, no allowlist edits.

## Test plan

- [x] \`pnpm -w typecheck\` (24/24)
- [x] \`pnpm -w lint\` (only the pre-existing \`inbox.controller.ts\` warning)
- [x] \`pnpm --filter @getmunin/types test\` — 8/8
- [x] \`pnpm --filter @getmunin/agent-runtime test\` — 96/96
- [x] Smoke-tested the loader against the new .md — returns \`{ uri: 'task://web/scrape-site', name: 'Website import', public: false, audiences: ['admin'] }\`
- [ ] CI to confirm backend-core integration tests (can't run locally — DB perms)
- [ ] After merge: \`/dashboard/settings/assistants\` shows alphabetically sorted cards, chat assistant shows FAST, descriptions one line each, Website import description matches the new .md frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)