### PR TITLE
feat(conv): email unread widget messages after a quiet period

### DIFF
--- a/packages/backend-core/src/modules/conv/conv.module.ts
+++ b/packages/backend-core/src/modules/conv/conv.module.ts
@@ -13,6 +13,7 @@ import { OutboundDeliveryWorker } from './channels/outbound-delivery.worker.js';
 import { WidgetAdapter } from './widget/widget-adapter.js';
 import { WidgetIngestService } from './widget/widget-ingest.service.js';
 import { WidgetController } from './widget/widget.controller.js';
+import { WidgetEmailFallbackWorker } from './widget/widget-email-fallback.worker.js';
 import { WidgetAdminTools } from './widget/widget.tools.js';
 
 @Module({
@@ -29,6 +30,7 @@ import { WidgetAdminTools } from './widget/widget.tools.js';
     InboundPollWorker,
     OutboundDeliveryWorker,
     WidgetAdapter,
+    WidgetEmailFallbackWorker,
     WidgetIngestService,
     WidgetAdminTools,
     {
@@ -45,6 +47,7 @@ import { WidgetAdminTools } from './widget/widget.tools.js';
     EmailAdminTools,
     WidgetAdapter,
     WidgetAdminTools,
+    WidgetEmailFallbackWorker,
     InboundPollWorker,
     OutboundDeliveryWorker,
     CHANNEL_ADAPTERS,

--- a/packages/backend-core/src/modules/conv/widget/widget-email-fallback.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-email-fallback.integration.test.ts
@@ -1,0 +1,259 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import type { StubMailer } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql, eq } from 'drizzle-orm';
+import { AppModule } from '../../../app.module.js';
+import { MAILER } from '../../../common/mail/mail.module.js';
+import { WidgetEmailFallbackWorker } from './widget-email-fallback.worker.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run widget fallback integration tests.';
+
+const REPLY_DOMAIN = 'reply.example.test';
+
+(skipReason ? describe.skip : describe)('Widget → email fallback worker', () => {
+  let app: INestApplication;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let widgetChannelId: string;
+  let emailChannelId: string;
+  let endUserId: string;
+  let contactId: string;
+  let worker: WidgetEmailFallbackWorker;
+  let mailer: StubMailer;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_ENCRYPTION_KEY ??= 'integration-test-encryption-key';
+    process.env.MUNIN_EMAIL_REPLY_DOMAIN = REPLY_DOMAIN;
+    process.env.MUNIN_WIDGET_EMAIL_FALLBACK_THRESHOLD_MS = '0';
+
+    await runMigrations(TEST_URL!);
+
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const ts = Date.now();
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Fallback IT', slug: `wfb-it-${ts}` })
+      .returning();
+    orgId = org!.id;
+
+    const [widget] = await db
+      .insert(schema.convChannels)
+      .values({ orgId, type: 'chat', name: 'Widget', active: true, config: {} })
+      .returning();
+    widgetChannelId = widget!.id;
+
+    const [email] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'email',
+        name: 'Acme Support',
+        active: true,
+        config: {
+          addressing: { fromAddress: 'support@acme.test', fromName: 'Acme Support' },
+          outbound: { provider: 'mailer' },
+        },
+      })
+      .returning();
+    emailChannelId = email!.id;
+
+    const [eu] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, email: 'visitor@customer.test', name: 'Visitor One' })
+      .returning();
+    endUserId = eu!.id;
+
+    const [c] = await db
+      .insert(schema.convContacts)
+      .values({ orgId, endUserId, email: 'visitor@customer.test', name: 'Visitor One' })
+      .returning();
+    contactId = c!.id;
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.init();
+
+    worker = app.get(WidgetEmailFallbackWorker);
+    mailer = app.get<StubMailer>(MAILER);
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  beforeEach(async () => {
+    mailer.clear();
+    await db.delete(schema.convWidgetEmailFallbacks).where(eq(schema.convWidgetEmailFallbacks.orgId, orgId));
+    await db.delete(schema.convMessageDeliveries).where(eq(schema.convMessageDeliveries.orgId, orgId));
+    await db.delete(schema.convMessageReads).where(eq(schema.convMessageReads.orgId, orgId));
+    await db.delete(schema.convMessages).where(eq(schema.convMessages.orgId, orgId));
+    await db.delete(schema.convConversations).where(eq(schema.convConversations.orgId, orgId));
+  });
+
+  async function newConv(subject = 'Hello'): Promise<string> {
+    const rows = await db.execute<{ next: number } & Record<string, unknown>>(
+      sql`SELECT conv_next_display_id(${orgId}) AS next`,
+    );
+    const list = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);
+    const displayId = (list[0] as { next: number }).next;
+    const [conv] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        channelId: widgetChannelId,
+        contactId,
+        endUserId,
+        displayId,
+        subject,
+        lastMessageAt: new Date(),
+      })
+      .returning();
+    return conv!.id;
+  }
+
+  async function insertMsg(
+    convId: string,
+    authorType: 'end_user' | 'agent',
+    body: string,
+    ageMs = 30_000,
+  ): Promise<string> {
+    const createdAt = new Date(Date.now() - ageMs);
+    const [m] = await db
+      .insert(schema.convMessages)
+      .values({
+        orgId,
+        conversationId: convId,
+        authorType,
+        authorId: authorType === 'end_user' ? contactId : 'system',
+        body,
+        createdAt,
+      })
+      .returning();
+    return m!.id;
+  }
+
+  it('sends a digest when an agent message is unread and writes a delivery row for threading', async () => {
+    const convId = await newConv('Login help');
+    await insertMsg(convId, 'end_user', 'Hi, I need help.', 60_000);
+    const agentMsgId = await insertMsg(convId, 'agent', 'Sure — what are you stuck on?', 30_000);
+
+    const result = await worker.tick();
+    expect(result.sent).toBe(1);
+
+    expect(mailer.outbox).toHaveLength(1);
+    const sent = mailer.outbox[0]!;
+    expect(sent.to).toBe('visitor@customer.test');
+    expect(sent.from).toContain('support@acme.test');
+    expect(sent.text).toContain('Sure — what are you stuck on?');
+    expect(sent.replyTo).toBe(`support+conv-${convId}@${REPLY_DOMAIN}`);
+    const stamped = sent.headers?.['Message-ID'];
+    expect(stamped).toMatch(/^<[^<>]+@acme\.test>$/);
+
+    const fallbacks = await db
+      .select()
+      .from(schema.convWidgetEmailFallbacks)
+      .where(eq(schema.convWidgetEmailFallbacks.conversationId, convId));
+    expect(fallbacks).toHaveLength(1);
+    expect(fallbacks[0]!.status).toBe('sent');
+    expect(fallbacks[0]!.messageIdHeader).toBeTruthy();
+    expect(fallbacks[0]!.triggerMessageId).toBe(agentMsgId);
+    expect(fallbacks[0]!.messageCount).toBe(1);
+
+    const deliveries = await db
+      .select()
+      .from(schema.convMessageDeliveries)
+      .where(eq(schema.convMessageDeliveries.messageId, agentMsgId));
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]!.channelId).toBe(emailChannelId);
+    expect(deliveries[0]!.status).toBe('sent');
+    expect(deliveries[0]!.messageIdHeader).toBe(fallbacks[0]!.messageIdHeader);
+  });
+
+  it('bundles multiple unread agent messages into one digest with N delivery rows', async () => {
+    const convId = await newConv();
+    await insertMsg(convId, 'end_user', 'Hi.', 90_000);
+    const m1 = await insertMsg(convId, 'agent', 'First reply.', 60_000);
+    const m2 = await insertMsg(convId, 'agent', 'And a follow-up.', 30_000);
+
+    const result = await worker.tick();
+    expect(result.sent).toBe(1);
+
+    expect(mailer.outbox).toHaveLength(1);
+    expect(mailer.outbox[0]!.text).toContain('First reply.');
+    expect(mailer.outbox[0]!.text).toContain('And a follow-up.');
+
+    const fb = (
+      await db.select().from(schema.convWidgetEmailFallbacks).where(eq(schema.convWidgetEmailFallbacks.conversationId, convId))
+    )[0]!;
+    expect(fb.messageCount).toBe(2);
+
+    const deliveries = await db
+      .select()
+      .from(schema.convMessageDeliveries)
+      .where(eq(schema.convMessageDeliveries.channelId, emailChannelId));
+    expect(deliveries.map((d) => d.messageId).sort()).toEqual([m1, m2].sort());
+  });
+
+  it('does not fire a second time in the same quiet period', async () => {
+    const convId = await newConv();
+    await insertMsg(convId, 'end_user', 'Hi.', 90_000);
+    await insertMsg(convId, 'agent', 'Reply.', 30_000);
+
+    const r1 = await worker.tick();
+    expect(r1.sent).toBe(1);
+    const r2 = await worker.tick();
+    expect(r2.sent).toBe(0);
+    expect(mailer.outbox).toHaveLength(1);
+  });
+
+  it('does not fire when the end-user has already read the agent message', async () => {
+    const convId = await newConv();
+    await insertMsg(convId, 'end_user', 'Hi.', 90_000);
+    const agentMsgId = await insertMsg(convId, 'agent', 'Reply.', 30_000);
+
+    await db.insert(schema.convMessageReads).values({
+      orgId,
+      conversationId: convId,
+      messageId: agentMsgId,
+      endUserId,
+    });
+
+    const r = await worker.tick();
+    expect(r.sent).toBe(0);
+    expect(mailer.outbox).toHaveLength(0);
+  });
+
+  it('fires again once the end-user engages (resetting the quiet period)', async () => {
+    const convId = await newConv();
+    await insertMsg(convId, 'end_user', 'Hi.', 120_000);
+    await insertMsg(convId, 'agent', 'First reply.', 60_000);
+
+    const r1 = await worker.tick();
+    expect(r1.sent).toBe(1);
+
+    await insertMsg(convId, 'end_user', 'Sorry — back now. Still stuck.', 0);
+    await insertMsg(convId, 'agent', 'No worries — try X.', 0);
+
+    const r2 = await worker.tick();
+    expect(r2.sent).toBe(1);
+    expect(mailer.outbox).toHaveLength(2);
+  });
+});

--- a/packages/backend-core/src/modules/conv/widget/widget-email-fallback.worker.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-email-fallback.worker.ts
@@ -1,0 +1,460 @@
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { schema, type Db } from '@getmunin/db';
+import { and, eq, sql } from 'drizzle-orm';
+import { createTransport, type Transporter } from 'nodemailer';
+import { type Mailer } from '@getmunin/core';
+import { DB } from '../../../common/db/db.module.js';
+import { MAILER } from '../../../common/mail/mail.module.js';
+import { EmailService, jsonbToStored, type StoredEmailChannelConfig } from '../email/email.service.js';
+import { smtpTransportOptions } from '../email/email.tools.js';
+import { buildOutbound, type BuiltMessage } from '../email/mime.js';
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const DEFAULT_THRESHOLD_MS = 10 * 60_000;
+const CANDIDATE_BATCH_SIZE = 50;
+
+type CandidateRow = {
+  conversation_id: string;
+  org_id: string;
+  end_user_id: string;
+  email_channel_id: string;
+  end_user_email: string;
+  end_user_name: string | null;
+  conv_created_at: Date | string;
+  conv_subject: string | null;
+} & Record<string, unknown>;
+
+type UnreadRow = {
+  id: string;
+  body: string;
+  body_html: string | null;
+  author_type: string;
+  created_at: Date | string;
+} & Record<string, unknown>;
+
+@Injectable()
+export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WidgetEmailFallbackWorker.name);
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private readonly disabled =
+    process.env.MUNIN_WIDGET_EMAIL_FALLBACK_DISABLED === '1' ||
+    process.env.NODE_ENV === 'test';
+  private readonly intervalMs = Number(
+    process.env.MUNIN_WIDGET_EMAIL_FALLBACK_INTERVAL_MS ?? DEFAULT_INTERVAL_MS,
+  );
+  private readonly thresholdMs = Number(
+    process.env.MUNIN_WIDGET_EMAIL_FALLBACK_THRESHOLD_MS ?? DEFAULT_THRESHOLD_MS,
+  );
+
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(MAILER) private readonly mailer: Mailer,
+    @Inject(EmailService) private readonly emailService: EmailService,
+  ) {}
+
+  onModuleInit(): void {
+    if (this.disabled) return;
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.intervalMs);
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async tick(): Promise<{ scanned: number; sent: number; skipped: number; failed: number }> {
+    if (this.running) return { scanned: 0, sent: 0, skipped: 0, failed: 0 };
+    this.running = true;
+    try {
+      return await this.sweep();
+    } catch (err) {
+      this.logger.warn(`sweep failed: ${describeError(err)}`);
+      return { scanned: 0, sent: 0, skipped: 0, failed: 0 };
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async sweep(): Promise<{
+    scanned: number;
+    sent: number;
+    skipped: number;
+    failed: number;
+  }> {
+    const cutoff = new Date(Date.now() - this.thresholdMs);
+    const candidates = await this.findCandidates(cutoff);
+
+    let sent = 0;
+    let skipped = 0;
+    let failed = 0;
+    for (const cand of candidates) {
+      try {
+        const outcome = await this.processOne(cand);
+        if (outcome === 'sent') sent += 1;
+        else if (outcome === 'skipped') skipped += 1;
+        else failed += 1;
+      } catch (err) {
+        failed += 1;
+        this.logger.warn(
+          `fallback for conversation ${cand.conversation_id} failed: ${describeError(err)}`,
+        );
+      }
+    }
+    return { scanned: candidates.length, sent, skipped, failed };
+  }
+
+  private async findCandidates(cutoff: Date): Promise<CandidateRow[]> {
+    const rows = await this.db.execute<CandidateRow>(sql`
+      SELECT
+        c.id AS conversation_id,
+        c.org_id,
+        c.end_user_id,
+        ec.id AS email_channel_id,
+        eu.email AS end_user_email,
+        eu.name AS end_user_name,
+        c.created_at AS conv_created_at,
+        c.subject AS conv_subject
+      FROM conv_conversations c
+      JOIN conv_channels ch ON ch.id = c.channel_id
+      JOIN end_users eu ON eu.id = c.end_user_id
+      JOIN LATERAL (
+        SELECT id FROM conv_channels
+        WHERE org_id = c.org_id
+          AND type = 'email'
+          AND active = true
+          AND archived_at IS NULL
+        ORDER BY created_at ASC
+        LIMIT 1
+      ) ec ON TRUE
+      WHERE ch.type = 'chat'
+        AND c.end_user_id IS NOT NULL
+        AND eu.email IS NOT NULL
+        AND eu.email <> ''
+        AND EXISTS (
+          SELECT 1 FROM conv_messages m
+          WHERE m.conversation_id = c.id
+            AND m.author_type <> 'end_user'
+            AND m.internal = false
+            AND m.created_at < ${cutoff.toISOString()}::timestamptz
+            AND NOT EXISTS (
+              SELECT 1 FROM conv_message_reads r
+              WHERE r.message_id = m.id AND r.end_user_id = c.end_user_id
+            )
+        )
+      ORDER BY c.last_message_at ASC NULLS LAST
+      LIMIT ${CANDIDATE_BATCH_SIZE}
+    `);
+    return toArray(rows);
+  }
+
+  private async processOne(cand: CandidateRow): Promise<'sent' | 'skipped' | 'failed'> {
+    const engagement = await this.computeLastEngagement(cand);
+    const unread = await this.loadUnread(cand.conversation_id, cand.end_user_id);
+    if (unread.length === 0) return 'skipped';
+    const trigger = unread[0]!;
+
+    const claimed = await this.db
+      .insert(schema.convWidgetEmailFallbacks)
+      .values({
+        orgId: cand.org_id,
+        conversationId: cand.conversation_id,
+        endUserId: cand.end_user_id,
+        emailChannelId: cand.email_channel_id,
+        triggerMessageId: trigger.id,
+        lastEngagementAt: engagement,
+        messageCount: unread.length,
+        status: 'queued',
+      })
+      .onConflictDoNothing({
+        target: [
+          schema.convWidgetEmailFallbacks.conversationId,
+          schema.convWidgetEmailFallbacks.lastEngagementAt,
+        ],
+      })
+      .returning({ id: schema.convWidgetEmailFallbacks.id });
+    const fallbackId = claimed[0]?.id;
+    if (!fallbackId) return 'skipped';
+
+    const stillUnread = await this.loadUnread(cand.conversation_id, cand.end_user_id);
+    if (stillUnread.length === 0) {
+      await this.markStatus(fallbackId, 'cancelled', null);
+      return 'skipped';
+    }
+
+    const channel = await this.loadEmailChannel(cand.email_channel_id);
+    if (!channel) {
+      await this.markStatus(fallbackId, 'failed', 'email channel missing');
+      return 'failed';
+    }
+    let config: StoredEmailChannelConfig;
+    try {
+      config = jsonbToStored(channel.config);
+    } catch (err) {
+      await this.markStatus(fallbackId, 'failed', `invalid email channel config: ${describeError(err)}`);
+      return 'failed';
+    }
+
+    const replyTo = this.composeReplyTo(config, cand.conversation_id);
+    let built: BuiltMessage;
+    try {
+      built = this.buildDigest({
+        config,
+        replyTo,
+        subject: cand.conv_subject,
+        recipientEmail: cand.end_user_email,
+        recipientName: cand.end_user_name,
+        unread: stillUnread,
+      });
+    } catch (err) {
+      await this.markStatus(fallbackId, 'failed', `digest build failed: ${describeError(err)}`);
+      return 'failed';
+    }
+
+    try {
+      await this.send(config, cand.end_user_email, replyTo, built);
+    } catch (err) {
+      await this.markStatus(fallbackId, 'failed', describeError(err));
+      return 'failed';
+    }
+
+    await this.db.transaction(async (tx) => {
+      await tx
+        .update(schema.convWidgetEmailFallbacks)
+        .set({
+          status: 'sent',
+          sentAt: new Date(),
+          messageIdHeader: built.messageId,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.convWidgetEmailFallbacks.id, fallbackId));
+
+      const deliveryRows = stillUnread.map((m) => ({
+        orgId: cand.org_id,
+        messageId: m.id,
+        channelId: cand.email_channel_id,
+        status: 'sent',
+        attempt: 1,
+        sentAt: new Date(),
+        messageIdHeader: built.messageId,
+      }));
+      if (deliveryRows.length > 0) {
+        await tx.insert(schema.convMessageDeliveries).values(deliveryRows);
+      }
+    });
+
+    return 'sent';
+  }
+
+  private async computeLastEngagement(cand: CandidateRow): Promise<Date> {
+    const rows = await this.db.execute<{ engagement_at: Date | string } & Record<string, unknown>>(sql`
+      SELECT GREATEST(
+        ${asTimestamp(cand.conv_created_at)},
+        COALESCE((
+          SELECT MAX(m.created_at) FROM conv_messages m
+          WHERE m.conversation_id = ${cand.conversation_id}
+            AND m.author_type = 'end_user'
+        ), ${asTimestamp(cand.conv_created_at)}),
+        COALESCE((
+          SELECT MAX(r.read_at) FROM conv_message_reads r
+          WHERE r.conversation_id = ${cand.conversation_id}
+            AND r.end_user_id = ${cand.end_user_id}
+        ), ${asTimestamp(cand.conv_created_at)})
+      ) AS engagement_at
+    `);
+    const row = toArray<{ engagement_at: Date | string }>(rows)[0];
+    if (!row) return toDate(cand.conv_created_at);
+    return toDate(row.engagement_at);
+  }
+
+  private async loadUnread(conversationId: string, endUserId: string): Promise<UnreadRow[]> {
+    const cutoff = new Date(Date.now() - this.thresholdMs);
+    const rows = await this.db.execute<UnreadRow>(sql`
+      SELECT m.id, m.body, m.body_html, m.author_type, m.created_at
+      FROM conv_messages m
+      WHERE m.conversation_id = ${conversationId}
+        AND m.author_type <> 'end_user'
+        AND m.internal = false
+        AND m.created_at < ${cutoff.toISOString()}::timestamptz
+        AND NOT EXISTS (
+          SELECT 1 FROM conv_message_reads r
+          WHERE r.message_id = m.id AND r.end_user_id = ${endUserId}
+        )
+      ORDER BY m.created_at ASC
+    `);
+    return toArray(rows);
+  }
+
+  private async loadEmailChannel(
+    channelId: string,
+  ): Promise<typeof schema.convChannels.$inferSelect | null> {
+    const rows = await this.db
+      .select()
+      .from(schema.convChannels)
+      .where(
+        and(
+          eq(schema.convChannels.id, channelId),
+          eq(schema.convChannels.active, true),
+        ),
+      )
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  private async markStatus(
+    fallbackId: string,
+    status: 'failed' | 'cancelled',
+    error: string | null,
+  ): Promise<void> {
+    await this.db
+      .update(schema.convWidgetEmailFallbacks)
+      .set({ status, error, updatedAt: new Date() })
+      .where(eq(schema.convWidgetEmailFallbacks.id, fallbackId));
+  }
+
+  private buildDigest(params: {
+    config: StoredEmailChannelConfig;
+    replyTo: string | undefined;
+    subject: string | null;
+    recipientEmail: string;
+    recipientName: string | null;
+    unread: UnreadRow[];
+  }): BuiltMessage {
+    const { config, replyTo, recipientEmail, recipientName, unread } = params;
+    const fromName = (config.addressing.fromName ?? '').trim() || 'Support';
+    const subjectBase = params.subject?.trim() || `New message from ${fromName}`;
+    const subject = unread.length > 1 ? `${subjectBase} (${unread.length} new messages)` : subjectBase;
+
+    const textParts: string[] = [];
+    textParts.push(
+      recipientName
+        ? `Hi ${recipientName.split(/\s+/)[0]},`
+        : 'Hi,',
+    );
+    textParts.push('');
+    textParts.push(
+      unread.length === 1
+        ? `${fromName} sent you a message you haven't seen yet:`
+        : `${fromName} sent you ${unread.length} messages you haven't seen yet:`,
+    );
+    textParts.push('');
+    for (const m of unread) {
+      textParts.push(stripHtml(m.body).trim() || '(no message)');
+      textParts.push('');
+    }
+    textParts.push('—');
+    textParts.push('Reply to this email to continue the conversation.');
+    const text = textParts.join('\n');
+
+    return buildOutbound({
+      from: composeFrom(config.addressing.fromName, config.addressing.fromAddress),
+      to: composeFrom(recipientName ?? undefined, recipientEmail),
+      replyTo,
+      subject,
+      text,
+      messageIdDomain: config.addressing.fromAddress,
+    });
+  }
+
+  private composeReplyTo(
+    config: StoredEmailChannelConfig,
+    conversationId: string,
+  ): string | undefined {
+    if (config.addressing.replyToTemplate) {
+      return config.addressing.replyToTemplate.replace('{conversationId}', conversationId);
+    }
+    const replyDomain = process.env.MUNIN_EMAIL_REPLY_DOMAIN;
+    if (!replyDomain) return undefined;
+    const local = config.addressing.fromAddress.split('@')[0] ?? 'support';
+    return `${local}+conv-${conversationId}@${replyDomain}`;
+  }
+
+  private async send(
+    config: StoredEmailChannelConfig,
+    recipient: string,
+    replyTo: string | undefined,
+    built: BuiltMessage,
+  ): Promise<void> {
+    if (config.outbound.provider === 'smtp') {
+      const password = await this.db.transaction((tx) =>
+        this.emailService.decryptSmtpPassword(
+          tx,
+          config.outbound.provider === 'smtp' ? config.outbound.encryptedPassword : '',
+        ),
+      );
+      const transport: Transporter = createTransport(
+        smtpTransportOptions(
+          config.outbound.host,
+          config.outbound.port,
+          config.outbound.secure,
+          { user: config.outbound.username, pass: password },
+        ),
+      );
+      try {
+        await transport.sendMail({
+          envelope: { from: config.addressing.fromAddress, to: recipient },
+          raw: built.raw,
+        });
+      } finally {
+        transport.close();
+      }
+    } else {
+      await this.mailer.send({
+        from: composeFrom(config.addressing.fromName, config.addressing.fromAddress),
+        to: recipient,
+        subject: extractSubject(built.raw) ?? 'New message',
+        text: extractTextBody(built.raw),
+        replyTo,
+        headers: { 'Message-ID': `<${built.messageId}>` },
+      });
+    }
+  }
+}
+
+function composeFrom(name: string | undefined, address: string): string {
+  if (!name) return address;
+  const clean = name.replace(/[",\r\n]/g, '').trim();
+  return `${clean} <${address}>`;
+}
+
+function stripHtml(input: string): string {
+  return input
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function toArray<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  const rows = (result as { rows?: unknown[] }).rows;
+  return Array.isArray(rows) ? (rows as T[]) : [];
+}
+
+function toDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+function asTimestamp(value: Date | string): ReturnType<typeof sql> {
+  const iso = (value instanceof Date ? value : new Date(value)).toISOString();
+  return sql`${iso}::timestamptz`;
+}
+
+function extractSubject(raw: string): string | null {
+  const m = raw.match(/^Subject:\s*(.+)$/m);
+  return m?.[1]?.trim() ?? null;
+}
+
+function extractTextBody(raw: string): string {
+  const split = raw.indexOf('\r\n\r\n');
+  if (split < 0) return '';
+  return raw.slice(split + 4);
+}
+

--- a/packages/db/drizzle/0024_widget_email_fallbacks.sql
+++ b/packages/db/drizzle/0024_widget_email_fallbacks.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "conv_widget_email_fallbacks" (
+  "id" text PRIMARY KEY NOT NULL,
+  "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+  "conversation_id" text NOT NULL REFERENCES "conv_conversations"("id") ON DELETE CASCADE,
+  "end_user_id" text NOT NULL REFERENCES "end_users"("id") ON DELETE CASCADE,
+  "email_channel_id" text NOT NULL REFERENCES "conv_channels"("id") ON DELETE CASCADE,
+  "trigger_message_id" text NOT NULL REFERENCES "conv_messages"("id") ON DELETE CASCADE,
+  "last_engagement_at" timestamptz NOT NULL,
+  "message_id_header" text,
+  "message_count" integer NOT NULL,
+  "status" varchar(16) NOT NULL DEFAULT 'queued',
+  "error" text,
+  "sent_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "conv_widget_email_fallbacks_conv_engagement_uq"
+  ON "conv_widget_email_fallbacks" ("conversation_id", "last_engagement_at");
+CREATE INDEX IF NOT EXISTS "conv_widget_email_fallbacks_org_idx"
+  ON "conv_widget_email_fallbacks" ("org_id");
+CREATE INDEX IF NOT EXISTS "conv_widget_email_fallbacks_status_idx"
+  ON "conv_widget_email_fallbacks" ("status");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1779400000000,
       "tag": "0023_curator_jobs_rename_skill_uri",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1779500000000,
+      "tag": "0024_widget_email_fallbacks",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -948,6 +948,51 @@ export const convMessageReads = pgTable(
   }),
 );
 
+// Ledger for widget→email fallback sends. When an agent message on a widget
+// conversation is unread by the end-user for the fallback threshold, the
+// sweeper claims a row here (unique on conversation_id + last_engagement_at,
+// so at most one fallback fires per "quiet period"), composes a digest of
+// all unread agent messages, and emails it. Replies thread back through
+// `conv_message_deliveries.message_id_header` written by the sweeper.
+export const convWidgetEmailFallbacks = pgTable(
+  'conv_widget_email_fallbacks',
+  {
+    id: id('cwf'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    conversationId: text('conversation_id')
+      .notNull()
+      .references(() => convConversations.id, { onDelete: 'cascade' }),
+    endUserId: text('end_user_id')
+      .notNull()
+      .references(() => endUsers.id, { onDelete: 'cascade' }),
+    emailChannelId: text('email_channel_id')
+      .notNull()
+      .references(() => convChannels.id, { onDelete: 'cascade' }),
+    triggerMessageId: text('trigger_message_id')
+      .notNull()
+      .references(() => convMessages.id, { onDelete: 'cascade' }),
+    lastEngagementAt: timestamp('last_engagement_at', { withTimezone: true }).notNull(),
+    messageIdHeader: text('message_id_header'),
+    messageCount: integer('message_count').notNull(),
+    status: varchar('status', { length: 16 }).notNull().default('queued'),
+    // 'queued' | 'sent' | 'failed' | 'cancelled'
+    error: text('error'),
+    sentAt: timestamp('sent_at', { withTimezone: true }),
+    createdAt,
+    updatedAt,
+  },
+  (t) => ({
+    convEngagementUq: uniqueIndex('conv_widget_email_fallbacks_conv_engagement_uq').on(
+      t.conversationId,
+      t.lastEngagementAt,
+    ),
+    orgIdx: index('conv_widget_email_fallbacks_org_idx').on(t.orgId),
+    statusIdx: index('conv_widget_email_fallbacks_status_idx').on(t.status),
+  }),
+);
+
 // One row per poll-mode channel for inbound bookkeeping. `cursor` is the
 // adapter-specific high-water mark (email: { lastUid }; future SMS-poll
 // or other adapters use whatever shape they need). RLS inherits from the
@@ -1610,6 +1655,7 @@ export const allTables = {
   convMessages,
   convMessageDeliveries,
   convMessageReads,
+  convWidgetEmailFallbacks,
   convInboundState,
   crmCompanies,
   crmContacts,


### PR DESCRIPTION
## Summary

- Adds a sweeper that finds widget conversations where an agent message has been unread by the end-user past a ~10 min threshold and emails the batched unread tail via the org's existing email channel.
- Replies thread back into the **same** conversation via the existing inbound matcher (In-Reply-To against the stamped `Message-ID`, or `+conv-<id>` plus-address on Reply-To). No new inbound pipeline required.
- One fallback per quiet period: unique `(conversation_id, last_engagement_at)` on the ledger collapses concurrent sweeps to a single send. Any end-user activity — widget read, widget reply, or inbound email reply — opens a new quiet period and re-enables the fallback.

## Design notes

- **Engagement** = `MAX(conv.created_at, last end_user message, last conv_message_reads.read_at)`. Inbound email replies create an `end_user` `conv_messages` row, so engagement resets symmetrically across channels.
- **Cross-channel without forking the conversation**: conversation stays bound to the widget channel; the sweeper writes one `conv_message_deliveries` row per bundled message against the email channel, carrying the stamped `Message-ID`. That's the same key `email/threading.ts` already uses to match inbound replies.
- **Cancel in-flight**: the sweeper re-loads unread messages after the claim insert; if the end-user read them in the meantime, the row is marked `cancelled` and no email goes out.
- **Org gating**: no users yet, so this is on by default for any org with an active email channel. Orgs without one are skipped silently.

## Knobs

- `MUNIN_WIDGET_EMAIL_FALLBACK_INTERVAL_MS` (default 60_000)
- `MUNIN_WIDGET_EMAIL_FALLBACK_THRESHOLD_MS` (default 600_000)
- `MUNIN_WIDGET_EMAIL_FALLBACK_DISABLED=1` to turn off (also off when `NODE_ENV=test`)

## Test plan

- [ ] Run the new `widget-email-fallback.integration.test.ts` against a Postgres with migration privileges (covers happy path, multi-message digest, idempotent re-tick, no-fire-after-read, re-fire after engagement).
- [ ] Manual: send an agent message via widget, leave it unread 10+ min, confirm an email arrives at the visitor's address with the bundled body and `Reply-To: …+conv-<id>@…`.
- [ ] Manual: reply to that email; confirm the reply lands as an `end_user` `conv_messages` row on the **same** conversation.
- [ ] Manual: trigger a second agent message right after the reply, leave unread, confirm a fresh fallback fires (engagement reset worked).

## Follow-ups intentionally out of scope

- HTML digest body (text-only for now).
- Per-org/per-channel toggle (deferred until there are users with strong preferences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)