### PR TITLE
feat(conv,widget): personal email fallback, working read receipts, launcher unread badge

### DIFF
--- a/apps/chat-widget/src/api.ts
+++ b/apps/chat-widget/src/api.ts
@@ -39,6 +39,7 @@ export interface ListedMessage {
   body: string;
   bodyHtml: string | null;
   at: string;
+  readAt: string | null;
 }
 
 export interface ConversationEnvelope {

--- a/apps/chat-widget/src/styles.ts
+++ b/apps/chat-widget/src/styles.ts
@@ -48,6 +48,7 @@ button {
 
 /* ─── Launcher ───────────────────────────────────────── */
 .launcher {
+  position: relative;
   width: 60px;
   height: 60px;
   border-radius: 50%;
@@ -74,19 +75,22 @@ button {
   position: absolute;
   top: -2px;
   right: -2px;
-  min-width: 20px;
-  height: 20px;
-  padding: 0 6px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  box-sizing: border-box;
   border-radius: 999px;
   background: var(--munin-theme);
   color: #fff;
   font-family: var(--munin-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
+  line-height: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border: 2px solid var(--munin-bone);
+  pointer-events: none;
 }
 
 /* ─── Panel ──────────────────────────────────────────── */

--- a/apps/chat-widget/src/ui.test.ts
+++ b/apps/chat-widget/src/ui.test.ts
@@ -52,6 +52,7 @@ function msg(partial: Partial<ListedMessage> & { id: string; role: ListedMessage
     authorName: partial.role === 'agent' ? 'Munin' : null,
     bodyHtml: null,
     at: '2026-01-01T00:00:00Z',
+    readAt: null,
     ...partial,
   };
 }
@@ -93,6 +94,34 @@ describe('ui: mount + lifecycle', () => {
     controller.destroy();
     controller = null;
     expect(document.querySelector('[data-munin-widget]')).toBeNull();
+  });
+});
+
+describe('ui: launcher unread badge', () => {
+  beforeEach(() => {
+    controller = mount(baseConfig, strings, { onSend: () => {}, onTypingIntent: () => {} });
+  });
+
+  it('hides the badge by default', () => {
+    expect(($('.launcher-badge') as HTMLElement).hidden).toBe(true);
+  });
+
+  it('shows the count when setLauncherUnread is called with a positive number', () => {
+    controller!.setLauncherUnread(3);
+    const badge = $('.launcher-badge') as HTMLElement;
+    expect(badge.hidden).toBe(false);
+    expect(badge.textContent).toBe('3');
+  });
+
+  it('caps the displayed count at 9+', () => {
+    controller!.setLauncherUnread(42);
+    expect($('.launcher-badge').textContent).toBe('9+');
+  });
+
+  it('hides the badge again when count drops to 0', () => {
+    controller!.setLauncherUnread(2);
+    controller!.setLauncherUnread(0);
+    expect(($('.launcher-badge') as HTMLElement).hidden).toBe(true);
   });
 });
 
@@ -226,8 +255,8 @@ describe('ui: addMessages', () => {
 
   it('tags agent messages with the human/AI chip', () => {
     controller!.addMessages([
-      { id: 'm1', role: 'agent', body: 'hi', bodyHtml: null, at: '2026-01-01T00:00:00Z', authorKind: 'ai', authorName: 'Munin' },
-      { id: 'm2', role: 'agent', body: 'taking over', bodyHtml: null, at: '2026-01-01T00:00:01Z', authorKind: 'human', authorName: 'Maja' },
+      { id: 'm1', role: 'agent', body: 'hi', bodyHtml: null, at: '2026-01-01T00:00:00Z', authorKind: 'ai', authorName: 'Munin', readAt: null },
+      { id: 'm2', role: 'agent', body: 'taking over', bodyHtml: null, at: '2026-01-01T00:00:01Z', authorKind: 'human', authorName: 'Maja', readAt: null },
     ]);
     const heads = $$('.msg-head');
     const labels = heads.map((h) => h.textContent ?? '');

--- a/apps/chat-widget/src/ui.test.ts
+++ b/apps/chat-widget/src/ui.test.ts
@@ -103,12 +103,12 @@ describe('ui: launcher unread badge', () => {
   });
 
   it('hides the badge by default', () => {
-    expect(($('.launcher-badge') as HTMLElement).hidden).toBe(true);
+    expect($('.launcher-badge').hidden).toBe(true);
   });
 
   it('shows the count when setLauncherUnread is called with a positive number', () => {
     controller!.setLauncherUnread(3);
-    const badge = $('.launcher-badge') as HTMLElement;
+    const badge = $('.launcher-badge');
     expect(badge.hidden).toBe(false);
     expect(badge.textContent).toBe('3');
   });
@@ -121,7 +121,7 @@ describe('ui: launcher unread badge', () => {
   it('hides the badge again when count drops to 0', () => {
     controller!.setLauncherUnread(2);
     controller!.setLauncherUnread(0);
-    expect(($('.launcher-badge') as HTMLElement).hidden).toBe(true);
+    expect($('.launcher-badge').hidden).toBe(true);
   });
 });
 

--- a/apps/chat-widget/src/ui.ts
+++ b/apps/chat-widget/src/ui.ts
@@ -29,6 +29,7 @@ export interface UiController {
   setSending(sending: boolean): void;
   setPastConversations(convs: ConversationSummary[]): void;
   setConversation(envelope: ConversationEnvelope | null): void;
+  setLauncherUnread(count: number): void;
   showEmailCard(): void;
   setEmailSaved(email: string): void;
   setView(view: 'welcome' | 'chat'): void;
@@ -61,7 +62,7 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
   root.style.setProperty('--munin-theme', config.themeColor);
   shadow.appendChild(root);
 
-  const launcher = renderLauncher(strings);
+  const { btn: launcher, badge: launcherBadge } = renderLauncher(strings);
   const panel = renderPanel(config, strings);
   root.append(launcher, panel.el);
   panel.el.hidden = true;
@@ -336,6 +337,16 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
   setPastConversations([]);
   paintChatHead();
 
+  function setLauncherUnread(count: number): void {
+    if (count <= 0) {
+      launcherBadge.hidden = true;
+      launcherBadge.textContent = '';
+      return;
+    }
+    launcherBadge.hidden = false;
+    launcherBadge.textContent = count > 9 ? '9+' : String(count);
+  }
+
   return {
     addMessages,
     setAgentTyping,
@@ -343,6 +354,7 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
     setSending,
     setPastConversations,
     setConversation,
+    setLauncherUnread,
     showEmailCard,
     setEmailSaved,
     setView,
@@ -536,7 +548,7 @@ function renderEmailCardDone(strings: Strings, email: string): HTMLDivElement {
   return card;
 }
 
-function renderLauncher(strings: Strings): HTMLButtonElement {
+function renderLauncher(strings: Strings): { btn: HTMLButtonElement; badge: HTMLSpanElement } {
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'launcher';
@@ -544,7 +556,11 @@ function renderLauncher(strings: Strings): HTMLButtonElement {
   btn.innerHTML =
     '<svg viewBox="0 0 24 24" aria-hidden="true" stroke-linecap="round" stroke-linejoin="round">' +
     '<path d="M7.9 20A9 9 0 1 0 4 16.1L2 22z" /></svg>';
-  return btn;
+  const badge = document.createElement('span');
+  badge.className = 'launcher-badge';
+  badge.hidden = true;
+  btn.appendChild(badge);
+  return { btn, badge };
 }
 
 interface PanelHandles {

--- a/apps/chat-widget/src/widget.ts
+++ b/apps/chat-widget/src/widget.ts
@@ -6,7 +6,7 @@ import {
   mintNewSession,
   setCurrentSession,
 } from './session.js';
-import { createApiClient, WidgetApiError, type ConversationSummary } from './api.js';
+import { createApiClient, WidgetApiError, type ConversationSummary, type ListedMessage } from './api.js';
 import { createRealtimeClient, type IncomingTyping } from './realtime.js';
 import { mount, type UiController } from './ui.js';
 import { pickLocale } from './strings/index.js';
@@ -61,6 +61,29 @@ function start(config: WidgetConfig): void {
   let agentTurnsThisSession = 0;
   let visitorHasEmail = !!config.visitor?.email;
   let emailCardShown = false;
+  const messagesById = new Map<string, ListedMessage>();
+  const locallyRead = new Set<string>();
+
+  function recordMessages(messages: ListedMessage[]): void {
+    for (const m of messages) messagesById.set(m.id, m);
+    refreshUnreadBadge();
+  }
+
+  function markLocallyRead(messageId: string): void {
+    locallyRead.add(messageId);
+    refreshUnreadBadge();
+  }
+
+  function refreshUnreadBadge(): void {
+    let n = 0;
+    for (const m of messagesById.values()) {
+      if (m.role !== 'agent') continue;
+      if (m.readAt) continue;
+      if (locallyRead.has(m.id)) continue;
+      n += 1;
+    }
+    ui.setLauncherUnread(n);
+  }
 
   async function backfill(): Promise<void> {
     if (backfillInFlight) {
@@ -74,6 +97,7 @@ function start(config: WidgetConfig): void {
         const res = await api.backfillSince(lastSeenAt);
         if (res.messages.length > 0) {
           ui.addMessages(res.messages);
+          recordMessages(res.messages);
           for (const m of res.messages) {
             if (m.role === 'agent') {
               agentTurnsThisSession += 1;
@@ -197,6 +221,7 @@ function start(config: WidgetConfig): void {
     },
     onMessageRead(messageId) {
       realtime.sendRead([messageId]);
+      markLocallyRead(messageId);
     },
   });
 

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import {
   ActorIdentity,
   WebhookDispatcher,
@@ -29,11 +29,11 @@ import {
   detectSignatureBlock,
   ensureReSubject,
   formatQuotedHistory,
+  loadPriorMessagesForQuote,
   splitSignatureText,
   stripQuotedReplyHtml,
   stripQuotedReplyText,
   stripSignatureHtml,
-  type QuotedPriorMessage,
 } from './reply-history.js';
 import { classifySender, hasAnyClassification } from './classify-sender.js';
 import type {
@@ -138,7 +138,15 @@ export class EmailAdapter implements ChannelAdapter {
     const recipient = ctx.contact?.email ?? extractToFromMetadata(ctx.message.metadata);
     if (!recipient) throw new Error('no recipient on conversation contact');
 
-    const prior = await this.loadPriorMessagesForQuote(ctx, 3);
+    const channelFromName = config.addressing.fromName?.trim() || 'Support';
+    const prior = await loadPriorMessagesForQuote(this.db, {
+      conversationId: ctx.conversation.id,
+      excludeMessageId: ctx.message.id,
+      contactName: ctx.contact?.name?.trim() || null,
+      contactEmail: ctx.contact?.email ?? null,
+      channelFromName,
+      limit: 3,
+    });
     const quoted = formatQuotedHistory(prior, 3);
     const body = quoted ? `${ctx.message.body}\n\n${quoted}` : ctx.message.body;
 
@@ -191,49 +199,6 @@ export class EmailAdapter implements ChannelAdapter {
     }
 
     return { providerMessageId: built.messageId };
-  }
-
-  private async loadPriorMessagesForQuote(
-    ctx: SendContext,
-    limit: number,
-  ): Promise<QuotedPriorMessage[]> {
-    const contactName = ctx.contact?.name?.trim() || null;
-    const contactEmail = ctx.contact?.email ?? null;
-    const channelFromName = (() => {
-      const cfg = jsonbToStored(ctx.channel.config);
-      return cfg.addressing.fromName?.trim() || 'Support';
-    })();
-
-    return this.db.transaction(async (tx) => {
-      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
-      const rows = await tx
-        .select({
-          id: schema.convMessages.id,
-          authorType: schema.convMessages.authorType,
-          body: schema.convMessages.body,
-          createdAt: schema.convMessages.createdAt,
-        })
-        .from(schema.convMessages)
-        .where(
-          and(
-            eq(schema.convMessages.conversationId, ctx.conversation.id),
-            eq(schema.convMessages.internal, false),
-            sql`${schema.convMessages.id} <> ${ctx.message.id}`,
-          ),
-        )
-        .orderBy(desc(schema.convMessages.createdAt))
-        .limit(limit);
-
-      return rows.map((r) => {
-        const isContact = r.authorType === 'end_user';
-        return {
-          authorName: isContact ? contactName ?? 'User' : channelFromName,
-          authorEmail: isContact ? contactEmail : null,
-          createdAt: r.createdAt instanceof Date ? r.createdAt : new Date(r.createdAt),
-          body: r.body,
-        };
-      });
-    });
   }
 
   // ─── inbound poll ───────────────────────────────────────────────────────

--- a/packages/backend-core/src/modules/conv/email/reply-history.ts
+++ b/packages/backend-core/src/modules/conv/email/reply-history.ts
@@ -1,3 +1,6 @@
+import { schema, type Db } from '@getmunin/db';
+import { and, desc, eq, sql } from 'drizzle-orm';
+
 const QUOTE_HEADER_PATTERNS: RegExp[] = [
   /^on .+ wrote:\s*$/i,
   /^op .+ schreef .+:\s*$/i,
@@ -219,6 +222,47 @@ export interface QuotedPriorMessage {
   authorEmail: string | null;
   createdAt: Date;
   body: string;
+}
+
+export async function loadPriorMessagesForQuote(
+  db: Db,
+  args: {
+    conversationId: string;
+    excludeMessageId: string;
+    contactName: string | null;
+    contactEmail: string | null;
+    channelFromName: string;
+    limit: number;
+  },
+): Promise<QuotedPriorMessage[]> {
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+    const rows = await tx
+      .select({
+        authorType: schema.convMessages.authorType,
+        body: schema.convMessages.body,
+        createdAt: schema.convMessages.createdAt,
+      })
+      .from(schema.convMessages)
+      .where(
+        and(
+          eq(schema.convMessages.conversationId, args.conversationId),
+          eq(schema.convMessages.internal, false),
+          sql`${schema.convMessages.id} <> ${args.excludeMessageId}`,
+        ),
+      )
+      .orderBy(desc(schema.convMessages.createdAt))
+      .limit(args.limit);
+    return rows.map((r) => {
+      const isContact = r.authorType === 'end_user';
+      return {
+        authorName: isContact ? args.contactName ?? 'User' : args.channelFromName,
+        authorEmail: isContact ? args.contactEmail : null,
+        createdAt: r.createdAt instanceof Date ? r.createdAt : new Date(r.createdAt),
+        body: r.body,
+      };
+    });
+  });
 }
 
 export function formatQuotedHistory(prior: QuotedPriorMessage[], limit = 3): string {

--- a/packages/backend-core/src/modules/conv/widget/widget-email-fallback.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-email-fallback.integration.test.ts
@@ -131,18 +131,21 @@ const REPLY_DOMAIN = 'reply.example.test';
 
   async function insertMsg(
     convId: string,
-    authorType: 'end_user' | 'agent',
+    authorType: 'end_user' | 'agent' | 'user',
     body: string,
     ageMs = 30_000,
+    authorIdOverride?: string,
   ): Promise<string> {
     const createdAt = new Date(Date.now() - ageMs);
+    const fallbackAuthorId =
+      authorType === 'end_user' ? contactId : authorType === 'user' ? 'system' : 'system';
     const [m] = await db
       .insert(schema.convMessages)
       .values({
         orgId,
         conversationId: convId,
         authorType,
-        authorId: authorType === 'end_user' ? contactId : 'system',
+        authorId: authorIdOverride ?? fallbackAuthorId,
         body,
         createdAt,
       })
@@ -150,7 +153,7 @@ const REPLY_DOMAIN = 'reply.example.test';
     return m!.id;
   }
 
-  it('sends a digest when an agent message is unread and writes a delivery row for threading', async () => {
+  it('sends the latest unread agent message with quoted history, signoff, and no digest framing', async () => {
     const convId = await newConv('Login help');
     await insertMsg(convId, 'end_user', 'Hi, I need help.', 60_000);
     const agentMsgId = await insertMsg(convId, 'agent', 'Sure — what are you stuck on?', 30_000);
@@ -166,6 +169,18 @@ const REPLY_DOMAIN = 'reply.example.test';
     expect(sent.replyTo).toBe(`support+conv-${convId}@${REPLY_DOMAIN}`);
     const stamped = sent.headers?.['Message-ID'];
     expect(stamped).toMatch(/^<[^<>]+@acme\.test>$/);
+
+    const body = sent.text!;
+    expect(body).not.toMatch(/^Hi,/m);
+    expect(body).not.toContain('sent you');
+    expect(body).not.toContain('Reply to this email');
+    expect(body).not.toContain('Best regards,');
+    // No assistants row for this org → agent signoff falls back to the channel fromName.
+    expect(body).toContain('— Acme Support');
+    expect(body).toContain('> Hi, I need help.');
+    expect(body.indexOf('— Acme Support')).toBeGreaterThan(body.indexOf('Sure — what are you stuck on?'));
+    expect(body.indexOf('— Acme Support')).toBeLessThan(body.indexOf('> Hi, I need help.'));
+    expect(sent.subject).toBe('Login help');
 
     const fallbacks = await db
       .select()
@@ -187,7 +202,7 @@ const REPLY_DOMAIN = 'reply.example.test';
     expect(deliveries[0]!.messageIdHeader).toBe(fallbacks[0]!.messageIdHeader);
   });
 
-  it('bundles multiple unread agent messages into one digest with N delivery rows', async () => {
+  it('emails only the latest of multiple unread agent messages, quoting earlier ones, with N delivery rows', async () => {
     const convId = await newConv();
     await insertMsg(convId, 'end_user', 'Hi.', 90_000);
     const m1 = await insertMsg(convId, 'agent', 'First reply.', 60_000);
@@ -197,8 +212,10 @@ const REPLY_DOMAIN = 'reply.example.test';
     expect(result.sent).toBe(1);
 
     expect(mailer.outbox).toHaveLength(1);
-    expect(mailer.outbox[0]!.text).toContain('First reply.');
-    expect(mailer.outbox[0]!.text).toContain('And a follow-up.');
+    const body = mailer.outbox[0]!.text!;
+    expect(body).toContain('And a follow-up.');
+    expect(body).toContain('> First reply.');
+    expect(body.indexOf('And a follow-up.')).toBeLessThan(body.indexOf('> First reply.'));
 
     const fb = (
       await db.select().from(schema.convWidgetEmailFallbacks).where(eq(schema.convWidgetEmailFallbacks.conversationId, convId))
@@ -239,6 +256,74 @@ const REPLY_DOMAIN = 'reply.example.test';
     const r = await worker.tick();
     expect(r.sent).toBe(0);
     expect(mailer.outbox).toHaveLength(0);
+  });
+
+  it('does not re-email an already-delivered agent message even if it stays unread', async () => {
+    const convId = await newConv();
+    await insertMsg(convId, 'end_user', 'Hi.', 90_000);
+    await insertMsg(convId, 'agent', 'Old agent reply.', 60_000);
+
+    const r1 = await worker.tick();
+    expect(r1.sent).toBe(1);
+    expect(mailer.outbox[0]!.text!).toContain('Old agent reply.');
+
+    // Engage via a new end-user message (resetting the quiet period) and
+    // an agent reply. The old reply remains unread server-side. The
+    // end-user message must be later than `conv_created_at` so r2's
+    // engagement timestamp differs from r1's (otherwise the unique
+    // `(conversation_id, last_engagement_at)` constraint blocks the
+    // second fallback row). The agent message gets a small age so its
+    // `created_at` lands reliably before `tick`'s cutoff.
+    await insertMsg(convId, 'end_user', 'Followup question.', 0);
+    await insertMsg(convId, 'agent', 'Fresh agent reply.', 50);
+
+    const r2 = await worker.tick();
+    expect(r2.sent).toBe(1);
+    expect(mailer.outbox).toHaveLength(2);
+
+    const secondBody = mailer.outbox[1]!.text!;
+    const beforeSignoff = secondBody.split('\n— ')[0]!;
+    expect(beforeSignoff).toContain('Fresh agent reply.');
+    expect(beforeSignoff).not.toContain('Old agent reply.');
+  });
+
+  it('signs off with the assistants.name when the latest unread is from the AI', async () => {
+    await db
+      .insert(schema.assistants)
+      .values({ orgId, name: 'Jens' })
+      .onConflictDoUpdate({ target: schema.assistants.orgId, set: { name: 'Jens', updatedAt: new Date() } });
+
+    const convId = await newConv('Login help');
+    await insertMsg(convId, 'end_user', 'Hi.', 90_000);
+    await insertMsg(convId, 'agent', 'Sure — what are you stuck on?', 30_000);
+
+    const result = await worker.tick();
+    expect(result.sent).toBe(1);
+    const body = mailer.outbox[0]!.text!;
+    expect(body).toContain('— Jens');
+    expect(body).not.toContain('— Acme Support');
+
+    await db.delete(schema.assistants).where(eq(schema.assistants.orgId, orgId));
+  });
+
+  it('signs off with the human operator first name when the latest unread is from a human', async () => {
+    const [op] = await db
+      .insert(schema.users)
+      .values({ email: `op-${Date.now()}@example.test`, name: 'Maja Hansen' })
+      .returning();
+    const opId = op!.id;
+
+    const convId = await newConv('Login help');
+    await insertMsg(convId, 'end_user', 'Hi.', 90_000);
+    await insertMsg(convId, 'user', 'Hi — Maja here, let me look.', 30_000, opId);
+
+    const result = await worker.tick();
+    expect(result.sent).toBe(1);
+    const body = mailer.outbox[0]!.text!;
+    expect(body).toContain('— Maja');
+    expect(body).not.toContain('— Maja Hansen');
+
+    await db.delete(schema.users).where(eq(schema.users.id, opId));
   });
 
   it('fires again once the end-user engages (resetting the quiet period)', async () => {

--- a/packages/backend-core/src/modules/conv/widget/widget-email-fallback.worker.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-email-fallback.worker.ts
@@ -8,6 +8,11 @@ import { MAILER } from '../../../common/mail/mail.module.js';
 import { EmailService, jsonbToStored, type StoredEmailChannelConfig } from '../email/email.service.js';
 import { smtpTransportOptions } from '../email/email.tools.js';
 import { buildOutbound, type BuiltMessage } from '../email/mime.js';
+import {
+  formatQuotedHistory,
+  loadPriorMessagesForQuote,
+  type QuotedPriorMessage,
+} from '../email/reply-history.js';
 
 const DEFAULT_INTERVAL_MS = 60_000;
 const DEFAULT_THRESHOLD_MS = 10 * 60_000;
@@ -29,6 +34,7 @@ type UnreadRow = {
   body: string;
   body_html: string | null;
   author_type: string;
+  author_id: string;
   created_at: Date | string;
 } & Record<string, unknown>;
 
@@ -138,10 +144,14 @@ export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy 
           WHERE m.conversation_id = c.id
             AND m.author_type <> 'end_user'
             AND m.internal = false
-            AND m.created_at < ${cutoff.toISOString()}::timestamptz
+            AND m.created_at <= ${cutoff.toISOString()}::timestamptz
             AND NOT EXISTS (
               SELECT 1 FROM conv_message_reads r
               WHERE r.message_id = m.id AND r.end_user_id = c.end_user_id
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM conv_message_deliveries d
+              WHERE d.message_id = m.id
             )
         )
       ORDER BY c.last_message_at ASC NULLS LAST
@@ -198,6 +208,31 @@ export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy 
     }
 
     const replyTo = this.composeReplyTo(config, cand.conversation_id);
+    const latestUnread = stillUnread[stillUnread.length - 1]!;
+    const channelFromName = (config.addressing.fromName ?? '').trim() || 'Support';
+    let prior: QuotedPriorMessage[];
+    try {
+      prior = await loadPriorMessagesForQuote(this.db, {
+        conversationId: cand.conversation_id,
+        excludeMessageId: latestUnread.id,
+        contactName: cand.end_user_name,
+        contactEmail: cand.end_user_email,
+        channelFromName,
+        limit: 3,
+      });
+    } catch (err) {
+      await this.markStatus(fallbackId, 'failed', `quote-history load failed: ${describeError(err)}`);
+      return 'failed';
+    }
+
+    let signoffName: string;
+    try {
+      signoffName = await this.resolveSignoffName(cand.org_id, latestUnread, channelFromName);
+    } catch (err) {
+      await this.markStatus(fallbackId, 'failed', `signoff resolution failed: ${describeError(err)}`);
+      return 'failed';
+    }
+
     let built: BuiltMessage;
     try {
       built = this.buildDigest({
@@ -206,7 +241,9 @@ export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy 
         subject: cand.conv_subject,
         recipientEmail: cand.end_user_email,
         recipientName: cand.end_user_name,
-        unread: stillUnread,
+        latest: latestUnread,
+        prior,
+        signoffName,
       });
     } catch (err) {
       await this.markStatus(fallbackId, 'failed', `digest build failed: ${describeError(err)}`);
@@ -272,15 +309,19 @@ export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy 
   private async loadUnread(conversationId: string, endUserId: string): Promise<UnreadRow[]> {
     const cutoff = new Date(Date.now() - this.thresholdMs);
     const rows = await this.db.execute<UnreadRow>(sql`
-      SELECT m.id, m.body, m.body_html, m.author_type, m.created_at
+      SELECT m.id, m.body, m.body_html, m.author_type, m.author_id, m.created_at
       FROM conv_messages m
       WHERE m.conversation_id = ${conversationId}
         AND m.author_type <> 'end_user'
         AND m.internal = false
-        AND m.created_at < ${cutoff.toISOString()}::timestamptz
+        AND m.created_at <= ${cutoff.toISOString()}::timestamptz
         AND NOT EXISTS (
           SELECT 1 FROM conv_message_reads r
           WHERE r.message_id = m.id AND r.end_user_id = ${endUserId}
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM conv_message_deliveries d
+          WHERE d.message_id = m.id
         )
       ORDER BY m.created_at ASC
     `);
@@ -314,39 +355,53 @@ export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy 
       .where(eq(schema.convWidgetEmailFallbacks.id, fallbackId));
   }
 
+  private async resolveSignoffName(
+    orgId: string,
+    latest: UnreadRow,
+    channelFromName: string,
+  ): Promise<string> {
+    if (latest.author_type === 'user' && latest.author_id) {
+      const [u] = await this.db
+        .select({ name: schema.users.name })
+        .from(schema.users)
+        .where(eq(schema.users.id, latest.author_id))
+        .limit(1);
+      const first = firstWord(u?.name);
+      if (first) return first;
+      return channelFromName;
+    }
+    if (latest.author_type === 'agent') {
+      const [a] = await this.db
+        .select({ name: schema.assistants.name })
+        .from(schema.assistants)
+        .where(eq(schema.assistants.orgId, orgId))
+        .limit(1);
+      const trimmed = a?.name?.trim();
+      if (trimmed) return trimmed;
+      return channelFromName;
+    }
+    return channelFromName;
+  }
+
   private buildDigest(params: {
     config: StoredEmailChannelConfig;
     replyTo: string | undefined;
     subject: string | null;
     recipientEmail: string;
     recipientName: string | null;
-    unread: UnreadRow[];
+    latest: UnreadRow;
+    prior: QuotedPriorMessage[];
+    signoffName: string;
   }): BuiltMessage {
-    const { config, replyTo, recipientEmail, recipientName, unread } = params;
+    const { config, replyTo, recipientEmail, recipientName, latest, prior, signoffName } = params;
     const fromName = (config.addressing.fromName ?? '').trim() || 'Support';
-    const subjectBase = params.subject?.trim() || `New message from ${fromName}`;
-    const subject = unread.length > 1 ? `${subjectBase} (${unread.length} new messages)` : subjectBase;
+    const subject = params.subject?.trim() || `New message from ${fromName}`;
 
-    const textParts: string[] = [];
-    textParts.push(
-      recipientName
-        ? `Hi ${recipientName.split(/\s+/)[0]},`
-        : 'Hi,',
-    );
-    textParts.push('');
-    textParts.push(
-      unread.length === 1
-        ? `${fromName} sent you a message you haven't seen yet:`
-        : `${fromName} sent you ${unread.length} messages you haven't seen yet:`,
-    );
-    textParts.push('');
-    for (const m of unread) {
-      textParts.push(stripHtml(m.body).trim() || '(no message)');
-      textParts.push('');
-    }
-    textParts.push('—');
-    textParts.push('Reply to this email to continue the conversation.');
-    const text = textParts.join('\n');
+    const latestBody = stripHtml(latest.body).trim() || '(no message)';
+    const quoted = formatQuotedHistory(prior, 3);
+    const sections = [latestBody, `— ${signoffName}`];
+    if (quoted) sections.push(quoted);
+    const text = sections.join('\n\n');
 
     return buildOutbound({
       from: composeFrom(config.addressing.fromName, config.addressing.fromAddress),
@@ -411,6 +466,12 @@ export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy 
       });
     }
   }
+}
+
+function firstWord(name: string | null | undefined): string | null {
+  const trimmed = name?.trim();
+  if (!trimmed) return null;
+  return trimmed.split(/\s+/)[0]!;
 }
 
 function composeFrom(name: string | undefined, address: string): string {

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -66,6 +66,7 @@ export class WidgetIngestService {
       .select({
         id: schema.convConversations.id,
         contactId: schema.convConversations.contactId,
+        endUserId: schema.convConversations.endUserId,
         subject: schema.convConversations.subject,
         status: schema.convConversations.status,
         assigneeUserId: schema.convConversations.assigneeUserId,
@@ -137,8 +138,20 @@ export class WidgetIngestService {
         ? await this.loadUserNames(tx, Array.from(userIdSet))
         : new Map<string, string>();
     const assigneeName = conv[0].assigneeUserId
-      ? userNames.get(conv[0].assigneeUserId) ?? null
+      ? firstWord(userNames.get(conv[0].assigneeUserId)) ?? null
       : null;
+
+    const hasAgentMessage = visible.some((r) => r.authorType === 'agent');
+    const assistantName = hasAgentMessage ? await this.loadAssistantName(tx, orgId) : null;
+    const agentDisplayName = assistantName ?? 'Munin';
+
+    const readableIds = visible
+      .filter((r) => r.authorType !== 'end_user')
+      .map((r) => r.id);
+    const readsByMessageId =
+      conv[0].endUserId && readableIds.length > 0
+        ? await this.loadReadsForEndUser(tx, readableIds, conv[0].endUserId)
+        : new Map<string, Date>();
 
     const messages: WidgetListedMessage[] = visible.map((r) => ({
       id: r.id,
@@ -146,13 +159,14 @@ export class WidgetIngestService {
       authorKind: authorKindFor(r.authorType),
       authorName:
         r.authorType === 'user'
-          ? userNames.get(r.authorId) ?? null
+          ? firstWord(userNames.get(r.authorId)) ?? null
           : r.authorType === 'agent'
-            ? 'Munin'
+            ? agentDisplayName
             : null,
       body: r.body,
       bodyHtml: r.bodyHtml,
       at: r.createdAt.toISOString(),
+      readAt: readsByMessageId.get(r.id)?.toISOString() ?? null,
     }));
 
     const envelope: WidgetConversationEnvelope = {
@@ -459,6 +473,40 @@ export class WidgetIngestService {
       displayId: created!.displayId,
       contactId: contact.id,
     };
+  }
+
+  private async loadAssistantName(tx: Tx, orgId: string): Promise<string | null> {
+    const [row] = await tx
+      .select({ name: schema.assistants.name })
+      .from(schema.assistants)
+      .where(eq(schema.assistants.orgId, orgId))
+      .limit(1);
+    return row?.name?.trim() || null;
+  }
+
+  private async loadReadsForEndUser(
+    tx: Tx,
+    messageIds: string[],
+    endUserId: string,
+  ): Promise<Map<string, Date>> {
+    if (messageIds.length === 0) return new Map();
+    const rows = await tx
+      .select({
+        messageId: schema.convMessageReads.messageId,
+        readAt: schema.convMessageReads.readAt,
+      })
+      .from(schema.convMessageReads)
+      .where(
+        and(
+          eq(schema.convMessageReads.endUserId, endUserId),
+          inArray(schema.convMessageReads.messageId, messageIds),
+        ),
+      );
+    const out = new Map<string, Date>();
+    for (const r of rows) {
+      out.set(r.messageId, r.readAt instanceof Date ? r.readAt : new Date(r.readAt));
+    }
+    return out;
   }
 
   private async loadUserNames(tx: Tx, userIds: string[]): Promise<Map<string, string>> {
@@ -850,6 +898,12 @@ export class WidgetIngestService {
     });
     return created!;
   }
+}
+
+function firstWord(name: string | null | undefined): string | null {
+  const trimmed = name?.trim();
+  if (!trimmed) return null;
+  return trimmed.split(/\s+/)[0]!;
 }
 
 function normalizeRole(authorType: string): WidgetListedMessage['role'] {

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -1016,8 +1016,150 @@ const skipReason = TEST_URL
     };
     const agent = body.messages.find((m) => m.role === 'agent')!;
     expect(agent.authorKind).toBe('ai');
+    // No assistants row for this org → falls back to 'Munin'.
     expect(agent.authorName).toBe('Munin');
     expect(body.conversation?.status).toBe('open');
+  });
+
+  it('uses the configured assistants.name for agent authorName when set', async () => {
+    await db
+      .insert(schema.assistants)
+      .values({ orgId, name: 'Jens' })
+      .onConflictDoUpdate({
+        target: schema.assistants.orgId,
+        set: { name: 'Jens', updatedAt: new Date() },
+      });
+    try {
+      const sid = `vis_assistant_${Date.now()}`;
+      await call('POST', '/api/v1/widget/messages', widgetKey, {
+        channelId,
+        sessionId: sid,
+        messages: [
+          { role: 'end_user', body: 'hi' },
+          { role: 'agent', body: 'hello there' },
+        ],
+      });
+      const res = await call(
+        'GET',
+        `/api/v1/widget/messages?${qs({ channelId, sessionId: sid })}`,
+        widgetKey,
+      );
+      const body = res.json as {
+        messages: Array<{ role: string; authorName: string | null }>;
+      };
+      const agent = body.messages.find((m) => m.role === 'agent')!;
+      expect(agent.authorName).toBe('Jens');
+    } finally {
+      await db.delete(schema.assistants).where(eq(schema.assistants.orgId, orgId));
+    }
+  });
+
+  it('returns first-name only for human-author messages', async () => {
+    const [op] = await db
+      .insert(schema.users)
+      .values({ email: `widget-op-${Date.now()}@example.test`, name: 'Maja Hansen' })
+      .returning();
+    const opId = op!.id;
+    try {
+      const sid = `vis_human_${Date.now()}`;
+      await call('POST', '/api/v1/widget/messages', widgetKey, {
+        channelId,
+        sessionId: sid,
+        messages: [{ role: 'end_user', body: 'hi' }],
+      });
+      const conv = (
+        await db
+          .select({ id: schema.convConversations.id })
+          .from(schema.convConversations)
+          .where(
+            and(
+              eq(schema.convConversations.orgId, orgId),
+              sql`${schema.convConversations.metadata}->>'sessionId' = ${sid}`,
+            ),
+          )
+          .limit(1)
+      )[0]!;
+      await db.insert(schema.convMessages).values({
+        orgId,
+        conversationId: conv.id,
+        authorType: 'user',
+        authorId: opId,
+        body: 'Hi — Maja here, let me look.',
+      });
+
+      const res = await call(
+        'GET',
+        `/api/v1/widget/messages?${qs({ channelId, sessionId: sid })}`,
+        widgetKey,
+      );
+      const body = res.json as {
+        messages: Array<{ role: string; authorKind: string | null; authorName: string | null }>;
+      };
+      const human = body.messages.find((m) => m.authorKind === 'human')!;
+      expect(human.authorName).toBe('Maja');
+    } finally {
+      await db
+        .delete(schema.convMessages)
+        .where(and(eq(schema.convMessages.orgId, orgId), eq(schema.convMessages.authorId, opId)));
+      await db.delete(schema.users).where(eq(schema.users.id, opId));
+    }
+  });
+
+  it('returns readAt on listed messages, null until a conv_message_reads row exists', async () => {
+    const sid = `vis_read_${Date.now()}`;
+    await call('POST', '/api/v1/widget/messages', widgetKey, {
+      channelId,
+      sessionId: sid,
+      messages: [
+        { role: 'end_user', body: 'hello there' },
+        { role: 'agent', body: 'an agent reply for read-state test' },
+      ],
+    });
+
+    const firstRes = await call(
+      'GET',
+      `/api/v1/widget/messages?${qs({ channelId, sessionId: sid })}`,
+      widgetKey,
+    );
+    const firstBody = firstRes.json as {
+      messages: Array<{ id: string; role: string; readAt: string | null }>;
+    };
+    for (const m of firstBody.messages) expect(m.readAt).toBeNull();
+
+    const agent = firstBody.messages.find((m) => m.role === 'agent')!;
+    expect(agent).toBeDefined();
+
+    const conv = (
+      await db
+        .select({ id: schema.convConversations.id, endUserId: schema.convConversations.endUserId })
+        .from(schema.convConversations)
+        .where(
+          and(
+            eq(schema.convConversations.orgId, orgId),
+            sql`${schema.convConversations.metadata}->>'sessionId' = ${sid}`,
+          ),
+        )
+        .limit(1)
+    )[0]!;
+    await db.insert(schema.convMessageReads).values({
+      orgId,
+      conversationId: conv.id,
+      messageId: agent.id,
+      endUserId: conv.endUserId!,
+    });
+
+    const secondRes = await call(
+      'GET',
+      `/api/v1/widget/messages?${qs({ channelId, sessionId: sid })}`,
+      widgetKey,
+    );
+    const secondBody = secondRes.json as {
+      messages: Array<{ id: string; role: string; readAt: string | null }>;
+    };
+    const markedAgent = secondBody.messages.find((m) => m.id === agent.id)!;
+    expect(markedAgent.readAt).not.toBeNull();
+    const visitorMsg = secondBody.messages.find((m) => m.role === 'end_user')!;
+    expect(visitorMsg.readAt).toBeNull();
   });
 
   it('redirects GET /widget.js to the current hashed bundle with a short revalidate cache', async () => {

--- a/packages/backend-core/src/modules/conv/widget/widget.types.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.types.ts
@@ -108,6 +108,7 @@ export interface WidgetListedMessage {
   body: string;
   bodyHtml: string | null;
   at: string;
+  readAt: string | null;
 }
 
 export interface WidgetConversationEnvelope {

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -461,6 +461,10 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     if (!convRow || !convRow.endUserId) return;
     if (convRow.orgId !== entry.orgId) return;
 
+    const messageIdList = sql.join(
+      messageIds.map((id) => sql`${id}`),
+      sql`, `,
+    );
     const inserted = await this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.org_id', ${convRow.orgId}, true)`);
       return tx.execute<{ message_id: string; read_at: Date | string }>(sql`
@@ -473,7 +477,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
           ${convRow.endUserId},
           NOW()
         FROM conv_messages m
-        WHERE m.id = ANY(${messageIds}::text[])
+        WHERE m.id IN (${messageIdList})
           AND m.conversation_id = ${conversationId}
           AND m.author_type <> 'end_user'
         ON CONFLICT (message_id, end_user_id) DO NOTHING

--- a/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
+++ b/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
@@ -878,6 +878,75 @@ const skipReason = TEST_URL
       wsOperator.terminate();
     }
   });
+
+  it('persists conv_message_reads rows for both single and multiple message-id reads', async () => {
+    const sessionId = `rt_read_${Date.now()}`;
+    const ingestRes = await fetch(`${baseUrl}/api/v1/widget/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${widgetKey}`,
+        Origin: ALLOWED_ORIGIN,
+      },
+      body: JSON.stringify({
+        channelId,
+        sessionId,
+        messages: [
+          { role: 'end_user', body: 'hello' },
+          { role: 'agent', body: 'first reply' },
+          { role: 'agent', body: 'second reply' },
+          { role: 'agent', body: 'third reply' },
+        ],
+      }),
+    });
+    const conversationId = ((await ingestRes.json()) as { conversationId: string }).conversationId;
+
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    const agentRows = await db
+      .select({ id: schema.convMessages.id })
+      .from(schema.convMessages)
+      .where(sql`${schema.convMessages.conversationId} = ${conversationId} AND ${schema.convMessages.authorType} = 'agent'`);
+    expect(agentRows.length).toBe(3);
+    const [firstId, secondId, thirdId] = agentRows.map((r) => r.id);
+
+    const wsVisitor = connectWs(widgetKey, { origin: ALLOWED_ORIGIN });
+    await waitForOpen(wsVisitor);
+    try {
+      // Single-id read — exercises the IN (...) path with one element.
+      wsVisitor.send(
+        JSON.stringify({
+          type: 'read',
+          channel: 'widget',
+          channelId,
+          sessionId,
+          messageIds: [firstId],
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 200));
+
+      // Multi-id read — exercises sql.join with multiple elements.
+      wsVisitor.send(
+        JSON.stringify({
+          type: 'read',
+          channel: 'widget',
+          channelId,
+          sessionId,
+          messageIds: [secondId, thirdId],
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 200));
+
+      const readRows = await db
+        .select({ messageId: schema.convMessageReads.messageId })
+        .from(schema.convMessageReads)
+        .where(sql`${schema.convMessageReads.conversationId} = ${conversationId}`);
+      expect(readRows.map((r) => r.messageId).sort()).toEqual(
+        [firstId, secondId, thirdId].sort(),
+      );
+    } finally {
+      wsVisitor.terminate();
+    }
+  });
 });
 
 function decodeWsData(data: WebSocket.RawData): string {


### PR DESCRIPTION
## Summary

Three connected changes around the chat-widget → email path:

1. **Email fallback reads like a personal mid-thread email**, not a system digest. Only the latest unread agent message goes in the body; the prior thread is quoted underneath; the signoff is `— <name>` (no localized "Best regards"). Greeting, "X sent you N messages" intro, and "Reply to this email" footer are gone. Subject drops the `(N new messages)` suffix.
2. **Widget read receipts actually persist.** `handleRead` was building a SQL `ANY(${array}::text[])` that drizzle expanded as a record cast, so Postgres rejected every read. No widget read had ever been written to `conv_message_reads` since the feature shipped. Fixed with `IN (...)` via `sql.join`.
3. **Unread message badge on the launcher.** Real-time-aware while the panel is closed, server-`readAt`-backed across reloads, capped at `9+`.

Also folded in:
- **Author-aware signoff:** human operator → `users.name` first word, AI → `assistants.name`, fallback → channel `fromName`.
- **Widget display names:** agent author uses `assistants.name` (fallback `"Munin"`), human author is first-name only. Same goes for `assigneeName` in the conversation envelope.
- **No re-emailing already-delivered messages:** `loadUnread` and `findCandidates` exclude messages already in `conv_message_deliveries`. Prevents the bug where a previously-emailed message kept surfacing as the "latest unread" because the user read it in their inbox, never in the widget.
- **Timing-boundary fix:** `m.created_at < cutoff` → `<=` matches "wait at least N ms" semantics and eliminates an `ageMs=0` race in the integration tests.

## Why

The current fallback email reads like a notification ("Test Testesen sent you 4 messages…") when it should read like the next message in a thread. The read-receipt bug compounded that — without working reads, an unread message would re-surface every time the user reloaded the page or hit the quiet-period threshold again. And without a launcher badge, the user has no in-product signal that there's something to look at when they're already on the host page.

## Data model

No schema changes. The `assistants` table, `conv_message_reads`, and `conv_message_deliveries` already had everything needed; only their use changed.

## Key files

**Backend**
- `packages/backend-core/src/modules/conv/widget/widget-email-fallback.worker.ts` — rewrote `buildDigest()`, added `resolveSignoffName()`, added `firstWord()` helper, tightened both `loadUnread()` and `findCandidates()` (exclude already-delivered, switch `<` → `<=`).
- `packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts` — `listMessages()` now joins `conv_message_reads` for `readAt`, uses `assistants.name` for agent display, first-names human authors.
- `packages/backend-core/src/modules/conv/widget/widget.types.ts` — `WidgetListedMessage.readAt`.
- `packages/backend-core/src/modules/conv/email/reply-history.ts` — `loadPriorMessagesForQuote` extracted from EmailAdapter as a shared free function.
- `packages/backend-core/src/modules/conv/email/email-adapter.ts` — calls the extracted helper (behavioural no-op for the email channel).
- `packages/backend-core/src/realtime/realtime.gateway.ts` — `handleRead` uses `IN (...)` via `sql.join` instead of the broken `ANY(::text[])` form.

**Widget**
- `apps/chat-widget/src/api.ts` — `ListedMessage.readAt`.
- `apps/chat-widget/src/ui.ts` — `setLauncherUnread()` API, `.launcher-badge` element rendered inside the launcher button.
- `apps/chat-widget/src/styles.ts` — `position: relative` on `.launcher`, `pointer-events: none` on the badge, tightened badge dimensions for single-digit roundness.
- `apps/chat-widget/src/widget.ts` — local `messagesById` + `locallyRead`; `refreshUnreadBadge()` runs on every backfill and every observer-driven read.

## Test plan

- [ ] Open a widget chat, let the AI reply, leave for >10 min. Email arrives with: only the latest reply at the top, end-user's prior message quoted below with `> `, signoff `— <name>` (assistants.name if set, else channel fromName), no `Hi,`/intro/footer, subject without `(N new messages)`.
- [ ] Reply to the fallback from the inbox — reply lands back in the same conversation (threading unchanged).
- [ ] Reopen the widget; scroll to messages → reads land in `conv_message_reads` server-side; reload the page → badge stays at 0.
- [ ] Have a human operator reply via dashboard — fallback email signoff is the operator's **first name** only.
- [ ] Multiple unread agent messages: first fallback emails the latest with the rest quoted; a later fallback (after engagement) doesn't re-include any message already in `conv_message_deliveries`.
- [ ] Launcher badge: increments on incoming agent messages while closed; clears as messages scroll into view; shows `9+` when count > 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)