### PR TITLE
chore: changeset for #166 (minor)

### DIFF
--- a/.changeset/dashboard-shells-extensibility.md
+++ b/.changeset/dashboard-shells-extensibility.md
@@ -1,0 +1,27 @@
+---
+"@getmunin/core": minor
+"@getmunin/db": minor
+"@getmunin/types": minor
+"@getmunin/sdk": minor
+"@getmunin/mcp-toolkit": minor
+"@getmunin/bootstrap": minor
+"@getmunin/ui": minor
+"@getmunin/dashboard-pages": minor
+"@getmunin/backend-core": minor
+"@getmunin/agent-runtime": minor
+"@getmunin/agent-host": minor
+---
+
+Extract dashboard + settings shells from `@getmunin/web` into `@getmunin/dashboard-pages` so downstream consumers can compose the same dashboard structure instead of redeclaring it.
+
+**New exports from `@getmunin/dashboard-pages`:**
+
+- `DashboardShell` — wraps `useDashboardGate`, session check, topbar render, and the `inSettings` pathname toggle. Props: `brand`, `logoSrc?`, `leftSlot?`, `withConfirmDialog?`.
+- `SettingsShell` — wraps the settings layout: role gate, `SettingsTopbar`, `RailNav` sidebar built from a `groups` prop, and the mobile `Sheet`. Consumers pass a `SettingsSubNavGroup[]`.
+- `OSS_SETTINGS_GROUPS` — the canonical OSS settings nav config (moved from `apps/web/.../nav-config.ts`).
+- `extendSettingsGroups(base, extensions)` — merges items into existing groups (or appends a new group). Supports `insertAfter`, `insertBefore` (by slug or labelKey), and `position: 'start' | 'end'` for ordering.
+- `createSettingsIndexRedirect({ defaultLocale, target? })` — factory for the `settings/page.tsx` default redirect.
+
+**Convention:** any `labelKey` you put in a settings group must have a matching `nav.*` entry in the host app's `messages/*.json`. Group keys map to `dashboard.settings.groups.*`.
+
+This is purely additive — no public API removed. The web app's own `dashboard/{layout,settings/layout,settings/page}.tsx` files were collapsed onto the new shells in the same PR (#166).


### PR DESCRIPTION
## Summary
- Minor bump for the fixed-version group covering #166 (dashboard + settings shell extraction in `@getmunin/dashboard-pages`).
- API is purely additive: new `DashboardShell`, `SettingsShell`, `OSS_SETTINGS_GROUPS`, `extendSettingsGroups`, `createSettingsIndexRedirect`.

## Test plan
- [ ] Merge → release PR opens → publishes new minor of the fixed group.
- [ ] Bump `@getmunin/dashboard-pages` dep in `munin-cloud/apps/web-cloud` to the new version, then land the cloud-side collapse PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)