### PR TITLE
feat(core): add generic SmtpMailer provider

### DIFF
--- a/.changeset/smtp-mailer.md
+++ b/.changeset/smtp-mailer.md
@@ -1,0 +1,21 @@
+---
+'@getmunin/core': minor
+'@getmunin/db': minor
+'@getmunin/types': minor
+'@getmunin/sdk': minor
+'@getmunin/mcp-toolkit': minor
+'@getmunin/bootstrap': minor
+'@getmunin/ui': minor
+'@getmunin/dashboard-pages': minor
+'@getmunin/backend-core': minor
+'@getmunin/agent-runtime': minor
+'@getmunin/agent-host': minor
+---
+
+Add generic `SmtpMailer` provider to `@getmunin/core`.
+
+Covers any SMTP-speaking transactional email service (Scaleway TEM, Postmark,
+Mailgun, Postmark, etc.) via a single implementation. Activated by setting
+`MUNIN_MAIL_PROVIDER=smtp` along with `MUNIN_SMTP_HOST`, `MUNIN_SMTP_PORT`,
+`MUNIN_SMTP_USER`, `MUNIN_SMTP_PASSWORD` (optional `MUNIN_SMTP_SECURE=1` for
+implicit-TLS on port 465). `nodemailer` is the underlying transport.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -28748,7 +28748,7 @@ THE SOFTWARE.
 
 ---
 
-## nodemailer@8.0.5, 8.0.7
+## nodemailer@7.0.13, 8.0.5, 8.0.7
 
 > Easy as cake e-mail sending from your Node.js applications
 - Homepage: https://nodemailer.com/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,12 +36,14 @@
     "@getmunin/db": "workspace:*",
     "@getmunin/types": "workspace:*",
     "drizzle-orm": "^0.45.2",
+    "nodemailer": "^7.0.13",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@getmunin/eslint-config": "workspace:*",
     "@getmunin/tsconfig": "workspace:*",
     "@types/node": "^22.7.0",
+    "@types/nodemailer": "^7.0.5",
     "eslint": "^9.10.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/packages/core/src/providers/mailer.test.ts
+++ b/packages/core/src/providers/mailer.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { StubMailer } from './mailer.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readMailerFromEnv, SmtpMailer, StubMailer } from './mailer.js';
+
+vi.mock('nodemailer', () => ({
+  createTransport: vi.fn(() => ({
+    sendMail: vi.fn().mockResolvedValue({ messageId: 'stubbed' }),
+  })),
+}));
 
 describe('StubMailer', () => {
   it('captures sent messages in outbox', async () => {
@@ -23,5 +29,93 @@ describe('StubMailer', () => {
     await m.send({ to: 'a@example.com', subject: 'x', text: 'y' });
     m.clear();
     expect(m.outbox).toHaveLength(0);
+  });
+});
+
+describe('SmtpMailer', () => {
+  it('forwards messages to nodemailer with sender + headers', async () => {
+    const nodemailer = await import('nodemailer');
+    const sendMail = vi.fn().mockResolvedValue({ messageId: 'm-1' });
+    vi.mocked(nodemailer.createTransport).mockReturnValue({ sendMail } as never);
+
+    const m = new SmtpMailer({
+      host: 'smtp.example.com',
+      port: 587,
+      user: 'u',
+      password: 'p',
+      from: 'Munin <hello@example.com>',
+    });
+
+    await m.send({
+      to: 'kjell@example.com',
+      subject: 'Hi',
+      text: 'Hello',
+      headers: { 'X-Trace': 'abc' },
+    });
+
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    expect(sendMail.mock.calls[0]![0]).toMatchObject({
+      from: 'Munin <hello@example.com>',
+      to: 'kjell@example.com',
+      subject: 'Hi',
+      text: 'Hello',
+      headers: { 'X-Trace': 'abc' },
+    });
+  });
+
+  it('per-message from overrides default', async () => {
+    const nodemailer = await import('nodemailer');
+    const sendMail = vi.fn().mockResolvedValue({ messageId: 'm-2' });
+    vi.mocked(nodemailer.createTransport).mockReturnValue({ sendMail } as never);
+
+    const m = new SmtpMailer({
+      host: 'h',
+      port: 25,
+      user: 'u',
+      password: 'p',
+      from: 'default@example.com',
+    });
+    await m.send({ to: 't@example.com', subject: 's', text: 'b', from: 'override@example.com' });
+    expect(sendMail.mock.calls[0]![0]).toMatchObject({ from: 'override@example.com' });
+  });
+
+  it('throws when neither text nor html provided', async () => {
+    const m = new SmtpMailer({ host: 'h', port: 25, user: 'u', password: 'p', from: 'x@example.com' });
+    await expect(m.send({ to: 't@example.com', subject: 's' })).rejects.toThrow(/text.*html/);
+  });
+});
+
+describe('readMailerFromEnv', () => {
+  const baseEnv = { ...process.env };
+  beforeEach(() => {
+    process.env = { ...baseEnv };
+    delete process.env.MUNIN_MAIL_PROVIDER;
+    delete process.env.RESEND_API_KEY;
+    delete process.env.MUNIN_SMTP_HOST;
+    delete process.env.MUNIN_SMTP_PORT;
+    delete process.env.MUNIN_SMTP_USER;
+    delete process.env.MUNIN_SMTP_PASSWORD;
+    delete process.env.MUNIN_SMTP_SECURE;
+  });
+  afterEach(() => {
+    process.env = baseEnv;
+  });
+
+  it('returns SmtpMailer when MUNIN_MAIL_PROVIDER=smtp and creds present', () => {
+    process.env.MUNIN_MAIL_PROVIDER = 'smtp';
+    process.env.MUNIN_SMTP_HOST = 'smtp.tem.scw.cloud';
+    process.env.MUNIN_SMTP_PORT = '587';
+    process.env.MUNIN_SMTP_USER = 'tem-user';
+    process.env.MUNIN_SMTP_PASSWORD = 'tem-pass';
+    expect(readMailerFromEnv()).toBeInstanceOf(SmtpMailer);
+  });
+
+  it('throws when MUNIN_MAIL_PROVIDER=smtp without creds', () => {
+    process.env.MUNIN_MAIL_PROVIDER = 'smtp';
+    expect(() => readMailerFromEnv()).toThrow(/MUNIN_SMTP_HOST/);
+  });
+
+  it('falls back to StubMailer when no provider configured', () => {
+    expect(readMailerFromEnv()).toBeInstanceOf(StubMailer);
   });
 });

--- a/packages/core/src/providers/mailer.ts
+++ b/packages/core/src/providers/mailer.ts
@@ -86,6 +86,52 @@ export class ResendMailer implements Mailer {
   }
 }
 
+// ─── Generic SMTP (covers Scaleway TEM, Postmark, Mailgun, etc.) ────────────
+
+import { createTransport, type Transporter, type SendMailOptions } from 'nodemailer';
+
+export interface SmtpMailerOptions {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  from: string;
+  /** When true, uses TLS from the start (implicit TLS, typically port 465). When false (default), starts plain and upgrades via STARTTLS. */
+  secure?: boolean;
+}
+
+export class SmtpMailer implements Mailer {
+  readonly name = 'smtp';
+  readonly from: string;
+  private readonly transporter: Transporter;
+
+  constructor(opts: SmtpMailerOptions) {
+    this.from = opts.from;
+    this.transporter = createTransport({
+      host: opts.host,
+      port: opts.port,
+      secure: opts.secure ?? false,
+      auth: { user: opts.user, pass: opts.password },
+    });
+  }
+
+  async send(msg: MailMessage): Promise<void> {
+    if (!msg.text && !msg.html) {
+      throw new Error('mailer: at least one of `text` or `html` is required');
+    }
+    const mail: SendMailOptions = {
+      from: msg.from ?? this.from,
+      to: msg.to,
+      subject: msg.subject,
+      text: msg.text,
+      html: msg.html,
+      replyTo: msg.replyTo,
+      headers: msg.headers,
+    };
+    await this.transporter.sendMail(mail);
+  }
+}
+
 // ─── Stub (collects in-memory; for tests + offline dev) ──────────────────────
 
 export interface SentMessage extends MailMessage {
@@ -128,6 +174,10 @@ export class StubMailer implements Mailer {
  *
  * `MUNIN_MAIL_PROVIDER`:
  *   `resend` — HTTP send via Resend (requires RESEND_API_KEY).
+ *   `smtp`   — Generic SMTP (Scaleway TEM, Postmark, Mailgun, …). Requires
+ *              MUNIN_SMTP_HOST, MUNIN_SMTP_PORT, MUNIN_SMTP_USER,
+ *              MUNIN_SMTP_PASSWORD. Optional MUNIN_SMTP_SECURE=1 forces
+ *              implicit TLS (port 465); otherwise STARTTLS is used.
  *   `stub`   — in-memory; default when no provider is configured.
  *
  * `MUNIN_MAIL_FROM` — sender address (e.g. "Munin <hello@getmunin.com>").
@@ -136,6 +186,25 @@ export function readMailerFromEnv(): Mailer {
   const provider = process.env.MUNIN_MAIL_PROVIDER?.toLowerCase();
   const from = process.env.MUNIN_MAIL_FROM ?? 'Munin <no-reply@getmunin.com>';
   if (provider === 'stub') return new StubMailer(from);
+  if (provider === 'smtp') {
+    const host = process.env.MUNIN_SMTP_HOST;
+    const port = Number(process.env.MUNIN_SMTP_PORT);
+    const user = process.env.MUNIN_SMTP_USER;
+    const password = process.env.MUNIN_SMTP_PASSWORD;
+    if (!host || !Number.isFinite(port) || !user || !password) {
+      throw new Error(
+        'MUNIN_MAIL_PROVIDER=smtp requires MUNIN_SMTP_HOST, MUNIN_SMTP_PORT, MUNIN_SMTP_USER, MUNIN_SMTP_PASSWORD',
+      );
+    }
+    return new SmtpMailer({
+      host,
+      port,
+      user,
+      password,
+      from,
+      secure: process.env.MUNIN_SMTP_SECURE === '1',
+    });
+  }
   const apiKey = process.env.RESEND_API_KEY;
   if (apiKey || provider === 'resend') {
     if (!apiKey) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,7 +217,7 @@ importers:
         version: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl:
         specifier: ^4.11.0
-        version: 4.11.0(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.11.0(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -553,6 +553,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+      nodemailer:
+        specifier: ^7.0.13
+        version: 7.0.13
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -566,6 +569,9 @@ importers:
       '@types/node':
         specifier: ^22.7.0
         version: 22.19.17
+      '@types/nodemailer':
+        specifier: ^7.0.5
+        version: 7.0.11
       eslint:
         specifier: ^9.10.0
         version: 9.39.4(jiti@1.21.7)
@@ -592,7 +598,7 @@ importers:
         version: 1.14.0(react@19.2.5)
       next-intl:
         specifier: ^4.0.0
-        version: 4.11.0(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.11.0(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -3042,6 +3048,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/nodemailer@7.0.11':
+    resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
+
   '@types/nodemailer@8.0.0':
     resolution: {integrity: sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==}
 
@@ -5231,6 +5240,10 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  nodemailer@7.0.13:
+    resolution: {integrity: sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==}
+    engines: {node: '>=6.0.0'}
 
   nodemailer@8.0.5:
     resolution: {integrity: sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==}
@@ -8867,6 +8880,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/nodemailer@7.0.11':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/nodemailer@8.0.0':
     dependencies:
       '@types/node': 22.19.17
@@ -11094,7 +11111,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.11.0: {}
 
-  next-intl@4.11.0(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+  next-intl@4.11.0(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.5
       '@parcel/watcher': 2.5.6
@@ -11166,6 +11183,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-releases@2.0.38: {}
+
+  nodemailer@7.0.13: {}
 
   nodemailer@8.0.5: {}
 


### PR DESCRIPTION
## Summary

Add a generic `SmtpMailer` to `@getmunin/core` so any SMTP-speaking transactional email service (Scaleway TEM, Postmark, Mailgun, Sendgrid, …) works with one implementation. Selected by setting:

```
MUNIN_MAIL_PROVIDER=smtp
MUNIN_SMTP_HOST=smtp.tem.scw.cloud
MUNIN_SMTP_PORT=587
MUNIN_SMTP_USER=...
MUNIN_SMTP_PASSWORD=...
# optional:
MUNIN_SMTP_SECURE=1       # implicit TLS (port 465). Default uses STARTTLS.
```

`nodemailer` is the underlying transport.

## Why this and not a TEM-specific HTTP mailer

Scaleway TEM-only would be ~80 LOC and locked to one vendor. SMTP is the same code count and works with every transactional mail provider on the market — no future provider switch will need a new class.

## Test plan

- [x] `pnpm -F @getmunin/core typecheck` clean
- [x] `pnpm -F @getmunin/core test` — 9 mailer tests pass (SmtpMailer happy path, per-message from override, validation error, factory env-var matrix)
- [ ] CI: full repo typecheck + test
- [ ] Smoke after release: bump cloud's `@getmunin/core` to the new minor and switch `MUNIN_MAIL_PROVIDER=smtp` against Scaleway TEM creds

🤖 Generated with [Claude Code](https://claude.com/claude-code)