### PR TITLE
fix(dashboard-pages): wrap org switcher menu in DropdownMenuGroup

### DIFF
--- a/.changeset/fix-org-switcher-menu-group.md
+++ b/.changeset/fix-org-switcher-menu-group.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Fix the org switcher dropdown throwing `Base UI error #31` (MenuGroupRootContext missing) when opened. Wrap the label, separator and items in a `<DropdownMenuGroup>` so `Menu.GroupLabel` has the group context it now requires under base-ui 1.4.

--- a/packages/dashboard-pages/src/components/org-switcher.tsx
+++ b/packages/dashboard-pages/src/components/org-switcher.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -73,25 +74,27 @@ export function OrgSwitcher() {
         <ChevronDown className="size-3.5 text-muted-foreground" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-64">
-        <DropdownMenuLabel className="text-xs text-muted-foreground">{t('yourOrgs')}</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {memberships.map((m) => (
-          <DropdownMenuItem
-            key={m.orgId}
-            onClick={() => void onSwitch(m.orgId)}
-            disabled={switching === m.orgId}
-            className="flex items-center justify-between gap-2"
-          >
-            <div className="flex flex-col">
-              <span className="text-sm">{m.name}</span>
-              <span className="text-xs text-muted-foreground">
-                {m.role}
-                {switching === m.orgId ? t('switching') : ''}
-              </span>
-            </div>
-            {m.orgId === active.orgId && <Check className="size-4 text-muted-foreground" />}
-          </DropdownMenuItem>
-        ))}
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="text-xs text-muted-foreground">{t('yourOrgs')}</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {memberships.map((m) => (
+            <DropdownMenuItem
+              key={m.orgId}
+              onClick={() => void onSwitch(m.orgId)}
+              disabled={switching === m.orgId}
+              className="flex items-center justify-between gap-2"
+            >
+              <div className="flex flex-col">
+                <span className="text-sm">{m.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  {m.role}
+                  {switching === m.orgId ? t('switching') : ''}
+                </span>
+              </div>
+              {m.orgId === active.orgId && <Check className="size-4 text-muted-foreground" />}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
Base UI 1.4 requires `Menu.GroupLabel` to live inside a `Menu.Group`. The org switcher renders a `<DropdownMenuLabel>` (which is `Menu.GroupLabel` under the hood) as a direct child of `<DropdownMenuContent>`, so it throws `Base UI error #31 — MenuGroupRootContext is missing` the moment the dropdown opens. This crashes the whole dashboard page in cloud.

Wrap label + separator + items in `<DropdownMenuGroup>` to provide the context. No semantic change for the user.

## Test plan
- Open the org switcher on the dashboard in cloud
- Console should be free of `Base UI error #31`
- Switching between orgs still works