### PR TITLE
fix(core): load prompt-cache entries serially

### DIFF
--- a/.changeset/prompt-cache-serial-load.md
+++ b/.changeset/prompt-cache-serial-load.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/core': patch
+---
+
+Load prompt-cache entries serially instead of via `Promise.all`. The previous burst could saturate the in-process MCP transport on cold start (especially when KB seeding is still in flight in the same session) and the parallel reads would all hit the MCP client's 60s timeout in a single instant. Serial load drains one request at a time and adds negligible wall-clock cost (sub-second for a handful of KB doc reads).

--- a/packages/core/src/prompts/cache.ts
+++ b/packages/core/src/prompts/cache.ts
@@ -80,7 +80,9 @@ export async function createPromptCache(opts: PromptCacheOptions): Promise<Promp
     }
   }
 
-  await Promise.all(Object.keys(opts.entries).map((slug) => load(slug)));
+  for (const slug of Object.keys(opts.entries)) {
+    await load(slug);
+  }
 
   return {
     get(slug) {
@@ -95,7 +97,9 @@ export async function createPromptCache(opts: PromptCacheOptions): Promise<Promp
       log.info?.(`prompt-cache: refreshed ${slug}`);
     },
     async refreshAll() {
-      await Promise.all(Object.keys(opts.entries).map((slug) => load(slug)));
+      for (const slug of Object.keys(opts.entries)) {
+        await load(slug);
+      }
     },
   };
 }


### PR DESCRIPTION
## Summary
`Promise.all` over `SEEDABLE_PROMPTS` bursts the in-process MCP transport on cold start. When KB seeding is still draining on the same session, the parallel reads all queue behind it and time out together at the MCP client's 60s default — taking down the runner spawn even though steady-state DB queries are sub-50ms.

Drain entries one at a time. Negligible wall-clock cost for a handful of KB doc reads.

## Repro / signal
- Local dev backend (talks to deployed dev DB across the internet) running the AgentHostRunner cold-start would emit `prompt-cache: failed to load <slug>: MCP error -32001: Request timed out` for every entry at the same instant 60s after the last KB seed log.
- Same code in the deployed dev cluster (backend + DB co-located) doesn't trip the timeout because seeding is fast enough that the burst doesn't overlap.