### PR TITLE
feat(dashboard-pages): black + square auth pages

### DIFF
--- a/.changeset/auth-pages-black-square.md
+++ b/.changeset/auth-pages-black-square.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': minor
+---
+
+Update auth-page styling: primary action (Sign in / Continue) is now black (`bg-ink`) with cobalt-deep on hover, matching the rest of the dashboard's primary buttons. Inputs and buttons are now square (12px corner radius removed) on auth and invite acceptance pages. The `variant="navy"` prop name on `AuthSubmit` is kept for backwards compatibility but no longer uses the navy color token.

--- a/packages/dashboard-pages/src/components/auth-shell/auth-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/auth-form.tsx
@@ -33,7 +33,7 @@ export const AuthInput = forwardRef<HTMLInputElement, AuthInputProps>(
         ref={ref}
         {...props}
         className={cn(
-          'rounded-[12px] border-[0.5px] bg-paper px-4 py-3.5 text-[15px] text-ink',
+          'border-[0.5px] bg-paper px-4 py-3.5 text-[15px] text-ink',
           'placeholder:text-ink-mute',
           'transition-colors duration-fast ease-munin',
           'focus:outline-none focus:ring-[3px] focus:ring-ink/[0.08]',
@@ -58,11 +58,11 @@ export const AuthSubmit = forwardRef<HTMLButtonElement, AuthSubmitProps>(
         ref={ref}
         {...props}
         className={cn(
-          'mt-2 inline-flex w-full items-center justify-center gap-2 rounded-[12px] border-[0.5px] px-[18px] py-4 text-[15px] font-medium',
+          'mt-2 inline-flex w-full items-center justify-center gap-2 border-[0.5px] px-[18px] py-4 text-[15px] font-medium',
           'transition-colors duration-fast ease-munin active:translate-y-px',
           'disabled:cursor-not-allowed disabled:opacity-60',
           variant === 'navy'
-            ? 'border-auth-navy bg-auth-navy text-white hover:border-auth-navy-hover hover:bg-auth-navy-hover'
+            ? 'border-ink bg-ink text-paper hover:border-cobalt-deep hover:bg-cobalt-deep'
             : 'border-ink bg-transparent text-ink hover:bg-ink hover:text-paper',
           className,
         )}
@@ -102,7 +102,7 @@ export function AuthOAuthButton({
       type="button"
       {...props}
       className={cn(
-        'inline-flex w-full items-center justify-center gap-3.5 rounded-[12px] border-[0.5px] border-rule-soft bg-paper px-[18px] py-4 text-[15px] text-ink',
+        'inline-flex w-full items-center justify-center gap-3.5 border-[0.5px] border-rule-soft bg-paper px-[18px] py-4 text-[15px] text-ink',
         'transition-colors duration-fast ease-munin hover:border-ink active:translate-y-px',
         className,
       )}

--- a/packages/dashboard-pages/src/components/auth-shell/error-alert.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/error-alert.tsx
@@ -10,7 +10,7 @@ export function ErrorAlert({ title, children }: ErrorAlertProps) {
   return (
     <div
       role="alert"
-      className="mb-[22px] flex gap-3 rounded-[12px] bg-alert-bad px-4 py-3.5 text-[13px] leading-[1.5] text-alert-bad-ink"
+      className="mb-[22px] flex gap-3 bg-alert-bad px-4 py-3.5 text-[13px] leading-[1.5] text-alert-bad-ink"
     >
       <AlertCircle className="mt-px size-[18px] shrink-0" strokeWidth={2.2} />
       <div>

--- a/packages/dashboard-pages/src/pages/accept-invite.tsx
+++ b/packages/dashboard-pages/src/pages/accept-invite.tsx
@@ -75,7 +75,7 @@ function AcceptInviteInner({ footer }: { footer: AuthFooter }) {
             primary={
               <Link
                 href="/dashboard"
-                className="inline-flex items-center gap-2.5 rounded-[12px] border-[0.5px] border-auth-navy bg-auth-navy px-[22px] py-3.5 text-[15px] font-medium text-white transition-colors duration-fast ease-munin hover:border-auth-navy-hover hover:bg-auth-navy-hover"
+                className="inline-flex items-center gap-2.5 border-[0.5px] border-ink bg-ink px-[22px] py-3.5 text-[15px] font-medium text-paper transition-colors duration-fast ease-munin hover:border-cobalt-deep hover:bg-cobalt-deep"
               >
                 {t('goToDashboard')}
                 <ArrowRight className="size-4" strokeWidth={2} />
@@ -101,7 +101,7 @@ function AcceptInviteInner({ footer }: { footer: AuthFooter }) {
             primary={
               <Link
                 href={session ? '/dashboard' : '/login'}
-                className="inline-flex items-center gap-2 rounded-[12px] border-[0.5px] border-ink bg-transparent px-[18px] py-3 text-[14px] text-ink transition-colors duration-fast ease-munin hover:bg-ink hover:text-paper"
+                className="inline-flex items-center gap-2 border-[0.5px] border-ink bg-transparent px-[18px] py-3 text-[14px] text-ink transition-colors duration-fast ease-munin hover:bg-ink hover:text-paper"
               >
                 <ArrowLeft className="size-3.5" strokeWidth={2} />
                 {session ? t('backToDashboard') : t('errors.expired')}


### PR DESCRIPTION
Bring the auth/invite flows in line with the rest of the dashboard's primary-button language.

## Changes
- `AuthSubmit` (variant=navy) and the invite 'Go to dashboard' CTA now use `bg-ink` with `hover:bg-cobalt-deep` instead of `bg-auth-navy`. The dark blue token isn't removed — it just stops being the main-action color.
- `AuthInput`, `AuthOAuthButton`, `ErrorAlert`, and the invite-flow buttons drop their `rounded-[12px]` corners. Matches the broader square aesthetic.
- The `variant="navy"` prop name on `AuthSubmit` is kept for backwards compatibility but is now just 'primary' (no navy color).