### PR TITLE
fix(dashboard-pages): sticky settings sidebar + align account Save UI

### DIFF
--- a/.changeset/sticky-sidebar-save-consistency.md
+++ b/.changeset/sticky-sidebar-save-consistency.md
@@ -1,0 +1,8 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Two polish fixes:
+
+- Settings sidebar (nav + sign-out) is now `sticky` under the topbar so scrolling the main content area no longer hides the nav or the sign-out button.
+- Account page's save button label and confirmation message now match the rest of the dashboard: `Save` (not `Save changes`) and a muted-gray `Saved` toast (matching `identity-card`/`models-card`) instead of the previous cobalt-blue confirmation.

--- a/packages/dashboard-pages/src/pages/account.tsx
+++ b/packages/dashboard-pages/src/pages/account.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
-import { Button, Hero, Input, SectionHead, cn } from '@getmunin/ui';
+import { Button, Hero, Input, SectionHead } from '@getmunin/ui';
 import { api } from '../api';
 import { invalidateActiveMembershipCache } from '../auth/use-active-role';
 import { useTranslateError } from '../i18n/translate-error';
@@ -104,16 +104,11 @@ export function AccountPage({ extraSections }: AccountPageProps) {
 
           <div className="flex items-center gap-3">
             <Button type="submit" disabled={!dirty || saving}>
-              {saving ? tCommon('saving') : tCommon('saveChanges')}
+              {saving ? tCommon('saving') : tCommon('save')}
             </Button>
             {savedAt && !dirty && !error ? (
-              <span
-                key={savedAt}
-                className={cn(
-                  'font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft',
-                )}
-              >
-                {t('saved')}
+              <span key={savedAt} className="text-sm text-muted-foreground">
+                {tCommon('saved')}
               </span>
             ) : null}
           </div>

--- a/packages/dashboard-pages/src/shells/settings-shell.tsx
+++ b/packages/dashboard-pages/src/shells/settings-shell.tsx
@@ -97,7 +97,7 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
       />
 
       <div className="flex min-h-[calc(100vh-3.5rem)]">
-        <aside className="hidden w-72 shrink-0 flex-col border-r-[0.5px] border-rule-soft bg-bone md:flex dark:border-rule-on-dark dark:bg-secondary">
+        <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-72 shrink-0 flex-col self-start border-r-[0.5px] border-rule-soft bg-bone md:flex dark:border-rule-on-dark dark:bg-secondary">
           <div className="flex-1 overflow-y-auto px-6 py-10">{navTree}</div>
           <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
             {signOutButton}


### PR DESCRIPTION
## Changes
1. **Sticky settings sidebar** — `SettingsShell`'s `<aside>` is now sticky beneath the topbar (`sticky top-14 h-[calc(100vh-3.5rem)] self-start`), so the nav rail and the Sign out button stay anchored as the main column scrolls. Mobile drawer unaffected.
2. **Account page Save consistency** — button label uses `common.save` instead of `common.saveChanges`, and the post-save confirmation drops its cobalt-blue eyebrow styling in favor of a plain `text-sm text-muted-foreground` 'Saved' span. Matches the pattern in `identity-card` / `models-card`.