### PR TITLE
chore(dashboard-pages): rename account page title to perch / grein

### DIFF
--- a/.changeset/account-title-perch.md
+++ b/.changeset/account-title-perch.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Rename the Account settings page title from "Your workspace." to "Your perch." (en) / "Din grein." (nb), aligning with the raven/flock metaphor used on the rest of the dashboard pages.

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -807,7 +807,7 @@
     },
     "account": {
       "eyebrow": "Workspace · Account",
-      "title": "Your <em>workspace</em>.",
+      "title": "Your <em>perch</em>.",
       "subtitle": "Settings that apply to the whole organization.",
       "orgSectionTitle": "Organization",
       "orgNameLabel": "Organization name",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -807,7 +807,7 @@
     },
     "account": {
       "eyebrow": "Arbeidsområde · Konto",
-      "title": "Ditt <em>arbeidsområde</em>.",
+      "title": "Din <em>grein</em>.",
       "subtitle": "Innstillinger som gjelder hele organisasjonen.",
       "orgSectionTitle": "Organisasjon",
       "orgNameLabel": "Organisasjonsnavn",


### PR DESCRIPTION
Aligns the Account settings page title with the raven/flock metaphor used across the dashboard.

- en: `Your workspace.` → `Your perch.`
- nb: `Ditt arbeidsområde.` → `Din grein.`

The Activity page already uses `From the perch.` / `Fra greina.`, so the metaphor is reused across pages in both locales.