### PR TITLE
fix(dashboard-pages): sign-in alert renders the right text

### DIFF
--- a/.changeset/sign-in-error-alert.md
+++ b/.changeset/sign-in-error-alert.md
@@ -1,0 +1,8 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Fix sign-in error alert. Two bugs:
+
+- `auth.signIn.invalid.hintWithReset` used `{resetLink}` placeholder syntax, but the consumer (cloud login) calls `t.rich(...)` with a React-function value, which requires `<resetLink>...</resetLink>` tag syntax. The mismatch silently rendered nothing for the link, producing user-visible text like `"Check the address, or ."`. Switched the message to tag syntax (`<resetLink>reset your password</resetLink>`); the dead `resetLinkLabel` key is removed.
+- Added `auth.signIn.unreachable.{title,hint}` so consumers can distinguish "wrong credentials" from "backend unreachable" instead of showing the same alert title for both. The OSS login page now picks the right title/body based on whether `authClient.signIn.email` returned a structured error or the request threw.

--- a/apps/web/app/[locale]/(auth)/login/page.tsx
+++ b/apps/web/app/[locale]/(auth)/login/page.tsx
@@ -25,9 +25,12 @@ function safeRedirect(raw: string | null): string {
   return '/dashboard';
 }
 
+type SignInError = { kind: 'invalid' | 'unreachable'; detail: string };
+
 function LoginForm() {
   const t = useTranslations('auth.signIn');
   const tInvalid = useTranslations('auth.signIn.invalid');
+  const tUnreachable = useTranslations('auth.signIn.unreachable');
   const tFields = useTranslations('auth.fields');
   const tCommon = useTranslations('common');
   const translateError = useTranslateError();
@@ -41,7 +44,7 @@ function LoginForm() {
   const { refetch } = authClient.useSession();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<SignInError | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   async function onSubmit(event: React.FormEvent) {
@@ -51,19 +54,27 @@ function LoginForm() {
     try {
       const result = await authClient.signIn.email({ email, password });
       if (result.error) {
-        setError(translateError(result.error, 'unknownError') || t('failed'));
+        setError({
+          kind: 'invalid',
+          detail: translateError(result.error, 'unknownError') || t('failed'),
+        });
         return;
       }
       await refetch();
       router.push(redirectTo);
     } catch (err) {
-      setError(translateError(err) || tCommon('networkError'));
+      setError({
+        kind: 'unreachable',
+        detail: translateError(err) || tCommon('networkError'),
+      });
     } finally {
       setSubmitting(false);
     }
   }
 
   const epigraphState = error ? 'login-error' : 'login';
+  const alertTitle = error?.kind === 'unreachable' ? tUnreachable('title') : tInvalid('title');
+  const alertHint = error?.kind === 'unreachable' ? tUnreachable('hint') : tInvalid('hint');
 
   return (
     <AuthShell
@@ -73,7 +84,7 @@ function LoginForm() {
           <AuthHeading>{t('title')}</AuthHeading>
           <AuthSubheading>{t('subtitle')}</AuthSubheading>
 
-          {error && <ErrorAlert title={tInvalid('title')}>{tInvalid('hint')}</ErrorAlert>}
+          {error && <ErrorAlert title={alertTitle}>{alertHint}</ErrorAlert>}
 
           <form
             onSubmit={(event) => {

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -29,7 +29,8 @@ export default {
   '*.{ts,tsx,mjs,cjs,js,jsx}': (files) => {
     const groups = groupByPackage(files);
     return [...groups.entries()].map(
-      ([pkgDir, rel]) => `bash -c "cd ${pkgDir} && pnpm exec eslint --fix --no-warn-ignored ${rel.join(' ')}"`,
+      ([pkgDir, rel]) =>
+        `bash -c "cd ${pkgDir} && pnpm exec eslint --fix --no-warn-ignored ${rel.map((p) => `'${p}'`).join(' ')}"`,
     );
   },
   'packages/backend-core/src/**/*.ts': () => [

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -53,8 +53,11 @@
       "invalid": {
         "title": "That email and password don't match.",
         "hint": "Check the address, or try again.",
-        "hintWithReset": "Check the address, or {resetLink}.",
-        "resetLinkLabel": "reset your password"
+        "hintWithReset": "Check the address, or <resetLink>reset your password</resetLink>."
+      },
+      "unreachable": {
+        "title": "Couldn't reach the server.",
+        "hint": "Check your connection and try again."
       }
     },
     "signUp": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -53,8 +53,11 @@
       "invalid": {
         "title": "Den e-postadressen og passordet stemmer ikke.",
         "hint": "Sjekk adressen, eller prøv igjen.",
-        "hintWithReset": "Sjekk adressen, eller {resetLink}.",
-        "resetLinkLabel": "tilbakestill passordet"
+        "hintWithReset": "Sjekk adressen, eller <resetLink>tilbakestill passordet</resetLink>."
+      },
+      "unreachable": {
+        "title": "Får ikke kontakt med serveren.",
+        "hint": "Sjekk tilkoblingen og prøv igjen."
       }
     },
     "signUp": {


### PR DESCRIPTION
## Summary
Two bugs in the failed-sign-in alert, plus an unrelated lint-staged shell-quoting fix that gated the commit.

- **`"Check the address, or ."`** — `auth.signIn.invalid.hintWithReset` used `{resetLink}` placeholder syntax, but cloud's login page calls `t.rich(..., { resetLink: (chunks) => <Link>...</Link> })`, which only fills `<resetLink>...</resetLink>` tag syntax. The function got called with no chunks and rendered nothing. Switched to tag syntax (`<resetLink>reset your password</resetLink>`); the dead `resetLinkLabel` key is removed. Cloud picks this up via version bump (no consumer change needed).
- **Wrong alert title when the backend is down** — OSS login hard-coded `auth.signIn.invalid.title` for every failure, so a network error showed _"That email and password don't match."_ Added `auth.signIn.unreachable.{title,hint}`, and the OSS login page now tracks `errorKind` in state and picks the right title/body. (The cloud login page has the same bug; that's a parallel cloud PR.)
- **`lint-staged.config.mjs`** — the eslint command pasted relative paths unquoted, which broke for any path containing `(...)` (Next.js route groups). Single-quoted each path in the bash command; the commit hook now works on the touched file.

## Test plan
- [x] `pnpm --filter @getmunin/web typecheck` clean
- [x] commit hook passes on `apps/web/app/[locale]/(auth)/login/page.tsx`
- [ ] manual: stop backend, attempt login → see "Couldn't reach the server" / "Check your connection and try again"
- [ ] manual: wrong password → see "That email and password don't match." / "Check the address, or try again."

🤖 Generated with [Claude Code](https://claude.com/claude-code)