### PR TITLE
fix(web): keep sign-in button disabled through redirect

### DIFF
--- a/apps/web/app/[locale]/(auth)/login/page.tsx
+++ b/apps/web/app/[locale]/(auth)/login/page.tsx
@@ -58,6 +58,7 @@ function LoginForm() {
           kind: 'invalid',
           detail: translateError(result.error, 'unknownError') || t('failed'),
         });
+        setSubmitting(false);
         return;
       }
       await refetch();
@@ -67,7 +68,6 @@ function LoginForm() {
         kind: 'unreachable',
         detail: translateError(err) || tCommon('networkError'),
       });
-    } finally {
       setSubmitting(false);
     }
   }


### PR DESCRIPTION
## Summary
Follow-up to #193 — that PR merged before I pushed this last commit, so it's orphaned. New PR re-applies it on top of `main`.

`setSubmitting(false)` in the `finally` block fired even on the success path, briefly re-enabling the button before `router.push` actually unmounted the page. Visible UX: _Sign in_ → _Signing in…_ → _Sign in_ flash → page swap. Moves the reset into the two error paths so the button stays disabled through the redirect.

## Test plan
- [x] `pnpm --filter @getmunin/web typecheck` clean
- [ ] manual: correct credentials → button stays "Signing in…" until the dashboard renders (no flash back to "Sign in")
- [ ] manual: wrong password → error alert appears, button re-enables to "Sign in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)