### PR TITLE
feat(backend-core): host-header allow-list middleware

### DIFF
--- a/.changeset/host-allowlist-middleware.md
+++ b/.changeset/host-allowlist-middleware.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Add an optional `MUNIN_ALLOWED_HOSTS` env var that activates a Host-header allow-list middleware. When set, requests whose `Host` header (port stripped, case-insensitive) isn't in the comma-separated list get a 421 `misdirected_request` response before any controller runs.
+
+Defense-in-depth: cloud deployments are reachable both by the custom domain (`api.dev.getmunin.com`) and by the raw Scaleway container hostname. A future CORS or cookie-domain misconfig could leak via the raw hostname; this middleware rejects it at the edge. Pass-through (no enforcement) when the env var is unset — OSS dev and tests are unaffected.

--- a/packages/backend-core/src/bootstrap-app.test.ts
+++ b/packages/backend-core/src/bootstrap-app.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { hostAllowlistMiddleware } from './bootstrap-app.js';
+
+function run(mw: ReturnType<typeof hostAllowlistMiddleware>, hostHeader: string | undefined) {
+  const req = { headers: { host: hostHeader } } as unknown as Request;
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
+  const res = { status } as unknown as Response;
+  const next = vi.fn() as NextFunction;
+  mw(req, res, next);
+  return { status, json, next };
+}
+
+describe('hostAllowlistMiddleware', () => {
+  const mw = hostAllowlistMiddleware(['api.dev.example.com', 'mcp.dev.example.com']);
+
+  it('passes through a host on the allow-list', () => {
+    const { next, status } = run(mw, 'api.dev.example.com');
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('strips the port before matching', () => {
+    const { next } = run(mw, 'api.dev.example.com:3101');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('matches case-insensitively', () => {
+    const { next } = run(mw, 'API.DEV.example.com');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a host not on the allow-list with 421', () => {
+    const { status, json, next } = run(mw, 'muninclouddev920614ee-backend-dev.functions.fnc.nl-ams.scw.cloud');
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(421);
+    expect(json).toHaveBeenCalledWith({ error: 'misdirected_request' });
+  });
+
+  it('rejects a missing host header with 421', () => {
+    const { status, next } = run(mw, undefined);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(421);
+  });
+});

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -25,6 +25,12 @@ function readAllowedOrigins(): string[] | true {
   return env.split(',').map((s) => s.trim()).filter(Boolean);
 }
 
+function readAllowedHosts(): string[] | null {
+  const env = process.env.MUNIN_ALLOWED_HOSTS;
+  if (!env) return null;
+  return env.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+}
+
 export interface CreateAppOptions extends NestApplicationOptions {
   /**
    * Absolute path to the directory holding the chat-widget's hashed
@@ -56,6 +62,8 @@ export async function createApp(
 ): Promise<INestApplication> {
   const { widgetAssetDir, ...nestOpts } = opts;
   const app = await NestFactory.create(appModule, { rawBody: true, ...nestOpts });
+  const allowedHosts = readAllowedHosts();
+  if (allowedHosts) app.use(hostAllowlistMiddleware(allowedHosts));
   app.use(corsMiddleware(readAllowedOrigins()));
   app.use(requestIdMiddleware);
 
@@ -79,6 +87,19 @@ function isPublicWidgetPath(path: string): boolean {
     path.startsWith('/widget/') ||
     path.startsWith('/api/v1/widget')
   );
+}
+
+export function hostAllowlistMiddleware(allowedHosts: string[]) {
+  const allowed = new Set(allowedHosts);
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const raw = typeof req.headers.host === 'string' ? req.headers.host : '';
+    const host = raw.split(':', 1)[0]!.toLowerCase();
+    if (!host || !allowed.has(host)) {
+      res.status(421).json({ error: 'misdirected_request' });
+      return;
+    }
+    next();
+  };
 }
 
 function corsMiddleware(strictOrigins: string[] | true) {


### PR DESCRIPTION
First half of munin-cloud issue #83 P1 item — backend reachable via its raw Scaleway domain.

## Summary
Adds `MUNIN_ALLOWED_HOSTS` — a comma-separated allow-list activated only when the env var is set. Requests whose `Host` header (port stripped, case-insensitive) doesn't match get a 421 `misdirected_request` before any controller runs.

## Why
Cloud deploys are reachable both by the user-facing custom domain (`api.dev.getmunin.com`) and by the raw Scaleway container hostname (`muninclouddev…-backend-dev.functions.fnc.nl-ams.scw.cloud`). A future CORS or cookie-domain misconfig could be exploited via the raw host; this middleware rejects it at the edge. Pass-through (no enforcement) when the env var is unset — OSS dev/tests are unaffected.

## What's next
- Once this releases, a munin-cloud PR will set `MUNIN_ALLOWED_HOSTS = "${local.api_host},${local.mcp_host}"` in `terraform/containers.tf`.

## Test plan
- [x] Unit test for matcher (5 cases — pass, port-strip, case-insensitive, reject, missing).
- [x] `pnpm -F @getmunin/backend-core typecheck` clean.
- [ ] After release + cloud bump: `curl -H "Host: muninclouddev…fnc.nl-ams.scw.cloud" https://api.dev.getmunin.com/auth/get-session` → 421; same call with `Host: api.dev.getmunin.com` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)