### PR TITLE
feat(backend-core): Redis-backed rate-limit store for better-auth

### DIFF
--- a/.changeset/redis-rate-limit-store.md
+++ b/.changeset/redis-rate-limit-store.md
@@ -1,0 +1,27 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Add `createRedisRateLimitStore(...)` — a `RateLimit`-storage adapter compatible with better-auth's `rateLimit.customStorage` option, backed by an `ioredis` client. Lets multi-instance backends (e.g. autoscaled cloud deployments) share rate-limit counters across replicas instead of each replica counting only its own traffic.
+
+`ioredis` is an **optional peer dep** — consumers that don't use Redis-backed rate limiting don't need to install it. The store reads/writes JSON-encoded entries (`{ key, count, lastRequest }`) with a configurable TTL (default 1h, key prefix `munin:rate-limit:`).
+
+Usage:
+```ts
+import { Redis } from 'ioredis';
+import { createRedisRateLimitStore } from '@getmunin/backend-core';
+
+const client = new Redis(process.env.MUNIN_REDIS_URL!);
+const auth = betterAuth({
+  rateLimit: {
+    storage: 'custom',
+    customStorage: createRedisRateLimitStore({ client }),
+    customRules: {
+      '/sign-in/email':       { window: 60, max: 5 },
+      '/sign-up/email':       { window: 60, max: 3 },
+      '/forgot-password':     { window: 60, max: 3 },
+    },
+  },
+  // …
+});
+```

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -66,6 +66,12 @@
     "ws": "^8.18.0",
     "zod": "^4.3.6"
   },
+  "peerDependencies": {
+    "ioredis": "^5.4.0"
+  },
+  "peerDependenciesMeta": {
+    "ioredis": { "optional": true }
+  },
   "devDependencies": {
     "@getmunin/eslint-config": "workspace:*",
     "@getmunin/tsconfig": "workspace:*",
@@ -77,6 +83,7 @@
     "@types/nodemailer": "^8.0.0",
     "@types/ws": "^8.5.13",
     "eslint": "^9.10.0",
+    "ioredis": "^5.4.0",
     "typescript": "^5.6.0",
     "unplugin-swc": "^1.5.9",
     "vitest": "^2.1.0"

--- a/packages/backend-core/src/auth/better-auth-redis-store.test.ts
+++ b/packages/backend-core/src/auth/better-auth-redis-store.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { Redis } from 'ioredis';
+import { createRedisRateLimitStore } from './better-auth-redis-store.js';
+
+const REDIS_URL = process.env.TEST_REDIS_URL;
+const itIfRedis = REDIS_URL ? it : it.skip;
+
+describe('createRedisRateLimitStore', () => {
+  itIfRedis('persists a rate-limit entry across get() calls', async () => {
+    const client = new Redis(REDIS_URL!);
+    try {
+      const store = createRedisRateLimitStore({
+        client,
+        keyPrefix: `munin:test:${Date.now()}:`,
+      });
+
+      const key = `probe:${Math.random()}`;
+      expect(await store.get(key)).toBeNull();
+
+      await store.set(key, { key, count: 1, lastRequest: 1779000000000 });
+      const first = await store.get(key);
+      expect(first).toEqual({ key, count: 1, lastRequest: 1779000000000 });
+
+      await store.set(key, { key, count: 2, lastRequest: 1779000060000 });
+      const second = await store.get(key);
+      expect(second).toEqual({ key, count: 2, lastRequest: 1779000060000 });
+    } finally {
+      await client.quit();
+    }
+  });
+
+  itIfRedis('returns null when the entry is missing', async () => {
+    const client = new Redis(REDIS_URL!);
+    try {
+      const store = createRedisRateLimitStore({
+        client,
+        keyPrefix: `munin:test:${Date.now()}:`,
+      });
+      expect(await store.get('does-not-exist')).toBeNull();
+    } finally {
+      await client.quit();
+    }
+  });
+
+  itIfRedis('returns null when stored JSON is malformed', async () => {
+    const client = new Redis(REDIS_URL!);
+    try {
+      const prefix = `munin:test:${Date.now()}:`;
+      await client.set(`${prefix}corrupt`, '{not-valid-json', 'EX', 60);
+      const store = createRedisRateLimitStore({ client, keyPrefix: prefix });
+      expect(await store.get('corrupt')).toBeNull();
+    } finally {
+      await client.quit();
+    }
+  });
+});

--- a/packages/backend-core/src/auth/better-auth-redis-store.ts
+++ b/packages/backend-core/src/auth/better-auth-redis-store.ts
@@ -1,0 +1,58 @@
+import type { Redis } from 'ioredis';
+
+/**
+ * Shape better-auth passes to a custom rate-limit store. Matches
+ * `RateLimit` in the better-auth source: a tiny counter plus the
+ * timestamp of the last request, used to expire the window.
+ */
+export interface BetterAuthRateLimitEntry {
+  key: string;
+  count: number;
+  lastRequest: number;
+}
+
+export interface BetterAuthRateLimitStorage {
+  get(key: string): Promise<BetterAuthRateLimitEntry | null>;
+  set(key: string, value: BetterAuthRateLimitEntry): Promise<void>;
+}
+
+const DEFAULT_KEY_PREFIX = 'munin:rate-limit:';
+
+const DEFAULT_TTL_SECONDS = 60 * 60;
+
+export interface CreateRedisRateLimitStoreOptions {
+  client: Redis;
+  keyPrefix?: string;
+  ttlSeconds?: number;
+}
+
+export function createRedisRateLimitStore(
+  opts: CreateRedisRateLimitStoreOptions,
+): BetterAuthRateLimitStorage {
+  const { client } = opts;
+  const prefix = opts.keyPrefix ?? DEFAULT_KEY_PREFIX;
+  const ttl = opts.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+
+  return {
+    async get(key) {
+      const raw = await client.get(prefix + key);
+      if (raw === null) return null;
+      try {
+        const parsed = JSON.parse(raw) as Partial<BetterAuthRateLimitEntry>;
+        if (
+          typeof parsed.key === 'string' &&
+          typeof parsed.count === 'number' &&
+          typeof parsed.lastRequest === 'number'
+        ) {
+          return { key: parsed.key, count: parsed.count, lastRequest: parsed.lastRequest };
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    },
+    async set(key, value) {
+      await client.set(prefix + key, JSON.stringify(value), 'EX', ttl);
+    },
+  };
+}

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -17,6 +17,13 @@ export {
 } from './auth-controller-factory.js';
 
 export {
+  createRedisRateLimitStore,
+  type BetterAuthRateLimitEntry,
+  type BetterAuthRateLimitStorage,
+  type CreateRedisRateLimitStoreOptions,
+} from './auth/better-auth-redis-store.js';
+
+export {
   readGoogleProviderFromEnv,
   readTrustedOriginsFromEnv,
 } from './auth-env.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
       eslint:
         specifier: ^9.10.0
         version: 9.39.4(jiti@1.21.7)
+      ioredis:
+        specifier: ^5.4.0
+        version: 5.10.1
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -1862,6 +1865,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3709,6 +3715,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
@@ -3914,6 +3924,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -4668,6 +4682,10 @@ packages:
   intl-messageformat@11.2.3:
     resolution: {integrity: sha512-kZthTU+3WLcoWoRg5j6LOkN1TeUBtmkX0OIwSAbcHVIfQAEbGVdmANM8u6GL3eUDOqLwheYoXMUshAh1UdeXlQ==}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -4960,6 +4978,12 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -5760,6 +5784,14 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -6011,6 +6043,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -7697,6 +7732,8 @@ snapshots:
   '@inquirer/type@4.0.5(@types/node@22.19.17)':
     optionalDependencies:
       '@types/node': 22.19.17
+
+  '@ioredis/commands@1.5.1': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -9599,6 +9636,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   code-block-writer@13.0.3: {}
 
   color-convert@2.0.1:
@@ -9769,6 +9808,8 @@ snapshots:
       - canvas
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -10566,6 +10607,20 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.3
       '@formatjs/icu-messageformat-parser': 3.5.6
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -10824,6 +10879,10 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -11750,6 +11809,12 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect-metadata@0.2.2: {}
 
   remark-parse@11.0.0:
@@ -12108,6 +12173,8 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
First half of munin-cloud issue #83 P1 — better-auth's in-memory rate limit undercounts under autoscale. This PR adds a shared Redis store; the cloud PR (after this releases + cloud bumps deps) wires it into `cloud-auth.ts`.

## What's added

```ts
import { Redis } from 'ioredis';
import { createRedisRateLimitStore } from '@getmunin/backend-core';

const client = new Redis(process.env.MUNIN_REDIS_URL!);
const auth = betterAuth({
  rateLimit: {
    storage: 'custom',
    customStorage: createRedisRateLimitStore({ client }),
    customRules: {
      '/sign-in/email':   { window: 60, max: 5 },
      '/sign-up/email':   { window: 60, max: 3 },
      '/forgot-password': { window: 60, max: 3 },
    },
  },
  // …
});
```

- New module: `packages/backend-core/src/auth/better-auth-redis-store.ts`. Returns `{ get, set }` matching better-auth's `customStorage` interface (`RateLimit = { key: string; count: number; lastRequest: number }` — confirmed against the better-auth source).
- `ioredis` is added as an **optional peer dep** — consumers that don't use Redis-backed rate limiting don't pay the install cost.
- Tests gated on `TEST_REDIS_URL` (mirrors `rls.test.ts` pattern). Verified passing locally against `redis:7-alpine`:
  - persists across get() calls
  - returns null for missing key
  - returns null for malformed JSON
- Public API exported from `src/index.ts`.

## What's next
- Once this releases, munin-cloud bumps `@getmunin/backend-core`, plugs the store into `packages/cloud-onboarding/src/cloud-auth.ts`, and adds `MUNIN_REDIS_URL` to the backend container env (sourced from the Secret Manager entry that landed in munin-cloud#97).

## Test plan
- [x] `pnpm -F @getmunin/backend-core typecheck` clean.
- [x] Tests pass against real Redis (`docker run --rm -p 6379:6379 redis:7-alpine`).
- [x] Tests skip cleanly without `TEST_REDIS_URL`.
- [ ] After cloud bump + deploy: hit `/auth/sign-in/email` with bad creds 6 times in 60s, expect the 6th to return 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)