### PR TITLE
fix(backend-core): permissive CORS on /mcp + OAuth discovery

### DIFF
--- a/.changeset/mcp-cors-claude-ai.md
+++ b/.changeset/mcp-cors-claude-ai.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Send permissive CORS headers from `/mcp`, the OAuth/OIDC discovery endpoints, and the public client-info endpoint (`/api/v1/oauth/clients/:id`).
+
+Browser-based MCP clients like claude.ai web are served from `https://claude.ai`, which isn't in any deployment's `MUNIN_CORS_ORIGINS` (and shouldn't have to be). Previously the preflight to `/mcp` returned 204 with no `Access-Control-Allow-Origin`, so the browser blocked the POST and showed "Couldn't reach the MCP server". Same gap on the well-known discovery endpoints any OAuth client needs to read cross-origin during dynamic client registration.
+
+Renames the internal predicate `isPublicWidgetPath` → `isPublicCorsPath` and exports it for tests.

--- a/packages/backend-core/src/bootstrap-app.test.ts
+++ b/packages/backend-core/src/bootstrap-app.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
-import { hostAllowlistMiddleware } from './bootstrap-app.js';
+import { hostAllowlistMiddleware, isPublicCorsPath } from './bootstrap-app.js';
 
 function run(mw: ReturnType<typeof hostAllowlistMiddleware>, hostHeader: string | undefined) {
   const req = { headers: { host: hostHeader } } as unknown as Request;
@@ -42,5 +42,31 @@ describe('hostAllowlistMiddleware', () => {
     const { status, next } = run(mw, undefined);
     expect(next).not.toHaveBeenCalled();
     expect(status).toHaveBeenCalledWith(421);
+  });
+});
+
+describe('isPublicCorsPath', () => {
+  it('matches /mcp and sub-paths so claude.ai and other external MCP clients can call cross-origin', () => {
+    expect(isPublicCorsPath('/mcp')).toBe(true);
+    expect(isPublicCorsPath('/mcp/anything')).toBe(true);
+  });
+
+  it('matches OAuth + OIDC discovery + dynamic-client-registration helper endpoints', () => {
+    expect(isPublicCorsPath('/.well-known/oauth-authorization-server')).toBe(true);
+    expect(isPublicCorsPath('/.well-known/oauth-protected-resource')).toBe(true);
+    expect(isPublicCorsPath('/.well-known/openid-configuration')).toBe(true);
+    expect(isPublicCorsPath('/api/v1/oauth/clients/abc123')).toBe(true);
+  });
+
+  it('matches the widget bundle + ingest endpoints', () => {
+    expect(isPublicCorsPath('/widget.js')).toBe(true);
+    expect(isPublicCorsPath('/widget/abc.js')).toBe(true);
+    expect(isPublicCorsPath('/api/v1/widget/messages')).toBe(true);
+  });
+
+  it('does not match the rest of the control plane', () => {
+    expect(isPublicCorsPath('/api/v1/kb/spaces')).toBe(false);
+    expect(isPublicCorsPath('/auth/sign-in')).toBe(false);
+    expect(isPublicCorsPath('/healthz')).toBe(false);
   });
 });

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -81,11 +81,16 @@ export async function createApp(
   return app;
 }
 
-function isPublicWidgetPath(path: string): boolean {
+export function isPublicCorsPath(path: string): boolean {
   return (
     path === '/widget.js' ||
     path.startsWith('/widget/') ||
-    path.startsWith('/api/v1/widget')
+    path.startsWith('/api/v1/widget') ||
+    path === '/mcp' ||
+    path.startsWith('/mcp/') ||
+    path.startsWith('/.well-known/oauth-') ||
+    path.startsWith('/.well-known/openid-') ||
+    path.startsWith('/api/v1/oauth/clients/')
   );
 }
 
@@ -105,7 +110,7 @@ export function hostAllowlistMiddleware(allowedHosts: string[]) {
 function corsMiddleware(strictOrigins: string[] | true) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
-    const allowAny = isPublicWidgetPath(req.path);
+    const allowAny = isPublicCorsPath(req.path);
     const allowed =
       origin !== undefined &&
       (allowAny || strictOrigins === true || strictOrigins.includes(origin));


### PR DESCRIPTION
## Summary
- `/mcp`, `/.well-known/oauth-*`, `/.well-known/openid-*`, and `/api/v1/oauth/clients/:id` now reflect the request `Origin` back in `Access-Control-Allow-Origin` regardless of `MUNIN_CORS_ORIGINS`.
- Renames the internal predicate `isPublicWidgetPath` → `isPublicCorsPath` and exports it so the test file can pin the path list.

## Why
claude.ai web (and any other browser-hosted MCP client) is served from `https://claude.ai`. The dashboard's `MUNIN_CORS_ORIGINS` allowlist (e.g. `app.dev.getmunin.com`) is the right gate for the control-plane API, but it's the wrong gate for the public MCP endpoint — any external MCP client should be able to call it cross-origin after completing OAuth. Previously the browser blocked the POST and surfaced "Couldn't reach the MCP server" even though the consent flow had completed.

## Test plan
- [x] `pnpm -F @getmunin/backend-core test src/bootstrap-app.test.ts` — new predicate test
- [ ] CI green
- [ ] After release + cloud bump: claude.ai web → "Add custom integration" against `https://mcp.dev.getmunin.com/mcp` connects without the "Couldn't reach the MCP server" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)