### PR TITLE
feat(backend-core): canonical public URLs for MCP + REST

### DIFF
--- a/.changeset/host-canonical-urls.md
+++ b/.changeset/host-canonical-urls.md
@@ -1,0 +1,18 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+`MUNIN_PUBLIC_URL` is now the **canonical MCP resource URL** verbatim — no implicit `/mcp` appending. Adds an optional `MUNIN_API_URL` for a canonical REST URL.
+
+**Backend (`@getmunin/backend-core`)**
+- `mcpResourceUrl()` returns `MUNIN_PUBLIC_URL` exactly. `authorizationServerUrl()` (and `readPublicBaseUrl()`) return its origin.
+- New `publicUrlRewriteMiddleware` maps the canonical external URLs onto the internal Nest mount points — `/mcp` for MCP, `/api/v1` for REST. So a deploy can advertise `https://mcp.example.com` (no path) and `https://api.example.com/v1` while every controller stays mounted at its original internal path. Pass-through when the env vars name the same internal path (OSS default).
+- Adds `MCP_INTERNAL_PATH` (`'/mcp'`) and re-exports the old `MCP_RESOURCE_PATH` for back-compat.
+
+**Default change** — OSS default `MUNIN_PUBLIC_URL` is now `http://localhost:3001/mcp` (path included). Existing self-hosters who set `MUNIN_PUBLIC_URL=http://localhost:3001` (no path) will see their OAuth resource URL change from `…/mcp` to bare host — every active token will need refreshing. To keep the old behavior verbatim, set `MUNIN_PUBLIC_URL=http://localhost:3001/mcp`.
+
+**Dashboard (`@getmunin/dashboard-pages`)**
+- `GetStarted` fetches the canonical MCP URL from `/.well-known/oauth-protected-resource` and renders it in the Claude / ChatGPT / Gemini config snippets. OSS self-host now shows `http://localhost:3001/mcp` (or whatever the local backend advertises); cloud shows `mcp.getmunin.com`.
+- `mcp-setups.ts` ships a `buildMcpSetups(host)` helper alongside the static fallback.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,42 @@ The first user to sign up becomes the org admin; subsequent users need an invita
 
 **Hosted** (https://getmunin.com): multi-tenant, one signup per org.
 
+## Try it locally
+
+After `docker compose up`, the backend listens on `:3001` and the dashboard on `:3000`.
+
+1. Open `http://localhost:3000` and register the first user — they become the singleton org admin.
+2. In the dashboard, go to **Settings → API keys** and mint an admin key (`mn_admin_…`). Shown once; treat like a password.
+3. Pick one of:
+
+```sh
+# REST control plane — direct, no OAuth
+curl -s http://localhost:3001/api/v1/kb/spaces \
+  -H "Authorization: Bearer mn_admin_..." | jq
+
+# MCP tool browser (recommended for poking at tools/skills)
+npx @modelcontextprotocol/inspector
+# In its UI: URL = http://localhost:3001/mcp, Auth = Bearer mn_admin_...
+
+# Claude Code (CLI)
+claude mcp add munin-local http://localhost:3001/mcp
+# Then `claude` → OAuth flow opens in browser → tools available
+
+# Claude Desktop — claude_desktop_config.json
+# {
+#   "mcpServers": { "munin": { "url": "http://localhost:3001/mcp" } }
+# }
+
+# Raw curl over Streamable HTTP — useful for sanity-checking the transport
+curl -N -X POST http://localhost:3001/mcp \
+  -H "Authorization: Bearer mn_admin_..." \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+The OpenAPI spec for the REST control plane is at `packages/backend-core/openapi.json`.
+
 ## Connect your AI agent
 
 Once you've signed up (hosted) or run `docker compose up` (self-host), point your MCP client at the URL.

--- a/packages/backend-core/src/bootstrap-app.test.ts
+++ b/packages/backend-core/src/bootstrap-app.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
-import { hostAllowlistMiddleware, isPublicCorsPath } from './bootstrap-app.js';
+import {
+  hostAllowlistMiddleware,
+  isPublicCorsPath,
+  publicUrlRewriteMiddleware,
+} from './bootstrap-app.js';
 
 function run(mw: ReturnType<typeof hostAllowlistMiddleware>, hostHeader: string | undefined) {
   const req = { headers: { host: hostHeader } } as unknown as Request;
@@ -68,5 +72,84 @@ describe('isPublicCorsPath', () => {
     expect(isPublicCorsPath('/api/v1/kb/spaces')).toBe(false);
     expect(isPublicCorsPath('/auth/sign-in')).toBe(false);
     expect(isPublicCorsPath('/healthz')).toBe(false);
+  });
+});
+
+describe('publicUrlRewriteMiddleware', () => {
+  const originalPublic = process.env.MUNIN_PUBLIC_URL;
+  const originalApi = process.env.MUNIN_API_URL;
+
+  beforeEach(() => {
+    delete process.env.MUNIN_PUBLIC_URL;
+    delete process.env.MUNIN_API_URL;
+  });
+  afterEach(() => {
+    if (originalPublic === undefined) delete process.env.MUNIN_PUBLIC_URL;
+    else process.env.MUNIN_PUBLIC_URL = originalPublic;
+    if (originalApi === undefined) delete process.env.MUNIN_API_URL;
+    else process.env.MUNIN_API_URL = originalApi;
+  });
+
+  function runMw(host: string, url: string): { url: string; nextCalled: boolean } {
+    const req = { headers: { host }, url } as unknown as Request;
+    const res = {} as Response;
+    const next = vi.fn() as NextFunction;
+    publicUrlRewriteMiddleware()(req, res, next);
+    return { url: (req as { url: string }).url, nextCalled: (next as { mock?: { calls: unknown[] } }).mock!.calls.length > 0 };
+  }
+
+  it('passes /mcp through unchanged on the OSS default URL', () => {
+    process.env.MUNIN_PUBLIC_URL = 'http://localhost:3001/mcp';
+    const out = runMw('localhost:3001', '/mcp');
+    expect(out.url).toBe('/mcp');
+    expect(out.nextCalled).toBe(true);
+  });
+
+  it('maps the root URL on the canonical MCP host to /mcp internally', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://mcp.getmunin.com';
+    expect(runMw('mcp.getmunin.com', '/').url).toBe('/mcp');
+    expect(runMw('mcp.getmunin.com', '/?session=abc').url).toBe('/mcp?session=abc');
+    expect(runMw('mcp.getmunin.com', '').url).toBe('/mcp');
+  });
+
+  it('does NOT rewrite OAuth discovery or static asset paths on the canonical host', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://mcp.getmunin.com';
+    expect(runMw('mcp.getmunin.com', '/.well-known/oauth-protected-resource').url).toBe(
+      '/.well-known/oauth-protected-resource',
+    );
+    expect(runMw('mcp.getmunin.com', '/auth/oauth2/authorize?foo=1').url).toBe(
+      '/auth/oauth2/authorize?foo=1',
+    );
+    expect(runMw('mcp.getmunin.com', '/favicon.ico').url).toBe('/favicon.ico');
+  });
+
+  it('leaves other hosts untouched (api.* should not be MCP-rewritten)', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://mcp.getmunin.com';
+    expect(runMw('api.getmunin.com', '/').url).toBe('/');
+    expect(runMw('api.getmunin.com', '/api/v1/kb/spaces').url).toBe('/api/v1/kb/spaces');
+  });
+
+  it('maps /v1/... on the canonical API host to /api/v1/... internally', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://mcp.getmunin.com';
+    process.env.MUNIN_API_URL = 'https://api.getmunin.com/v1';
+    expect(runMw('api.getmunin.com', '/v1/kb/spaces').url).toBe('/api/v1/kb/spaces');
+    expect(runMw('api.getmunin.com', '/v1/kb/spaces?limit=10').url).toBe(
+      '/api/v1/kb/spaces?limit=10',
+    );
+    expect(runMw('api.getmunin.com', '/v1').url).toBe('/api/v1');
+  });
+
+  it('still accepts legacy /api/v1/* requests on the canonical API host', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://mcp.getmunin.com';
+    process.env.MUNIN_API_URL = 'https://api.getmunin.com/v1';
+    // /api/v1 does not start with /v1/ — it starts with /api — so the
+    // rewriter leaves it alone and the internal mount handles it as-is.
+    expect(runMw('api.getmunin.com', '/api/v1/kb/spaces').url).toBe('/api/v1/kb/spaces');
+  });
+
+  it('does not match a path that just starts with the prefix as a substring', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://mcp.getmunin.com';
+    process.env.MUNIN_API_URL = 'https://api.getmunin.com/v1';
+    expect(runMw('api.getmunin.com', '/v1foo/bar').url).toBe('/v1foo/bar');
   });
 });

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -73,6 +73,11 @@ export async function createApp(
   const app = await NestFactory.create(appModule, { rawBody: true, ...nestOpts });
   const allowedHosts = readAllowedHosts();
   if (allowedHosts) app.use(hostAllowlistMiddleware(allowedHosts));
+  // Map the canonical external URLs (MUNIN_PUBLIC_URL for MCP,
+  // MUNIN_API_URL for REST) onto the internal Nest mount paths
+  // (`/mcp`, `/api/v1`). Runs before every other middleware so CORS,
+  // routing, and tests all see the rewritten URL.
+  app.use(publicUrlRewriteMiddleware());
   app.use(corsMiddleware(readAllowedOrigins()));
   app.use(requestIdMiddleware);
 
@@ -104,6 +109,83 @@ export function isPublicCorsPath(path: string): boolean {
     path.startsWith('/.well-known/openid-') ||
     path.startsWith('/api/v1/oauth/clients/')
   );
+}
+
+/**
+ * Maps the canonical public URLs onto the internal Nest mount points.
+ *
+ *   - `MUNIN_PUBLIC_URL`'s host + path → `/mcp`
+ *   - `MUNIN_API_URL`'s host + path     → `/api/v1`
+ *
+ * So a cloud deploy can advertise `https://mcp.getmunin.com` (no path)
+ * for MCP and `https://api.getmunin.com/v1` for REST while every Nest
+ * controller stays mounted at its original internal path. The
+ * middleware mutates `req.url`; everything downstream (CORS check,
+ * routing, audit log, tests) sees the rewritten URL.
+ *
+ * Pass-through when the env vars name the same internal path: OSS
+ * default `MUNIN_PUBLIC_URL=http://localhost:3001/mcp` keeps `/mcp` →
+ * `/mcp` (no-op). Same for `/api/v1` → `/api/v1`.
+ */
+export function publicUrlRewriteMiddleware() {
+  const mcp = parseRewriteSource(process.env.MUNIN_PUBLIC_URL ?? 'http://localhost:3001/mcp');
+  const api = parseRewriteSource(process.env.MUNIN_API_URL);
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const rawHost = typeof req.headers.host === 'string' ? req.headers.host : '';
+    const host = rawHost.split(':', 1)[0]!.toLowerCase();
+    rewriteIfMatch(req, host, mcp, '/mcp');
+    if (api) rewriteIfMatch(req, host, api, '/api/v1');
+    next();
+  };
+}
+
+interface RewriteSource {
+  host: string;
+  externalPath: string;
+}
+
+function parseRewriteSource(raw: string | undefined): RewriteSource | null {
+  if (!raw) return null;
+  try {
+    const u = new URL(raw);
+    const path = u.pathname.replace(/\/+$/, '');
+    return { host: u.hostname.toLowerCase(), externalPath: path };
+  } catch {
+    return null;
+  }
+}
+
+function rewriteIfMatch(
+  req: Request,
+  host: string,
+  src: RewriteSource | null,
+  internal: string,
+): void {
+  if (!src) return;
+  if (src.host !== host) return;
+  if (src.externalPath === internal) return; // pass-through
+
+  const [path, qs] = splitQuery(req.url ?? '/');
+  // Empty external path → resource lives at the host root; only the
+  // root URL itself maps to the internal mount. `/auth`, `/.well-known/*`,
+  // `/favicon.ico` and friends pass through unchanged.
+  if (src.externalPath === '') {
+    if (path === '/' || path === '') {
+      req.url = internal + (qs ? `?${qs}` : '');
+    }
+    return;
+  }
+  // Path-segment match — `/v1` matches `/v1/...` but not `/v1foo`.
+  if (path === src.externalPath) {
+    req.url = internal + (qs ? `?${qs}` : '');
+  } else if (path.startsWith(`${src.externalPath}/`)) {
+    req.url = `${internal}${path.slice(src.externalPath.length)}${qs ? `?${qs}` : ''}`;
+  }
+}
+
+function splitQuery(url: string): [string, string] {
+  const i = url.indexOf('?');
+  return i < 0 ? [url, ''] : [url.slice(0, i), url.slice(i + 1)];
 }
 
 export function hostAllowlistMiddleware(allowedHosts: string[]) {

--- a/packages/backend-core/src/oauth/oauth-conformance.integration.test.ts
+++ b/packages/backend-core/src/oauth/oauth-conformance.integration.test.ts
@@ -37,7 +37,7 @@ const skipReason = TEST_URL
     const address = server.address();
     if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
     baseUrl = `http://127.0.0.1:${address.port}`;
-    process.env.MUNIN_PUBLIC_URL = baseUrl;
+    process.env.MUNIN_PUBLIC_URL = `${baseUrl}/mcp`;
   });
 
   afterAll(async () => {

--- a/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
@@ -14,8 +14,8 @@ describe('OAuthResourceController', () => {
     else process.env.MUNIN_PUBLIC_URL = originalUrl;
   });
 
-  it('returns RFC 9728 metadata pointing at the configured public URL', () => {
-    process.env.MUNIN_PUBLIC_URL = 'https://api.example.test';
+  it('returns RFC 9728 metadata when MUNIN_PUBLIC_URL carries the /mcp path', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://api.example.test/mcp';
     const meta = new OAuthResourceController().metadata();
     expect(meta).toEqual({
       resource: 'https://api.example.test/mcp',
@@ -27,8 +27,16 @@ describe('OAuthResourceController', () => {
     });
   });
 
+  it('advertises MCP at the host root when MUNIN_PUBLIC_URL has no path', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://mcp.example.test';
+    const meta = new OAuthResourceController().metadata();
+    expect(meta.resource).toBe('https://mcp.example.test');
+    expect(meta.authorization_servers).toEqual(['https://mcp.example.test']);
+    expect(meta.resource_documentation).toBe('https://mcp.example.test/docs');
+  });
+
   it('strips trailing slashes from MUNIN_PUBLIC_URL', () => {
-    process.env.MUNIN_PUBLIC_URL = 'https://api.example.test/';
+    process.env.MUNIN_PUBLIC_URL = 'https://api.example.test/mcp/';
     const meta = new OAuthResourceController().metadata();
     expect(meta.resource).toBe('https://api.example.test/mcp');
     expect(meta.authorization_servers).toEqual(['https://api.example.test']);

--- a/packages/backend-core/src/oauth/oauth.constants.ts
+++ b/packages/backend-core/src/oauth/oauth.constants.ts
@@ -1,4 +1,12 @@
-export const MCP_RESOURCE_PATH = '/mcp';
+/**
+ * Nest mount path for the MCP controller. External clients see whatever
+ * URL `MUNIN_PUBLIC_URL` advertises; the host-based rewriter in
+ * `bootstrap-app.ts` maps that external URL to this internal mount path.
+ */
+export const MCP_INTERNAL_PATH = '/mcp';
+
+/** Back-compat re-export — older callers imported MCP_RESOURCE_PATH. */
+export const MCP_RESOURCE_PATH = MCP_INTERNAL_PATH;
 
 export const SUPPORTED_SCOPES = [
   'mcp:tools',
@@ -18,18 +26,75 @@ export const SUPPORTED_SCOPES = [
 
 export type SupportedScope = (typeof SUPPORTED_SCOPES)[number];
 
-export function readPublicBaseUrl(): string {
-  return (process.env.MUNIN_PUBLIC_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
-}
+const DEFAULT_PUBLIC_URL = 'http://localhost:3001/mcp';
 
+/**
+ * `MUNIN_PUBLIC_URL` is the **canonical MCP resource URL** — the URL
+ * external clients (claude.ai, the local MCP Inspector, …) configure
+ * verbatim. Returned exactly as-is (minus trailing slashes); the OAuth
+ * issuer is derived from its origin (scheme + host + port).
+ *
+ * Cloud sets this to `https://mcp.getmunin.com` (no path); the
+ * bootstrap-app middleware rewrites root requests on that host to
+ * `/mcp` internally. OSS default keeps the `/mcp` path segment so
+ * `http://localhost:3001/mcp` is the canonical URL out of the box.
+ */
 export function mcpResourceUrl(): string {
-  return `${readPublicBaseUrl()}${MCP_RESOURCE_PATH}`;
+  return (process.env.MUNIN_PUBLIC_URL ?? DEFAULT_PUBLIC_URL).replace(/\/+$/, '');
 }
 
+/** Origin (scheme + host + port) of `MUNIN_PUBLIC_URL`. The OAuth issuer. */
 export function authorizationServerUrl(): string {
-  return readPublicBaseUrl();
+  return parsePublicUrl().origin;
+}
+
+/**
+ * Origin of `MUNIN_PUBLIC_URL` — used by non-MCP code that needs to
+ * compose a public URL pointing back at this backend (e.g. email
+ * tracking pixel URLs). Kept as an alias of `authorizationServerUrl()`.
+ */
+export function readPublicBaseUrl(): string {
+  return authorizationServerUrl();
 }
 
 export function resourceMetadataUrl(): string {
-  return `${readPublicBaseUrl()}/.well-known/oauth-protected-resource`;
+  return `${authorizationServerUrl()}/.well-known/oauth-protected-resource`;
+}
+
+/** Hostname of `MUNIN_PUBLIC_URL` — `mcp.getmunin.com`, `localhost`, … */
+export function mcpExternalHost(): string {
+  return parsePublicUrl().hostname;
+}
+
+/**
+ * Pathname of `MUNIN_PUBLIC_URL`. Empty string when the resource lives
+ * at the host root (e.g. `https://mcp.getmunin.com`). The host-based
+ * rewriter uses this to decide which incoming paths to forward to the
+ * internal `/mcp` mount.
+ */
+export function mcpExternalPath(): string {
+  const path = parsePublicUrl().pathname;
+  return path === '/' ? '' : path.replace(/\/+$/, '');
+}
+
+/**
+ * Optional canonical REST URL — e.g. `https://api.getmunin.com/v1`. When
+ * set, the bootstrap-app rewriter accepts requests on the parsed host
+ * whose path starts with the parsed prefix and rewrites them to the
+ * internal `/api/v1` mount. Lets the dashboard / external integrations
+ * call `/v1/…` without the legacy `/api/v1/…` prefix while keeping
+ * every controller path stable internally.
+ */
+export function apiExternalUrl(): string | null {
+  const raw = process.env.MUNIN_API_URL;
+  if (!raw) return null;
+  return raw.replace(/\/+$/, '');
+}
+
+function parsePublicUrl(): URL {
+  try {
+    return new URL(mcpResourceUrl());
+  } catch {
+    return new URL(DEFAULT_PUBLIC_URL);
+  }
 }

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -216,8 +216,7 @@ export class CredentialResolver {
 }
 
 function oauthMcpResourceAudience(): string {
-  const base = (process.env.MUNIN_PUBLIC_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
-  return `${base}/mcp`;
+  return (process.env.MUNIN_PUBLIC_URL ?? 'http://localhost:3001/mcp').replace(/\/+$/, '');
 }
 
 function deriveAudiencesFromScopes(scopes: string[]): Audience[] {

--- a/packages/dashboard-pages/src/components/dashboard/get-started.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/get-started.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { Link } from '../../i18n-navigation';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn, Eyebrow } from '@getmunin/ui';
-import { MCP_SETUPS, type McpSetup } from '../../data/mcp-setups';
+import { buildMcpSetups, MCP_SETUPS, type McpSetup } from '../../data/mcp-setups';
 import { RECIPES, type Recipe } from '../../data/recipes';
 import { RecipeDrawer } from './recipe-drawer';
 
@@ -13,8 +13,29 @@ export function GetStarted() {
   const [activeId, setActiveId] = useState<McpSetup['id']>('claude');
   const [openRecipe, setOpenRecipe] = useState<Recipe | null>(null);
   const [copied, setCopied] = useState(false);
+  const [mcpHost, setMcpHost] = useState<string | null>(null);
 
-  const setup = MCP_SETUPS.find((s) => s.id === activeId) ?? MCP_SETUPS[0]!;
+  // Pull the canonical MCP URL from the backend's RFC 9728 metadata so
+  // OSS self-host shows `http://localhost:3001` and cloud shows
+  // `https://mcp.getmunin.com` without rebuilding the dashboard.
+  useEffect(() => {
+    const apiBase = process.env.NEXT_PUBLIC_API_URL ?? '';
+    const url = `${apiBase}/.well-known/oauth-protected-resource`;
+    let cancelled = false;
+    void fetch(url, { credentials: 'omit' })
+      .then((res) => (res.ok ? (res.json() as Promise<{ resource?: unknown }>) : null))
+      .then((body) => {
+        if (cancelled) return;
+        if (body && typeof body.resource === 'string') setMcpHost(body.resource);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setups = useMemo(() => (mcpHost ? buildMcpSetups(mcpHost) : MCP_SETUPS), [mcpHost]);
+  const setup = setups.find((s) => s.id === activeId) ?? setups[0]!;
 
   function copySnippet() {
     if (navigator.clipboard) {
@@ -53,7 +74,7 @@ export function GetStarted() {
           </div>
 
           <div className="flex border-[0.5px] border-ink mb-3.5 dark:border-foreground">
-            {MCP_SETUPS.map((s) => {
+            {setups.map((s) => {
               const active = s.id === activeId;
               return (
                 <button

--- a/packages/dashboard-pages/src/data/mcp-setups.ts
+++ b/packages/dashboard-pages/src/data/mcp-setups.ts
@@ -7,61 +7,73 @@ export interface McpSetup {
   docsLabel: string;
 }
 
-const HOST = 'https://mcp.getmunin.com';
 const TOKEN_PLACEHOLDER = 'mn_live_••••••••';
 
-export const MCP_SETUPS: McpSetup[] = [
-  {
-    id: 'claude',
-    label: 'Claude',
-    sublabel: 'Desktop & Web',
-    snippet: `// claude_desktop_config.json
+/**
+ * Build the per-client config snippets for the dashboard's
+ * "Connect MCP" section. Pass the actual MCP host URL — the dashboard
+ * fetches it at runtime from `/.well-known/oauth-protected-resource`,
+ * so self-host instances render `http://localhost:3001` (or whatever
+ * `MUNIN_PUBLIC_URL` is set to) and cloud renders `mcp.getmunin.com`
+ * without a rebuild.
+ */
+export function buildMcpSetups(host: string): McpSetup[] {
+  return [
+    {
+      id: 'claude',
+      label: 'Claude',
+      sublabel: 'Desktop & Web',
+      snippet: `// claude_desktop_config.json
 {
   "mcpServers": {
     "munin": {
-      "url": "${HOST}",
+      "url": "${host}",
       "headers": {
         "Authorization": "Bearer ${TOKEN_PLACEHOLDER}"
       }
     }
   }
 }`,
-    docsHref: 'https://docs.getmunin.com/mcp/claude',
-    docsLabel: 'docs.getmunin.com/mcp/claude',
-  },
-  {
-    id: 'chatgpt',
-    label: 'ChatGPT',
-    sublabel: 'Custom Connector',
-    snippet: `// Settings → Connectors → New connector → MCP
+      docsHref: 'https://docs.getmunin.com/mcp/claude',
+      docsLabel: 'docs.getmunin.com/mcp/claude',
+    },
+    {
+      id: 'chatgpt',
+      label: 'ChatGPT',
+      sublabel: 'Custom Connector',
+      snippet: `// Settings → Connectors → New connector → MCP
 {
   "name": "Munin",
   "transport": "http",
-  "url":  "${HOST}",
+  "url":  "${host}",
   "auth": {
     "type":  "bearer",
     "token": "${TOKEN_PLACEHOLDER}"
   }
 }`,
-    docsHref: 'https://docs.getmunin.com/mcp/chatgpt',
-    docsLabel: 'docs.getmunin.com/mcp/chatgpt',
-  },
-  {
-    id: 'gemini',
-    label: 'Gemini',
-    sublabel: 'CLI & Studio',
-    snippet: `// ~/.gemini/mcp.json
+      docsHref: 'https://docs.getmunin.com/mcp/chatgpt',
+      docsLabel: 'docs.getmunin.com/mcp/chatgpt',
+    },
+    {
+      id: 'gemini',
+      label: 'Gemini',
+      sublabel: 'CLI & Studio',
+      snippet: `// ~/.gemini/mcp.json
 {
   "servers": {
     "munin": {
-      "url": "${HOST}",
+      "url": "${host}",
       "headers": {
         "Authorization": "Bearer ${TOKEN_PLACEHOLDER}"
       }
     }
   }
 }`,
-    docsHref: 'https://docs.getmunin.com/mcp/gemini',
-    docsLabel: 'docs.getmunin.com/mcp/gemini',
-  },
-];
+      docsHref: 'https://docs.getmunin.com/mcp/gemini',
+      docsLabel: 'docs.getmunin.com/mcp/gemini',
+    },
+  ];
+}
+
+/** Static fallback used before the runtime fetch resolves. */
+export const MCP_SETUPS: McpSetup[] = buildMcpSetups('https://mcp.getmunin.com');


### PR DESCRIPTION
## Summary
- `MUNIN_PUBLIC_URL` is now the **canonical MCP resource URL** verbatim — no implicit `/mcp` append.
- New optional `MUNIN_API_URL` names the canonical REST URL.
- `publicUrlRewriteMiddleware` maps the external URLs onto the internal Nest mount points (`/mcp`, `/api/v1`). Controllers don't move; tests stay green.
- Dashboard's `GetStarted` fetches the canonical MCP URL from `/.well-known/oauth-protected-resource` at runtime — OSS self-host shows `http://localhost:3001/mcp`, cloud shows `mcp.getmunin.com`, with no rebuild needed.
- README adds a "Try it locally" section with the four ways to exercise the API + MCP after `docker compose up`.

## Why
Cloud wants to advertise:
- `https://mcp.getmunin.com` (no path) for MCP
- `https://api.getmunin.com/v1` for REST

…without moving every Nest controller. The rewriter is the seam.

claude.ai web also surfaces a less-noisy "Couldn't reach the MCP server" message when the discovery doc's `resource` field is on a different host than the URL the user gave it. Aligning everything on `mcp_host` (via the cloud terraform follow-up) fixes that.

## Breaking change
Self-hosters who set `MUNIN_PUBLIC_URL=http://localhost:3001` (no path) will see the OAuth resource URL change from `…/mcp` to bare host. Every active token needs refreshing. Workaround: set `MUNIN_PUBLIC_URL=http://localhost:3001/mcp` to keep the old verbatim value.

## Test plan
- [x] `pnpm -F @getmunin/backend-core test` — 502 pass (incl. 7 new rewriter tests + updated OAuth tests)
- [x] Workspace typecheck clean
- [ ] CI green
- [ ] After release + cloud follow-up: `curl https://mcp.getmunin.com/.well-known/oauth-protected-resource | jq .resource` → `"https://mcp.getmunin.com"`; claude.ai web connects without "Couldn't reach the MCP server"; `https://api.getmunin.com/v1/kb/spaces` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)