### PR TITLE
fix(backend-core,backend): loopback host-allowlist + OSS validAudiences

### DIFF
--- a/.changeset/host-allowlist-loopback-and-oss-audiences.md
+++ b/.changeset/host-allowlist-loopback-and-oss-audiences.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Two follow-up fixes to the 4.7.0 canonical-URL roll-out:
+
+**`@getmunin/backend-core`** — `hostAllowlistMiddleware` always permits loopback (`127.0.0.1`, `localhost`, `::1`). Without this, the bundled `AgentHostRunner` (and any in-process MCP client) hit a 421 `misdirected_request` because their `Host` header is the loopback address — not a public hostname. Cloud has been emitting an `AgentHostRunner failed to start runner` error every 30s since `MUNIN_ALLOWED_HOSTS` shipped in 4.5.1.
+
+The middleware now also parses bracketed IPv6 host headers (`[::1]:3101` → `::1`) correctly.
+
+**`apps/backend`** — `validAudiences` in OSS `createMuninAuth` now equals `baseUrl` exactly instead of `baseUrl + '/mcp'`. After 4.7.0, the canonical resource URL is `MUNIN_PUBLIC_URL` verbatim, so the OAuth provider's audience whitelist needs to mirror that — otherwise external MCP clients (claude.ai web, etc.) can't complete the token exchange. Also drops the locally-shadowed `SUPPORTED_SCOPES` const in favor of `@getmunin/backend-core`'s canonical list (picks up `outreach:*`).

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -3,6 +3,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { jwt } from 'better-auth/plugins';
 import { oauthProvider } from '@better-auth/oauth-provider';
 import { APIError } from 'better-auth/api';
+import { SUPPORTED_SCOPES as BACKEND_SUPPORTED_SCOPES } from '@getmunin/backend-core';
 
 type BetterAuthInstance = ReturnType<typeof betterAuth>;
 
@@ -11,17 +12,7 @@ const SUPPORTED_SCOPES = [
   'profile',
   'email',
   'offline_access',
-  'mcp:tools',
-  'mcp:admin',
-  'mcp:self_service',
-  'kb:read',
-  'kb:write',
-  'conv:read',
-  'conv:write',
-  'crm:read',
-  'crm:write',
-  'cms:read',
-  'cms:write',
+  ...BACKEND_SUPPORTED_SCOPES,
 ] as const;
 
 const asMuninAuth = (instance: unknown): BetterAuthInstance => instance as BetterAuthInstance;
@@ -86,7 +77,7 @@ export function createMuninAuth({
         allowDynamicClientRegistration: true,
         allowUnauthenticatedClientRegistration: true,
         scopes: [...SUPPORTED_SCOPES],
-        validAudiences: [`${baseUrl.replace(/\/+$/, '')}/mcp`],
+        validAudiences: [baseUrl.replace(/\/+$/, '')],
         silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
       }),
     ],

--- a/packages/backend-core/src/bootstrap-app.test.ts
+++ b/packages/backend-core/src/bootstrap-app.test.ts
@@ -47,6 +47,12 @@ describe('hostAllowlistMiddleware', () => {
     expect(next).not.toHaveBeenCalled();
     expect(status).toHaveBeenCalledWith(421);
   });
+
+  it('always permits loopback hosts (in-process AgentHostRunner traffic)', () => {
+    expect(run(mw, '127.0.0.1:3101').next).toHaveBeenCalledOnce();
+    expect(run(mw, 'localhost:3001').next).toHaveBeenCalledOnce();
+    expect(run(mw, '[::1]:3001').next).toHaveBeenCalledOnce();
+  });
 });
 
 describe('isPublicCorsPath', () => {

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -188,12 +188,24 @@ function splitQuery(url: string): [string, string] {
   return i < 0 ? [url, ''] : [url.slice(0, i), url.slice(i + 1)];
 }
 
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
+
+function parseHostHeader(raw: string): string {
+  if (!raw) return '';
+  if (raw.startsWith('[')) {
+    const close = raw.indexOf(']');
+    if (close > 0) return raw.slice(1, close).toLowerCase();
+    return '';
+  }
+  return raw.split(':', 1)[0]!.toLowerCase();
+}
+
 export function hostAllowlistMiddleware(allowedHosts: string[]) {
   const allowed = new Set(allowedHosts);
   return (req: Request, res: Response, next: NextFunction): void => {
     const raw = typeof req.headers.host === 'string' ? req.headers.host : '';
-    const host = raw.split(':', 1)[0]!.toLowerCase();
-    if (!host || !allowed.has(host)) {
+    const host = parseHostHeader(raw);
+    if (!host || (!allowed.has(host) && !LOOPBACK_HOSTS.has(host))) {
       res.status(421).json({ error: 'misdirected_request' });
       return;
     }


### PR DESCRIPTION
## Summary
Two follow-up fixes to the 4.7.0 canonical-URL roll-out:

1. **`hostAllowlistMiddleware`** always permits loopback hosts (`127.0.0.1`, `localhost`, `::1`). Without this, the bundled `AgentHostRunner` (and any in-process MCP client) gets a 421 `misdirected_request` because the `Host` header is the loopback address. Cloud has been emitting `AgentHostRunner failed to start runner` errors every 30s since `MUNIN_ALLOWED_HOSTS` shipped in 4.5.1.
2. **OSS `createMuninAuth`** — `validAudiences` now matches `baseUrl` verbatim (no implicit `/mcp` suffix). After 4.7.0 the canonical resource URL is `MUNIN_PUBLIC_URL` exactly; the OAuth provider's audience whitelist needs to mirror that. Without it, external MCP clients (claude.ai web, …) can't complete the token exchange. Also drops the locally-shadowed `SUPPORTED_SCOPES` copy in favor of `@getmunin/backend-core`'s canonical list (picks up `outreach:*`).

## Why
Found by grepping Scaleway dev container logs after the cloud roll-out — both bugs were silently breaking flows. Cloud has the symmetric fix in [munin-cloud#111](https://github.com/getmunin/munin-cloud/pull/111).

## Test plan
- [x] `pnpm -F @getmunin/backend-core test src/bootstrap-app.test.ts` — 17 pass (new loopback case + IPv6 bracketed-host parse)
- [x] OSS workspace typecheck clean
- [ ] CI green
- [ ] After release: cloud bumps to 4.7.1 → AgentHostRunner errors stop in dev logs; OSS self-host OAuth flow against `MUNIN_PUBLIC_URL=http://localhost:3001/mcp` completes through claude.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)