### PR TITLE
fix(backend-core): forward raw body to Better Auth (unblocks OAuth /token)

### DIFF
--- a/.changeset/auth-body-passthrough.md
+++ b/.changeset/auth-body-passthrough.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Forward the raw request body to Better Auth instead of re-serializing it as JSON. The OAuth token endpoint requires `application/x-www-form-urlencoded` per RFC 6749 §3.2; the previous handler converted every body to JSON and set `Content-Type: application/json`, so Better Auth rejected token exchanges with `UNSUPPORTED_MEDIA_TYPE`. Externally-RFC-compliant clients like claude.ai web therefore never received an access token. Other Better Auth endpoints (sign-in, register, consent) happen to accept JSON, which is why the bug stayed latent until claude.ai connected.
+
+The handler now passes `req.rawBody` through verbatim (Nest's `rawBody: true` already captures it), preserving the original content-type. JSON fallback is kept for safety when no raw body was captured.

--- a/packages/backend-core/src/auth-controller-factory.ts
+++ b/packages/backend-core/src/auth-controller-factory.ts
@@ -38,8 +38,16 @@ function expressRequestToFetch(req: ExpressRequest): globalThis.Request {
   }
   const init: RequestInit = { method: req.method, headers };
   if (req.method !== 'GET' && req.method !== 'HEAD') {
-    init.body = JSON.stringify(req.body ?? {});
-    if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+    const rawBody = (req as ExpressRequest & { rawBody?: Buffer }).rawBody;
+    if (rawBody && rawBody.length > 0) {
+      init.body = new Uint8Array(rawBody);
+    } else {
+      const body: unknown = req.body;
+      if (body && typeof body === 'object' && Object.keys(body).length > 0) {
+        init.body = JSON.stringify(body);
+        if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+      }
+    }
   }
   return new globalThis.Request(url, init);
 }


### PR DESCRIPTION
## Summary
Pass `req.rawBody` (captured by Nest's `rawBody: true` config) verbatim to Better Auth instead of JSON-serializing it. Preserves the original `Content-Type` — critical for OAuth's `/auth/oauth2/token` which mandates `application/x-www-form-urlencoded` per RFC 6749 §3.2.

## Root cause of claude.ai's "stays inactive after Authorize"
claude.ai completes the consent flow, redirects back to its callback with an auth code, then POSTs to `/auth/oauth2/token` (form-encoded). The handler:

1. Express's urlencoded body parser populates `req.body` as an object.
2. `handleAuthRequest` does `init.body = JSON.stringify(req.body); headers.set('content-type', 'application/json')`.
3. Better Auth: `{"message":"Content-Type \"application/json\" is not allowed. Allowed types: application/x-www-form-urlencoded","code":"UNSUPPORTED_MEDIA_TYPE"}`
4. claude.ai never gets the access token → tile stays inactive, no UI error (server-to-server failure, no surface).

Verified end-to-end via curl. Other Better Auth endpoints (`/sign-in`, `/oauth2/register`, `/oauth2/consent`) happen to accept JSON, which is why the bug stayed latent until an RFC-compliant external OAuth client showed up.

## Test plan
- [x] Workspace typecheck + lint clean
- [ ] CI green
- [ ] After release + cloud bump: claude.ai web integration goes "active" after the Authorize click

🤖 Generated with [Claude Code](https://claude.com/claude-code)