### PR TITLE
feat(agent-host): in-process MCP for the admin path

### DIFF
--- a/.changeset/in-process-mcp-for-agent-host.md
+++ b/.changeset/in-process-mcp-for-agent-host.md
@@ -1,0 +1,22 @@
+---
+'@getmunin/mcp-toolkit': minor
+'@getmunin/backend-core': minor
+'@getmunin/core': minor
+'@getmunin/agent-host': minor
+---
+
+In-process MCP for the bundled `AgentHostRunner`.
+
+The runner previously POSTed every admin-side MCP call back into its own backend over loopback HTTP, authenticating with a long-lived per-org admin API key. Every layer added for the public edge (host-allowlist, CORS, audience checks, audit) had to grow a loopback escape hatch, and a single stale `MUNIN_KEY_PEPPER` rotation would dead-letter every agent spawn.
+
+This drops the loopback hop. The runner now dispatches admin MCP calls directly into the same handlers the HTTP transport runs.
+
+**`@getmunin/mcp-toolkit`** — factor `createMcpServer`'s per-request handlers into pure `listTools` / `callTool` / `listResources` / `readResource` helpers (new `dispatch.ts`). Both transports now share the exact same scope-check + input-validation + audit logic. Adds `openInProcessMcpClient({ registry, actor, audience, audit, skills? })`.
+
+**`@getmunin/core`** — exports `buildAdminAgentActor(orgId)` for synthesising the agent's `ActorIdentity` (admin audience, `['*']` scopes).
+
+**`@getmunin/backend-core`** — exports `openAgentMcpClient({ db, orgId, registry, skills? })`. Every call self-wraps in a tenancy transaction (same GUCs as `TenancyInterceptor` would set on an HTTP request). Also exports `McpRegistryService` + `McpSkillRegistryService` so external modules (agent-host) can inject the registries.
+
+**`@getmunin/agent-host`** — `AgentHostRunner` uses `openAgentMcpClient` for the admin MCP handle. `AgentHostModule.forRoot(...)` now imports `McpModule` so the registry services resolve. The per-conversation `openMcp({ delegatedToken })` callback inside the chat handler stays on HTTP — that's a real cross-trust boundary (end-user agent calling the backend).
+
+The REST + realtime paths still use the admin API key (deferred to a follow-up). The admin-key encryption columns and `AdminKeyProvider` interface stay.

--- a/packages/agent-host/src/module.ts
+++ b/packages/agent-host/src/module.ts
@@ -1,5 +1,5 @@
 import { DynamicModule, Module, Provider, Type } from '@nestjs/common';
-import { DB, DbModule } from '@getmunin/backend-core';
+import { DB, DbModule, McpModule } from '@getmunin/backend-core';
 import { AgentConfigService } from './config.service.js';
 import { AgentConfigController } from './config.controller.js';
 import { AgentModelsService } from './models.service.js';
@@ -39,7 +39,7 @@ export class AgentHostModule {
     };
     return {
       module: AgentHostModule,
-      imports: [DbModule],
+      imports: [DbModule, McpModule],
       providers: [
         repoProvider,
         keyProvider,

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -10,6 +10,12 @@ import { hostname } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import type { Db } from '@getmunin/db';
 import {
+  McpRegistryService,
+  McpSkillRegistryService,
+  openAgentMcpClient,
+  type AgentMcpClient,
+} from '@getmunin/backend-core';
+import {
   createConversationHandler,
   createMuninRestClient,
   createPromptResolver,
@@ -70,7 +76,7 @@ interface PerConfigRunner {
   realtime: { stop: () => Promise<void> };
   handler: ConversationHandler;
   prompts: PromptResolver;
-  adminMcp: { close: () => Promise<void> };
+  adminMcp: AgentMcpClient;
   curatorWorker: CuratorWorker;
 }
 
@@ -95,6 +101,8 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
   constructor(
     @Inject(AGENT_CONFIG_REPOSITORY) private readonly repo: AgentConfigRepository,
     @Inject(AGENT_HOST_DB) private readonly db: Db,
+    @Inject(McpRegistryService) private readonly mcpRegistry: McpRegistryService,
+    @Inject(McpSkillRegistryService) private readonly mcpSkills: McpSkillRegistryService,
     @Optional() @Inject('AGENT_HOST_RUNNER_OPTIONS') options?: AgentHostRunnerOptions,
   ) {
     this.baseUrl = options?.baseUrl ?? process.env.MUNIN_BASE_URL ?? 'http://localhost:3001';
@@ -269,10 +277,11 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
 
     const rest = createMuninRestClient({ baseUrl: this.baseUrl, adminApiKey });
 
-    const adminMcp = await openMcpClient({
-      baseUrl: this.baseUrl,
-      bearerToken: adminApiKey,
-      clientName: `agent-host-${id}`,
+    const adminMcp = openAgentMcpClient({
+      db: this.db,
+      orgId: id,
+      registry: this.mcpRegistry,
+      skills: this.mcpSkills,
     });
 
     const prompts = await createPromptResolver({

--- a/packages/backend-core/src/agent/in-process-context.ts
+++ b/packages/backend-core/src/agent/in-process-context.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from 'node:crypto';
+import {
+  AuditLogger,
+  RequestContextStore,
+  buildAdminAgentActor,
+  type ActorIdentity,
+  type RequestContext,
+} from '@getmunin/core';
+import type { Db } from '@getmunin/db';
+import { openInProcessMcpClient, type InProcessMcpClient } from '@getmunin/mcp-toolkit';
+import type { McpToolRegistry, SkillRegistry } from '@getmunin/mcp-toolkit';
+import { applyTenancyGUCs } from '../common/tenancy/tenancy.interceptor.js';
+
+export interface OpenAgentMcpClientOptions {
+  db: Db;
+  orgId: string;
+  registry: McpToolRegistry;
+  skills?: SkillRegistry;
+  audit?: AuditLogger;
+}
+
+export interface AgentMcpClient extends InProcessMcpClient {
+  readonly actor: ActorIdentity;
+  close(): Promise<void>;
+}
+
+export function openAgentMcpClient(opts: OpenAgentMcpClientOptions): AgentMcpClient {
+  const actor = buildAdminAgentActor(opts.orgId);
+  const audit = opts.audit ?? new AuditLogger();
+
+  const inner = openInProcessMcpClient({
+    registry: opts.registry,
+    skills: opts.skills,
+    actor,
+    audience: 'admin',
+    audit,
+  });
+
+  function withTenancy<T>(fn: () => Promise<T>): Promise<T> {
+    return opts.db.transaction(async (tx) => {
+      await applyTenancyGUCs(tx, actor);
+      const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+      return RequestContextStore.run(ctx, fn);
+    });
+  }
+
+  return {
+    actor,
+    listTools: () => withTenancy(() => inner.listTools()),
+    callTool: (name, args) => withTenancy(() => inner.callTool(name, args)),
+    listResources: () => withTenancy(() => inner.listResources()),
+    readResource: (uri) => withTenancy(() => inner.readResource(uri)),
+    close: () => Promise.resolve(),
+  };
+}

--- a/packages/backend-core/src/common/tenancy/tenancy.interceptor.ts
+++ b/packages/backend-core/src/common/tenancy/tenancy.interceptor.ts
@@ -17,7 +17,7 @@ interface RequestWithAuth {
   correlationId?: string;
 }
 
-async function applyTenancyGUCs(tx: Db | Tx, actor: ActorIdentity): Promise<void> {
+export async function applyTenancyGUCs(tx: Db | Tx, actor: ActorIdentity): Promise<void> {
   await applyEncryptionKeyGUC(tx);
   if (actor.type === 'partner') {
     await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -40,6 +40,13 @@ export { StorageModule } from './common/storage/storage.module.js';
 // Feature modules (re-export so cloud can selectively replace any of them
 // if it ever needs to — currently it just composes the array as-is).
 export { McpModule } from './mcp/mcp.module.js';
+export { McpRegistryService } from './mcp/mcp.registry.js';
+export { McpSkillRegistryService } from './mcp/mcp.skill-registry.service.js';
+export {
+  openAgentMcpClient,
+  type AgentMcpClient,
+  type OpenAgentMcpClientOptions,
+} from './agent/in-process-context.js';
 export { ControlModule } from './control/control.module.js';
 export { KbModule } from './modules/kb/kb.module.js';
 export { ConvModule } from './modules/conv/conv.module.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export {
   getCurrentContext,
   withContext,
 } from './request/context.js';
+export { buildAdminAgentActor } from './request/synth-agent-actor.js';
 export { AuditLogger, type AuditEventInput } from './request/audit.js';
 export { ClaimManager, type ClaimResult } from './request/claims.js';
 export { CredentialResolver, type ResolvedCredential } from './request/credentials.js';

--- a/packages/core/src/request/synth-agent-actor.ts
+++ b/packages/core/src/request/synth-agent-actor.ts
@@ -1,0 +1,5 @@
+import { ActorIdentity } from './context.js';
+
+export function buildAdminAgentActor(orgId: string): ActorIdentity {
+  return new ActorIdentity('admin_agent', `agent-host:${orgId}`, orgId, ['*'], ['admin']);
+}

--- a/packages/mcp-toolkit/src/dispatch.ts
+++ b/packages/mcp-toolkit/src/dispatch.ts
@@ -1,0 +1,172 @@
+import {
+  getCurrentContext,
+  type AuditLogger,
+  type ActorIdentity,
+  type Audience,
+} from '@getmunin/core';
+import type { McpToolRegistry } from './registry.js';
+import type { RegisteredSkill, SkillRegistry } from './skill-registry.js';
+
+export interface DispatchContext {
+  registry: McpToolRegistry;
+  audience: Audience;
+  actor: ActorIdentity;
+  audit: AuditLogger;
+  rateLimit?: (toolName: string) => Promise<void> | void;
+  skills?: SkillRegistry;
+}
+
+export interface ToolListing {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations: {
+    title: string;
+    readOnlyHint: boolean;
+    destructiveHint: boolean;
+  };
+}
+
+export interface ToolCallResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+export interface ResourceListing {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+}
+
+export interface ResourceContent {
+  uri: string;
+  mimeType: string;
+  text: string;
+}
+
+export function listTools(ctx: DispatchContext): ToolListing[] {
+  return ctx.registry.list(ctx.audience).map((t) => ({
+    name: t.meta.name,
+    description: t.meta.description,
+    inputSchema: t.inputJsonSchema as Record<string, unknown>,
+    annotations: {
+      title: t.meta.title ?? t.meta.name,
+      readOnlyHint: t.meta.readOnlyHint ?? false,
+      destructiveHint: t.meta.destructiveHint ?? false,
+    },
+  }));
+}
+
+export async function callTool(
+  ctx: DispatchContext,
+  name: string,
+  args: Record<string, unknown> | undefined,
+): Promise<ToolCallResult> {
+  const tool = ctx.registry.get(name);
+  if (!tool) {
+    await ctx.audit.record({ tool: name, result: 'denied', error: 'unknown_tool' });
+    return errorResult(`Unknown tool: ${name}`);
+  }
+
+  if (!tool.meta.audiences.includes(ctx.audience)) {
+    await ctx.audit.record({ tool: tool.meta.name, result: 'denied', error: 'audience_mismatch' });
+    return errorResult(`Tool ${tool.meta.name} is not available for this caller`);
+  }
+
+  for (const scope of tool.meta.scopes) {
+    if (!ctx.actor.hasScope(scope)) {
+      await ctx.audit.record({ tool: tool.meta.name, result: 'denied', error: `missing_scope:${scope}` });
+      return errorResult(`Missing required scope: ${scope}`);
+    }
+  }
+
+  const parseResult = tool.meta.input.safeParse(args ?? {});
+  if (!parseResult.success) {
+    await ctx.audit.record({ tool: tool.meta.name, result: 'error', error: 'invalid_input' });
+    return errorResult(`Invalid input: ${parseResult.error.message}`);
+  }
+
+  if (ctx.rateLimit) {
+    try {
+      await ctx.rateLimit(tool.meta.name);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.audit.record({ tool: tool.meta.name, result: 'denied', error: 'rate_limited' });
+      return errorResult(message);
+    }
+  }
+
+  const startedAt = Date.now();
+  let value: unknown;
+  let thrown: unknown = null;
+  try {
+    const reqCtx = getCurrentContext();
+    value = await reqCtx.db.transaction(() => Promise.resolve(tool.handler(parseResult.data)));
+  } catch (err) {
+    thrown = err;
+  }
+  if (thrown !== null) {
+    const message =
+      thrown instanceof Error
+        ? thrown.message
+        : typeof thrown === 'string'
+          ? thrown
+          : JSON.stringify(thrown);
+    await ctx.audit.record({
+      tool: tool.meta.name,
+      result: 'error',
+      error: message,
+      durationMs: Date.now() - startedAt,
+    });
+    return errorResult(message);
+  }
+  await ctx.audit.record({
+    tool: tool.meta.name,
+    args: parseResult.data,
+    result: 'ok',
+    durationMs: Date.now() - startedAt,
+  });
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: typeof value === 'string' ? value : JSON.stringify(value),
+      },
+    ],
+  };
+}
+
+export function listResources(ctx: DispatchContext): ResourceListing[] {
+  if (!ctx.skills) return [];
+  return ctx.skills
+    .list(ctx.audience)
+    .filter((s) => s.uri.startsWith('skill://'))
+    .map((s) => ({
+      uri: s.uri,
+      name: s.name,
+      description: s.description,
+      mimeType: s.mimeType,
+    }));
+}
+
+export function readResource(ctx: DispatchContext, uri: string): ResourceContent {
+  if (!ctx.skills) throw new Error(`Unknown resource: ${uri}`);
+  const skill: RegisteredSkill | undefined = ctx.skills.get(uri);
+  if (!skill) throw new Error(`Unknown resource: ${uri}`);
+  if (!skill.audiences.includes(ctx.audience)) {
+    throw new Error(`Resource ${skill.uri} is not available for this caller`);
+  }
+  return {
+    uri: skill.uri,
+    mimeType: skill.mimeType,
+    text: skill.content,
+  };
+}
+
+function errorResult(message: string): ToolCallResult {
+  return {
+    isError: true,
+    content: [{ type: 'text' as const, text: message }],
+  };
+}

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { ActorIdentity, RequestContextStore, type RequestContext } from '@getmunin/core';
+import { McpToolRegistry } from './registry.js';
+import { SkillRegistry } from './skill-registry.js';
+import { openInProcessMcpClient } from './in-process-client.js';
+
+const fakeAudit = { record: vi.fn(() => Promise.resolve()) };
+
+const fakeTx = {
+  transaction: <T>(fn: () => Promise<T>): Promise<T> => fn(),
+} as unknown as RequestContext['db'];
+
+function runInCtx<T>(actor: ActorIdentity, fn: () => Promise<T>): Promise<T> {
+  const ctx: RequestContext = { db: fakeTx, actor, correlationId: 'test-corr' };
+  return RequestContextStore.run(ctx, fn);
+}
+
+function adminActor(orgId = 'org_test'): ActorIdentity {
+  return new ActorIdentity('admin_agent', `agent:${orgId}`, orgId, ['*'], ['admin']);
+}
+
+function buildRegistry(): McpToolRegistry {
+  const r = new McpToolRegistry();
+  r.register(
+    {
+      name: 'echo',
+      description: 'echo',
+      audiences: ['admin'],
+      scopes: [],
+      input: z.object({ msg: z.string() }),
+    },
+    (args: { msg: string }) => args.msg,
+  );
+  r.register(
+    {
+      name: 'self_only',
+      description: 'self',
+      audiences: ['self_service'],
+      scopes: [],
+      input: z.object({}),
+    },
+    () => 'ok',
+  );
+  r.register(
+    {
+      name: 'kb_write',
+      description: 'requires kb:write',
+      audiences: ['admin'],
+      scopes: ['kb:write'],
+      input: z.object({}),
+    },
+    () => 'wrote',
+  );
+  return r;
+}
+
+describe('openInProcessMcpClient', () => {
+  it('listTools returns audience-filtered tools', async () => {
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+    });
+    const tools = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('echo');
+    expect(names).toContain('kb_write');
+    expect(names).not.toContain('self_only');
+  });
+
+  it('callTool dispatches the handler, returns text content, audits ok', async () => {
+    fakeAudit.record.mockClear();
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+    });
+    const out = await runInCtx(adminActor(), () => client.callTool('echo', { msg: 'hi' }));
+    expect(out.isError).toBeUndefined();
+    expect(out.content[0]).toEqual({ type: 'text', text: 'hi' });
+    expect(fakeAudit.record).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: 'echo', result: 'ok' }),
+    );
+  });
+
+  it('callTool rejects an unknown tool with a denied audit row', async () => {
+    fakeAudit.record.mockClear();
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+    });
+    const out = await client.callTool('nope', {});
+    expect(out.isError).toBe(true);
+    expect(out.content[0].text).toMatch(/Unknown tool/);
+    expect(fakeAudit.record).toHaveBeenCalledWith(
+      expect.objectContaining({ result: 'denied', error: 'unknown_tool' }),
+    );
+  });
+
+  it('callTool rejects audience-mismatched tool', async () => {
+    fakeAudit.record.mockClear();
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+    });
+    const out = await client.callTool('self_only', {});
+    expect(out.isError).toBe(true);
+    expect(fakeAudit.record).toHaveBeenCalledWith(
+      expect.objectContaining({ result: 'denied', error: 'audience_mismatch' }),
+    );
+  });
+
+  it('callTool enforces scopes against the actor', async () => {
+    fakeAudit.record.mockClear();
+    const scopedActor = new ActorIdentity(
+      'admin_agent',
+      'agent:scoped',
+      'org_test',
+      ['kb:read'],
+      ['admin'],
+    );
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: scopedActor,
+      audience: 'admin',
+      audit: fakeAudit,
+    });
+    const out = await client.callTool('kb_write', {});
+    expect(out.isError).toBe(true);
+    expect(fakeAudit.record).toHaveBeenCalledWith(
+      expect.objectContaining({ result: 'denied', error: 'missing_scope:kb:write' }),
+    );
+  });
+
+  it('readResource returns audience-filtered skill content', () => {
+    const skills = new SkillRegistry();
+    skills.register({
+      uri: 'skill://kb/onboarding',
+      name: 'Onboarding',
+      description: 'KB onboarding',
+      audiences: ['admin'],
+      mimeType: 'text/markdown',
+      content: '# go',
+      public: false,
+    });
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+      skills,
+    });
+    return expect(client.readResource('skill://kb/onboarding')).resolves.toEqual({
+      uri: 'skill://kb/onboarding',
+      mimeType: 'text/markdown',
+      text: '# go',
+    });
+  });
+});

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -30,7 +30,7 @@ function buildRegistry(): McpToolRegistry {
       scopes: [],
       input: z.object({ msg: z.string() }),
     },
-    (args: { msg: string }) => args.msg,
+    (args) => (args as { msg: string }).msg,
   );
   r.register(
     {
@@ -96,7 +96,7 @@ describe('openInProcessMcpClient', () => {
     });
     const out = await client.callTool('nope', {});
     expect(out.isError).toBe(true);
-    expect(out.content[0].text).toMatch(/Unknown tool/);
+    expect(out.content[0]?.text).toMatch(/Unknown tool/);
     expect(fakeAudit.record).toHaveBeenCalledWith(
       expect.objectContaining({ result: 'denied', error: 'unknown_tool' }),
     );

--- a/packages/mcp-toolkit/src/in-process-client.ts
+++ b/packages/mcp-toolkit/src/in-process-client.ts
@@ -1,0 +1,47 @@
+import type { AuditLogger, ActorIdentity, Audience } from '@getmunin/core';
+import type { McpToolRegistry } from './registry.js';
+import type { SkillRegistry } from './skill-registry.js';
+import {
+  callTool as dispatchCall,
+  listResources as dispatchListResources,
+  listTools as dispatchListTools,
+  readResource as dispatchReadResource,
+  type DispatchContext,
+  type ResourceContent,
+  type ResourceListing,
+  type ToolCallResult,
+  type ToolListing,
+} from './dispatch.js';
+
+export interface OpenInProcessMcpClientOptions {
+  registry: McpToolRegistry;
+  actor: ActorIdentity;
+  audience: Audience;
+  audit: AuditLogger;
+  rateLimit?: (toolName: string) => Promise<void> | void;
+  skills?: SkillRegistry;
+}
+
+export interface InProcessMcpClient {
+  listTools(): Promise<ToolListing[]>;
+  callTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult>;
+  listResources(): Promise<ResourceListing[]>;
+  readResource(uri: string): Promise<ResourceContent>;
+}
+
+export function openInProcessMcpClient(opts: OpenInProcessMcpClientOptions): InProcessMcpClient {
+  const ctx: DispatchContext = {
+    registry: opts.registry,
+    audience: opts.audience,
+    actor: opts.actor,
+    audit: opts.audit,
+    rateLimit: opts.rateLimit,
+    skills: opts.skills,
+  };
+  return {
+    listTools: () => Promise.resolve(dispatchListTools(ctx)),
+    callTool: (name, args) => dispatchCall(ctx, name, args),
+    listResources: () => Promise.resolve(dispatchListResources(ctx)),
+    readResource: (uri) => Promise.resolve(dispatchReadResource(ctx, uri)),
+  };
+}

--- a/packages/mcp-toolkit/src/index.ts
+++ b/packages/mcp-toolkit/src/index.ts
@@ -2,3 +2,14 @@ export { McpTool, getMcpToolMeta, MCP_TOOL_META, type McpToolMeta } from './deco
 export { McpToolRegistry, type RegisteredMcpTool } from './registry.js';
 export { SkillRegistry, type RegisteredSkill } from './skill-registry.js';
 export { createMcpServer, type CreateMcpServerOptions } from './server.js';
+export {
+  openInProcessMcpClient,
+  type InProcessMcpClient,
+  type OpenInProcessMcpClientOptions,
+} from './in-process-client.js';
+export {
+  type ResourceContent,
+  type ResourceListing,
+  type ToolCallResult,
+  type ToolListing,
+} from './dispatch.js';

--- a/packages/mcp-toolkit/src/server.ts
+++ b/packages/mcp-toolkit/src/server.ts
@@ -5,169 +5,58 @@ import {
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { getCurrentContext, type AuditLogger, type ActorIdentity, type Audience } from '@getmunin/core';
+import type { AuditLogger, ActorIdentity, Audience } from '@getmunin/core';
 import type { McpToolRegistry } from './registry.js';
 import type { SkillRegistry } from './skill-registry.js';
+import { callTool, listResources, listTools, readResource, type DispatchContext } from './dispatch.js';
 
 export interface CreateMcpServerOptions {
   registry: McpToolRegistry;
   audience: Audience;
   actor: ActorIdentity;
   audit: AuditLogger;
-  /**
-   * Called once per tools/call before dispatch. If it throws, the call is
-   * denied with the thrown error's message and an audit row is written
-   * with `result: 'denied'`. tools/list is intentionally not gated so
-   * agents can still discover capabilities while rate-limited.
-   */
   rateLimit?: (toolName: string) => Promise<void> | void;
   serverInfo?: { name: string; version: string };
   skills?: SkillRegistry;
   instructions?: string;
 }
 
-/**
- * Build an MCP `Server` instance configured for one request / one actor.
- *
- * Lifecycle: create per request (Streamable HTTP, stateless mode), wire to
- * a transport, let the transport drive it, dispose. This way each call
- * sees only the tools the actor is allowed to use, and audit attribution
- * is correct.
- */
 export function createMcpServer(opts: CreateMcpServerOptions): Server {
-  const { registry, audience, actor, audit, rateLimit, skills, instructions } = opts;
   const info = opts.serverInfo ?? { name: 'munin', version: process.env.MUNIN_VERSION ?? '0.4.0' };
+  const dispatch: DispatchContext = {
+    registry: opts.registry,
+    audience: opts.audience,
+    actor: opts.actor,
+    audit: opts.audit,
+    rateLimit: opts.rateLimit,
+    skills: opts.skills,
+  };
 
   const server = new Server(info, {
-    capabilities: { tools: {}, ...(skills ? { resources: {} } : {}) },
-    instructions,
+    capabilities: { tools: {}, ...(opts.skills ? { resources: {} } : {}) },
+    instructions: opts.instructions,
   });
 
-  // tools/list — visible-to-this-audience subset.
   server.setRequestHandler(ListToolsRequestSchema, () => ({
-    tools: registry.list(audience).map((t) => ({
-      name: t.meta.name,
-      description: t.meta.description,
-      inputSchema: t.inputJsonSchema as Record<string, unknown>,
-      annotations: {
-        title: t.meta.title ?? t.meta.name,
-        readOnlyHint: t.meta.readOnlyHint ?? false,
-        destructiveHint: t.meta.destructiveHint ?? false,
-      },
-    })),
+    tools: listTools(dispatch),
   }));
 
-  // tools/call — audience + scope check, validate input, dispatch, audit.
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
-    const tool = registry.get(req.params.name);
-    if (!tool) {
-      await audit.record({ tool: req.params.name, result: 'denied', error: 'unknown_tool' });
-      return errorResult(`Unknown tool: ${req.params.name}`);
-    }
-
-    if (!tool.meta.audiences.includes(audience)) {
-      await audit.record({ tool: tool.meta.name, result: 'denied', error: 'audience_mismatch' });
-      return errorResult(`Tool ${tool.meta.name} is not available for this caller`);
-    }
-
-    for (const scope of tool.meta.scopes) {
-      if (!actor.hasScope(scope)) {
-        await audit.record({ tool: tool.meta.name, result: 'denied', error: `missing_scope:${scope}` });
-        return errorResult(`Missing required scope: ${scope}`);
-      }
-    }
-
-    const parseResult = tool.meta.input.safeParse(req.params.arguments ?? {});
-    if (!parseResult.success) {
-      await audit.record({ tool: tool.meta.name, result: 'error', error: 'invalid_input' });
-      return errorResult(`Invalid input: ${parseResult.error.message}`);
-    }
-
-    if (rateLimit) {
-      try {
-        await rateLimit(tool.meta.name);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        await audit.record({ tool: tool.meta.name, result: 'denied', error: 'rate_limited' });
-        return errorResult(message);
-      }
-    }
-
-    const startedAt = Date.now();
-    let value: unknown;
-    let thrown: unknown = null;
-    try {
-      const ctx = getCurrentContext();
-      value = await ctx.db.transaction(() => Promise.resolve(tool.handler(parseResult.data)));
-    } catch (err) {
-      thrown = err;
-    }
-    if (thrown !== null) {
-      const message =
-        thrown instanceof Error
-          ? thrown.message
-          : typeof thrown === 'string'
-            ? thrown
-            : JSON.stringify(thrown);
-      await audit.record({
-        tool: tool.meta.name,
-        result: 'error',
-        error: message,
-        durationMs: Date.now() - startedAt,
-      });
-      return errorResult(message);
-    }
-    await audit.record({
-      tool: tool.meta.name,
-      args: parseResult.data,
-      result: 'ok',
-      durationMs: Date.now() - startedAt,
-    });
-    return {
-      content: [{ type: 'text' as const, text: typeof value === 'string' ? value : JSON.stringify(value) }],
-    };
+    const out = await callTool(dispatch, req.params.name, req.params.arguments);
+    return out as unknown as Awaited<ReturnType<Parameters<typeof server.setRequestHandler>[1]>>;
   });
 
-  if (skills) {
+  if (opts.skills) {
     server.setRequestHandler(ListResourcesRequestSchema, () => ({
-      resources: skills
-        .list(audience)
-        .filter((s) => s.uri.startsWith('skill://'))
-        .map((s) => ({
-          uri: s.uri,
-          name: s.name,
-          description: s.description,
-          mimeType: s.mimeType,
-          annotations: { audience: ['assistant'] as const, priority: 0.9 },
-        })),
+      resources: listResources(dispatch).map((r) => ({
+        ...r,
+        annotations: { audience: ['assistant'] as const, priority: 0.9 },
+      })),
     }));
-
-    server.setRequestHandler(ReadResourceRequestSchema, (req) => {
-      const skill = skills.get(req.params.uri);
-      if (!skill) {
-        throw new Error(`Unknown resource: ${req.params.uri}`);
-      }
-      if (!skill.audiences.includes(audience)) {
-        throw new Error(`Resource ${skill.uri} is not available for this caller`);
-      }
-      return {
-        contents: [
-          {
-            uri: skill.uri,
-            mimeType: skill.mimeType,
-            text: skill.content,
-          },
-        ],
-      };
-    });
+    server.setRequestHandler(ReadResourceRequestSchema, (req) => ({
+      contents: [readResource(dispatch, req.params.uri)],
+    }));
   }
 
   return server;
-}
-
-function errorResult(message: string) {
-  return {
-    isError: true,
-    content: [{ type: 'text' as const, text: message }],
-  };
 }


### PR DESCRIPTION
## Summary
\`AgentHostRunner\` now dispatches admin MCP calls directly into the toolkit handlers instead of POSTing back to its own backend over loopback HTTP. The per-conversation end-user MCP path keeps using HTTP (real cross-trust hop).

Factors \`createMcpServer\`'s per-request handlers into pure helpers so both transports (HTTP + in-process) share the same scope-check + input-validation + audit logic.

## Why
The loopback HTTP shape was costing us:

- Every layer added for the public edge (host-allowlist, CORS, audience checks) had to grow a loopback escape hatch.
- A stale \`MUNIN_KEY_PEPPER\` or rotated \`MUNIN_ENCRYPTION_KEY\` would dead-letter every agent spawn because the runner's decrypted admin key wouldn't hash to any \`api_keys\` row.
- HTTP/JSON-RPC serialisation for what's a function call.

The in-process path is functionally the same — scope check, audit, tenancy GUCs — minus the network and the token-resolution dance.

## What lands
- \`@getmunin/mcp-toolkit\`: new \`dispatch.ts\` (shared listTools/callTool/listResources/readResource helpers) + \`openInProcessMcpClient\` + 6 new tests.
- \`@getmunin/core\`: \`buildAdminAgentActor(orgId)\` synthesiser.
- \`@getmunin/backend-core\`: \`openAgentMcpClient({ db, orgId, registry, skills? })\` — each call self-wraps in the tenancy transaction. Re-exports \`McpRegistryService\` + \`McpSkillRegistryService\` for DI.
- \`@getmunin/agent-host\`: runner swaps the admin \`openMcpClient\` (HTTP) for \`openAgentMcpClient\` (in-process). \`AgentHostModule\` imports \`McpModule\`.

## What stays (deferred follow-ups)
- REST client (\`createMuninRestClient\`) — still HTTP. Migrating it requires factoring a service-level surface; tracked but not in this PR.
- Realtime WS client — still HTTP. Same.
- The admin API key columns and \`AdminKeyProvider\` interface stay (REST + realtime still need them).
- Once those land, the host-allowlist loopback exception can come out.

## Test plan
- [x] \`pnpm -F @getmunin/mcp-toolkit test\` — 11 pass (5 existing + 6 new for in-process client)
- [x] \`pnpm -F @getmunin/backend-core test\` — 503 pass
- [x] Workspace typecheck clean
- [ ] CI green
- [ ] After release + cloud bump: \`AgentHostRunner failed to start runner\` log spam from the MCP path stops on cloud-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)