### PR TITLE
feat(agent-host): realtime + chat MCP + curator in-process

### DIFF
--- a/.changeset/in-process-realtime-and-chat-mcp.md
+++ b/.changeset/in-process-realtime-and-chat-mcp.md
@@ -1,0 +1,29 @@
+---
+'@getmunin/core': minor
+---
+
+AgentHostRunner: realtime + chat MCP + curator workers now run fully in-process. Closes the prod 401-reconnect loop on stale admin API keys.
+
+**Why.** Prior to this change, the AgentHostRunner subscribed to realtime events over WebSocket (`/api/v1/realtime`) and made chat-side MCP calls over HTTP, both authenticated with a per-org admin API key. When that key drifted (e.g. an org was deleted but its `agent_configs.admin_api_key` row stuck around), the WebSocket 401'd every 30 seconds forever — observed in prod for `org_fgf0a6f1fwu6nfa6aq3xwf` at attempt 411+ before this fix. PR #211 had already moved the prompts/skills loader path in-process, but realtime + chat + curator stayed HTTP and kept burning.
+
+**What changed.**
+
+- New `RealtimeEventBus` provider in `@getmunin/backend-core/realtime`. Wraps `DbListenerService` so the same Postgres `NOTIFY munin_events` stream the WS gateway already consumes fans out to in-process subscribers with `{ orgId, endUserId? }` filtering identical to the gateway's. Adds an in-memory `publishConversationTyping` / `subscribeAgentTyping` channel for the runner-emitted typing signal (no DB write — typing is ephemeral). The gateway also subscribes to this and pushes to widget WS clients on the matching conversation channel.
+- New `openEndUserAgentMcpClient(...)` in `@getmunin/backend-core/agent/in-process-context.ts`. Mirrors the existing admin in-process opener but synthesizes an `end_user_agent` actor with `audience='self_service'`, the user's default org membership, and proper `applyTenancyGUCs(actor)` per call — so RLS still enforces end-user scoping even though the auth guard is bypassed.
+- New `buildEndUserAgentActor({ orgId, endUserId, scopes?, audiences? })` in `@getmunin/core`, sibling of `buildAdminAgentActor`.
+- `runner.service.ts`: `createRealtimeClient({ baseUrl, adminApiKey, … })` → `this.eventBus.subscribe({ orgId }, handlers)`. `openMcp: ({ delegatedToken }) => openHttpMcpClient(HTTP)` → `openMcp: ({ endUserId }) => openEndUserAgentMcpClient(IN-PROCESS)`. `realtime.sendConversationTyping(...)` → `eventBus.publishConversationTyping(orgId, ...)`. Curator workers and `runWebImportJob` now receive an in-process `AgentMcpClient` (built from `openAdminAgentMcpClient`) instead of opening their own HTTP MCP.
+- `conversation-handler.ts`: dropped `getDelegatedToken`, `tokenCache`, and the `TOKEN_REFRESH_MARGIN_MS` constant. The chat handler passes `endUserId` directly to `deps.openMcp` — no token mint, no REST round-trip per message. `mintDelegatedToken` REST endpoint stays for external callers (widget).
+- `runSkillPass`: signature dropped `baseUrl`/`adminApiKey`/`clientName`, added `mcp: McpToolHandle` + `skills: SkillReader`. No HTTP MCP connect.
+- `runWebImportJob`: signature dropped `baseUrl`/`adminApiKey`, added `mcp: McpToolHandle`. No HTTP MCP connect.
+
+**Naming sweep alongside.** The pre-existing public exports were asymmetric (`openAgentMcpClient` paired with the new `openDelegatedMcpClient`, plus a misleadingly-named `openMcpClient` for the HTTP transport). Renamed for clarity:
+
+- `openAgentMcpClient` → `openAdminAgentMcpClient`
+- `openDelegatedMcpClient` → `openEndUserAgentMcpClient`
+- `openMcpClient` (HTTP) → `openHttpMcpClient`
+
+Pairs now match `ActorType` and the transport is explicit. No external consumers yet, so safe.
+
+**What still requires the admin API key.** The REST control plane (`createMuninRestClient`) still goes over HTTP, since lifting Nest controllers in-process is a much larger refactor with low value for low-traffic config reads. The runner still bails if no admin key is configured — but the realtime/MCP/curator paths no longer depend on it.
+
+**Closes** the prod incident on stale admin keys for both the realtime intake and the per-message chat MCP path.

--- a/.changeset/oauth-jwt-and-tool-titles.md
+++ b/.changeset/oauth-jwt-and-tool-titles.md
@@ -1,0 +1,17 @@
+---
+'@getmunin/core': minor
+---
+
+OAuth bearer-token verification overhaul + MCP tool/skill title prefixes.
+
+**JWT access tokens.** Better Auth issues a signed JWT (not an opaque token) whenever the token request carries a `resource` indicator and the JWT plugin is enabled — and JWTs are **never** written to `oauth_access_token`; only the refresh token is. `CredentialResolver.resolveBearerToken` now detects the JWT shape, verifies it locally against the JWKS stored in the `jwks` table (per-`kid` in-memory cache), checks the issuer + audience, and builds an `ActorIdentity` from the `sub`, `scope`, and the user's default org membership. claude.ai web's MCP connector now resolves on the first `/mcp` call instead of 401-ing.
+
+**Audience tolerance.** External MCP clients normalize the resource indicator inconsistently — claude.ai sends `https://<host>/` even when our metadata advertises `https://<host>/mcp`. JWT audience is now matched against the canonical URL plus its trailing-slash, bare-origin, and origin-with-slash variants, so the same backend works for clients that drop the path or fiddle with the slash. The same variant set is applied to Better Auth's `validAudiences` config (`apps/backend/src/auth/auth.config.ts`) so the `/auth/oauth2/token` exchange accepts the same shapes.
+
+**Opaque-token hash fallback retained.** For installs that disable the JWT plugin (`disableJwtPlugin: true`), the opaque-token path still looks up `oauth_access_token.token` by `SHA-256(token)` (base64url), matching Better Auth's default `storeTokens: "hashed"`. Previously we compared the raw bearer against the column, which always missed.
+
+**MCP tool/skill titles get module prefixes.** Every `@McpTool({ title })` and every `skill://*` frontmatter title now starts with the module label (`KB:`, `Conv:`, `CRM:`, `CMS:`, `Outreach:`, `Web:`, `Playbook:`). In claude.ai's alphabetical tool picker, all KB tools cluster together, all CRM tools cluster together, etc. Duplicate module words were stripped from the body when the prefix made them redundant ("Read CRM segment" → "CRM: Read segment"). Internal tool *names* (`kb_*`, `crm_*`, …) and skill URIs are unchanged — only the user-facing display titles moved.
+
+**Internal refactor.** Split JWT-only logic (JWKS load, key cache, audience variants, JWT verification) out of `credentials.ts` into a sibling `oauth-jwt.ts`. The `CredentialResolver` class stays the public entry point. Exports `oauthMcpResourceAudience` and `deriveAudiencesFromScopes` so the JWT path can reuse them.
+
+**Side-quests in the same PR.** OSS + cloud sign-in/sign-up pages resume the OAuth authorize flow after auth (so the MCP connector dance survives a fresh signup). The OAuth consent page reads `resp.url` (Better Auth's actual response field) in addition to `resp.redirect_uri`. AgentHostRunner resolves the singleton repository's literal id to a real `org_id` before opening its admin MCP client, so per-org RLS-bound writes don't hit a `kb_spaces_org_id_orgs_id_fk` FK violation.

--- a/apps/backend/src/auth/auth.config.test.ts
+++ b/apps/backend/src/auth/auth.config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { computeValidAudiences } from './auth.config.js';
+
+describe('computeValidAudiences', () => {
+  it('returns canonical URL plus trailing-slash variant when baseUrl has a path', () => {
+    expect(computeValidAudiences('https://api.example.com/mcp')).toEqual([
+      'https://api.example.com/mcp',
+      'https://api.example.com/mcp/',
+      'https://api.example.com',
+      'https://api.example.com/',
+    ]);
+  });
+
+  it('returns origin variants when baseUrl is bare host', () => {
+    expect(computeValidAudiences('https://mcp.example.com')).toEqual([
+      'https://mcp.example.com',
+      'https://mcp.example.com/',
+    ]);
+  });
+
+  it('strips trailing slashes from the input before computing variants', () => {
+    expect(computeValidAudiences('https://api.example.com/mcp/')).toEqual([
+      'https://api.example.com/mcp',
+      'https://api.example.com/mcp/',
+      'https://api.example.com',
+      'https://api.example.com/',
+    ]);
+  });
+
+  it('accepts http origins (loopback dev)', () => {
+    expect(computeValidAudiences('http://localhost:3001/mcp')).toEqual([
+      'http://localhost:3001/mcp',
+      'http://localhost:3001/mcp/',
+      'http://localhost:3001',
+      'http://localhost:3001/',
+    ]);
+  });
+
+  it('falls back to canonical-only when the input is not a parseable URL', () => {
+    expect(computeValidAudiences('not-a-url')).toEqual(['not-a-url', 'not-a-url/']);
+  });
+});

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -50,6 +50,7 @@ export function createMuninAuth({
 }: MuninAuthOptions): BetterAuthInstance {
   const origins = uniqueOrigins([baseUrl, ...(trustedOrigins ?? [])]);
   const dashboardUrl = (webBaseUrl ?? trustedOrigins?.[0] ?? baseUrl).replace(/\/+$/, '');
+  const validAudiences = computeValidAudiences(baseUrl);
 
   return asMuninAuth(betterAuth({
     baseURL: baseUrl,
@@ -77,7 +78,7 @@ export function createMuninAuth({
         allowDynamicClientRegistration: true,
         allowUnauthenticatedClientRegistration: true,
         scopes: [...SUPPORTED_SCOPES],
-        validAudiences: [baseUrl.replace(/\/+$/, '')],
+        validAudiences,
         silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
       }),
     ],
@@ -230,6 +231,19 @@ async function ensureSingletonOrgMembershipFor(
 
 function uniqueOrigins(values: string[]): string[] {
   return Array.from(new Set(values.map((v) => v.replace(/\/+$/, ''))));
+}
+
+export function computeValidAudiences(baseUrl: string): string[] {
+  const canonical = baseUrl.replace(/\/+$/, '');
+  const variants = new Set<string>([canonical, `${canonical}/`]);
+  try {
+    const origin = new URL(canonical).origin;
+    variants.add(origin);
+    variants.add(`${origin}/`);
+  } catch (err) {
+    console.warn('[auth] computeValidAudiences: baseUrl is not a parseable URL', { baseUrl, err });
+  }
+  return Array.from(variants);
 }
 
 export function readAllowedEmailDomainsFromEnv(): string[] {

--- a/apps/web/app/[locale]/(auth)/login/page.tsx
+++ b/apps/web/app/[locale]/(auth)/login/page.tsx
@@ -25,6 +25,14 @@ function safeRedirect(raw: string | null): string {
   return '/dashboard';
 }
 
+function resumeOauthAuthorizeUrl(params: URLSearchParams): string | null {
+  if (params.get('response_type') !== 'code') return null;
+  if (!params.get('client_id')) return null;
+  const apiBase = (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
+  if (!/^https?:\/\//.test(apiBase)) return null;
+  return `${apiBase}/auth/oauth2/authorize?${params.toString()}`;
+}
+
 type SignInError = { kind: 'invalid' | 'unreachable'; detail: string };
 
 function LoginForm() {
@@ -62,6 +70,11 @@ function LoginForm() {
         return;
       }
       await refetch();
+      const oauthResume = resumeOauthAuthorizeUrl(params);
+      if (oauthResume) {
+        window.location.assign(oauthResume);
+        return;
+      }
       router.push(redirectTo);
     } catch (err) {
       setError({

--- a/apps/web/app/[locale]/(auth)/signup/page.tsx
+++ b/apps/web/app/[locale]/(auth)/signup/page.tsx
@@ -27,6 +27,14 @@ function safeRedirect(raw: string | null): string {
   return '/dashboard';
 }
 
+function resumeOauthAuthorizeUrl(params: URLSearchParams): string | null {
+  if (params.get('response_type') !== 'code') return null;
+  if (!params.get('client_id')) return null;
+  const apiBase = (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
+  if (!/^https?:\/\//.test(apiBase)) return null;
+  return `${apiBase}/auth/oauth2/authorize?${params.toString()}`;
+}
+
 function extractInviteToken(redirectRaw: string | null): string | null {
   if (!redirectRaw) return null;
   if (!redirectRaw.startsWith('/accept-invite')) return null;
@@ -82,13 +90,18 @@ function SignupForm() {
       const result = await authClient.signUp.email({ email, password, name });
       if (result.error) {
         setError(translateError(result.error) || t('failed'));
+        setSubmitting(false);
         return;
       }
       await refetch();
+      const oauthResume = resumeOauthAuthorizeUrl(params);
+      if (oauthResume) {
+        window.location.assign(oauthResume);
+        return;
+      }
       router.push(redirectTo);
     } catch (err) {
       setError(translateError(err) || tCommon('networkError'));
-    } finally {
       setSubmitting(false);
     }
   }

--- a/packages/agent-host/src/config.repository.ts
+++ b/packages/agent-host/src/config.repository.ts
@@ -24,6 +24,7 @@ export interface AgentConfigPatch {
 
 export interface AgentConfigRepository {
   resolveCurrentId(): string;
+  resolveOrgId(id: string): Promise<string>;
   read(id: string): Promise<AgentConfigRow>;
   update(id: string, patch: AgentConfigPatch): Promise<AgentConfigRow>;
   listProvisionedIds(): Promise<string[]>;

--- a/packages/agent-host/src/config.service.test.ts
+++ b/packages/agent-host/src/config.service.test.ts
@@ -29,6 +29,7 @@ function makeRepo(opts: {
   const update = vi.fn().mockResolvedValue(opts.after);
   return {
     resolveCurrentId: () => opts.before.id,
+    resolveOrgId: (id: string) => Promise.resolve(id),
     read: vi.fn().mockResolvedValue(opts.before),
     update,
     listProvisionedIds: vi.fn().mockResolvedValue([]),

--- a/packages/agent-host/src/models.service.test.ts
+++ b/packages/agent-host/src/models.service.test.ts
@@ -21,6 +21,7 @@ function makeRepo(overrides: { apiKey?: string | null; row?: AgentConfigRow } = 
   const apiKey = 'apiKey' in overrides ? overrides.apiKey : 'sk-test';
   return {
     resolveCurrentId: () => row.id,
+    resolveOrgId: (id: string) => Promise.resolve(id),
     read: vi.fn().mockResolvedValue(row),
     update: vi.fn().mockResolvedValue(row),
     listProvisionedIds: vi.fn().mockResolvedValue([]),

--- a/packages/agent-host/src/module.ts
+++ b/packages/agent-host/src/module.ts
@@ -1,5 +1,5 @@
 import { DynamicModule, Module, Provider, Type } from '@nestjs/common';
-import { DB, DbModule, McpModule } from '@getmunin/backend-core';
+import { DB, DbModule, McpModule, RealtimeModule } from '@getmunin/backend-core';
 import { AgentConfigService } from './config.service.js';
 import { AgentConfigController } from './config.controller.js';
 import { AgentModelsService } from './models.service.js';
@@ -39,7 +39,7 @@ export class AgentHostModule {
     };
     return {
       module: AgentHostModule,
-      imports: [DbModule, McpModule],
+      imports: [DbModule, McpModule, RealtimeModule],
       providers: [
         repoProvider,
         keyProvider,

--- a/packages/agent-host/src/per-org-config.repository.ts
+++ b/packages/agent-host/src/per-org-config.repository.ts
@@ -19,6 +19,10 @@ export class PerOrgConfigRepository implements AgentConfigRepository {
     return actor.orgId;
   }
 
+  resolveOrgId(id: string): Promise<string> {
+    return Promise.resolve(id);
+  }
+
   async read(id: string): Promise<AgentConfigRow> {
     return readOrMaterialize(id);
   }

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -258,6 +258,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
 
   private async spawnRunner(id: string): Promise<PerConfigRunner | null> {
     const config = await runWithServiceContext(this.db, id, () => this.repo.read(id));
+    const orgId = await runWithServiceContext(this.db, id, () => this.repo.resolveOrgId(id));
     const adminApiKey =
       (await runWithServiceContext(this.db, id, () =>
         this.repo.readDecryptedAdminKey(id),
@@ -279,7 +280,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
 
     const adminMcp = openAgentMcpClient({
       db: this.db,
-      orgId: id,
+      orgId,
       registry: this.mcpRegistry,
       skills: this.mcpSkills,
     });

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -12,27 +12,29 @@ import type { Db } from '@getmunin/db';
 import {
   McpRegistryService,
   McpSkillRegistryService,
-  openAgentMcpClient,
+  RealtimeEventBus,
+  openAdminAgentMcpClient,
+  openEndUserAgentMcpClient,
   type AgentMcpClient,
+  type AgentConfigChangedBusEvent,
+  type CuratorJobPendingBusEvent,
+  type GreetRequestedBusEvent,
+  type KbDocumentChangedBusEvent,
+  type MessageReceivedBusEvent,
+  type RealtimeBusSubscription,
 } from '@getmunin/backend-core';
 import {
   createConversationHandler,
   createMuninRestClient,
   createPromptResolver,
-  createRealtimeClient,
-  openMcpClient,
   runSkillPass,
-  type AgentConfigChangedEvent,
   type ConversationHandler,
   type CuratorJob,
-  type CuratorJobPendingEvent,
-  type GreetRequestedEvent,
   type HandlerConfig,
-  type KbDocumentChangedEvent,
-  type MessageReceivedEvent,
   type MuninRestClient,
   type PromptResolver,
   type SkillPassResult,
+  type SkillReader,
 } from '@getmunin/agent-runtime';
 import {
   jobKindOf,
@@ -48,8 +50,7 @@ import { runWebImportJob } from './web-import.handler.js';
 
 interface TaskHandlerContext {
   job: CuratorJob;
-  baseUrl: string;
-  adminApiKey: string;
+  mcp: AgentMcpClient;
   providerBaseUrl: string;
   providerApiKey: string;
   model: string;
@@ -73,7 +74,7 @@ export interface AgentHostRunnerOptions {
 }
 
 interface PerConfigRunner {
-  realtime: { stop: () => Promise<void> };
+  realtime: RealtimeBusSubscription;
   handler: ConversationHandler;
   prompts: PromptResolver;
   adminMcp: AgentMcpClient;
@@ -81,7 +82,7 @@ interface PerConfigRunner {
 }
 
 interface CuratorWorker {
-  onPending(event: CuratorJobPendingEvent): void;
+  onPending(event: CuratorJobPendingBusEvent): void;
   onConnected(): void;
   stop(): Promise<void>;
 }
@@ -103,6 +104,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     @Inject(AGENT_HOST_DB) private readonly db: Db,
     @Inject(McpRegistryService) private readonly mcpRegistry: McpRegistryService,
     @Inject(McpSkillRegistryService) private readonly mcpSkills: McpSkillRegistryService,
+    @Inject(RealtimeEventBus) private readonly eventBus: RealtimeEventBus,
     @Optional() @Inject('AGENT_HOST_RUNNER_OPTIONS') options?: AgentHostRunnerOptions,
   ) {
     this.baseUrl = options?.baseUrl ?? process.env.MUNIN_BASE_URL ?? 'http://localhost:3001';
@@ -136,7 +138,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     }
     await Promise.all(
       [...this.runners.values()].map(async (r) => {
-        await r.realtime.stop();
+        r.realtime.unsubscribe();
         await r.handler.stop();
         await r.curatorWorker.stop();
         await r.adminMcp.close().catch((err: unknown) => {
@@ -165,7 +167,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     for (const [id, runner] of this.runners) {
       if (!desired.has(id)) {
         this.logger.log(`stopping runner for ${id}`);
-        await runner.realtime.stop();
+        runner.realtime.unsubscribe();
         await runner.handler.stop();
         await runner.curatorWorker.stop();
         await runner.adminMcp.close().catch((err: unknown) => {
@@ -215,7 +217,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       if (existing) {
         this.logger.log(`respawn: stopping runner for ${id}`);
         try {
-          await existing.realtime.stop();
+          existing.realtime.unsubscribe();
           await existing.handler.stop();
           await existing.curatorWorker.stop();
           await existing.adminMcp.close();
@@ -278,7 +280,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
 
     const rest = createMuninRestClient({ baseUrl: this.baseUrl, adminApiKey });
 
-    const adminMcp = openAgentMcpClient({
+    const adminMcp = openAdminAgentMcpClient({
       db: this.db,
       orgId,
       registry: this.mcpRegistry,
@@ -299,57 +301,64 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       debounceMs: config.debounceMs,
     };
 
-    const curatorWorker = this.buildCuratorWorker({ id, config, providerApiKey, rest });
+    const curatorWorker = this.buildCuratorWorker({ id, orgId, config, providerApiKey, rest });
 
     const handlerRef: { current: ConversationHandler | null } = { current: null };
-    const realtime = createRealtimeClient({
-      baseUrl: this.baseUrl,
-      adminApiKey,
-      onMessageReceived: (event: MessageReceivedEvent) => {
-        if (this.lockManager && !this.lockManager.holds(id)) return;
-        handlerRef.current?.handle({
-          conversationId: event.conversationId,
-          authorType: event.authorType,
-        });
+    const realtime = this.eventBus.subscribe(
+      { orgId },
+      {
+        onMessageReceived: (event: MessageReceivedBusEvent) => {
+          if (this.lockManager && !this.lockManager.holds(id)) return;
+          handlerRef.current?.handle({
+            conversationId: event.conversationId,
+            authorType: event.authorType,
+          });
+        },
+        onGreetRequested: (event: GreetRequestedBusEvent) => {
+          if (this.lockManager && !this.lockManager.holds(id)) return;
+          handlerRef.current?.greet({ conversationId: event.conversationId });
+        },
+        onCuratorJobPending: (event) => curatorWorker.onPending(event),
+        onConnected: () => curatorWorker.onConnected(),
+        onKbDocumentChanged: (event: KbDocumentChangedBusEvent) => {
+          if (event.type === 'deleted') return;
+          if (!event.slug || !prompts.isPromptDocument(event.slug)) return;
+          void prompts.refresh(event.slug);
+        },
+        onAgentConfigChanged: (event: AgentConfigChangedBusEvent) => {
+          if (event.configId !== id) return;
+          setImmediate(() => void this.respawnRunner(id));
+        },
       },
-      onGreetRequested: (event: GreetRequestedEvent) => {
-        if (this.lockManager && !this.lockManager.holds(id)) return;
-        handlerRef.current?.greet({ conversationId: event.conversationId });
-      },
-      onCuratorJobPending: (event) => curatorWorker.onPending(event),
-      onConnected: () => curatorWorker.onConnected(),
-      onKbDocumentChanged: (event: KbDocumentChangedEvent) => {
-        if (event.type === 'deleted') return;
-        if (!event.slug || !prompts.isPromptDocument(event.slug)) return;
-        void prompts.refresh(event.slug);
-      },
-      onAgentConfigChanged: (event: AgentConfigChangedEvent) => {
-        if (event.configId !== id) return;
-        setImmediate(() => void this.respawnRunner(id));
-      },
-      logger: this.scopedLogger(id, 'realtime'),
-    });
+    );
 
     const handler = createConversationHandler({
       config: handlerConfig,
       rest,
       prompts,
-      openMcp: ({ delegatedToken }) =>
-        openMcpClient({ baseUrl: this.baseUrl, bearerToken: delegatedToken }),
+      openMcp: ({ endUserId }) =>
+        Promise.resolve(
+          openEndUserAgentMcpClient({
+            db: this.db,
+            orgId,
+            endUserId,
+            registry: this.mcpRegistry,
+            skills: this.mcpSkills,
+          }),
+        ),
       holderId: this.holderId,
       logger: this.scopedLogger(id, 'chat'),
       onTyping: (conversationId, isTyping) =>
-        realtime.sendConversationTyping(conversationId, isTyping),
+        this.eventBus.publishConversationTyping(orgId, conversationId, isTyping),
     });
     handlerRef.current = handler;
-
-    realtime.start();
 
     return { realtime, handler, prompts, adminMcp, curatorWorker };
   }
 
   private buildCuratorWorker(opts: {
     id: string;
+    orgId: string;
     config: AgentConfigRow;
     providerApiKey: string;
     rest: MuninRestClient;
@@ -372,17 +381,29 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     const executeOne = async (job: CuratorJob): Promise<void> => {
       log.info(`running ${job.jobUri} for ${job.id} (attempt ${job.attempts}/${job.maxAttempts})`);
       let result: SkillPassResult;
+      const jobMcp = openAdminAgentMcpClient({
+        db: this.db,
+        orgId: opts.orgId,
+        registry: this.mcpRegistry,
+        skills: this.mcpSkills,
+      });
+      const skills: SkillReader = {
+        readSkill: async (uri: string) => {
+          try {
+            const res = await jobMcp.readResource(uri);
+            return typeof res.text === 'string' ? res.text : null;
+          } catch (err) {
+            log.warn(`readSkill failed for ${uri}: ${describe(err)}`);
+            return null;
+          }
+        },
+      };
       try {
-        const adminKey =
-          (await runWithServiceContext(this.db, opts.id, () =>
-            this.repo.readDecryptedAdminKey(opts.id),
-          )) ?? this.fallbackAdminApiKey ?? '';
         const tier = tierFor(job.jobUri);
         const model = tier === 'fast' ? fastModel : smartModel;
         const ctx: TaskHandlerContext = {
           job,
-          baseUrl: this.baseUrl,
-          adminApiKey: adminKey,
+          mcp: jobMcp,
           providerBaseUrl: opts.config.providerBaseUrl,
           providerApiKey: opts.providerApiKey,
           model,
@@ -399,8 +420,8 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
         } else if (kind === 'skill') {
           const prefixes = toolPrefixesFor(job.jobUri);
           result = await runSkillPass({
-            baseUrl: this.baseUrl,
-            adminApiKey: adminKey,
+            mcp: jobMcp,
+            skills,
             providerBaseUrl: opts.config.providerBaseUrl,
             providerApiKey: opts.providerApiKey,
             model,
@@ -409,7 +430,6 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
             assistantName: job.assistantName,
             maxToolIterations: 24,
             maxHistoryChars: opts.config.maxHistoryChars,
-            clientName: `agent-host-curator-${job.id.slice(-6)}`,
             allowedToolPrefixes: prefixes ? [...prefixes] : undefined,
             logger: log,
           });

--- a/packages/agent-host/src/singleton-config.repository.ts
+++ b/packages/agent-host/src/singleton-config.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { decryptSecretSql, encryptSecretSql, getCurrentContext } from '@getmunin/core';
-import { eq, isNotNull, sql } from 'drizzle-orm';
+import { schema } from '@getmunin/db';
+import { asc, eq, isNotNull, sql } from 'drizzle-orm';
 import { agentConfig, SINGLETON_ID } from './schema.js';
 import type {
   AgentConfigPatch,
@@ -12,6 +13,19 @@ import type {
 export class SingletonConfigRepository implements AgentConfigRepository {
   resolveCurrentId(): string {
     return SINGLETON_ID;
+  }
+
+  async resolveOrgId(id: string): Promise<string> {
+    assertSingleton(id);
+    const ctx = getCurrentContext();
+    const rows = await ctx.db
+      .select({ id: schema.orgs.id })
+      .from(schema.orgs)
+      .orderBy(asc(schema.orgs.createdAt))
+      .limit(1);
+    const row = rows[0];
+    if (!row) throw new Error('SingletonConfigRepository.resolveOrgId: no org has been created yet');
+    return row.id;
   }
 
   async read(id: string): Promise<AgentConfigRow> {

--- a/packages/agent-host/src/web-import.handler.ts
+++ b/packages/agent-host/src/web-import.handler.ts
@@ -1,7 +1,6 @@
 import {
   WebCrawler,
   openAiCompatibleProvider,
-  openMcpClient,
   type CrawledPage,
   type CrawlResult,
   type CuratorJob,
@@ -17,8 +16,7 @@ const PROFILE_MAX_TOKENS = 1200;
 
 export interface WebImportHandlerOpts {
   job: CuratorJob;
-  baseUrl: string;
-  adminApiKey: string;
+  mcp: McpToolHandle;
   providerBaseUrl: string;
   providerApiKey: string;
   model: string;
@@ -30,7 +28,6 @@ export interface WebImportHandlerOpts {
 }
 
 export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<SkillPassResult> {
-  if (!opts.adminApiKey) return { ok: false, skipped: 'no_admin_key' };
   if (!opts.providerApiKey) return { ok: false, skipped: 'no_provider_key' };
 
   const url = opts.job.userPrompt.trim();
@@ -48,63 +45,47 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
     return { ok: false, skipped: 'agent_error', error: message };
   }
 
-  let mcp: Awaited<ReturnType<typeof openMcpClient>>;
+  const mcp = opts.mcp;
+
+  let spaceId: string;
   try {
-    mcp = await openMcpClient({
-      baseUrl: opts.baseUrl,
-      bearerToken: opts.adminApiKey,
-      clientName: `agent-host-web-import-${opts.job.id.slice(-6)}`,
-    });
+    spaceId = await ensureSpace(mcp);
   } catch (err) {
-    opts.logger.warn(`mcp connect failed: ${describe(err)}`);
-    return { ok: false, skipped: 'mcp_connect_failed' };
+    return { ok: false, skipped: 'agent_error', error: `ensureSpace failed: ${describe(err)}` };
   }
 
-  try {
-    let spaceId: string;
-    try {
-      spaceId = await ensureSpace(mcp);
-    } catch (err) {
-      return { ok: false, skipped: 'agent_error', error: `ensureSpace failed: ${describe(err)}` };
-    }
+  let created = 0;
+  const pagesToInsert = crawl.pages.slice(0, MAX_PAGES_TO_INSERT);
+  for (const page of pagesToInsert) {
+    const ok = await upsertPageDocument(mcp, spaceId, page, opts.logger);
+    if (ok) created++;
+  }
 
-    let created = 0;
-    const pagesToInsert = crawl.pages.slice(0, MAX_PAGES_TO_INSERT);
-    for (const page of pagesToInsert) {
-      const ok = await upsertPageDocument(mcp, spaceId, page, opts.logger);
+  let profileTokens = 0;
+  if (crawl.pages.length > 0) {
+    const profile = await generateCompanyProfile({
+      provider: { baseUrl: opts.providerBaseUrl, apiKey: opts.providerApiKey },
+      model: opts.model,
+      siteTitle: crawl.siteTitle,
+      siteUrl: crawl.siteUrl,
+      pages: crawl.pages.slice(0, PROFILE_CONTEXT_PAGES),
+      logger: opts.logger,
+    });
+    if (profile) {
+      profileTokens = profile.totalTokens;
+      const ok = await upsertProfileDocument(mcp, spaceId, profile.markdown, opts.logger);
       if (ok) created++;
     }
-
-    let profileTokens = 0;
-    if (crawl.pages.length > 0) {
-      const profile = await generateCompanyProfile({
-        provider: { baseUrl: opts.providerBaseUrl, apiKey: opts.providerApiKey },
-        model: opts.model,
-        siteTitle: crawl.siteTitle,
-        siteUrl: crawl.siteUrl,
-        pages: crawl.pages.slice(0, PROFILE_CONTEXT_PAGES),
-        logger: opts.logger,
-      });
-      if (profile) {
-        profileTokens = profile.totalTokens;
-        const ok = await upsertProfileDocument(mcp, spaceId, profile.markdown, opts.logger);
-        if (ok) created++;
-      }
-    }
-
-    const replyText = `Imported ${created} document(s) from ${crawl.siteUrl}; ${crawl.skipped.length} URL(s) skipped.`;
-    return {
-      ok: true,
-      toolCalls: created,
-      totalTokens: profileTokens,
-      finishReason: 'stop',
-      replyText,
-    };
-  } finally {
-    await mcp.close().catch((err: unknown) => {
-      opts.logger.warn(`mcp close failed: ${describe(err)}`);
-    });
   }
+
+  const replyText = `Imported ${created} document(s) from ${crawl.siteUrl}; ${crawl.skipped.length} URL(s) skipped.`;
+  return {
+    ok: true,
+    toolCalls: created,
+    totalTokens: profileTokens,
+    finishReason: 'stop',
+    replyText,
+  };
 }
 
 async function ensureSpace(mcp: McpToolHandle): Promise<string> {

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -418,11 +418,11 @@ describe('createConversationHandler', () => {
     expect(handoverCalls).toEqual(['conv_request_handover_in_my_conversation']);
   });
 
-  it('caches the delegated token per end-user across triggering events', async () => {
+  it('passes endUserId to openMcp once per attempt and never calls rest.mintDelegatedToken', async () => {
     const rest = buildRest();
     const mintSpy = vi.fn(() =>
       Promise.resolve({
-        accessToken: 'mn_eu_cached',
+        accessToken: 'unused',
         endUserId: 'eu_1',
         expiresAt: new Date(Date.now() + 600_000).toISOString(),
       }),
@@ -436,11 +436,12 @@ describe('createConversationHandler', () => {
     };
     const stubProvider: Provider = () => Promise.resolve(happyResponse);
 
+    const openMcpSpy = vi.fn((_opts: { endUserId: string }) => Promise.resolve(buildMcp()));
     const handler = createConversationHandler({
       config: baseConfig,
       rest,
       prompts: buildPrompts(),
-      openMcp: () => Promise.resolve(buildMcp()),
+      openMcp: openMcpSpy,
       logger: silentLogger,
       scheduler: noDelayScheduler,
       provider: stubProvider,
@@ -453,48 +454,9 @@ describe('createConversationHandler', () => {
     handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
     await handler.flush();
 
-    expect(mintSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('re-mints when the cached token is within the refresh margin', async () => {
-    const rest = buildRest();
-    let call = 0;
-    const mintSpy = vi.fn(() => {
-      call += 1;
-      // First mint returns a token expiring in 30s (inside the 60s margin).
-      // Second mint returns a fresh long-lived token.
-      const ttlMs = call === 1 ? 30_000 : 600_000;
-      return Promise.resolve({
-        accessToken: `mn_eu_${call}`,
-        endUserId: 'eu_1',
-        expiresAt: new Date(Date.now() + ttlMs).toISOString(),
-      });
-    });
-    rest.mintDelegatedToken = mintSpy;
-
-    const happyResponse: ProviderResponse = {
-      message: { role: 'assistant', content: 'hi' },
-      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-      finishReason: 'stop',
-    };
-    const stubProvider: Provider = () => Promise.resolve(happyResponse);
-
-    const handler = createConversationHandler({
-      config: baseConfig,
-      rest,
-      prompts: buildPrompts(),
-      openMcp: () => Promise.resolve(buildMcp()),
-      logger: silentLogger,
-      scheduler: noDelayScheduler,
-      provider: stubProvider,
-    });
-
-    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
-    await handler.flush();
-    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
-    await handler.flush();
-
-    expect(mintSpy).toHaveBeenCalledTimes(2);
+    expect(mintSpy).not.toHaveBeenCalled();
+    expect(openMcpSpy).toHaveBeenCalledTimes(3);
+    expect(openMcpSpy.mock.calls[0]?.[0]).toEqual({ endUserId: 'eu_1' });
   });
 
   it('aborts the in-flight debounce when a new triggering event arrives for the same conversation', async () => {

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -23,7 +23,6 @@ export interface HandlerConfig {
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
 const HANDOVER_TOOL_NAME = 'conv_request_handover_in_my_conversation';
-const TOKEN_REFRESH_MARGIN_MS = 60_000;
 
 export interface OpenedMcp extends McpToolHandle {
   close(): Promise<void>;
@@ -33,7 +32,7 @@ export interface ConversationHandlerDeps {
   config: HandlerConfig;
   rest: MuninRestClient;
   prompts: PromptResolver;
-  openMcp: (opts: { delegatedToken: string }) => Promise<OpenedMcp>;
+  openMcp: (opts: { endUserId: string }) => Promise<OpenedMcp>;
   holderId?: string;
   leaseSeconds?: number;
   logger?: {
@@ -78,7 +77,6 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
   const scheduler = deps.scheduler ?? defaultScheduler;
   const inFlight = new Map<string, InFlight>();
   const claimsHeld = new Set<string>();
-  const tokenCache = new Map<string, { accessToken: string; expiresAtMs: number }>();
   const holderId = deps.holderId ?? `runner-${randomUUID()}`;
   const leaseSeconds = deps.leaseSeconds ?? 3600;
 
@@ -91,20 +89,6 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
           `${conversationId} release claim failed: ${err instanceof Error ? err.message : String(err)}`,
         ),
       );
-  }
-
-  async function getDelegatedToken(endUserId: string): Promise<string> {
-    const now = Date.now();
-    const cached = tokenCache.get(endUserId);
-    if (cached && cached.expiresAtMs - now > TOKEN_REFRESH_MARGIN_MS) {
-      return cached.accessToken;
-    }
-    const minted = await deps.rest.mintDelegatedToken(endUserId);
-    tokenCache.set(endUserId, {
-      accessToken: minted.accessToken,
-      expiresAtMs: Date.parse(minted.expiresAt),
-    });
-    return minted.accessToken;
   }
 
   function shouldRespond(detail: ConversationDetail, mode: 'reply' | 'greet'): boolean {
@@ -233,8 +217,7 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     let lastError: Error | null = null;
     for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
       if (signal.aborted) return;
-      const accessToken = await getDelegatedToken(endUserId);
-      const mcp = await deps.openMcp({ delegatedToken: accessToken });
+      const mcp = await deps.openMcp({ endUserId });
       startTyping();
       try {
         const reply = await runAgent({
@@ -289,7 +272,6 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
           return;
         }
         log.warn(`${conversationId} produced empty body (finishReason=${reply.finishReason})`);
-        // Empty body is treated like an error → retry.
         lastError = new Error(`empty reply (finishReason=${reply.finishReason})`);
       } catch (err) {
         if (signal.aborted) return;
@@ -421,8 +403,7 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
   }
 
   async function requestHandover(conversationId: string, endUserId: string): Promise<void> {
-    const accessToken = await getDelegatedToken(endUserId);
-    const mcp = await deps.openMcp({ delegatedToken: accessToken });
+    const mcp = await deps.openMcp({ endUserId });
     try {
       await mcp.callTool(HANDOVER_TOOL_NAME, {
         conversationId,

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -42,15 +42,16 @@ export {
   type MuninRestClient,
 } from './munin-rest.js';
 export {
-  openMcpClient,
-  type OpenMcpClientOptions,
-  type OpenedMcpClient,
+  openHttpMcpClient,
+  type OpenHttpMcpClientOptions,
+  type OpenedHttpMcpClient,
 } from './mcp-client.js';
 export {
   runSkillPass,
   withAllowedToolPrefixes,
   type SkillPassOptions,
   type SkillPassResult,
+  type SkillReader,
 } from './skill-pass.js';
 export {
   WebCrawler,

--- a/packages/agent-runtime/src/mcp-client.ts
+++ b/packages/agent-runtime/src/mcp-client.ts
@@ -2,17 +2,17 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { McpTool, McpToolHandle, McpToolResult } from './types.js';
 
-export interface OpenMcpClientOptions {
+export interface OpenHttpMcpClientOptions {
   baseUrl: string;
   bearerToken: string;
   clientName?: string;
 }
 
-export interface OpenedMcpClient extends McpToolHandle {
+export interface OpenedHttpMcpClient extends McpToolHandle {
   close(): Promise<void>;
 }
 
-export async function openMcpClient(opts: OpenMcpClientOptions): Promise<OpenedMcpClient> {
+export async function openHttpMcpClient(opts: OpenHttpMcpClientOptions): Promise<OpenedHttpMcpClient> {
   const url = new URL(`${opts.baseUrl.replace(/\/+$/, '')}/mcp`);
   const transport = new StreamableHTTPClientTransport(url, {
     requestInit: {

--- a/packages/agent-runtime/src/skill-pass.test.ts
+++ b/packages/agent-runtime/src/skill-pass.test.ts
@@ -1,25 +1,21 @@
 import { describe, it, expect, vi } from 'vitest';
-import { runSkillPass, withAllowedToolPrefixes } from './skill-pass.js';
+import { runSkillPass, withAllowedToolPrefixes, type SkillReader } from './skill-pass.js';
 import type { McpTool, McpToolHandle, McpToolResult } from './types.js';
 
-describe('runSkillPass', () => {
-  it('returns skipped:no_admin_key when adminApiKey is empty', async () => {
-    const result = await runSkillPass({
-      baseUrl: 'http://localhost:1',
-      adminApiKey: '',
-      providerBaseUrl: 'http://localhost:1',
-      providerApiKey: 'k',
-      model: 'm',
-      skillUri: 'skill://x/y',
-      userPrompt: 'go',
-    });
-    expect(result).toEqual({ ok: false, skipped: 'no_admin_key' });
-  });
+const noopMcp: McpToolHandle = {
+  listTools: () => Promise.resolve([]),
+  callTool: () => Promise.resolve({ content: [] }),
+};
 
+const noopSkills: SkillReader = {
+  readSkill: () => Promise.resolve(null),
+};
+
+describe('runSkillPass', () => {
   it('returns skipped:no_provider_key when providerApiKey is empty', async () => {
     const result = await runSkillPass({
-      baseUrl: 'http://localhost:1',
-      adminApiKey: 'k',
+      mcp: noopMcp,
+      skills: noopSkills,
       providerBaseUrl: 'http://localhost:1',
       providerApiKey: '',
       model: 'm',
@@ -27,6 +23,20 @@ describe('runSkillPass', () => {
       userPrompt: 'go',
     });
     expect(result).toEqual({ ok: false, skipped: 'no_provider_key' });
+  });
+
+  it('returns skipped:skill_missing when readSkill resolves to null', async () => {
+    const result = await runSkillPass({
+      mcp: noopMcp,
+      skills: noopSkills,
+      providerBaseUrl: 'http://localhost:1',
+      providerApiKey: 'k',
+      model: 'm',
+      skillUri: 'skill://x/missing',
+      userPrompt: 'go',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    expect(result).toEqual({ ok: false, skipped: 'skill_missing' });
   });
 
   it('withAllowedToolPrefixes filters listTools and blocks disallowed callTool', async () => {
@@ -70,21 +80,4 @@ describe('runSkillPass', () => {
     };
     expect(withAllowedToolPrefixes(inner, [])).toBe(inner);
   });
-
-  it('returns skipped:mcp_connect_failed against an unreachable baseUrl', async () => {
-    const result = await runSkillPass({
-      baseUrl: 'http://127.0.0.1:1',
-      adminApiKey: 'k',
-      providerBaseUrl: 'http://localhost:1',
-      providerApiKey: 'k',
-      model: 'm',
-      skillUri: 'skill://x/y',
-      userPrompt: 'go',
-      logger: { info: () => {}, warn: () => {}, error: () => {} },
-    });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.skipped).toBe('mcp_connect_failed');
-    }
-  }, 15_000);
 });

--- a/packages/agent-runtime/src/skill-pass.ts
+++ b/packages/agent-runtime/src/skill-pass.ts
@@ -1,12 +1,14 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { assistantNamePreamble } from './conversation-handler.js';
 import { runAgent } from './runtime.js';
 import type { McpTool, McpToolHandle, McpToolResult, Provider } from './types.js';
 
+export interface SkillReader {
+  readSkill(uri: string): Promise<string | null>;
+}
+
 export interface SkillPassOptions {
-  baseUrl: string;
-  adminApiKey: string;
+  mcp: McpToolHandle;
+  skills: SkillReader;
   providerBaseUrl: string;
   providerApiKey: string;
   model: string;
@@ -15,7 +17,6 @@ export interface SkillPassOptions {
   assistantName?: string | null;
   maxToolIterations?: number;
   maxHistoryChars?: number;
-  clientName?: string;
   providerImpl?: Provider;
   allowedToolPrefixes?: string[];
   logger?: {
@@ -53,101 +54,55 @@ export async function runSkillPass(opts: SkillPassOptions): Promise<SkillPassRes
       error: (m: string) => console.error(`[skill-pass] ${m}`),
     };
 
-  if (!opts.adminApiKey) return { ok: false, skipped: 'no_admin_key' };
   if (!opts.providerApiKey) return { ok: false, skipped: 'no_provider_key' };
 
-  const url = new URL(`${opts.baseUrl.replace(/\/+$/, '')}/mcp`);
-  const transport = new StreamableHTTPClientTransport(url, {
-    requestInit: { headers: { authorization: `Bearer ${opts.adminApiKey}` } },
-  });
-  const client = new Client(
-    { name: opts.clientName ?? 'munin-skill-pass', version: '0.0.1' },
-    { capabilities: {} },
-  );
+  let skill: string | null;
   try {
-    await client.connect(transport);
+    skill = await opts.skills.readSkill(opts.skillUri);
   } catch (err) {
-    log.warn(`mcp connect failed: ${err instanceof Error ? err.message : String(err)}`);
-    return { ok: false, skipped: 'mcp_connect_failed' };
+    log.warn(`readSkill failed: ${err instanceof Error ? err.message : String(err)}`);
+    return { ok: false, skipped: 'skill_missing' };
+  }
+  if (!skill) {
+    log.warn(`${opts.skillUri} not available`);
+    return { ok: false, skipped: 'skill_missing' };
   }
 
+  const mcp = opts.allowedToolPrefixes
+    ? withAllowedToolPrefixes(opts.mcp, opts.allowedToolPrefixes)
+    : opts.mcp;
+
   try {
-    const skill = await readSkillFromClient(client, opts.skillUri);
-    if (!skill) {
-      log.warn(`${opts.skillUri} not available on ${opts.baseUrl}`);
-      return { ok: false, skipped: 'skill_missing' };
-    }
-    const baseHandle = adaptToToolHandle(client);
-    const mcp = opts.allowedToolPrefixes
-      ? withAllowedToolPrefixes(baseHandle, opts.allowedToolPrefixes)
-      : baseHandle;
-    try {
-      const reply = await runAgent({
-        config: {
-          provider: { baseUrl: opts.providerBaseUrl, apiKey: opts.providerApiKey },
-          model: opts.model,
-          systemPrompt: assistantNamePreamble(opts.assistantName) + skill,
-          maxToolIterations: opts.maxToolIterations ?? 24,
-          maxHistoryChars: opts.maxHistoryChars ?? 32_000,
+    const reply = await runAgent({
+      config: {
+        provider: { baseUrl: opts.providerBaseUrl, apiKey: opts.providerApiKey },
+        model: opts.model,
+        systemPrompt: assistantNamePreamble(opts.assistantName) + skill,
+        maxToolIterations: opts.maxToolIterations ?? 24,
+        maxHistoryChars: opts.maxHistoryChars ?? 32_000,
+      },
+      history: [
+        {
+          authorType: 'user',
+          body: opts.userPrompt,
+          createdAt: new Date().toISOString(),
         },
-        history: [
-          {
-            authorType: 'user',
-            body: opts.userPrompt,
-            createdAt: new Date().toISOString(),
-          },
-        ],
-        mcp,
-        provider: opts.providerImpl,
-      });
-      return {
-        ok: true,
-        toolCalls: reply.toolCalls.length,
-        totalTokens: reply.usage.totalTokens,
-        finishReason: reply.finishReason,
-        replyText: reply.body,
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.error(`runAgent failed: ${message}`);
-      return { ok: false, skipped: 'agent_error', error: message };
-    }
-  } finally {
-    await client.close().catch(() => undefined);
-    await transport.close().catch(() => undefined);
+      ],
+      mcp,
+      provider: opts.providerImpl,
+    });
+    return {
+      ok: true,
+      toolCalls: reply.toolCalls.length,
+      totalTokens: reply.usage.totalTokens,
+      finishReason: reply.finishReason,
+      replyText: reply.body,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(`runAgent failed: ${message}`);
+    return { ok: false, skipped: 'agent_error', error: message };
   }
-}
-
-async function readSkillFromClient(client: Client, uri: string): Promise<string | null> {
-  try {
-    const res = await client.readResource({ uri });
-    const item = res.contents[0];
-    if (!item) return null;
-    if ('text' in item && typeof item.text === 'string') return item.text;
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function adaptToToolHandle(client: Client): McpToolHandle {
-  return {
-    async listTools(): Promise<McpTool[]> {
-      const result = await client.listTools();
-      return result.tools.map((t) => ({
-        name: t.name,
-        description: t.description,
-        inputSchema: t.inputSchema ?? { type: 'object', properties: {} },
-      }));
-    },
-    async callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
-      const result = await client.callTool({ name, arguments: args });
-      return {
-        content: (result.content ?? []) as McpToolResult['content'],
-        isError: typeof result.isError === 'boolean' ? result.isError : undefined,
-      };
-    },
-  };
 }
 
 export function withAllowedToolPrefixes(

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -56,6 +56,7 @@
     "drizzle-orm": "^0.45.2",
     "express": "^5.1.0",
     "imapflow": "^1.3.2",
+    "jose": "^6.0.0",
     "mailparser": "^3.9.8",
     "marked": "^18.0.3",
     "nodemailer": "^8.0.7",

--- a/packages/backend-core/src/agent/in-process-context.ts
+++ b/packages/backend-core/src/agent/in-process-context.ts
@@ -3,7 +3,9 @@ import {
   AuditLogger,
   RequestContextStore,
   buildAdminAgentActor,
+  buildEndUserAgentActor,
   type ActorIdentity,
+  type Audience,
   type RequestContext,
 } from '@getmunin/core';
 import type { Db } from '@getmunin/db';
@@ -11,7 +13,7 @@ import { openInProcessMcpClient, type InProcessMcpClient } from '@getmunin/mcp-t
 import type { McpToolRegistry, SkillRegistry } from '@getmunin/mcp-toolkit';
 import { applyTenancyGUCs } from '../common/tenancy/tenancy.interceptor.js';
 
-export interface OpenAgentMcpClientOptions {
+export interface OpenAdminAgentMcpClientOptions {
   db: Db;
   orgId: string;
   registry: McpToolRegistry;
@@ -19,33 +21,81 @@ export interface OpenAgentMcpClientOptions {
   audit?: AuditLogger;
 }
 
+export interface OpenEndUserAgentMcpClientOptions {
+  db: Db;
+  orgId: string;
+  endUserId: string;
+  registry: McpToolRegistry;
+  skills?: SkillRegistry;
+  audit?: AuditLogger;
+  scopes?: readonly string[];
+  audiences?: readonly Audience[];
+}
+
 export interface AgentMcpClient extends InProcessMcpClient {
   readonly actor: ActorIdentity;
   close(): Promise<void>;
 }
 
-export function openAgentMcpClient(opts: OpenAgentMcpClientOptions): AgentMcpClient {
+export function openAdminAgentMcpClient(opts: OpenAdminAgentMcpClientOptions): AgentMcpClient {
   const actor = buildAdminAgentActor(opts.orgId);
-  const audit = opts.audit ?? new AuditLogger();
+  return wrapInProcessMcp({
+    db: opts.db,
+    actor,
+    audience: 'admin',
+    registry: opts.registry,
+    skills: opts.skills,
+    audit: opts.audit,
+  });
+}
 
+export function openEndUserAgentMcpClient(opts: OpenEndUserAgentMcpClientOptions): AgentMcpClient {
+  const actor = buildEndUserAgentActor({
+    orgId: opts.orgId,
+    endUserId: opts.endUserId,
+    scopes: opts.scopes,
+    audiences: opts.audiences,
+  });
+  const audience: Audience = actor.audiences.includes('self_service') ? 'self_service' : 'admin';
+  return wrapInProcessMcp({
+    db: opts.db,
+    actor,
+    audience,
+    registry: opts.registry,
+    skills: opts.skills,
+    audit: opts.audit,
+  });
+}
+
+interface WrapOptions {
+  db: Db;
+  actor: ActorIdentity;
+  audience: Audience;
+  registry: McpToolRegistry;
+  skills?: SkillRegistry;
+  audit?: AuditLogger;
+}
+
+function wrapInProcessMcp(opts: WrapOptions): AgentMcpClient {
+  const audit = opts.audit ?? new AuditLogger();
   const inner = openInProcessMcpClient({
     registry: opts.registry,
     skills: opts.skills,
-    actor,
-    audience: 'admin',
+    actor: opts.actor,
+    audience: opts.audience,
     audit,
   });
 
   function withTenancy<T>(fn: () => Promise<T>): Promise<T> {
     return opts.db.transaction(async (tx) => {
-      await applyTenancyGUCs(tx, actor);
-      const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+      await applyTenancyGUCs(tx, opts.actor);
+      const ctx: RequestContext = { db: tx, actor: opts.actor, correlationId: randomUUID() };
       return RequestContextStore.run(ctx, fn);
     });
   }
 
   return {
-    actor,
+    actor: opts.actor,
     listTools: () => withTenancy(() => inner.listTools()),
     callTool: (name, args) => withTenancy(() => inner.callTool(name, args)),
     listResources: () => withTenancy(() => inner.listResources()),

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -1,8 +1,3 @@
-/**
- * `@getmunin/backend-core` — reusable Nest building blocks for any Munin
- * backend (OSS `apps/backend` or downstream apps). Auth modules are
- * intentionally NOT included here; each consumer wires its own.
- */
 export {
   BACKEND_FEATURE_MODULES_NO_AUTH,
   BACKEND_BASE_CONTROLLERS,
@@ -21,7 +16,6 @@ export {
   readTrustedOriginsFromEnv,
 } from './auth-env.js';
 
-// Common building blocks
 export {
   AuthGuard,
   AllowAnonymous,
@@ -37,15 +31,29 @@ export { MAILER, MailModule } from './common/mail/mail.module.js';
 export { STORAGE } from './common/storage/storage.token.js';
 export { StorageModule } from './common/storage/storage.module.js';
 
-// Feature modules (re-export so cloud can selectively replace any of them
-// if it ever needs to — currently it just composes the array as-is).
 export { McpModule } from './mcp/mcp.module.js';
 export { McpRegistryService } from './mcp/mcp.registry.js';
 export { McpSkillRegistryService } from './mcp/mcp.skill-registry.service.js';
 export {
-  openAgentMcpClient,
+  RealtimeEventBus,
+  type RealtimeBusHandlers,
+  type RealtimeBusSubscription,
+  type RealtimeBusSubscriptionFilter,
+  type MessageReceivedBusEvent,
+  type KbDocumentChangedBusEvent,
+  type HandoverResolvedBusEvent,
+  type CuratorJobPendingBusEvent,
+  type GreetRequestedBusEvent,
+  type AgentConfigChangedBusEvent,
+  type AgentTypingBusEvent,
+} from './realtime/realtime-event-bus.js';
+export { RealtimeModule } from './realtime/realtime.module.js';
+export {
+  openAdminAgentMcpClient,
+  openEndUserAgentMcpClient,
   type AgentMcpClient,
-  type OpenAgentMcpClientOptions,
+  type OpenAdminAgentMcpClientOptions,
+  type OpenEndUserAgentMcpClientOptions,
 } from './agent/in-process-context.js';
 export { ControlModule } from './control/control.module.js';
 export { KbModule } from './modules/kb/kb.module.js';

--- a/packages/backend-core/src/modules/cms/cms.tools.ts
+++ b/packages/backend-core/src/modules/cms/cms.tools.ts
@@ -140,7 +140,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_collections',
-    title: 'List CMS collections',
+    title: 'CMS: List collections',
     description: 'List CMS collections (content types) defined for your org.',
     audiences: ['admin'],
     scopes: ['cms:read'],
@@ -154,7 +154,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_get_collection',
-    title: 'Read CMS collection',
+    title: 'CMS: Read collection',
     description: 'Read one collection by id or slug, including its field definitions.',
     audiences: ['admin'],
     scopes: ['cms:read'],
@@ -168,7 +168,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_create_collection',
-    title: 'Create CMS collection',
+    title: 'CMS: Create collection',
     description:
       'Define a new collection. Fields is an array of { name, type, required?, options? } — see field types: text, rich_text, markdown, number, integer, boolean, date, datetime, select, multi_select, asset, reference, array, json.',
     audiences: ['admin'],
@@ -183,7 +183,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_update_collection',
-    title: 'Update CMS collection',
+    title: 'CMS: Update collection',
     description:
       'Patch a collection. Field migration is lossy: dropped or renamed fields stay in entries\' `data` jsonb but stop being read by the projection layer.',
     audiences: ['admin'],
@@ -198,7 +198,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_delete_collection',
-    title: 'Delete CMS collection',
+    title: 'CMS: Delete collection',
     description: 'Delete a collection. Cascades to all entries, versions, and references.',
     audiences: ['admin'],
     scopes: ['cms:write'],
@@ -214,7 +214,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_entries',
-    title: 'List CMS entries',
+    title: 'CMS: List entries',
     description:
       'List entries. Filters: collection (id or slug), status, locale. Drafts and scheduled entries are returned to admins; the public delivery API only ever returns published.',
     audiences: ['admin'],
@@ -229,7 +229,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_get_entry',
-    title: 'Read CMS entry',
+    title: 'CMS: Read entry',
     description: 'Read one entry. Data is projected through the collection\'s current field schema.',
     audiences: ['admin'],
     scopes: ['cms:read'],
@@ -243,7 +243,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_create_entry',
-    title: 'Create CMS entry',
+    title: 'CMS: Create entry',
     description:
       'Create a new entry in a collection. `data` is keyed by field name; required fields must be present. Pass `status: "published"` to publish on creation; default is draft.',
     audiences: ['admin'],
@@ -258,7 +258,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_update_entry',
-    title: 'Update CMS entry',
+    title: 'CMS: Update entry',
     description:
       'Update an entry. Pass `ifVersion` (the current version you read) for optimistic concurrency. Updating `data` re-validates against the collection schema, regenerates search_text + embedding, and rewrites references.',
     audiences: ['admin'],
@@ -273,7 +273,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_publish_entry',
-    title: 'Publish CMS entry',
+    title: 'CMS: Publish entry',
     description: 'Flip an entry to status="published". Stamps publishedAt and fires cms.entry.published.',
     audiences: ['admin'],
     scopes: ['cms:write'],
@@ -287,7 +287,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_unpublish_entry',
-    title: 'Unpublish CMS entry',
+    title: 'CMS: Unpublish entry',
     description: 'Revert an entry to status="draft". Clears publishedAt; fires cms.entry.unpublished.',
     audiences: ['admin'],
     scopes: ['cms:write'],
@@ -301,7 +301,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_schedule_publish',
-    title: 'Schedule CMS entry publish',
+    title: 'CMS: Schedule entry publish',
     description:
       'Schedule an entry to flip to published at a future ISO 8601 datetime. The schedule worker drains due rows every minute.',
     audiences: ['admin'],
@@ -316,7 +316,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_delete_entry',
-    title: 'Delete CMS entry',
+    title: 'CMS: Delete entry',
     description: 'Delete an entry. Cascades to its versions and references.',
     audiences: ['admin'],
     scopes: ['cms:write'],
@@ -330,7 +330,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_versions',
-    title: 'List CMS entry versions',
+    title: 'CMS: List entry versions',
     description: 'List all prior versions of an entry, newest first.',
     audiences: ['admin'],
     scopes: ['cms:read'],
@@ -344,7 +344,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_restore_version',
-    title: 'Restore CMS entry version',
+    title: 'CMS: Restore entry version',
     description:
       'Roll an entry back to an earlier version. Creates a new current version with that historical data.',
     audiences: ['admin'],
@@ -361,7 +361,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_assets',
-    title: 'List CMS assets',
+    title: 'CMS: List assets',
     description: 'List media-library assets in your org.',
     audiences: ['admin'],
     scopes: ['cms:read'],
@@ -375,7 +375,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_request_asset_upload',
-    title: 'Request CMS asset upload URL',
+    title: 'CMS: Request asset upload URL',
     description:
       'Mint a presigned upload URL for a new asset. The asset row is created in `uploaded:false` state; PUT the file body to `uploadUrl`, then call cms_complete_asset_upload to mark it live.',
     audiences: ['admin'],
@@ -390,7 +390,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_complete_asset_upload',
-    title: 'Complete CMS asset upload',
+    title: 'CMS: Complete asset upload',
     description: 'Mark a previously-requested asset upload as complete.',
     audiences: ['admin'],
     scopes: ['cms:write'],
@@ -404,7 +404,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_delete_asset',
-    title: 'Delete CMS asset',
+    title: 'CMS: Delete asset',
     description: 'Delete an asset and remove the underlying file from storage.',
     audiences: ['admin'],
     scopes: ['cms:write'],
@@ -420,7 +420,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_locales',
-    title: 'List CMS locales',
+    title: 'CMS: List locales',
     description: 'List configured locales for your org. The default locale is used when an entry omits one.',
     audiences: ['admin'],
     scopes: ['cms:read'],
@@ -434,7 +434,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_create_locale',
-    title: 'Create CMS locale',
+    title: 'CMS: Create locale',
     description: 'Add a locale. Code is ISO 639-1 (e.g. "en") or BCP-47 ("en-US"). The first locale is the default unless overridden.',
     audiences: ['admin'],
     scopes: ['cms:write'],
@@ -448,7 +448,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_set_default_locale',
-    title: 'Set default CMS locale',
+    title: 'CMS: Set default locale',
     description: 'Set which locale is treated as the org\'s default for new entries.',
     audiences: ['admin'],
     scopes: ['cms:write'],
@@ -464,7 +464,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_list_inbound_references',
-    title: 'List inbound CMS references',
+    title: 'CMS: List inbound references',
     description:
       'List entries that link to the given entry. Useful before deleting — see "what would break".',
     audiences: ['admin'],
@@ -481,7 +481,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_search',
-    title: 'Search CMS entries',
+    title: 'CMS: Search entries',
     description:
       'Hybrid full-text + semantic search across CMS entries. Returns drafts and published; the public delivery API runs the same engine but hard-filters to published-only.',
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/cms/skills/localize-entry.md
+++ b/packages/backend-core/src/modules/cms/skills/localize-entry.md
@@ -1,5 +1,5 @@
 ---
-title: Localize an entry
+title: CMS: Localize an entry
 description: Configure locales, author entries per language, and switch the org's default locale without breaking already-published entries.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/cms/skills/migrate-content.md
+++ b/packages/backend-core/src/modules/cms/skills/migrate-content.md
@@ -1,5 +1,5 @@
 ---
-title: Migrate content in bulk
+title: CMS: Migrate content in bulk
 description: Move entries from an external CMS (or between Munin collections) idempotently — preserve references, rewrite assets, reconcile schema drift.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/cms/skills/publish-entry.md
+++ b/packages/backend-core/src/modules/cms/skills/publish-entry.md
@@ -1,5 +1,5 @@
 ---
-title: Publish a CMS entry
+title: 'CMS: Publish an entry'
 description: Move a CMS entry through draft → published — immediate, scheduled, or rolled back — without losing work to optimistic-lock conflicts.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/cms/skills/review-stale-entries.md
+++ b/packages/backend-core/src/modules/cms/skills/review-stale-entries.md
@@ -1,5 +1,5 @@
 ---
-title: Review stale entries
+title: CMS: Review stale entries
 description: Periodic curator pass — find drafts that have stalled, published entries that haven't been touched in months, and orphaned assets. Reports findings with recommended actions. No persistence layer; the operator reviews the curator-runner's log/reply and acts manually via existing CMS tools.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/cms/skills/upload-asset-and-embed.md
+++ b/packages/backend-core/src/modules/cms/skills/upload-asset-and-embed.md
@@ -1,5 +1,5 @@
 ---
-title: Upload an asset and embed it
+title: CMS: Upload an asset and embed it
 description: Two-phase asset upload (request presigned URL → PUT binary → complete), embed in entries, and audit unused assets.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
@@ -15,7 +15,7 @@ export class ConvSelfServiceTools {
 
   @McpTool({
     name: 'conv_request_handover_in_my_conversation',
-    title: 'Request a human teammate to take over',
+    title: 'Conv: Request a human teammate to take over',
     description:
       'Flag the current conversation as needing human attention. Use this when you can\'t answer the end-user\'s question on your own — pricing exceptions, account-specific issues you can\'t verify, anything sensitive. Pass the exact `conversationId` you were given in the system context. Sets a "needs human attention" flag on the conversation (pinning it to the top of the team\'s dashboard) and posts an internal note recording your `reason`. Also pass `suggestedReply` — your best guess at what a human teammate could send to resolve the issue. The team sees this as a starting draft they can edit, approve, or rewrite. After calling this, do not keep generating replies on your own — let the user know a teammate will follow up, then stop. The flag clears once a teammate replies. The end-user does not see the system note or the suggested reply — only the team does.',
     audiences: ['self_service'],

--- a/packages/backend-core/src/modules/conv/conv.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.tools.ts
@@ -77,7 +77,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_list_conversations',
-    title: 'List conversations',
+    title: 'Conv: List conversations',
     description:
       'List conversations for your org, newest activity first. Filter by status (open / snoozed / closed / spam), assignee, or topic.',
     audiences: ['admin'],
@@ -92,7 +92,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_get_conversation',
-    title: 'Read conversation',
+    title: 'Conv: Read conversation',
     description: 'Read one conversation including every public + internal message.',
     audiences: ['admin'],
     scopes: ['conv:read'],
@@ -106,7 +106,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_send_message',
-    title: 'Send message in conversation',
+    title: 'Conv: Send message in conversation',
     description:
       'Append a message to a conversation. Pass `internal: true` to leave a staff-only note (drafts, side comments) — end-user agents never see internal messages.',
     audiences: ['admin'],
@@ -127,7 +127,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_assign_conversation',
-    title: 'Assign conversation',
+    title: 'Conv: Assign conversation',
     description:
       'Assign a conversation to a user (pass user id) or unassign (pass null). Useful for routing escalated conversations.',
     audiences: ['admin'],
@@ -142,7 +142,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_change_status',
-    title: 'Change conversation status',
+    title: 'Conv: Change conversation status',
     description:
       'Change a conversation\'s status. `snoozeUntil` (ISO 8601) is required when status is "snoozed".',
     audiences: ['admin'],
@@ -157,7 +157,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_request_handover',
-    title: 'Request handover to a human',
+    title: 'Conv: Request handover to a human',
     description:
       'Flag a conversation as needing human attention. Use this when you have reached the limit of what you can resolve autonomously — billing decisions, refunds outside policy, sensitive complaints, anything where a human teammate should step in. Appends an internal system note (visible only to staff) recording your stated `reason`, sets the conversation\'s "needs human attention" flag (which pins it to the top of the dashboard\'s Conversations page), and emits `conversation.handover_requested`. Also pass `suggestedReply` — your best guess at what a human teammate could send to resolve the issue. The team sees this as a starting draft they can edit, approve, or rewrite. Idempotent — calling again on an already-flagged conversation is a no-op. The flag clears automatically once a human teammate replies or closes the conversation.',
     audiences: ['admin'],
@@ -172,7 +172,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_search_messages',
-    title: 'Search conversation messages',
+    title: 'Conv: Search conversation messages',
     description:
       'Substring search over message bodies. Returns the matching messages newest first; use conv_get_conversation to load surrounding context.',
     audiences: ['admin'],
@@ -187,7 +187,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_list_channels',
-    title: 'List conversation channels',
+    title: 'Conv: List conversation channels',
     description: 'List conversation channels configured for your org. Currently shipping adapters: email and chat (widget). The `voice` and `sms` channel types are reserved for upcoming adapters.',
     audiences: ['admin'],
     scopes: ['conv:read'],
@@ -201,7 +201,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_create_channel',
-    title: 'Create conversation channel',
+    title: 'Conv: Create conversation channel',
     description:
       'Add a new conversation channel. Currently shipping adapters: `email` and `chat` (widget). Channel-specific configuration goes in `config`. The `voice` and `sms` channel types are reserved and not yet wired to an adapter.',
     audiences: ['admin'],
@@ -216,7 +216,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_list_topics',
-    title: 'List conversation topics',
+    title: 'Conv: List conversation topics',
     description: 'List conversation topics (Billing, Support, Refunds, …) for your org.',
     audiences: ['admin'],
     scopes: ['conv:read'],
@@ -230,7 +230,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_create_topic',
-    title: 'Create conversation topic',
+    title: 'Conv: Create conversation topic',
     description: 'Add a new conversation topic. Slug must be lowercase letters, digits, hyphens.',
     audiences: ['admin'],
     scopes: ['conv:write'],
@@ -244,7 +244,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_set_topic',
-    title: 'Set or clear a conversation topic',
+    title: 'Conv: Set or clear a conversation topic',
     description:
       'Tag a conversation with one of the org\'s existing topics, or pass `topicId: null` to clear the topic. Use `conv_list_topics` first to see what topics exist; topics must be pre-created via `conv_create_topic`.',
     audiences: ['admin'],
@@ -259,7 +259,7 @@ export class ConvAdminTools {
 
   @McpTool({
     name: 'conv_strip_message_signature',
-    title: 'Strip the signature from an inbound message',
+    title: 'Conv: Strip the signature from an inbound message',
     description:
       "Replace an inbound message's body with a signature-stripped version. Used by the strip-email-signature curator skill — runs after the regex quote-stripper to clean up the trailing sign-off / contact block. The original body is kept in `metadata.preStripBody` for audit; the removed signature (if provided) is stored in `metadata.signatureText`. Refuses if the new body is empty, more than 50% shorter than the original, or if the message isn't an end-user inbound in the caller's org.",
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/conv/email/email.tools.ts
+++ b/packages/backend-core/src/modules/conv/email/email.tools.ts
@@ -41,7 +41,7 @@ export class EmailAdminTools {
 
   @McpTool({
     name: 'conv_email_setup_channel',
-    title: 'Set up email channel',
+    title: 'Conv: Set up email channel',
     description:
       "Create or update an email channel's transport configuration. Pass plaintext SMTP / IMAP passwords; the server encrypts them before storage and returns them redacted. Set `outbound.provider: 'mailer'` to send via Munin's configured Resend mailer instead of a custom SMTP host.",
     audiences: ['admin'],
@@ -63,7 +63,7 @@ export class EmailAdminTools {
 
   @McpTool({
     name: 'conv_email_test_channel',
-    title: 'Test email channel credentials',
+    title: 'Conv: Test email channel credentials',
     description:
       'Test an email channel\'s stored credentials. Attempts an SMTP connect (and an IMAP connect if inbound is configured) without sending or fetching anything. Returns `{ smtp: "ok" | error, imap: "ok" | error | "not configured" }`.',
     audiences: ['admin'],
@@ -93,7 +93,7 @@ export class EmailAdminTools {
 
   @McpTool({
     name: 'conv_email_send_test',
-    title: 'Send test email',
+    title: 'Conv: Send test email',
     description:
       "Send a real test email through this channel's configured outbound transport (SMTP or Mailer). The message is addressed `to` the recipient you pass in. Useful for confirming credentials and deliverability end-to-end.",
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.tools.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.tools.ts
@@ -60,7 +60,7 @@ export class MessageBirdSmsAdminTools {
 
   @McpTool({
     name: 'conv_messagebird_sms_configure',
-    title: 'Configure MessageBird SMS channel',
+    title: 'Conv: Configure MessageBird SMS channel',
     description:
       'Create or update a MessageBird SMS channel. Pass `channelId` to update; omit to create. The plaintext `accessKey` and `signingKey` are encrypted before storage and returned redacted. On update, omit either secret to keep the existing one.',
     audiences: ['admin'],
@@ -97,7 +97,7 @@ export class MessageBirdSmsAdminTools {
 
   @McpTool({
     name: 'conv_messagebird_sms_test_channel',
-    title: 'Test MessageBird SMS channel credentials',
+    title: 'Conv: Test MessageBird SMS channel credentials',
     description:
       "Verify a MessageBird channel's stored Access Key by fetching the account balance. Returns `{ ok: true, balance }` on success.",
     audiences: ['admin'],
@@ -117,7 +117,7 @@ export class MessageBirdSmsAdminTools {
 
   @McpTool({
     name: 'conv_messagebird_sms_send_test',
-    title: 'Send a real test SMS via MessageBird',
+    title: 'Conv: Send a real test SMS via MessageBird',
     description:
       "Send a real SMS through this channel's MessageBird account. Useful for end-to-end deliverability checks.",
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/conv/skills/escalate-to-human.md
+++ b/packages/backend-core/src/modules/conv/skills/escalate-to-human.md
@@ -1,5 +1,5 @@
 ---
-title: Escalate a conversation to a human
+title: Conv: Escalate a conversation to a human
 description: How an external chat-widget bot detects that a human/agent in Munin has replied and yields the conversation.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/conv/skills/setup-chat-widget.md
+++ b/packages/backend-core/src/modules/conv/skills/setup-chat-widget.md
@@ -1,5 +1,5 @@
 ---
-title: Set up a chat widget
+title: Conv: Set up a chat widget
 description: Provision a per-channel widget API key, push transcripts via POST /api/v1/widget/messages, and wire the human-handoff webhook.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/conv/skills/setup-email-and-widget-channels.md
+++ b/packages/backend-core/src/modules/conv/skills/setup-email-and-widget-channels.md
@@ -1,5 +1,5 @@
 ---
-title: Set up email and chat-widget channels together
+title: Conv: Set up email and chat-widget channels together
 description: Stand up email + widget conversation channels for a new tenant in one pass — configure, test, hand off.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/conv/skills/setup-email-channel.md
+++ b/packages/backend-core/src/modules/conv/skills/setup-email-channel.md
@@ -1,5 +1,5 @@
 ---
-title: Set up an email channel
+title: Conv: Set up an email channel
 description: Configure SMTP outbound and optional IMAP inbound for an email channel, then verify the credentials.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/conv/skills/strip-email-signature.md
+++ b/packages/backend-core/src/modules/conv/skills/strip-email-signature.md
@@ -1,5 +1,5 @@
 ---
-title: Strip the signature from an inbound email message
+title: Conv: Strip the signature from an inbound email message
 description: Cleanup pass that removes the sender's sign-off and contact block from an inbound email body that has already had its quoted reply stripped, then writes the cleaned body back via `conv_strip_message_signature`.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms.tools.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms.tools.ts
@@ -69,7 +69,7 @@ export class TwilioSmsAdminTools {
 
   @McpTool({
     name: 'conv_twilio_sms_configure',
-    title: 'Configure Twilio SMS channel',
+    title: 'Conv: Configure Twilio SMS channel',
     description:
       'Create or update a Twilio SMS channel. Pass `channelId` to update an existing channel; omit to create one. The plaintext `authToken` is encrypted before storage and is returned redacted. On update, omit `authToken` to keep the existing one. Either `fromNumber` (E.164) or `messagingServiceSid` is required.',
     audiences: ['admin'],
@@ -110,7 +110,7 @@ export class TwilioSmsAdminTools {
 
   @McpTool({
     name: 'conv_twilio_sms_test_channel',
-    title: 'Test Twilio SMS channel credentials',
+    title: 'Conv: Test Twilio SMS channel credentials',
     description:
       "Verify a Twilio SMS channel's stored Account SID + Auth Token by fetching the account record from Twilio. Returns `{ ok: true, friendlyName, status }` on success.",
     audiences: ['admin'],
@@ -133,7 +133,7 @@ export class TwilioSmsAdminTools {
 
   @McpTool({
     name: 'conv_twilio_sms_send_test',
-    title: 'Send a real test SMS',
+    title: 'Conv: Send a real test SMS',
     description:
       "Send a real SMS through this channel's Twilio account. The recipient must be a number Twilio is permitted to reach (verified caller ID on trial accounts). Useful for end-to-end deliverability checks.",
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/conv/vapi/vapi.tools.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi.tools.ts
@@ -70,7 +70,7 @@ export class VapiAdminTools {
 
   @McpTool({
     name: 'conv_vapi_configure',
-    title: 'Configure Vapi voice channel',
+    title: 'Conv: Configure Vapi voice channel',
     description:
       'Create or update a Vapi voice channel. Pass `channelId` to update; omit to create. The plaintext `apiKey` and `webhookSecret` are encrypted before storage and returned redacted. The assistant + phone number must already exist in Vapi — paste their IDs here.',
     audiences: ['admin'],
@@ -111,7 +111,7 @@ export class VapiAdminTools {
 
   @McpTool({
     name: 'conv_vapi_test_channel',
-    title: 'Test Vapi voice channel credentials',
+    title: 'Conv: Test Vapi voice channel credentials',
     description:
       "Verify a Vapi channel's stored API key and assistant by fetching the assistant from Vapi. Returns `{ ok: true, assistant }` on success.",
     audiences: ['admin'],
@@ -133,7 +133,7 @@ export class VapiAdminTools {
 
   @McpTool({
     name: 'conv_voice_call_initiate',
-    title: 'Place an outbound voice call',
+    title: 'Conv: Place an outbound voice call',
     description:
       'Initiate an outbound voice call through this channel. The Vapi assistant will run the conversation. Returns the Vapi call id and status.',
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/conv/voice-callback.tools.ts
+++ b/packages/backend-core/src/modules/conv/voice-callback.tools.ts
@@ -15,7 +15,7 @@ export class VoiceCallbackTools {
 
   @McpTool({
     name: 'conv_request_phone_call_for_my_conversation',
-    title: 'Place a phone call to the user in this conversation',
+    title: 'Conv: Place a phone call to the user in this conversation',
     description:
       "Place an outbound phone call to the contact in this conversation. Use this only when the user has asked to be called — e.g. \"can you call me?\". The call goes to the phone number already on file for this conversation's contact; you cannot specify an arbitrary number. The org must have an active Vapi voice channel configured. After requesting the call, tell the user briefly that a call is on the way and stop replying — the rest of the conversation happens on the phone.",
     audiences: ['self_service'],
@@ -30,7 +30,7 @@ export class VoiceCallbackTools {
 
   @McpTool({
     name: 'conv_voice_call_contact',
-    title: "Place a voice call to this conversation's contact",
+    title: "Conv: Place a voice call to this conversation's contact",
     description:
       "Place an outbound voice call to the contact attached to a conversation. Resolves the phone number from the conversation's contact and picks the org's active Vapi voice channel automatically. For arbitrary destinations, use `conv_voice_call_initiate` instead.",
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/conv/widget/widget.tools.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.tools.ts
@@ -58,7 +58,7 @@ interface RotateIdentitySecretResult {
 export class WidgetAdminTools {
   @McpTool({
     name: 'conv_widget_create_channel',
-    title: 'Create chat-widget channel',
+    title: 'Conv: Create chat-widget channel',
     description:
       'Create a chat-widget channel and mint a widget API key (`mn_widget_*`) bound to it. Returns the plaintext key once; store it server-side and pass it as `Authorization: Bearer` when calling POST /api/v1/widget/messages from the external agent.',
     audiences: ['admin'],
@@ -116,7 +116,7 @@ export class WidgetAdminTools {
 
   @McpTool({
     name: 'conv_widget_update_channel',
-    title: 'Update chat-widget channel',
+    title: 'Conv: Update chat-widget channel',
     description:
       'Update a chat-widget channel\'s originAllowlist / webhookOnEscalation. Pass null to clear webhookOnEscalation. The widget API key is unchanged.',
     audiences: ['admin'],
@@ -171,7 +171,7 @@ export class WidgetAdminTools {
 
   @McpTool({
     name: 'conv_widget_rotate_key',
-    title: 'Rotate widget API key',
+    title: 'Conv: Rotate widget API key',
     description:
       'Revoke any active widget keys bound to this channel and mint a fresh `mn_widget_*` key. Returns the new plaintext key once. Existing inflight requests using the old key keep working until revocation lands.',
     audiences: ['admin'],
@@ -223,7 +223,7 @@ export class WidgetAdminTools {
 
   @McpTool({
     name: 'conv_widget_rotate_identity_secret',
-    title: 'Rotate widget identity-verification secret',
+    title: 'Conv: Rotate widget identity-verification secret',
     description:
       'Generate a fresh per-channel HMAC secret used to verify browser-side `data-user-hash` values against `data-external-id`. The previous secret is replaced atomically; any previously-issued user hashes stop verifying immediately and the operator must re-render their pages with newly-computed hashes. Returns the new plaintext once.',
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/crm/crm.self-service.tools.ts
+++ b/packages/backend-core/src/modules/crm/crm.self-service.tools.ts
@@ -26,7 +26,7 @@ export class CrmSelfServiceTools {
 
   @McpTool({
     name: 'crm_get_my_contact',
-    title: 'Read my CRM contact',
+    title: 'CRM: Read my contact',
     description:
       'Read the CRM contact linked to the calling end-user. RLS restricts visibility to that single row.',
     audiences: ['self_service'],
@@ -41,7 +41,7 @@ export class CrmSelfServiceTools {
 
   @McpTool({
     name: 'crm_update_my_contact',
-    title: 'Update my CRM contact',
+    title: 'CRM: Update my contact',
     description:
       'Update the calling end-user\'s own contact record. Only basic personal fields (name, phone, address) are editable from this surface — tags, ownership, custom fields, and AI fields are admin-only.',
     audiences: ['self_service'],
@@ -57,7 +57,7 @@ export class CrmSelfServiceTools {
 
   @McpTool({
     name: 'crm_log_activity_self',
-    title: 'Log activity as end-user',
+    title: 'CRM: Log activity as end-user',
     description:
       'Record an activity attributed to the calling end-user agent (e.g. a voice agent logging "spoke with customer for 4m, follow-up needed"). Auto-scoped to the end-user\'s own CRM contact when one exists.',
     audiences: ['self_service'],

--- a/packages/backend-core/src/modules/crm/crm.tools.ts
+++ b/packages/backend-core/src/modules/crm/crm.tools.ts
@@ -225,7 +225,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_contacts',
-    title: 'List contacts',
+    title: 'CRM: List contacts',
     description: 'List contacts in your org, newest-updated first. Filter by company or tag.',
     audiences: ['admin'],
     scopes: ['crm:read'],
@@ -239,7 +239,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_get_contact',
-    title: 'Read contact',
+    title: 'CRM: Read contact',
     description: 'Read one contact, including AI fields, tags, custom fields, and compliance flags.',
     audiences: ['admin'],
     scopes: ['crm:read'],
@@ -253,7 +253,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_find_contact',
-    title: 'Find contact by email or phone',
+    title: 'CRM: Find contact by email or phone',
     description:
       'Find an existing contact by email and/or phone before creating a new one. Returns null if no match.',
     audiences: ['admin'],
@@ -268,7 +268,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_create_contact',
-    title: 'Create contact',
+    title: 'CRM: Create contact',
     description: 'Create a new contact. Search with crm_find_contact first to avoid duplicates.',
     audiences: ['admin'],
     scopes: ['crm:write'],
@@ -282,7 +282,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_update_contact',
-    title: 'Update contact',
+    title: 'CRM: Update contact',
     description:
       "Update fields on a contact. Setting `doNotContact: true` also stamps `unsubscribedAt`; setting it false clears it. Pass `mode: 'fill-null'` from automated/curator contexts to refuse overwriting existing non-null values (only null/empty fields are filled). Default `mode: 'overwrite'` applies the patch as-is and is appropriate for human-driven edits.",
     audiences: ['admin'],
@@ -297,7 +297,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_bulk_create_contacts',
-    title: 'Bulk-create contacts',
+    title: 'CRM: Bulk-create contacts',
     description:
       'Bulk-create contacts with dedupe + compliance checks: rows whose email or phone already match a do_not_contact contact are skipped, as are rows that would duplicate an existing contact.',
     audiences: ['admin'],
@@ -312,7 +312,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_search_contacts',
-    title: 'Search contacts',
+    title: 'CRM: Search contacts',
     description:
       'Substring search across name, email, phone, and title. Returns contacts ordered newest-updated first.',
     audiences: ['admin'],
@@ -329,7 +329,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_companies',
-    title: 'List companies',
+    title: 'CRM: List companies',
     description: 'List companies in your org.',
     audiences: ['admin'],
     scopes: ['crm:read'],
@@ -343,7 +343,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_create_company',
-    title: 'Create company',
+    title: 'CRM: Create company',
     description: 'Create a new company.',
     audiences: ['admin'],
     scopes: ['crm:write'],
@@ -359,7 +359,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_pipelines',
-    title: 'List sales pipelines',
+    title: 'CRM: List sales pipelines',
     description: 'List sales pipelines for your org with their stages in position order.',
     audiences: ['admin'],
     scopes: ['crm:read'],
@@ -373,7 +373,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_create_pipeline',
-    title: 'Create sales pipeline',
+    title: 'CRM: Create sales pipeline',
     description:
       'Create a new sales pipeline with at least one stage. Stages are inserted in array order; mark a stage `winLoss: "won"` or `"lost"` to record terminal outcomes.',
     audiences: ['admin'],
@@ -388,7 +388,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_deals',
-    title: 'List deals',
+    title: 'CRM: List deals',
     description: 'List deals, optionally filtered by pipeline or stage.',
     audiences: ['admin'],
     scopes: ['crm:read'],
@@ -402,7 +402,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_create_deal',
-    title: 'Create deal',
+    title: 'CRM: Create deal',
     description:
       'Create a new deal in a pipeline. If `stageId` is omitted, the deal lands in the pipeline\'s first stage by position.',
     audiences: ['admin'],
@@ -417,7 +417,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_change_stage',
-    title: 'Change deal stage',
+    title: 'CRM: Change deal stage',
     description:
       'Move a deal to a new stage. If the destination stage is a won/lost terminal, `closedAt` is stamped automatically.',
     audiences: ['admin'],
@@ -434,7 +434,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_log_activity',
-    title: 'Log CRM activity',
+    title: 'CRM: Log activity',
     description:
       'Record an activity (note / call / email / meeting / task) against a contact, company, or deal. If `contactId` is set, the contact\'s `lastContactedAt` is also bumped.',
     audiences: ['admin'],
@@ -449,7 +449,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_activities',
-    title: 'List CRM activities',
+    title: 'CRM: List activities',
     description: 'List CRM activities filtered by contact, deal, or company.',
     audiences: ['admin'],
     scopes: ['crm:read'],
@@ -465,7 +465,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_set_ai_summary',
-    title: 'Set AI summary or next action',
+    title: 'CRM: Set AI summary or next action',
     description:
       'Set the AI-generated summary and/or next-action for a contact, company, or deal. These live in dedicated columns so agents do not pollute the human-edited description.',
     audiences: ['admin'],
@@ -482,7 +482,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_propose_merge_candidate',
-    title: 'Propose a CRM merge candidate',
+    title: 'CRM: Propose a merge candidate',
     description:
       'File a structured proposal that two contacts are the same person. Pass `confidence` ("high" | "medium"), `evidence` (the matched signals — same email, same phone, similar name, etc.), `recommendedKeeperId` (which row to keep), and optionally `recommendedPatch` (fields to copy onto the keeper from the duplicate). Idempotent on the (contactA, contactB) pair while a pending proposal exists — calling again upserts the existing pending row. The CRM clean-contact-data curator runs this on a periodic cadence; see `skill://crm/clean-contact-data`.',
     audiences: ['admin'],
@@ -497,7 +497,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_merge_proposals',
-    title: 'List CRM merge proposals',
+    title: 'CRM: List merge proposals',
     description:
       'List CRM merge proposals, defaulting to `status: "pending"` (the operator review queue). Returns each proposal with both contacts embedded as summaries — no extra `crm_get_contact` calls needed. Pass `status: "dismissed"` once per curator pass to skip pairs the operator has already rejected.',
     audiences: ['admin'],
@@ -512,7 +512,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_apply_merge_proposal',
-    title: 'Apply a CRM merge proposal',
+    title: 'CRM: Apply a merge proposal',
     description:
       "Atomically apply a pending merge proposal: copies `recommendedPatch` fields onto the keeper, archives the duplicate (adds `dedup-archived-YYYY-MM` tag, sets `customFields.mergedInto = <keeperId>`, sets `doNotContact: true`), and marks the proposal `applied`. Activities and deals stay on whichever contactId they were originally logged under — that's a documented v1 limitation. Throws if the proposal is not in `pending` status.",
     audiences: ['admin'],
@@ -527,7 +527,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_dismiss_merge_proposal',
-    title: 'Dismiss a CRM merge proposal',
+    title: 'CRM: Dismiss a merge proposal',
     description:
       'Mark a pending merge proposal as dismissed (the operator decided these are not the same person). The next CRM hygiene curator pass queries dismissed proposals and skips refiling the same pair. Optional `reason` is stored for audit. Throws if the proposal is not in `pending` status.',
     audiences: ['admin'],
@@ -544,7 +544,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_segments',
-    title: 'List CRM segments',
+    title: 'CRM: List segments',
     description:
       'List saved contact segments. A segment is a named CRM filter — used as the audience for outreach campaigns and other targeting workflows. Returns each segment with its filter definition.',
     audiences: ['admin'],
@@ -559,7 +559,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_get_segment',
-    title: 'Read CRM segment',
+    title: 'CRM: Read segment',
     description: 'Read one segment, including its filter definition.',
     audiences: ['admin'],
     scopes: ['crm:read'],
@@ -573,7 +573,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_create_segment',
-    title: 'Create CRM segment',
+    title: 'CRM: Create segment',
     description:
       'Create a saved contact segment. `filter` supports tagsAny (any-of match), tagsAll (all-of match), companyId, searchQuery (substring over name/email/title), and contactedSince (ISO-8601 — narrows to contacts NOT contacted since that timestamp). Combine fields and they AND together.',
     audiences: ['admin'],
@@ -588,7 +588,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_update_segment',
-    title: 'Update CRM segment',
+    title: 'CRM: Update segment',
     description: 'Patch a segment: rename, edit description, or replace the filter.',
     audiences: ['admin'],
     scopes: ['crm:write'],
@@ -602,7 +602,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_delete_segment',
-    title: 'Delete CRM segment',
+    title: 'CRM: Delete segment',
     description: 'Delete a segment. Outreach campaigns referencing it will fail until reassigned.',
     audiences: ['admin'],
     scopes: ['crm:write'],
@@ -616,7 +616,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_list_contacts_in_segment',
-    title: 'List contacts in segment',
+    title: 'CRM: List contacts in segment',
     description:
       'Resolve a segment to its current contacts. ALWAYS excludes suppressed contacts (do_not_contact OR unsubscribed) AND contacts without a recorded lawful basis (consent_lawful_basis IS NULL). Use this — not crm_list_contacts — to materialize an outreach audience: the suppression and consent floors are non-overridable here.',
     audiences: ['admin'],
@@ -633,7 +633,7 @@ export class CrmAdminTools {
 
   @McpTool({
     name: 'crm_set_contact_consent',
-    title: 'Set contact consent',
+    title: 'CRM: Set contact consent',
     description:
       'Record the lawful basis and source for contacting this person. Required before they can appear in any outreach segment. `lawfulBasis` is one of `consent`, `legitimate_interest`, or `contract`. `source` is a short label (e.g. "imported-2026-q2", "web-form-trial-signup", "event-attendee-summit-2025"). Logs a CRM activity for audit.',
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/crm/skills/clean-contact-data.md
+++ b/packages/backend-core/src/modules/crm/skills/clean-contact-data.md
@@ -1,5 +1,5 @@
 ---
-title: Clean up contact data
+title: CRM: Clean up contact data
 description: Periodic curator pass — find duplicate / inconsistent contacts, file high-confidence pairs as structured merge proposals via crm_propose_merge_candidate. Designed to be run on a cadence by an admin agent (weekly is a good default). The operator reviews via crm_list_merge_proposals and resolves with crm_apply_merge_proposal / crm_dismiss_merge_proposal.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/crm/skills/deduplicate-contacts.md
+++ b/packages/backend-core/src/modules/crm/skills/deduplicate-contacts.md
@@ -1,5 +1,5 @@
 ---
-title: Deduplicate contacts
+title: CRM: Deduplicate contacts
 description: Find duplicate contacts (same person, multiple rows) and consolidate them. There is no merge tool — this skill documents the manual reconcile pattern.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/crm/skills/extract-contact-from-message.md
+++ b/packages/backend-core/src/modules/crm/skills/extract-contact-from-message.md
@@ -1,5 +1,5 @@
 ---
-title: Extract a contact from a message
+title: CRM: Extract a contact from a message
 description: When a conversation closes, read the thread for identifying info the end-user volunteered (name, email, phone, company, title) and persist it to the CRM as a contact — auto-applied, no proposal queue. Designed to fire on every `conversation.closed` event so visitor-volunteered identity becomes structured CRM data without operator intervention.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/crm/skills/import-and-score-leads.md
+++ b/packages/backend-core/src/modules/crm/skills/import-and-score-leads.md
@@ -1,5 +1,5 @@
 ---
-title: Import and score leads
+title: CRM: Import and score leads
 description: Bulk-import contacts, attach them to companies and a deal pipeline, log the source touchpoint, and seed AI summaries for downstream prioritization.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/crm/skills/onboard-new-customer.md
+++ b/packages/backend-core/src/modules/crm/skills/onboard-new-customer.md
@@ -1,5 +1,5 @@
 ---
-title: Onboard a new customer
+title: CRM: Onboard a new customer
 description: Recommended sequence for capturing a new customer, attaching them to a company, and seeding the AI summary that drives later prioritization.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/crm/skills/progress-deal-through-pipeline.md
+++ b/packages/backend-core/src/modules/crm/skills/progress-deal-through-pipeline.md
@@ -1,5 +1,5 @@
 ---
-title: Progress a deal through the pipeline
+title: CRM: Progress a deal through the pipeline
 description: Move a deal through pipeline stages with the right activity log at each gate, then refresh AI summary so prioritization stays fresh.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/kb/kb.tools.ts
+++ b/packages/backend-core/src/modules/kb/kb.tools.ts
@@ -94,7 +94,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_list_spaces',
-    title: 'List KB spaces',
+    title: 'KB: List spaces',
     description: 'List knowledge-base spaces in your org.',
     audiences: ['admin'],
     scopes: ['kb:read'],
@@ -108,7 +108,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_create_space',
-    title: 'Create KB space',
+    title: 'KB: Create space',
     description:
       'Create a new knowledge-base space. Slug must be unique within your org and only contain lowercase letters, digits and hyphens.',
     audiences: ['admin'],
@@ -123,7 +123,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_list_documents',
-    title: 'List KB documents',
+    title: 'KB: List documents',
     description:
       'List knowledge-base documents in your org, newest-updated first. Optionally filter by space or tag.',
     audiences: ['admin'],
@@ -138,7 +138,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_get_document',
-    title: 'Read KB document',
+    title: 'KB: Read document',
     description:
       "Read one knowledge-base document, including its full body, tags, and current version. End-user agents see only documents whose `audiences` includes `'self_service'`.",
     audiences: ['admin', 'self_service'],
@@ -153,7 +153,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_get_document_by_slug',
-    title: 'Read KB document by slug',
+    title: 'KB: Read document by slug',
     description:
       "Read a knowledge-base document by its space slug and document slug — used when a stable identifier (e.g. 'agent-runtime/system-prompt') is needed instead of the document UUID. Returns null when the document does not exist.",
     audiences: ['admin'],
@@ -168,7 +168,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_search',
-    title: 'Search knowledge base',
+    title: 'KB: Search',
     description:
       "Search the knowledge base by natural-language query. Combines full-text search and vector similarity for the best of both. End-user agents see only documents whose `audiences` includes `'self_service'`.",
     audiences: ['admin', 'self_service'],
@@ -183,7 +183,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_create_document',
-    title: 'Create KB document',
+    title: 'KB: Create document',
     description:
       "Create a knowledge-base document inside a space. Body should be markdown. Set `audiences: ['admin', 'self_service']` to expose it to end-user agents; defaults to `['admin']` (admin-only).",
     audiences: ['admin'],
@@ -198,7 +198,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_update_document',
-    title: 'Update KB document',
+    title: 'KB: Update document',
     description:
       'Update a knowledge-base document. Pass `ifVersion` (the current version you read) for optimistic concurrency; the call fails if it has changed.',
     audiences: ['admin'],
@@ -213,7 +213,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_delete_document',
-    title: 'Delete KB document',
+    title: 'KB: Delete document',
     description:
       'Delete a knowledge-base document. Pass `ifVersion` for optimistic concurrency. Cascades to chunks and versions.',
     audiences: ['admin'],
@@ -228,7 +228,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_list_versions',
-    title: 'List KB document versions',
+    title: 'KB: List document versions',
     description: 'List all prior versions of a knowledge-base document, newest first.',
     audiences: ['admin'],
     scopes: ['kb:read'],
@@ -242,7 +242,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_propose_curation_candidate',
-    title: 'Propose KB curation candidate',
+    title: 'KB: Propose curation candidate',
     description:
       "File a draft FAQ-style document into the `kb-curation-inbox` KB space (admin audience only). Used after a curation pass over resolved-handover conversations. The space is created on first use. See `skill://kb/review-content` for the procedure. The candidate is NOT visible to end-user agents until it's promoted with `kb_publish_curation_candidate`.",
     audiences: ['admin'],
@@ -257,7 +257,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_publish_curation_candidate',
-    title: 'Publish KB curation candidate',
+    title: 'KB: Publish curation candidate',
     description:
       "Promote a reviewed curation candidate into a target KB space. Copies the doc to the target space (default audiences `['admin', 'self_service']` so the self-service agent can find it), drops the `curation`/`candidate` tags, and removes the candidate from the inbox. The target space must already exist.",
     audiences: ['admin'],
@@ -272,7 +272,7 @@ export class KbAdminTools {
 
   @McpTool({
     name: 'kb_restore_version',
-    title: 'Restore KB document version',
+    title: 'KB: Restore document version',
     description:
       'Roll a document back to an earlier version. Creates a new current version with that historical content.',
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/kb/skills/create-first-space.md
+++ b/packages/backend-core/src/modules/kb/skills/create-first-space.md
@@ -1,5 +1,5 @@
 ---
-title: Create the first knowledge-base space
+title: KB: Create the first space
 description: Stand up a fresh org's knowledge base — pick a space taxonomy, create the first space, optionally seed a welcome doc.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/kb/skills/import-articles-in-bulk.md
+++ b/packages/backend-core/src/modules/kb/skills/import-articles-in-bulk.md
@@ -1,5 +1,5 @@
 ---
-title: Import articles in bulk from CSV or JSON
+title: KB: Import articles in bulk from CSV or JSON
 description: Generalized bulk import pipeline for KB articles from any structured source. Companion to import-from-google-docs — that one covers chunking; this one covers source handling and idempotency.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/kb/skills/import-from-google-docs.md
+++ b/packages/backend-core/src/modules/kb/skills/import-from-google-docs.md
@@ -1,5 +1,5 @@
 ---
-title: Import knowledge from Google Docs (or any text source)
+title: KB: Import knowledge from Google Docs (or any text source)
 description: Bulk-load articles into the knowledge base, sized for vector search and FTS to perform well.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/kb/skills/review-content.md
+++ b/packages/backend-core/src/modules/kb/skills/review-content.md
@@ -1,5 +1,5 @@
 ---
-title: Review and curate content
+title: KB: Review and curate content
 description: How an admin agent turns resolved-handover conversations into KB documents, so the next end-user with the same question gets a real answer instead of another handover.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/outreach/outreach.tools.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.tools.ts
@@ -80,7 +80,7 @@ export class OutreachAdminTools {
 
   @McpTool({
     name: 'outreach_list_campaigns',
-    title: 'List outreach campaigns',
+    title: 'Outreach: List campaigns',
     description:
       'List outbound-campaign definitions for this org. Each row carries the brief, the targeted CRM segment, the email channel used to send, cadence rules, CTA URL, and the enabled flag. The draft-initial curator only drafts proposals for `enabled = true` campaigns.',
     audiences: ['admin'],
@@ -95,7 +95,7 @@ export class OutreachAdminTools {
 
   @McpTool({
     name: 'outreach_get_campaign',
-    title: 'Read one outreach campaign',
+    title: 'Outreach: Read one campaign',
     description: 'Read a single campaign by id, including brief and cadence rules.',
     audiences: ['admin'],
     scopes: ['outreach:read'],
@@ -109,7 +109,7 @@ export class OutreachAdminTools {
 
   @McpTool({
     name: 'outreach_create_campaign',
-    title: 'Create outreach campaign',
+    title: 'Outreach: Create campaign',
     description:
       'Create an outbound-campaign definition. Operators write `brief` as a one-paragraph human description of intent (the curator personalises per contact from this). `segmentId` chooses the audience; the curator calls `crm_list_contacts_in_segment` (which always enforces suppression+consent floor) to materialize it. `channelId` must reference an email channel. New campaigns default `enabled: false` so the curator does not start drafting until you flip it on.',
     audiences: ['admin'],
@@ -124,7 +124,7 @@ export class OutreachAdminTools {
 
   @McpTool({
     name: 'outreach_update_campaign',
-    title: 'Update outreach campaign',
+    title: 'Outreach: Update campaign',
     description: 'Patch fields on a campaign — rename, swap segment, adjust cadence, toggle enabled.',
     audiences: ['admin'],
     scopes: ['outreach:write'],
@@ -138,7 +138,7 @@ export class OutreachAdminTools {
 
   @McpTool({
     name: 'outreach_list_proposals',
-    title: 'List outreach proposals',
+    title: 'Outreach: List proposals',
     description:
       'List drafted outreach proposals (initials in PR2; replies in PR3). Defaults to all statuses. The draft-initial curator queries `status: "pending", kind: "initial"` filtered by `(campaignId, contactId)` to dedupe before drafting a new candidate. The operator review surface queries `status: "pending"`.',
     audiences: ['admin'],
@@ -153,7 +153,7 @@ export class OutreachAdminTools {
 
   @McpTool({
     name: 'outreach_propose_initial',
-    title: 'Propose an initial outreach draft',
+    title: 'Outreach: Propose an initial draft',
     description:
       'File one drafted initial outreach email per (campaign, contact) for human approval. Idempotent: re-proposing the same (campaign, contact, kind=initial) while a pending row exists throws — call `outreach_list_proposals` first to dedupe. Suppression and consent are re-checked at approve-time too; this tool refuses up-front if the contact is already suppressed.',
     audiences: ['admin'],
@@ -168,7 +168,7 @@ export class OutreachAdminTools {
 
   @McpTool({
     name: 'outreach_propose_reply',
-    title: 'Propose an outreach reply draft',
+    title: 'Outreach: Propose an reply draft',
     description:
       "File a drafted reply to an inbound message on an outreach-originated conversation, for human approval. The conversation must have an `outreachCampaignId` set (it's an outreach conversation) and a CRM contact resolvable by email. Idempotent: re-proposing while a pending reply exists for the same conversation throws — the operator should approve or dismiss the existing one first. Reply approvals send via `conv_send_message` on the existing conversation; no unsubscribe footer is appended (replies thread inside the existing email chain that already carries the unsubscribe link).",
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/outreach/skills/draft-initial-email.md
+++ b/packages/backend-core/src/modules/outreach/skills/draft-initial-email.md
@@ -1,5 +1,5 @@
 ---
-title: Draft an initial outreach email
+title: Outreach: Draft an initial email
 description: Periodic curator pass that drafts personalised first-touch outreach emails for every enabled campaign. One pending proposal per (campaign, contact). Drafts go into the operator review queue — never auto-send. Runs weekly by default; the operator approves each draft before it leaves the org.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/outreach/skills/draft-reply-email.md
+++ b/packages/backend-core/src/modules/outreach/skills/draft-reply-email.md
@@ -1,5 +1,5 @@
 ---
-title: Draft an outreach reply
+title: 'Outreach: Draft a reply'
 description: Per-message curator pass that drafts a suggested reply when an inbound message lands on an outreach-originated conversation. Drafts go to the operator review queue — never auto-send. Triggered event-driven from `conversation.message.received` whenever the conversation has an `outreachCampaignId` and `agentMode='draft_only'`.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/playbooks/skills/customer-acquisition.md
+++ b/packages/backend-core/src/modules/playbooks/skills/customer-acquisition.md
@@ -1,5 +1,5 @@
 ---
-title: Customer acquisition (CRM + Conv)
+title: Playbook: Customer acquisition (CRM + Conv)
 description: End-to-end flow from a fresh lead list to first conversation — bulk-import contacts, send a welcome email, log the touchpoint, hand off to a human if interest signals fire.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/playbooks/skills/publish-and-distribute.md
+++ b/packages/backend-core/src/modules/playbooks/skills/publish-and-distribute.md
@@ -1,5 +1,5 @@
 ---
-title: Publish and distribute (CMS + KB + Conv)
+title: Playbook: Publish and distribute (CMS + KB + Conv)
 description: Author content in the CMS, mirror the parts that should be searchable to the KB, and announce the publish to a conversation channel.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/playbooks/skills/support-desk-launch.md
+++ b/packages/backend-core/src/modules/playbooks/skills/support-desk-launch.md
@@ -1,5 +1,5 @@
 ---
-title: Support desk launch (Conv + CRM + KB)
+title: Playbook: Support desk launch (Conv + CRM + KB)
 description: Stand up a working support desk for a new tenant — channels, contacts, knowledge base — so the first ticket has tooling around it.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/modules/web/skills/scrape-website.md
+++ b/packages/backend-core/src/modules/web/skills/scrape-website.md
@@ -1,6 +1,6 @@
 ---
 kind: task
-title: Scrape a website
+title: Web: Scrape a website
 description: Crawls a customer's public website, populates the KB with one document per page, and synthesizes a company-profile document for the chat widget. Runs on a deterministic crawl pipeline with a single LLM call at the end for the profile.
 audiences: [admin]
 ---

--- a/packages/backend-core/src/oauth/oauth-jwt-resolver.integration.test.ts
+++ b/packages/backend-core/src/oauth/oauth-jwt-resolver.integration.test.ts
@@ -1,0 +1,178 @@
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { NestFactory } from '@nestjs/core';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+import { randomUUID } from 'node:crypto';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { AppModule } from '../app.module.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run OAuth JWT resolver integration tests.';
+
+(skipReason ? describe.skip : describe)('OAuth JWT resolver: end-to-end /mcp verification', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let userId: string;
+  let signingKey: Awaited<ReturnType<typeof generateKeyPair>>['privateKey'];
+  let kid: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod-it-must-be-32-chars';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_STORAGE_PROVIDER = 'local';
+    process.env.MUNIN_STORAGE_LOCAL_PATH = '/tmp/munin-oauth-jwt-it';
+    process.env.MUNIN_STORAGE_LOCAL_BASE_URL = 'http://127.0.0.1:0/static/assets';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED = '1';
+    process.env.MUNIN_BUILTIN_AGENT = '0';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'JWT Resolver IT Org' })
+      .returning();
+    const [user] = await db
+      .insert(schema.users)
+      .values({ email: `jwt-${randomUUID().slice(0, 8)}@test.example`, name: 'JWT IT User' })
+      .returning();
+    await db.insert(schema.orgMembers).values({
+      orgId: org!.id,
+      userId: user!.id,
+      role: 'owner',
+      isDefault: true,
+    });
+    userId = user!.id;
+
+    const { publicKey, privateKey } = await generateKeyPair('EdDSA', { extractable: true });
+    const publicJwk = await exportJWK(publicKey);
+    kid = `jwk_${randomUUID().slice(0, 12)}`;
+    await db.insert(schema.jwks).values({
+      id: kid,
+      publicKey: JSON.stringify(publicJwk),
+      privateKey: JSON.stringify(await exportJWK(privateKey)),
+    });
+    signingKey = privateKey;
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+    process.env.MUNIN_PUBLIC_URL = `${baseUrl}/mcp`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    delete process.env.MUNIN_PUBLIC_URL;
+  });
+
+  async function sign(claims: {
+    sub?: string;
+    aud?: string | string[];
+    iss?: string;
+    scope?: string;
+    expSeconds?: number;
+  }): Promise<string> {
+    const iat = Math.floor(Date.now() / 1000);
+    const jwt = new SignJWT({
+      sub: claims.sub ?? userId,
+      aud: claims.aud ?? `${baseUrl}/mcp`,
+      scope: claims.scope ?? 'mcp:tools kb:read',
+      azp: 'test-client',
+      iat,
+      exp: iat + (claims.expSeconds ?? 3600),
+    })
+      .setProtectedHeader({ alg: 'EdDSA', kid })
+      .setIssuer(claims.iss ?? baseUrl);
+    return jwt.sign(signingKey);
+  }
+
+  async function callMcp(token: string): Promise<{ status: number; wwwAuth: string | null }> {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    return { status: res.status, wwwAuth: res.headers.get('www-authenticate') };
+  }
+
+  it('accepts a JWT signed by the in-DB JWKS with canonical audience', async () => {
+    const token = await sign({});
+    const { status, wwwAuth } = await callMcp(token);
+    expect(status).not.toBe(401);
+    expect(wwwAuth).toBeNull();
+  });
+
+  it('accepts a JWT whose audience drops the /mcp path (bare host with trailing slash — claude.ai shape)', async () => {
+    const token = await sign({ aud: `${baseUrl}/` });
+    const { status } = await callMcp(token);
+    expect(status).not.toBe(401);
+  });
+
+  it('accepts a JWT whose audience is the bare origin without trailing slash', async () => {
+    const token = await sign({ aud: baseUrl });
+    const { status } = await callMcp(token);
+    expect(status).not.toBe(401);
+  });
+
+  it('rejects a JWT with an audience pointing at a different host', async () => {
+    const token = await sign({ aud: 'https://impostor.example.com/mcp' });
+    const { status, wwwAuth } = await callMcp(token);
+    expect(status).toBe(401);
+    expect(wwwAuth).toContain('Bearer');
+  });
+
+  it('rejects a JWT signed with a key the JWKS table does not contain', async () => {
+    const { privateKey } = await generateKeyPair('EdDSA', { extractable: true });
+    const iat = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({
+      sub: userId,
+      aud: `${baseUrl}/mcp`,
+      scope: 'mcp:tools',
+      iat,
+      exp: iat + 3600,
+    })
+      .setProtectedHeader({ alg: 'EdDSA', kid: 'jwk_does_not_exist' })
+      .setIssuer(baseUrl)
+      .sign(privateKey);
+    const { status } = await callMcp(token);
+    expect(status).toBe(401);
+  });
+
+  it('rejects a JWT whose issuer does not match the canonical origin', async () => {
+    const token = await sign({ iss: 'https://wrong-issuer.example.com' });
+    const { status } = await callMcp(token);
+    expect(status).toBe(401);
+  });
+
+  it('rejects an expired JWT', async () => {
+    const token = await sign({ expSeconds: -60 });
+    const { status } = await callMcp(token);
+    expect(status).toBe(401);
+  });
+
+  it('rejects a JWT whose sub is not a known user (no org membership)', async () => {
+    const token = await sign({ sub: 'usr_does_not_exist_xxxxxxxxxxxx' });
+    const { status } = await callMcp(token);
+    expect(status).toBe(401);
+  });
+});

--- a/packages/backend-core/src/realtime/realtime-event-bus.ts
+++ b/packages/backend-core/src/realtime/realtime-event-bus.ts
@@ -1,0 +1,214 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter } from 'node:events';
+import { DbListenerService, type EventRow } from './db-listener.service.js';
+
+export interface MessageReceivedBusEvent {
+  conversationId: string;
+  messageId: string;
+  authorType: 'user' | 'agent' | 'end_user' | 'system';
+  endUserId?: string;
+}
+
+export interface KbDocumentChangedBusEvent {
+  type: 'created' | 'updated' | 'deleted';
+  spaceId: string;
+  documentId: string;
+  slug: string | null;
+  version?: number;
+}
+
+export interface HandoverResolvedBusEvent {
+  conversationId: string;
+  messageId: string;
+  authorType: 'user' | 'agent' | 'end_user' | 'system';
+}
+
+export interface CuratorJobPendingBusEvent {
+  jobId: string;
+  jobUri: string;
+  dedupeKey: string | null;
+  nextAttemptAt: string;
+}
+
+export interface GreetRequestedBusEvent {
+  conversationId: string;
+  endUserId?: string;
+}
+
+export interface AgentConfigChangedBusEvent {
+  configId: string;
+}
+
+export interface RealtimeBusHandlers {
+  onMessageReceived?: (event: MessageReceivedBusEvent) => void;
+  onKbDocumentChanged?: (event: KbDocumentChangedBusEvent) => void;
+  onHandoverResolved?: (event: HandoverResolvedBusEvent) => void;
+  onCuratorJobPending?: (event: CuratorJobPendingBusEvent) => void;
+  onGreetRequested?: (event: GreetRequestedBusEvent) => void;
+  onAgentConfigChanged?: (event: AgentConfigChangedBusEvent) => void;
+  onConnected?: () => void;
+}
+
+export interface RealtimeBusSubscriptionFilter {
+  orgId: string;
+  endUserId?: string;
+}
+
+export interface RealtimeBusSubscription {
+  unsubscribe(): void;
+}
+
+export interface AgentTypingBusEvent {
+  orgId: string;
+  conversationId: string;
+  isTyping: boolean;
+}
+
+export type AgentTypingHandler = (event: AgentTypingBusEvent) => void;
+
+const TYPING_CHANNEL = 'agent_typing';
+
+@Injectable()
+export class RealtimeEventBus {
+  private readonly logger = new Logger(RealtimeEventBus.name);
+  private readonly typingEmitter = new EventEmitter();
+
+  constructor(private readonly listener: DbListenerService) {
+    this.typingEmitter.setMaxListeners(64);
+  }
+
+  subscribe(filter: RealtimeBusSubscriptionFilter, handlers: RealtimeBusHandlers): RealtimeBusSubscription {
+    const dbUnsubscribe = this.listener.subscribe((event) => {
+      if (event.org_id !== filter.orgId) return;
+      if (filter.endUserId && !ownsEvent(event, filter.endUserId)) return;
+      try {
+        dispatchEvent(event, handlers);
+      } catch (err) {
+        this.logger.warn(`bus handler threw for ${event.type}: ${describe(err)}`);
+      }
+    });
+    if (handlers.onConnected) {
+      setImmediate(() => {
+        try {
+          handlers.onConnected?.();
+        } catch (err) {
+          this.logger.warn(`onConnected handler threw: ${describe(err)}`);
+        }
+      });
+    }
+    return { unsubscribe: dbUnsubscribe };
+  }
+
+  publishConversationTyping(orgId: string, conversationId: string, isTyping: boolean): void {
+    this.typingEmitter.emit(TYPING_CHANNEL, {
+      orgId,
+      conversationId,
+      isTyping,
+    } satisfies AgentTypingBusEvent);
+  }
+
+  subscribeAgentTyping(handler: AgentTypingHandler): () => void {
+    this.typingEmitter.on(TYPING_CHANNEL, handler);
+    return () => {
+      this.typingEmitter.off(TYPING_CHANNEL, handler);
+    };
+  }
+}
+
+function dispatchEvent(event: EventRow, handlers: RealtimeBusHandlers): void {
+  const payload = event.payload ?? {};
+  const type = event.type;
+
+  if (type === 'conversation.message.received' && handlers.onMessageReceived) {
+    const conversationId = payload['conversationId'];
+    const messageId = payload['messageId'];
+    const authorType = payload['authorType'];
+    if (typeof conversationId !== 'string' || typeof messageId !== 'string') return;
+    handlers.onMessageReceived({
+      conversationId,
+      messageId,
+      authorType:
+        typeof authorType === 'string'
+          ? (authorType as MessageReceivedBusEvent['authorType'])
+          : 'end_user',
+      endUserId: typeof payload['endUserId'] === 'string' ? payload['endUserId'] : undefined,
+    });
+    return;
+  }
+
+  if (type === 'conversation.handover_resolved' && handlers.onHandoverResolved) {
+    const conversationId = payload['conversationId'];
+    const messageId = payload['messageId'];
+    const authorType = payload['authorType'];
+    if (typeof conversationId !== 'string' || typeof messageId !== 'string') return;
+    handlers.onHandoverResolved({
+      conversationId,
+      messageId,
+      authorType:
+        typeof authorType === 'string'
+          ? (authorType as HandoverResolvedBusEvent['authorType'])
+          : 'user',
+    });
+    return;
+  }
+
+  if (type === 'conversation.greet_requested' && handlers.onGreetRequested) {
+    const conversationId = payload['conversationId'];
+    if (typeof conversationId !== 'string') return;
+    handlers.onGreetRequested({
+      conversationId,
+      endUserId: typeof payload['endUserId'] === 'string' ? payload['endUserId'] : undefined,
+    });
+    return;
+  }
+
+  if (type === 'curator_job.pending' && handlers.onCuratorJobPending) {
+    const jobId = payload['jobId'];
+    const jobUri = payload['jobUri'];
+    const nextAttemptAt = payload['nextAttemptAt'];
+    if (typeof jobId !== 'string' || typeof jobUri !== 'string') return;
+    handlers.onCuratorJobPending({
+      jobId,
+      jobUri,
+      dedupeKey: typeof payload['dedupeKey'] === 'string' ? payload['dedupeKey'] : null,
+      nextAttemptAt:
+        typeof nextAttemptAt === 'string' ? nextAttemptAt : new Date().toISOString(),
+    });
+    return;
+  }
+
+  if (type === 'agent.config.updated' && handlers.onAgentConfigChanged) {
+    const configId = payload['configId'];
+    if (typeof configId !== 'string') return;
+    handlers.onAgentConfigChanged({ configId });
+    return;
+  }
+
+  if (
+    handlers.onKbDocumentChanged &&
+    (type === 'kb.document.created' ||
+      type === 'kb.document.updated' ||
+      type === 'kb.document.deleted')
+  ) {
+    const spaceId = payload['spaceId'];
+    const documentId = payload['documentId'];
+    if (typeof spaceId !== 'string' || typeof documentId !== 'string') return;
+    handlers.onKbDocumentChanged({
+      type: type.split('.').pop() as 'created' | 'updated' | 'deleted',
+      spaceId,
+      documentId,
+      slug: typeof payload['slug'] === 'string' ? payload['slug'] : null,
+      version: typeof payload['version'] === 'number' ? payload['version'] : undefined,
+    });
+  }
+}
+
+function ownsEvent(event: EventRow, endUserId: string): boolean {
+  const owner = event.payload?.['endUserId'];
+  if (typeof owner === 'string') return owner === endUserId;
+  return event.type.startsWith('conversation.');
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -28,6 +28,7 @@ import {
   type AdditionalCredentialResolver,
 } from '../common/auth/auth.guard.js';
 import { DbListenerService, type EventRow } from './db-listener.service.js';
+import { RealtimeEventBus, type AgentTypingBusEvent } from './realtime-event-bus.js';
 import {
   enforceOriginAllowlist,
   verifyIdentity,
@@ -77,6 +78,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   private readonly resolver: CredentialResolver;
   private readonly selfServiceSubscribersByOrg = new Map<string, Set<WebSocket>>();
   private readonly subscribersByChannel = new Map<string, Set<ConnectionEntry>>();
+  private busTypingUnsubscribe: (() => void) | null = null;
 
   selfServiceSubscriberCount(orgId: string): number {
     return this.selfServiceSubscribersByOrg.get(orgId)?.size ?? 0;
@@ -85,6 +87,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   constructor(
     private readonly adapterHost: HttpAdapterHost,
     private readonly listener: DbListenerService,
+    private readonly bus: RealtimeEventBus,
     @Inject(DB) private readonly db: Db,
     @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
     @Optional()
@@ -126,10 +129,19 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     };
     this.upgradeListener = listener;
     httpServer.on('upgrade', listener);
+    this.busTypingUnsubscribe = this.bus.subscribeAgentTyping((event) => {
+      this.handleBusAgentTyping(event).catch((err: unknown) =>
+        this.logger.warn(`bus typing dispatch failed: ${describeError(err)}`),
+      );
+    });
     this.logger.log(`gateway listening on ${PATH}`);
   }
 
   async onModuleDestroy(): Promise<void> {
+    if (this.busTypingUnsubscribe) {
+      this.busTypingUnsubscribe();
+      this.busTypingUnsubscribe = null;
+    }
     if (this.wss) {
       this.wss.clients.forEach((c) => c.terminate());
       await new Promise<void>((resolve) =>
@@ -523,6 +535,41 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     });
   }
 
+  private async handleBusAgentTyping(event: AgentTypingBusEvent): Promise<void> {
+    const meta = await this.resolveConversationMeta(event.conversationId);
+    if (!meta || meta.sessionId === null) return;
+    const outboundChannel = `widget:${meta.channelId}:${meta.sessionId}`;
+    const subs = this.subscribersByChannel.get(outboundChannel);
+    if (!subs) return;
+    const payload = JSON.stringify({
+      type: 'typing',
+      channel: outboundChannel,
+      isTyping: event.isTyping,
+      authorType: 'operator',
+    });
+    for (const sub of subs) {
+      if (sub.orgId !== event.orgId) continue;
+      if (sub.widgetCtx?.verifiedExternalId) {
+        const cached = sub.conversationMetaCache.get(event.conversationId);
+        if (
+          !cached ||
+          !cached.meta ||
+          cached.meta.contactExternalId !== sub.widgetCtx.verifiedExternalId
+        ) {
+          void this.resolveConversationMeta(event.conversationId).then((resolved) => {
+            sub.conversationMetaCache.set(event.conversationId, { meta: resolved });
+          });
+          continue;
+        }
+      }
+      try {
+        sub.ws.send(payload);
+      } catch (err) {
+        this.logger.debug?.(`fanoutTyping send failed (socket likely mid-close): ${describeError(err)}`);
+      }
+    }
+  }
+
   private fanoutTyping(
     fromEntry: ConnectionEntry,
     outboundChannel: string,
@@ -556,8 +603,8 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       }
       try {
         sub.ws.send(payload);
-      } catch {
-        // socket mid-close
+      } catch (err) {
+        this.logger.debug?.(`bus typing send failed (socket likely mid-close): ${describeError(err)}`);
       }
     }
   }

--- a/packages/backend-core/src/realtime/realtime.module.ts
+++ b/packages/backend-core/src/realtime/realtime.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { DbListenerService } from './db-listener.service.js';
+import { RealtimeEventBus } from './realtime-event-bus.js';
 import { RealtimeGateway } from './realtime.gateway.js';
 
 @Module({
-  providers: [DbListenerService, RealtimeGateway],
-  exports: [DbListenerService, RealtimeGateway],
+  providers: [DbListenerService, RealtimeEventBus, RealtimeGateway],
+  exports: [DbListenerService, RealtimeEventBus, RealtimeGateway],
 })
 export class RealtimeModule {}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "@getmunin/db": "workspace:*",
     "@getmunin/types": "workspace:*",
     "drizzle-orm": "^0.45.2",
+    "jose": "^6.0.0",
     "nodemailer": "^8.0.7",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,3 @@
-/**
- * @getmunin/core — framework-agnostic platform services.
- *
- * Everything here is plain TypeScript / Drizzle. NestJS-specific wrappers
- * (interceptors, guards, modules) live in apps/backend/src/common/.
- */
-
-// ── Request-scoped services (read RequestContext) ───────────────────
 export {
   ActorIdentity,
   type ActorType,
@@ -15,12 +7,15 @@ export {
   getCurrentContext,
   withContext,
 } from './request/context.js';
-export { buildAdminAgentActor } from './request/synth-agent-actor.js';
+export {
+  buildAdminAgentActor,
+  buildEndUserAgentActor,
+  type EndUserAgentActorInput,
+} from './request/synth-agent-actor.js';
 export { AuditLogger, type AuditEventInput } from './request/audit.js';
 export { ClaimManager, type ClaimResult } from './request/claims.js';
 export { CredentialResolver, type ResolvedCredential } from './request/credentials.js';
 
-// ── Crypto primitives, signed tokens, API key minting ───────────────
 export {
   hashSecret,
   randomToken,
@@ -46,7 +41,6 @@ export {
   verifyEmailOpenToken,
 } from './crypto/email-open-token.js';
 
-// ── External provider interfaces (swappable backends) ───────────────
 export {
   type EmbeddingProvider,
   OpenAIEmbeddingProvider,
@@ -70,7 +64,6 @@ export {
   readAssetStorageFromEnv,
 } from './providers/storage.js';
 
-// ── Domain utilities ────────────────────────────────────────────────
 export { WebhookDispatcher, type WebhookEventInput } from './webhooks.js';
 export {
   chunkDocument,
@@ -80,7 +73,6 @@ export {
   type ChunkOptions,
 } from './chunker.js';
 
-// ── Built-in prompt defaults + KB-backed prompt cache ───────────────
 export {
   AGENT_RUNTIME_PROMPT_SPACE_SLUG,
   COMPANY_PROFILE_SPACE_SLUG,

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -1,8 +1,14 @@
+import { createHash } from 'node:crypto';
 import type { Db } from '@getmunin/db';
 import { schema } from '@getmunin/db';
 import { and, eq, gt, isNull } from 'drizzle-orm';
 import { ActorIdentity, type Audience } from './context.js';
 import { hashSecret } from '../crypto/primitives.js';
+import { looksLikeJwt, resolveOauthJwtAccessToken } from './oauth-jwt.js';
+
+function hashOauthOpaqueToken(rawToken: string): string {
+  return createHash('sha256').update(rawToken).digest('base64url');
+}
 
 export interface ResolvedCredential {
   actor: ActorIdentity;
@@ -28,6 +34,10 @@ export class CredentialResolver {
    * a JWT-only flow can come later.
    */
   async resolveBearerToken(rawToken: string): Promise<ResolvedCredential | null> {
+    if (looksLikeJwt(rawToken)) {
+      const jwtHit = await resolveOauthJwtAccessToken(this.db, rawToken);
+      if (jwtHit) return jwtHit;
+    }
     const oauthHit = await this.resolveOauthAccessToken(rawToken);
     if (oauthHit) return oauthHit;
 
@@ -72,7 +82,7 @@ export class CredentialResolver {
     const tokenRows = await this.db
       .select()
       .from(schema.oauthAccessToken)
-      .where(eq(schema.oauthAccessToken.token, rawToken))
+      .where(eq(schema.oauthAccessToken.token, hashOauthOpaqueToken(rawToken)))
       .limit(1);
     const tokenRow = tokenRows[0];
     if (!tokenRow) return null;
@@ -215,11 +225,11 @@ export class CredentialResolver {
   }
 }
 
-function oauthMcpResourceAudience(): string {
+export function oauthMcpResourceAudience(): string {
   return (process.env.MUNIN_PUBLIC_URL ?? 'http://localhost:3001/mcp').replace(/\/+$/, '');
 }
 
-function deriveAudiencesFromScopes(scopes: string[]): Audience[] {
+export function deriveAudiencesFromScopes(scopes: string[]): Audience[] {
   const set = new Set<Audience>();
   for (const scope of scopes) {
     if (scope === 'mcp:admin') set.add('admin');

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -16,23 +16,9 @@ export interface ResolvedCredential {
   audience?: string;
 }
 
-/**
- * Resolves an incoming bearer token or API key into an `ActorIdentity`,
- * including org membership and audience scopes.
- *
- * This runs OUTSIDE the request transaction (auth must succeed before we
- * open a tenant-bound connection). So it takes the Db as a constructor
- * argument rather than reading from RequestContext.
- */
 export class CredentialResolver {
   constructor(private readonly db: Db) {}
 
-  /**
-   * Resolve an OAuth access token or delegated end-user JWT.
-   *
-   * For v0.4 we store these in the `tokens` table keyed by token-hash;
-   * a JWT-only flow can come later.
-   */
   async resolveBearerToken(rawToken: string): Promise<ResolvedCredential | null> {
     if (looksLikeJwt(rawToken)) {
       const jwtHit = await resolveOauthJwtAccessToken(this.db, rawToken);
@@ -118,15 +104,6 @@ export class CredentialResolver {
     };
   }
 
-  /**
-   * Resolve an admin API key (`mn_admin_*`).
-   *
-   * Format expected: `<prefix>_<random-base64url>`. The prefix narrows the
-   * lookup so we don't hash every key on every request.
-   *
-   * Downstream builds can compose this resolver with additional
-   * resolvers (see `ADDITIONAL_CREDENTIAL_RESOLVERS` in backend-core).
-   */
   async resolveApiKey(rawKey: string): Promise<ResolvedCredential | null> {
     const keyPrefix = rawKey.slice(0, 8);
     const keyHash = hashSecret(rawKey);
@@ -169,16 +146,6 @@ export class CredentialResolver {
     return { actor };
   }
 
-  /**
-   * Resolve a BetterAuth session cookie into a user-typed actor.
-   *
-   * Used by the dashboard so the user's browser session can call control-plane
-   * endpoints without first minting an API key. Returns null when the session
-   * is missing, expired, or the user has no org membership.
-   *
-   * Picks the user's default membership (`is_default = true`) if one is
-   * marked, falling back to the first membership ordered by created_at.
-   */
   async resolveSessionToken(rawToken: string): Promise<ResolvedCredential | null> {
     const sessionRows = await this.db
       .select()
@@ -211,10 +178,6 @@ export class CredentialResolver {
     return { actor, expiresAt: session.expiresAt };
   }
 
-  /**
-   * Look up just the user_id for a session token. Used by the accept-invite
-   * endpoint, where the invitee may have no memberships yet.
-   */
   async resolveSessionUserId(rawToken: string): Promise<string | null> {
     const rows = await this.db
       .select({ userId: schema.sessions.userId })

--- a/packages/core/src/request/oauth-jwt.test.ts
+++ b/packages/core/src/request/oauth-jwt.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { acceptedJwtAudiences, jwtIssuer, looksLikeJwt } from './oauth-jwt.js';
+
+describe('looksLikeJwt', () => {
+  it('accepts three-part dot-delimited strings with non-empty parts', () => {
+    expect(looksLikeJwt('aaa.bbb.ccc')).toBe(true);
+    expect(looksLikeJwt('eyJhbGciOi.eyJzdWIi.signature')).toBe(true);
+  });
+
+  it('rejects strings with fewer or more than three parts', () => {
+    expect(looksLikeJwt('aaa.bbb')).toBe(false);
+    expect(looksLikeJwt('aaa.bbb.ccc.ddd')).toBe(false);
+    expect(looksLikeJwt('nodots')).toBe(false);
+  });
+
+  it('rejects strings with any empty part', () => {
+    expect(looksLikeJwt('.bbb.ccc')).toBe(false);
+    expect(looksLikeJwt('aaa..ccc')).toBe(false);
+    expect(looksLikeJwt('aaa.bbb.')).toBe(false);
+    expect(looksLikeJwt('')).toBe(false);
+  });
+});
+
+describe('jwtIssuer + acceptedJwtAudiences', () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env.MUNIN_PUBLIC_URL;
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.MUNIN_PUBLIC_URL;
+    else process.env.MUNIN_PUBLIC_URL = original;
+  });
+
+  it('uses origin of MUNIN_PUBLIC_URL as issuer when it has a path', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://api.example.com/mcp';
+    expect(jwtIssuer()).toBe('https://api.example.com');
+  });
+
+  it('uses origin of MUNIN_PUBLIC_URL as issuer when it has no path', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://mcp.example.com';
+    expect(jwtIssuer()).toBe('https://mcp.example.com');
+  });
+
+  it('accepts canonical URL plus trailing-slash, origin, and origin-with-slash when URL has a path', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://api.example.com/mcp';
+    expect(acceptedJwtAudiences()).toEqual(
+      new Set([
+        'https://api.example.com/mcp',
+        'https://api.example.com/mcp/',
+        'https://api.example.com',
+        'https://api.example.com/',
+      ]),
+    );
+  });
+
+  it('accepts both bare-origin variants when URL has no path', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://mcp.example.com';
+    expect(acceptedJwtAudiences()).toEqual(
+      new Set(['https://mcp.example.com', 'https://mcp.example.com/']),
+    );
+  });
+
+  it('strips trailing slashes from the env value before computing variants', () => {
+    process.env.MUNIN_PUBLIC_URL = 'https://api.example.com/mcp/';
+    expect(acceptedJwtAudiences()).toEqual(
+      new Set([
+        'https://api.example.com/mcp',
+        'https://api.example.com/mcp/',
+        'https://api.example.com',
+        'https://api.example.com/',
+      ]),
+    );
+  });
+
+  it('handles http loopback (dev default) correctly', () => {
+    delete process.env.MUNIN_PUBLIC_URL;
+    expect(jwtIssuer()).toBe('http://localhost:3001');
+    expect(acceptedJwtAudiences()).toEqual(
+      new Set([
+        'http://localhost:3001/mcp',
+        'http://localhost:3001/mcp/',
+        'http://localhost:3001',
+        'http://localhost:3001/',
+      ]),
+    );
+  });
+});

--- a/packages/core/src/request/oauth-jwt.ts
+++ b/packages/core/src/request/oauth-jwt.ts
@@ -1,0 +1,146 @@
+import type { Db } from '@getmunin/db';
+import { schema } from '@getmunin/db';
+import { eq } from 'drizzle-orm';
+import { decodeProtectedHeader, importJWK, jwtVerify, type JWTPayload } from 'jose';
+import { ActorIdentity } from './context.js';
+import {
+  deriveAudiencesFromScopes,
+  oauthMcpResourceAudience,
+  type ResolvedCredential,
+} from './credentials.js';
+
+type VerifyKey = Awaited<ReturnType<typeof importJWK>>;
+
+interface JwksRow {
+  id: string;
+  publicKey: string;
+}
+
+const jwksCache = new Map<string, VerifyKey>();
+
+export function looksLikeJwt(raw: string): boolean {
+  const parts = raw.split('.');
+  if (parts.length !== 3) return false;
+  return parts.every((p) => (p?.length ?? 0) > 0);
+}
+
+export async function resolveOauthJwtAccessToken(
+  db: Db,
+  rawToken: string,
+): Promise<ResolvedCredential | null> {
+  let header: { kid?: string; alg?: string };
+  try {
+    header = decodeProtectedHeader(rawToken);
+  } catch (err) {
+    console.warn('[credentials] JWT header decode failed', { err });
+    return null;
+  }
+  if (!header.kid) return null;
+
+  const key = await loadVerificationKey(db, header.kid);
+  if (!key) return null;
+
+  let payload: JWTPayload;
+  try {
+    const verified = await jwtVerify(rawToken, key, { issuer: jwtIssuer() });
+    payload = verified.payload;
+  } catch (err) {
+    console.warn('[credentials] JWT verification failed', { err });
+    return null;
+  }
+
+  const userId = typeof payload.sub === 'string' ? payload.sub : null;
+  if (!userId) return null;
+
+  const audClaim = payload.aud;
+  const audiencesFromJwt = Array.isArray(audClaim)
+    ? audClaim
+    : typeof audClaim === 'string'
+      ? [audClaim]
+      : [];
+  if (!audiencesFromJwt.some((a) => isAcceptedJwtAudience(a))) return null;
+
+  const scopes =
+    typeof payload['scope'] === 'string' ? payload['scope'].split(/\s+/).filter(Boolean) : [];
+
+  const memberships = await db
+    .select()
+    .from(schema.orgMembers)
+    .where(eq(schema.orgMembers.userId, userId));
+  const active = memberships.find((m) => m.isDefault) ?? memberships[0];
+  if (!active) return null;
+
+  const audiences = deriveAudiencesFromScopes(scopes);
+
+  const actor = new ActorIdentity(
+    'user',
+    userId,
+    active.orgId,
+    scopes,
+    audiences,
+    undefined,
+    undefined,
+    undefined,
+    userId,
+  );
+
+  const expiresAt =
+    typeof payload.exp === 'number' ? new Date(payload.exp * 1000) : undefined;
+  return {
+    actor,
+    expiresAt,
+    audience: oauthMcpResourceAudience(),
+  };
+}
+
+async function loadVerificationKey(db: Db, kid: string): Promise<VerifyKey | null> {
+  const cached = jwksCache.get(kid);
+  if (cached) return cached;
+  const rows = (await db
+    .select({ id: schema.jwks.id, publicKey: schema.jwks.publicKey })
+    .from(schema.jwks)
+    .where(eq(schema.jwks.id, kid))
+    .limit(1)) as JwksRow[];
+  const row = rows[0];
+  if (!row) return null;
+  let jwk: Record<string, unknown>;
+  try {
+    jwk = JSON.parse(row.publicKey) as Record<string, unknown>;
+  } catch (err) {
+    console.warn('[credentials] jwks row has invalid JSON public_key', { kid, err });
+    return null;
+  }
+  const alg = (jwk['alg'] as string | undefined) ?? 'EdDSA';
+  const key = await importJWK(jwk, alg);
+  jwksCache.set(kid, key);
+  return key;
+}
+
+function publicUrl(): string {
+  return (process.env.MUNIN_PUBLIC_URL ?? 'http://localhost:3001/mcp').replace(/\/+$/, '');
+}
+
+function jwtIssuer(): string {
+  try {
+    return new URL(publicUrl()).origin;
+  } catch {
+    return publicUrl();
+  }
+}
+
+function acceptedJwtAudiences(): Set<string> {
+  const canonical = publicUrl();
+  const set = new Set<string>([canonical, `${canonical}/`]);
+  try {
+    const origin = new URL(canonical).origin;
+    set.add(origin);
+    set.add(`${origin}/`);
+  } catch (err) {
+    console.warn('[credentials] publicUrl is not a parseable URL', { err });
+  }
+  return set;
+}
+
+function isAcceptedJwtAudience(aud: string): boolean {
+  return acceptedJwtAudiences().has(aud);
+}

--- a/packages/core/src/request/oauth-jwt.ts
+++ b/packages/core/src/request/oauth-jwt.ts
@@ -120,7 +120,7 @@ function publicUrl(): string {
   return (process.env.MUNIN_PUBLIC_URL ?? 'http://localhost:3001/mcp').replace(/\/+$/, '');
 }
 
-function jwtIssuer(): string {
+export function jwtIssuer(): string {
   try {
     return new URL(publicUrl()).origin;
   } catch {
@@ -128,7 +128,7 @@ function jwtIssuer(): string {
   }
 }
 
-function acceptedJwtAudiences(): Set<string> {
+export function acceptedJwtAudiences(): Set<string> {
   const canonical = publicUrl();
   const set = new Set<string>([canonical, `${canonical}/`]);
   try {

--- a/packages/core/src/request/synth-agent-actor.ts
+++ b/packages/core/src/request/synth-agent-actor.ts
@@ -1,5 +1,25 @@
-import { ActorIdentity } from './context.js';
+import { ActorIdentity, type Audience } from './context.js';
 
 export function buildAdminAgentActor(orgId: string): ActorIdentity {
   return new ActorIdentity('admin_agent', `agent-host:${orgId}`, orgId, ['*'], ['admin']);
+}
+
+export interface EndUserAgentActorInput {
+  orgId: string;
+  endUserId: string;
+  scopes?: readonly string[];
+  audiences?: readonly Audience[];
+}
+
+export function buildEndUserAgentActor(input: EndUserAgentActorInput): ActorIdentity {
+  const scopes = input.scopes ?? [];
+  const audiences = input.audiences ?? (['self_service'] as const);
+  return new ActorIdentity(
+    'end_user_agent',
+    `agent-host:${input.orgId}:${input.endUserId}`,
+    input.orgId,
+    scopes,
+    audiences,
+    input.endUserId,
+  );
 }

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -9,6 +9,7 @@ import { api, ApiError } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 
 interface OAuthConsentResponse {
+  url?: string;
   redirect_uri?: string;
 }
 
@@ -127,7 +128,8 @@ export function OAuthConsentPage() {
         method: 'POST',
         body: JSON.stringify({ accept, oauth_query: oauthQuery }),
       });
-      if (resp?.redirect_uri) window.location.assign(resp.redirect_uri);
+      const target = resp?.url ?? resp?.redirect_uri;
+      if (target) window.location.assign(target);
       else window.history.back();
     } catch (err) {
       if (err instanceof ApiError) setError(translate(err) || err.message);
@@ -188,7 +190,6 @@ export function OAuthConsentPage() {
                   ))}
                 </ul>
               )}
-              <p className="mt-3 text-xs text-muted-foreground">{t('standardDisclosure')}</p>
             </div>
 
             {error && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,6 +518,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+      jose:
+        specifier: ^6.0.0
+        version: 6.2.3
       nodemailer:
         specifier: ^8.0.7
         version: 8.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,9 @@ importers:
       imapflow:
         specifier: ^1.3.2
         version: 1.3.3
+      jose:
+        specifier: ^6.0.0
+        version: 6.2.3
       mailparser:
         specifier: ^3.9.8
         version: 3.9.8


### PR DESCRIPTION
> Stacks on #213 — base set to `oauth-jwt-and-tool-titles`. Will auto-rebase to `main` when #213 merges.

## Summary

Closes the prod 401-reconnect loop on AgentHostRunner. Before this PR the runner's WebSocket subscription to `/api/v1/realtime` re-attempted an HTTP auth every 30s with the org's stored admin API key — when that key drifted (deleted org, manual rotation, restore-from-backup) the runner stayed "started" but was effectively deaf. Observed in prod for `org_fgf0a6f1fwu6nfa6aq3xwf` at attempt 411+ before this fix, even after PR #211 moved the prompts/skills path in-process.

This PR removes the remaining HTTP seams in the runner's hot paths.

### Realtime → in-process bus

- New `RealtimeEventBus` provider in `@getmunin/backend-core/realtime`. Wraps the existing `DbListenerService` so the same Postgres `NOTIFY munin_events` stream the WS gateway already consumes fans out to in-process subscribers with `{ orgId, endUserId? }` filtering identical to the gateway's.
- In-memory channel for the runner-emitted typing signal (no DB write — typing is ephemeral). The WS gateway subscribes and pushes to widget WS clients on the matching conversation channel.
- Runner: `createRealtimeClient({ baseUrl, adminApiKey, … })` → `this.eventBus.subscribe({ orgId }, handlers)`. No more WS, no more admin-key auth on the intake path.

### Chat MCP → in-process delegated

- New `openEndUserAgentMcpClient(...)` in backend-core. Synthesizes an `end_user_agent` actor with `audience='self_service'`, the user's default org membership, and applies `applyTenancyGUCs(actor)` per call — RLS still enforces end-user scoping even though the auth guard is bypassed.
- New `buildEndUserAgentActor({ orgId, endUserId, scopes?, audiences? })` in `@getmunin/core`, sibling of `buildAdminAgentActor`.
- `conversation-handler.ts`: dropped `getDelegatedToken`, `tokenCache`, `TOKEN_REFRESH_MARGIN_MS`. Passes `endUserId` directly to `deps.openMcp` — no token mint, no REST round-trip per message. (`mintDelegatedToken` REST endpoint stays for the widget.)

### Curator + web-import → in-process admin

- `runSkillPass` signature dropped `baseUrl/adminApiKey/clientName`, added `mcp: McpToolHandle` + `skills: SkillReader`.
- `runWebImportJob` signature dropped `baseUrl/adminApiKey`, added `mcp: McpToolHandle`.
- Runner opens an in-process `openAdminAgentMcpClient(...)` per job and passes it down.

### Naming sweep

Pre-existing exports were asymmetric. Renamed for consistency with `ActorType` + transport explicitness:

| Old | New |
|---|---|
| `openAgentMcpClient` | `openAdminAgentMcpClient` |
| `openDelegatedMcpClient` | `openEndUserAgentMcpClient` |
| `openMcpClient` (HTTP) | `openHttpMcpClient` |

`buildAdminAgentActor` / `buildEndUserAgentActor` were already symmetric. No external consumers, safe.

### Out of scope (still HTTP, deliberate)

REST control plane (`createMuninRestClient`) stays HTTP — lifting Nest controllers in-process is a separate, much larger refactor. The runner still bails on missing admin key for the REST path. But the realtime/MCP/curator paths no longer depend on it.

## Test plan

- [x] `pnpm -r typecheck` clean across all 15 packages
- [x] `pnpm -F @getmunin/agent-runtime test` 92/92 pass (updated tests where signatures changed; removed token-cache tests that are no longer meaningful)
- [x] `pnpm -F @getmunin/mcp-toolkit test` 11/11 pass
- [x] backend-core gateway unit tests 7/7 pass
- [ ] CI green
- [ ] Manual end-to-end: spawn runner against a stale admin-key org; confirm realtime intake works, end-user chat replies work, curator skill drains. Should be done in cloud-dev after merge.

## Out of scope (deliberate)

- Moving REST control plane in-process — too large for this PR.
- Integration test for the in-process delegated MCP RLS gate — worth doing in a follow-up. The risk is that synthesized `end_user_agent` actor + tenancy GUCs miss an edge case the auth guard would catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)