### PR TITLE
fix(core): align COMPANY_PROFILE_SPACE_SLUG with where web-import writes

### DIFF
--- a/.changeset/fix-company-profile-space-slug.md
+++ b/.changeset/fix-company-profile-space-slug.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/core': patch
+---
+
+Fix: `COMPANY_PROFILE_SPACE_SLUG` now matches where the web-import handler actually writes the scraped Company profile doc.
+
+Two constants pointed at different KB space slugs:
+
+- `web-import.handler.ts` wrote the "Company profile" doc into space `website-import`.
+- `prompts/index.ts` (`COMPANY_PROFILE_SPACE_SLUG`) looked for it in space `imported-from-website`.
+
+Same doc slug (`company-profile`), different space. Result: the PromptResolver's cache lookup never resolved the profile, `prompts.companyContext()` always returned `''`, and the `[Company context]\n…` block was never appended to the chat widget agent's system prompt. End-users asking "what does <company> do?" got generic answers because the scraped profile never reached the agent — even though the doc existed in the KB the whole time.
+
+Aligned `COMPANY_PROFILE_SPACE_SLUG` to `'website-import'` (the value the web-import handler actually uses). No data migration needed.

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -79,7 +79,7 @@ export {
 
 // ── Shared space / namespace constants ──────────────────────────────
 export const AGENT_RUNTIME_PROMPT_SPACE_SLUG = 'agent-runtime';
-export const COMPANY_PROFILE_SPACE_SLUG = 'imported-from-website';
+export const COMPANY_PROFILE_SPACE_SLUG = 'website-import';
 export const CHANNEL_PROMPT_PREFIX = 'channel-';
 export const COMPANY_PROFILE_SLUG = 'company-profile';
 


### PR DESCRIPTION
## Summary

Two constants pointed at different KB space slugs, so the chat widget agent never received the scraped company profile in its system prompt.

| Side | Constant | Value |
|---|---|---|
| `web-import.handler.ts:12` writes the scraped "Company profile" doc into space | `TARGET_SPACE_SLUG` | `'website-import'` |
| `core/src/prompts/index.ts:82` is where `PromptResolver` looks for it | `COMPANY_PROFILE_SPACE_SLUG` | `'imported-from-website'` |

Same doc slug (`company-profile`), different space. Result: `prompts.companyContext()` always returned `''`, and the `[Company context]\n…` block was never appended to the chat widget agent's system prompt at `conversation-handler.ts:206-209`. End-users asking "what does <company> do?" got generic answers — even though the scraped doc was sitting in the KB the whole time.

Aligned `COMPANY_PROFILE_SPACE_SLUG` to `'website-import'` (the value the web-import handler actually uses). One-line change. No data migration needed.

## Test plan

- [x] `pnpm typecheck` clean across 15 packages
- [ ] CI green
- [ ] Manual: re-onboard with a website import, then ask the chat widget "what does Apps AS do?" — agent should respond with details from the scraped profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)