### PR TITLE
refactor(backend-core): extract shared Better Auth factory

### DIFF
--- a/.changeset/shared-auth-factory.md
+++ b/.changeset/shared-auth-factory.md
@@ -1,0 +1,22 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Extract `createMuninAuthCore` factory in `@getmunin/backend-core/auth` so OSS and cloud share one Better Auth setup.
+
+Cloud has its own `cloud-auth.ts` because its multi-tenancy model is different (personal-org-per-signup vs OSS's single-shared-org-with-invite-gate) and it wires social providers + user-deletion flows OSS doesn't. But ~70% of the file was a literal copy of the OSS auth config: `drizzleAdapter` schema mapping, `jwt({ issuer })` plugin, `oauthProvider({...})` block, `emailAndPassword`, `emailVerification`, `SUPPORTED_SCOPES` composition, and the `computeValidAudiences` + `uniqueOrigins` helpers. That copy drifted twice — first when the original audience mismatch landed (fixed in OSS #208 then again in cloud #111), and again when the variant-tolerance fix landed (OSS #213, never propagated to cloud, which is why claude.ai's OAuth flow broke on cloud-dev after the 4.9.0 cloud bump).
+
+New shared factory accepts the caller-specific bits as options:
+
+- `signupBefore(user)` / `signupAfter(user)` — OSS passes invite-gate + singleton-org membership; cloud passes personal-org provisioning.
+- `sendResetPassword`, `sendVerificationEmail` — callers supply mailer-bound callbacks (OSS and cloud have different template copy).
+- `deleteUser?: { beforeDelete, sendDeleteAccountVerification }` — cloud-only.
+- `socialProviders?: { google, github }` — cloud-only.
+- `crossSubDomainCookies?: { domain }` — cloud-only (`*.getmunin.com`).
+- `rateLimit?` — cloud uses an env toggle for tests.
+
+Everything OAuth-protocol-related (oauthProvider config, validAudiences derivation, jwt issuer, supported scopes, JWKS schema mapping) lives in one place. `computeValidAudiences` is now exported from `@getmunin/backend-core` directly — its variant set (`{canonical, +slash, origin, origin+/}`) is the canonical source of truth for both OSS and cloud.
+
+OSS `apps/backend/src/auth/auth.config.ts` slimmed from ~250 to ~135 lines (now only the OSS-specific signup gate + singleton membership logic). The `computeValidAudiences` unit test moved to `packages/backend-core/src/auth/auth-factory.test.ts`.
+
+Cloud-side adoption ships in a separate cloud-repo PR alongside the @getmunin/* bump to the resulting release.

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -1,27 +1,16 @@
-import { betterAuth } from 'better-auth';
-import { drizzleAdapter } from 'better-auth/adapters/drizzle';
-import { jwt } from 'better-auth/plugins';
-import { oauthProvider } from '@better-auth/oauth-provider';
 import { APIError } from 'better-auth/api';
-import { SUPPORTED_SCOPES as BACKEND_SUPPORTED_SCOPES } from '@getmunin/backend-core';
-
-type BetterAuthInstance = ReturnType<typeof betterAuth>;
-
-const SUPPORTED_SCOPES = [
-  'openid',
-  'profile',
-  'email',
-  'offline_access',
-  ...BACKEND_SUPPORTED_SCOPES,
-] as const;
-
-const asMuninAuth = (instance: unknown): BetterAuthInstance => instance as BetterAuthInstance;
+import {
+  createMuninAuthCore,
+  type MuninAuthInstance,
+  type SignupBeforeUser,
+  type SignupHookUser,
+} from '@getmunin/backend-core';
 import { schema, type Db } from '@getmunin/db';
 import type { Mailer } from '@getmunin/core';
 import { and, asc, eq, isNull, sql } from 'drizzle-orm';
 import { resetPasswordEmail, verifyEmailEmail } from './email-templates.js';
 
-export type MuninAuth = BetterAuthInstance;
+export type MuninAuth = MuninAuthInstance;
 
 export interface MuninAuthOptions {
   db: Db;
@@ -29,13 +18,7 @@ export interface MuninAuthOptions {
   authSecret: string;
   trustedOrigins?: string[];
   mailer?: Mailer;
-  /** URL of the dashboard, used to build verification + reset links. */
   webBaseUrl?: string;
-  /**
-   * Lowercase email domains permitted to self-register without an invite.
-   * Empty = invite-only. The first user to sign up bootstraps the singleton
-   * org regardless of this allowlist.
-   */
   allowedEmailDomains?: string[];
 }
 
@@ -47,97 +30,31 @@ export function createMuninAuth({
   mailer,
   webBaseUrl,
   allowedEmailDomains = [],
-}: MuninAuthOptions): BetterAuthInstance {
-  const origins = uniqueOrigins([baseUrl, ...(trustedOrigins ?? [])]);
-  const dashboardUrl = (webBaseUrl ?? trustedOrigins?.[0] ?? baseUrl).replace(/\/+$/, '');
-  const validAudiences = computeValidAudiences(baseUrl);
-
-  return asMuninAuth(betterAuth({
-    baseURL: baseUrl,
-    basePath: '/auth',
-    secret: authSecret,
-    database: drizzleAdapter(db, {
-      provider: 'pg',
-      schema: {
-        user: schema.users,
-        session: schema.sessions,
-        account: schema.accounts,
-        verification: schema.verifications,
-        oauthClient: schema.oauthClient,
-        oauthAccessToken: schema.oauthAccessToken,
-        oauthRefreshToken: schema.oauthRefreshToken,
-        oauthConsent: schema.oauthConsent,
-        jwks: schema.jwks,
-      },
-    }),
-    plugins: [
-      jwt({ jwt: { issuer: baseUrl.replace(/\/+$/, '') } }),
-      oauthProvider({
-        loginPage: `${dashboardUrl}/login`,
-        consentPage: `${dashboardUrl}/dashboard/oauth/consent`,
-        allowDynamicClientRegistration: true,
-        allowUnauthenticatedClientRegistration: true,
-        scopes: [...SUPPORTED_SCOPES],
-        validAudiences,
-        silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
-      }),
-    ],
-    emailAndPassword: {
-      enabled: true,
-      requireEmailVerification: false,
-      autoSignIn: true,
-      sendResetPassword: mailer
-        ? async ({ user, url }: { user: { email: string }; url: string }) => {
-            const tpl = resetPasswordEmail(url);
-            await mailer.send({
-              to: user.email,
-              subject: tpl.subject,
-              text: tpl.text,
-            });
-          }
-        : undefined,
-    },
-    emailVerification: mailer
-      ? {
-          sendVerificationEmail: async ({ user, url }: { user: { email: string }; url: string }) => {
-            const tpl = verifyEmailEmail(url);
-            await mailer.send({
-              to: user.email,
-              subject: tpl.subject,
-              text: tpl.text,
-            });
-          },
-          sendOnSignUp: true,
+}: MuninAuthOptions): MuninAuthInstance {
+  return createMuninAuthCore({
+    db,
+    baseUrl,
+    authSecret,
+    trustedOrigins,
+    webBaseUrl,
+    sendResetPassword: mailer
+      ? async ({ user, url }) => {
+          const tpl = resetPasswordEmail(url);
+          await mailer.send({ to: user.email, subject: tpl.subject, text: tpl.text });
         }
       : undefined,
-    trustedOrigins: origins,
-    advanced: {
-      useSecureCookies: dashboardUrl.startsWith('https://'),
-    },
-    databaseHooks: {
-      user: {
-        create: {
-          before: async (user: { email: string; name?: string | null }) => {
-            await assertSignupAllowed(db, user.email, allowedEmailDomains);
-          },
-          after: async (user: { id: string; email: string; name?: string | null }) => {
-            await ensureSingletonOrgMembershipFor(db, user);
-          },
-        },
-      },
-    },
-  }));
+    sendVerificationEmail: mailer
+      ? async ({ user, url }) => {
+          const tpl = verifyEmailEmail(url);
+          await mailer.send({ to: user.email, subject: tpl.subject, text: tpl.text });
+        }
+      : undefined,
+    signupBefore: (user: SignupBeforeUser) =>
+      assertSignupAllowed(db, user.email, allowedEmailDomains),
+    signupAfter: (user: SignupHookUser) => ensureSingletonOrgMembershipFor(db, user),
+  });
 }
 
-/**
- * Gate signup. Allowed when:
- *   1. There are no users yet (first-run bootstrap — this user becomes admin).
- *   2. The email domain is in MUNIN_ALLOWED_EMAIL_DOMAINS.
- *   3. There is a pending, unrevoked, unexpired invitation for this email.
- *
- * Otherwise reject. Public deployments without an allowlist are invite-only —
- * strangers can't self-serve into the singleton org.
- */
 async function assertSignupAllowed(
   db: Db,
   rawEmail: string,
@@ -145,9 +62,7 @@ async function assertSignupAllowed(
 ): Promise<void> {
   const email = rawEmail.trim().toLowerCase();
 
-  const userCount = await db
-    .select({ c: sql<number>`count(*)::int` })
-    .from(schema.users);
+  const userCount = await db.select({ c: sql<number>`count(*)::int` }).from(schema.users);
   if ((userCount[0]?.c ?? 0) === 0) return;
 
   const domain = email.split('@')[1] ?? '';
@@ -181,12 +96,6 @@ async function assertSignupAllowed(
   });
 }
 
-/**
- * OSS single-tenant: ensure the one shared org exists, then attach the
- * user as a member. The first user becomes `owner`; subsequent users
- * become `member`. Idempotent — skips if the user already has any
- * membership (e.g. they came in via an invitation that pre-attached them).
- */
 async function ensureSingletonOrgMembershipFor(
   db: Db,
   user: { id: string; email: string; name?: string | null },
@@ -227,23 +136,6 @@ async function ensureSingletonOrgMembershipFor(
       .insert(schema.orgMembers)
       .values({ orgId: orgRow!.id, userId: user.id, role, isDefault: true });
   });
-}
-
-function uniqueOrigins(values: string[]): string[] {
-  return Array.from(new Set(values.map((v) => v.replace(/\/+$/, ''))));
-}
-
-export function computeValidAudiences(baseUrl: string): string[] {
-  const canonical = baseUrl.replace(/\/+$/, '');
-  const variants = new Set<string>([canonical, `${canonical}/`]);
-  try {
-    const origin = new URL(canonical).origin;
-    variants.add(origin);
-    variants.add(`${origin}/`);
-  } catch (err) {
-    console.warn('[auth] computeValidAudiences: baseUrl is not a parseable URL', { baseUrl, err });
-  }
-  return Array.from(variants);
 }
 
 export function readAllowedEmailDomainsFromEnv(): string[] {

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -44,6 +44,7 @@
     "@getmunin/db": "workspace:*",
     "@getmunin/mcp-toolkit": "workspace:*",
     "@getmunin/types": "workspace:*",
+    "@better-auth/oauth-provider": "^1.6.10",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@nestjs/common": "^11.1.19",
     "@nestjs/core": "^11.1.19",

--- a/packages/backend-core/src/auth/auth-factory.test.ts
+++ b/packages/backend-core/src/auth/auth-factory.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeValidAudiences } from './auth.config.js';
+import { computeValidAudiences } from './auth-factory.js';
 
 describe('computeValidAudiences', () => {
   it('returns canonical URL plus trailing-slash variant when baseUrl has a path', () => {

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -1,0 +1,188 @@
+import { betterAuth, type BetterAuthOptions } from 'better-auth';
+import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { jwt } from 'better-auth/plugins';
+import { oauthProvider } from '@better-auth/oauth-provider';
+import { schema, type Db } from '@getmunin/db';
+import { SUPPORTED_SCOPES as MUNIN_SUPPORTED_SCOPES } from '../oauth/oauth.constants.js';
+
+type BetterAuthInstance = ReturnType<typeof betterAuth>;
+
+export const STANDARD_OIDC_SCOPES = ['openid', 'profile', 'email', 'offline_access'] as const;
+
+export const SUPPORTED_AUTH_SCOPES = [
+  ...STANDARD_OIDC_SCOPES,
+  ...MUNIN_SUPPORTED_SCOPES,
+] as const;
+
+export interface SignupHookUser {
+  id: string;
+  email: string;
+  name?: string | null;
+}
+
+export interface SignupBeforeUser {
+  email: string;
+  name?: string | null;
+}
+
+export interface DeleteUserConfig {
+  beforeDelete?: (user: { id: string; email: string }) => Promise<void>;
+  sendDeleteAccountVerification?: (params: {
+    user: { email: string };
+    url: string;
+  }) => Promise<void>;
+}
+
+export interface MuninAuthCoreOptions {
+  db: Db;
+  baseUrl: string;
+  authSecret: string;
+  trustedOrigins?: string[];
+  webBaseUrl?: string;
+
+  sendResetPassword?: (params: { user: { email: string }; url: string }) => Promise<void>;
+  sendVerificationEmail?: (params: { user: { email: string }; url: string }) => Promise<void>;
+
+  signupBefore?: (user: SignupBeforeUser) => Promise<void>;
+  signupAfter?: (user: SignupHookUser) => Promise<void>;
+
+  deleteUser?: DeleteUserConfig;
+
+  socialProviders?: {
+    google?: { clientId: string; clientSecret: string };
+    github?: { clientId: string; clientSecret: string };
+  };
+
+  crossSubDomainCookies?: { domain: string };
+
+  rateLimit?: BetterAuthOptions['rateLimit'];
+}
+
+export type MuninAuthInstance = BetterAuthInstance;
+
+const asMuninAuth = (instance: unknown): MuninAuthInstance => instance as MuninAuthInstance;
+
+export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstance {
+  const origins = uniqueOrigins([opts.baseUrl, ...(opts.trustedOrigins ?? [])]);
+  const dashboardUrl = (opts.webBaseUrl ?? opts.trustedOrigins?.[0] ?? opts.baseUrl).replace(
+    /\/+$/,
+    '',
+  );
+  const validAudiences = computeValidAudiences(opts.baseUrl);
+  const issuer = opts.baseUrl.replace(/\/+$/, '');
+
+  const socialProviders = buildSocialProviders(opts.socialProviders);
+
+  return asMuninAuth(betterAuth({
+    baseURL: opts.baseUrl,
+    basePath: '/auth',
+    secret: opts.authSecret,
+    rateLimit: opts.rateLimit,
+    database: drizzleAdapter(opts.db, {
+      provider: 'pg',
+      schema: {
+        user: schema.users,
+        session: schema.sessions,
+        account: schema.accounts,
+        verification: schema.verifications,
+        oauthClient: schema.oauthClient,
+        oauthAccessToken: schema.oauthAccessToken,
+        oauthRefreshToken: schema.oauthRefreshToken,
+        oauthConsent: schema.oauthConsent,
+        jwks: schema.jwks,
+      },
+    }),
+    plugins: [
+      jwt({ jwt: { issuer } }),
+      oauthProvider({
+        loginPage: `${dashboardUrl}/login`,
+        consentPage: `${dashboardUrl}/dashboard/oauth/consent`,
+        allowDynamicClientRegistration: true,
+        allowUnauthenticatedClientRegistration: true,
+        scopes: [...SUPPORTED_AUTH_SCOPES],
+        validAudiences,
+        silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
+      }),
+    ],
+    emailAndPassword: {
+      enabled: true,
+      requireEmailVerification: false,
+      autoSignIn: true,
+      sendResetPassword: opts.sendResetPassword,
+    },
+    emailVerification: opts.sendVerificationEmail
+      ? {
+          sendVerificationEmail: opts.sendVerificationEmail,
+          sendOnSignUp: true,
+        }
+      : undefined,
+    socialProviders,
+    user: opts.deleteUser
+      ? {
+          deleteUser: {
+            enabled: true,
+            beforeDelete: opts.deleteUser.beforeDelete,
+            sendDeleteAccountVerification: opts.deleteUser.sendDeleteAccountVerification,
+          },
+        }
+      : undefined,
+    trustedOrigins: origins,
+    advanced: {
+      useSecureCookies: dashboardUrl.startsWith('https://'),
+      ...(opts.crossSubDomainCookies
+        ? {
+            crossSubDomainCookies: {
+              enabled: true,
+              domain: opts.crossSubDomainCookies.domain,
+            },
+          }
+        : {}),
+    },
+    databaseHooks:
+      opts.signupBefore || opts.signupAfter
+        ? {
+            user: {
+              create: {
+                before: opts.signupBefore,
+                after: opts.signupAfter,
+              },
+            },
+          }
+        : undefined,
+  }));
+}
+
+export function computeValidAudiences(baseUrl: string): string[] {
+  const canonical = baseUrl.replace(/\/+$/, '');
+  const variants = new Set<string>([canonical, `${canonical}/`]);
+  try {
+    const origin = new URL(canonical).origin;
+    variants.add(origin);
+    variants.add(`${origin}/`);
+  } catch (err) {
+    console.warn('[auth-factory] computeValidAudiences: baseUrl is not a parseable URL', {
+      baseUrl,
+      err,
+    });
+  }
+  return Array.from(variants);
+}
+
+function uniqueOrigins(values: string[]): string[] {
+  return Array.from(new Set(values.map((v) => v.replace(/\/+$/, ''))));
+}
+
+function buildSocialProviders(
+  cfg: MuninAuthCoreOptions['socialProviders'],
+): BetterAuthOptions['socialProviders'] | undefined {
+  if (!cfg) return undefined;
+  if (!cfg.google && !cfg.github) return undefined;
+  return {
+    ...(cfg.google
+      ? { google: { clientId: cfg.google.clientId, clientSecret: cfg.google.clientSecret } }
+      : {}),
+    ...(cfg.github
+      ? { github: { clientId: cfg.github.clientId, clientSecret: cfg.github.clientSecret } }
+      : {}),
+  };
+}

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -17,6 +17,18 @@ export {
 } from './auth-env.js';
 
 export {
+  createMuninAuthCore,
+  computeValidAudiences,
+  STANDARD_OIDC_SCOPES,
+  SUPPORTED_AUTH_SCOPES,
+  type MuninAuthCoreOptions,
+  type MuninAuthInstance,
+  type SignupHookUser,
+  type SignupBeforeUser,
+  type DeleteUserConfig,
+} from './auth/auth-factory.js';
+
+export {
   AuthGuard,
   AllowAnonymous,
   type AuthenticatedRequest,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,6 +388,9 @@ importers:
 
   packages/backend-core:
     dependencies:
+      '@better-auth/oauth-provider':
+        specifier: ^1.6.10
+        version: 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.10(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@2.1.9(@types/node@22.19.17)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@24.1.3)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)))(better-call@1.3.5(zod@4.3.6))
       '@getmunin/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

Closes a recurring drift problem: cloud has its own \`cloud-auth.ts\` because its tenancy model genuinely differs from OSS (personal-org-per-signup vs single-shared-org-with-invite-gate), but the OAuth-protocol config (\`oauthProvider\` block, \`validAudiences\`, JWT issuer, supported scopes, JWKS schema mapping) was copy-pasted between the two files. The copy drifted twice:

- **#208**: OSS audience mismatch fixed; cloud got mirrored fix in #111.
- **#213**: OSS got variant-tolerance fix (\`{canonical, +slash, origin, origin+/}\`); cloud *never* got it, which is why claude.ai's \`/auth/oauth2/token\` failed on cloud-dev right after the 4.9.0 bump.

This PR extracts a shared \`createMuninAuthCore\` factory in \`@getmunin/backend-core/auth\` that owns the OAuth-protocol config in one place. Both consumers now pass the genuinely-divergent bits as options:

| Option | OSS passes | Cloud passes |
|---|---|---|
| \`signupBefore(user)\` | invite-gate check | (nothing — open signup) |
| \`signupAfter(user)\` | singleton-org membership | personal-org provisioning |
| \`sendResetPassword\` | OSS template copy | cloud template copy |
| \`sendVerificationEmail\` | OSS template copy | cloud template copy |
| \`deleteUser\` | (none) | account-deletion cleanup + email |
| \`socialProviders\` | (none) | Google + GitHub |
| \`crossSubDomainCookies\` | (none) | \`*.getmunin.com\` |
| \`rateLimit\` | (default) | env-toggled for tests |

\`computeValidAudiences\` is now exported from \`@getmunin/backend-core\` directly. Its variant set (\`{canonical, canonical/, origin, origin/}\`) is the canonical source of truth — any future audience-tolerance change happens once.

OSS \`apps/backend/src/auth/auth.config.ts\` slimmed from ~250 to ~135 lines (only OSS-specific signup gate + singleton membership logic remain). \`computeValidAudiences\` unit test moved alongside the factory.

## Follow-up

A separate cloud-repo PR will bump \`@getmunin/*\` to the resulting release and refactor \`packages/cloud-onboarding/src/cloud-auth.ts\` to use the same factory. That replaces the pending cloud PR #115 which was a one-spot fix for the symptom but didn't solve the drift root cause.

## Test plan

- [x] \`pnpm typecheck\` clean across 15 packages
- [x] \`computeValidAudiences\` unit tests (5/5) pass at the new location
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)