### PR TITLE
test(backend-core): close the biggest MCP tool coverage gaps

### DIFF
--- a/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
+++ b/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
@@ -1,0 +1,167 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { AppModule } from '../app.module.js';
+import { McpRegistryService } from './mcp.registry.js';
+import { McpSkillRegistryService } from './mcp.skill-registry.service.js';
+import { DB } from '../common/db/db.module.js';
+import { openAdminAgentMcpClient, type AgentMcpClient } from '../agent/in-process-context.js';
+import type { Db } from '@getmunin/db';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run MCP tools smoke tests.';
+
+const EXPECTED_BY_MODULE: Record<string, RegExp> = {
+  kb: /^kb_/,
+  conv: /^conv_/,
+  crm: /^crm_/,
+  cms: /^cms_/,
+  outreach: /^outreach_/,
+};
+
+const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
+  kb: 12,
+  conv: 25,
+  crm: 25,
+  cms: 20,
+  outreach: 7,
+};
+
+(skipReason ? describe.skip : describe)('MCP tools smoke: registry shape across all modules', () => {
+  let app: INestApplication;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let admin: AgentMcpClient;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'MCP Smoke IT Org' })
+      .returning();
+    orgId = org!.id;
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.init();
+
+    const registry = app.get(McpRegistryService);
+    const skills = app.get(McpSkillRegistryService);
+    const appDb = app.get<Db>(DB);
+    admin = openAdminAgentMcpClient({ db: appDb, orgId, registry, skills });
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  describe('every registered tool has a well-formed shape', () => {
+    it('all tools expose a non-empty name, description, and object inputSchema', async () => {
+      const tools = await admin.listTools();
+      expect(tools.length).toBeGreaterThan(0);
+      for (const t of tools) {
+        expect(t.name, `tool with empty name in registry`).toMatch(/^[a-z][a-z0-9_]+$/);
+        expect(t.description?.length ?? 0, `${t.name}: description empty`).toBeGreaterThan(0);
+        const schema = t.inputSchema as { type?: string; properties?: Record<string, unknown> };
+        expect(schema.type, `${t.name}: inputSchema.type must be 'object'`).toBe('object');
+        expect(typeof t.annotations.title).toBe('string');
+        expect(typeof t.annotations.readOnlyHint).toBe('boolean');
+        expect(typeof t.annotations.destructiveHint).toBe('boolean');
+      }
+    });
+
+    it('every tool name follows the <module>_<verb> convention or is a known utility', async () => {
+      const tools = await admin.listTools();
+      const KNOWN_PREFIXES = Object.values(EXPECTED_BY_MODULE);
+      const UTILITY_TOOLS = new Set(['ping']);
+      for (const t of tools) {
+        if (UTILITY_TOOLS.has(t.name)) continue;
+        const matchesAny = KNOWN_PREFIXES.some((re) => re.test(t.name));
+        expect(matchesAny, `${t.name} doesn't match any known module prefix`).toBe(true);
+      }
+    });
+
+    it('every tool with module prefix has a title that starts with the matching display label', async () => {
+      const LABELS: Record<string, string> = {
+        kb: 'KB:',
+        conv: 'Conv:',
+        crm: 'CRM:',
+        cms: 'CMS:',
+        outreach: 'Outreach:',
+      };
+      const tools = await admin.listTools();
+      for (const t of tools) {
+        for (const [mod, re] of Object.entries(EXPECTED_BY_MODULE)) {
+          if (re.test(t.name)) {
+            const label = LABELS[mod]!;
+            expect(
+              t.annotations.title.startsWith(label),
+              `${t.name}: title "${t.annotations.title}" must start with "${label}"`,
+            ).toBe(true);
+            break;
+          }
+        }
+      }
+    });
+  });
+
+  describe('module coverage thresholds', () => {
+    for (const [mod, re] of Object.entries(EXPECTED_BY_MODULE)) {
+      it(`${mod} exposes at least ${MIN_EXPECTED_PER_MODULE[mod]} tools`, async () => {
+        const tools = await admin.listTools();
+        const count = tools.filter((t) => re.test(t.name)).length;
+        expect(count).toBeGreaterThanOrEqual(MIN_EXPECTED_PER_MODULE[mod]!);
+      });
+    }
+  });
+
+  describe('listing-style tools with empty inputs return cleanly for an empty org', () => {
+    const SMOKE_LIST_TOOLS = [
+      'kb_list_spaces',
+      'conv_list_conversation_channels',
+      'conv_list_conversation_topics',
+      'crm_list_contacts',
+      'crm_list_companies',
+      'crm_list_sales_pipelines',
+      'crm_list_crm_segments',
+      'cms_list_collections',
+      'cms_list_locales',
+      'outreach_list_campaigns',
+      'outreach_list_proposals',
+    ];
+
+    for (const name of SMOKE_LIST_TOOLS) {
+      it(`${name} returns without isError on a fresh org`, async () => {
+        const tools = await admin.listTools();
+        if (!tools.some((t) => t.name === name)) {
+          return;
+        }
+        const result = await admin.callTool(name, {});
+        const dumped = JSON.stringify(result);
+        expect(
+          result.isError,
+          `${name} returned isError on empty org. Raw: ${dumped.slice(0, 400)}`,
+        ).not.toBe(true);
+      });
+    }
+  });
+});

--- a/packages/backend-core/src/modules/kb/kb.integration.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.integration.test.ts
@@ -1,0 +1,248 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { AppModule } from '../../app.module.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run KB integration tests.';
+
+(skipReason ? describe.skip : describe)('KB integration: document lifecycle via /mcp', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let adminKey: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'KB IT Org' })
+      .returning();
+    orgId = org!.id;
+
+    adminKey = buildApiKey('admin');
+    await db.insert(schema.apiKeys).values({
+      orgId,
+      type: 'admin',
+      name: 'kb-it-admin',
+      keyHash: hashSecret(adminKey),
+      keyPrefix: keyPrefix(adminKey),
+      scopes: ['*'],
+    });
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  async function withClient<T>(token: string, fn: (c: Client) => Promise<T>): Promise<T> {
+    const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+      requestInit: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const c = new Client({ name: 'kb-it', version: '0.0.0' });
+    await c.connect(transport);
+    try {
+      return await fn(c);
+    } finally {
+      await transport.close();
+      await c.close();
+    }
+  }
+
+  function firstJson(result: { content: Array<{ type: string; text?: string }> }): unknown {
+    for (const item of result.content) {
+      if (item.type === 'text' && typeof item.text === 'string') {
+        try {
+          return JSON.parse(item.text);
+        } catch {
+          return item.text;
+        }
+      }
+    }
+    return null;
+  }
+
+  it('full doc lifecycle: create space → create doc → search → update with ifVersion → list versions → restore', async () => {
+    await withClient(adminKey, async (c) => {
+      const spaceRes = await c.callTool({
+        name: 'kb_create_space',
+        arguments: {
+          name: 'Engineering wiki',
+          slug: 'engineering',
+          description: 'Internal engineering docs.',
+        },
+      });
+      const space = firstJson(spaceRes as never) as { id: string; slug: string };
+      expect(space.id).toMatch(/^ksp_/);
+      expect(space.slug).toBe('engineering');
+
+      const created = await c.callTool({
+        name: 'kb_create_document',
+        arguments: {
+          spaceId: space.id,
+          title: 'How we deploy',
+          slug: 'how-we-deploy',
+          body: 'We use blue-green deploys with terraform.',
+          audiences: ['admin'],
+          tags: ['ops'],
+        },
+      });
+      const doc = firstJson(created as never) as { id: string; version: number };
+      expect(doc.id).toMatch(/^kdoc_/);
+      expect(doc.version).toBe(1);
+
+      const searched = await c.callTool({
+        name: 'kb_search',
+        arguments: { query: 'blue-green deploy' },
+      });
+      const hits = firstJson(searched as never) as Array<{ documentId: string }>;
+      expect(hits.length).toBeGreaterThanOrEqual(1);
+      expect(hits.some((h) => h.documentId === doc.id)).toBe(true);
+
+      const updated = await c.callTool({
+        name: 'kb_update_document',
+        arguments: {
+          id: doc.id,
+          ifVersion: doc.version,
+          body: 'We use blue-green deploys with terraform and feature flags.',
+        },
+      });
+      const updatedDoc = firstJson(updated as never) as { version: number };
+      expect(updatedDoc.version).toBe(2);
+
+      const staleUpdate = await c.callTool({
+        name: 'kb_update_document',
+        arguments: {
+          id: doc.id,
+          ifVersion: 1,
+          body: 'Stale update should fail',
+        },
+      });
+      expect(staleUpdate.isError).toBe(true);
+
+      const versions = await c.callTool({
+        name: 'kb_list_versions',
+        arguments: { documentId: doc.id },
+      });
+      const versionList = firstJson(versions as never) as Array<{ version: number }>;
+      expect(Array.isArray(versionList), `expected array, got ${JSON.stringify(versionList)}`).toBe(true);
+      expect(versionList.length).toBeGreaterThanOrEqual(1);
+      expect(versionList.map((v) => v.version)).toContain(1);
+
+      const restored = await c.callTool({
+        name: 'kb_restore_version',
+        arguments: { documentId: doc.id, version: 1, ifVersion: 2 },
+      });
+      const restoredDoc = firstJson(restored as never) as { version: number; body: string };
+      expect(restoredDoc.version).toBe(3);
+      expect(restoredDoc.body).toBe('We use blue-green deploys with terraform.');
+    });
+  });
+
+  it('get_document_by_slug returns the doc when the slug exists', async () => {
+    await withClient(adminKey, async (c) => {
+      const spaceRes = await c.callTool({
+        name: 'kb_create_space',
+        arguments: { name: 'Lookup space', slug: 'lookup', description: 'Lookup tests.' },
+      });
+      const space = firstJson(spaceRes as never) as { id: string; slug: string };
+
+      await c.callTool({
+        name: 'kb_create_document',
+        arguments: {
+          spaceId: space.id,
+          title: 'Findable by slug',
+          slug: 'findable',
+          body: 'This document is meant to be found.',
+          audiences: ['admin'],
+          tags: [],
+        },
+      });
+
+      const found = await c.callTool({
+        name: 'kb_get_document_by_slug',
+        arguments: { spaceSlug: space.slug, slug: 'findable' },
+      });
+      const doc = firstJson(found as never) as { slug: string; title: string };
+      expect(doc.slug).toBe('findable');
+      expect(doc.title).toBe('Findable by slug');
+    });
+  });
+
+  it('delete_document removes the doc and search no longer returns it', async () => {
+    await withClient(adminKey, async (c) => {
+      const spaceRes = await c.callTool({
+        name: 'kb_create_space',
+        arguments: { name: 'Trash space', slug: 'trash', description: 'Delete tests.' },
+      });
+      const space = firstJson(spaceRes as never) as { id: string };
+
+      const created = await c.callTool({
+        name: 'kb_create_document',
+        arguments: {
+          spaceId: space.id,
+          title: 'Soon to be deleted',
+          slug: 'doomed',
+          body: 'Some text with the word "unique-marker-xqz" inside.',
+          audiences: ['admin'],
+          tags: [],
+        },
+      });
+      const doc = firstJson(created as never) as { id: string; version: number };
+
+      const beforeDelete = await c.callTool({
+        name: 'kb_search',
+        arguments: { query: 'unique-marker-xqz' },
+      });
+      const beforeHits = firstJson(beforeDelete as never) as Array<{ documentId: string }>;
+      expect(Array.isArray(beforeHits)).toBe(true);
+
+      const deleted = await c.callTool({
+        name: 'kb_delete_document',
+        arguments: { id: doc.id, ifVersion: doc.version },
+      });
+      expect(deleted.isError).not.toBe(true);
+
+      const afterDelete = await c.callTool({
+        name: 'kb_search',
+        arguments: { query: 'unique-marker-xqz' },
+      });
+      const afterHits = firstJson(afterDelete as never) as Array<{ documentId: string }>;
+      expect(Array.isArray(afterHits)).toBe(true);
+      expect(afterHits.some((h) => h.documentId === doc.id)).toBe(false);
+    });
+  });
+});

--- a/packages/backend-core/src/modules/outreach/outreach.integration.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.integration.test.ts
@@ -1,0 +1,332 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { AppModule } from '../../app.module.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run Outreach integration tests.';
+
+(skipReason ? describe.skip : describe)('Outreach integration: admin tools via /mcp', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let adminKey: string;
+  let channelId: string;
+  let segmentId: string;
+  let contactId: string;
+  let conversationId: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Outreach IT Org' })
+      .returning();
+    orgId = org!.id;
+
+    adminKey = buildApiKey('admin');
+    await db.insert(schema.apiKeys).values({
+      orgId,
+      type: 'admin',
+      name: 'outreach-it-admin',
+      keyHash: hashSecret(adminKey),
+      keyPrefix: keyPrefix(adminKey),
+      scopes: ['*'],
+    });
+
+    const [ch] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'email',
+        vendor: 'smtp',
+        name: 'support',
+        active: true,
+        config: { addressing: { fromAddress: 'support@example.com' } },
+      })
+      .returning();
+    channelId = ch!.id;
+
+    const [seg] = await db
+      .insert(schema.crmSegments)
+      .values({
+        orgId,
+        name: 'priority-prospects',
+        description: null,
+        filterDefinition: { tagsAny: ['priority'] },
+        createdByActorType: 'admin_agent',
+        createdByActorId: 'outreach-it-setup',
+      })
+      .returning();
+    segmentId = seg!.id;
+
+    const [contact] = await db
+      .insert(schema.crmContacts)
+      .values({
+        orgId,
+        name: 'Jane Doe',
+        email: 'jane@acme.com',
+        consentLawfulBasis: 'legitimate_interest',
+        consentGivenAt: new Date(),
+        consentSource: 'imported-test',
+        tags: ['priority'],
+      })
+      .returning();
+    contactId = contact!.id;
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  async function withClient<T>(token: string, fn: (c: Client) => Promise<T>): Promise<T> {
+    const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+      requestInit: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const c = new Client({ name: 'outreach-it', version: '0.0.0' });
+    await c.connect(transport);
+    try {
+      return await fn(c);
+    } finally {
+      await transport.close();
+      await c.close();
+    }
+  }
+
+  function firstJson(result: { content: Array<{ type: string; text?: string }> }): unknown {
+    for (const item of result.content) {
+      if (item.type === 'text' && typeof item.text === 'string') {
+        try {
+          return JSON.parse(item.text);
+        } catch {
+          return item.text;
+        }
+      }
+    }
+    return null;
+  }
+
+  it('discovers all 7 outreach tools on tools/list', async () => {
+    await withClient(adminKey, async (c) => {
+      const { tools } = await c.listTools();
+      const names = tools.map((t) => t.name).filter((n) => n.startsWith('outreach_')).sort();
+      expect(names).toEqual(
+        [
+          'outreach_create_campaign',
+          'outreach_get_campaign',
+          'outreach_list_campaigns',
+          'outreach_list_proposals',
+          'outreach_propose_initial',
+          'outreach_propose_reply',
+          'outreach_update_campaign',
+        ].sort(),
+      );
+    });
+  });
+
+  it('full admin flow: list (empty) → create → get → update → list (1) → propose_initial → list_proposals', async () => {
+    let campaignId = '';
+    let proposalId = '';
+
+    await withClient(adminKey, async (c) => {
+      const empty = await c.callTool({ name: 'outreach_list_campaigns', arguments: {} });
+      const emptyList = firstJson(empty as never) as unknown[];
+      expect(Array.isArray(emptyList)).toBe(true);
+      expect(emptyList).toHaveLength(0);
+
+      const created = await c.callTool({
+        name: 'outreach_create_campaign',
+        arguments: {
+          name: 'Q2 outreach',
+          brief: 'Re-engage prospects who showed interest last quarter.',
+          segmentId,
+          channelId,
+        },
+      });
+      const campaign = firstJson(created as never) as { id: string; name: string; enabled: boolean };
+      expect(campaign.id).toMatch(/^ocmp_/);
+      expect(campaign.name).toBe('Q2 outreach');
+      expect(campaign.enabled).toBe(false);
+      campaignId = campaign.id;
+
+      const got = await c.callTool({
+        name: 'outreach_get_campaign',
+        arguments: { id: campaignId },
+      });
+      const gotCampaign = firstJson(got as never) as { id: string; brief: string };
+      expect(gotCampaign.id).toBe(campaignId);
+      expect(gotCampaign.brief).toContain('Re-engage');
+
+      const updated = await c.callTool({
+        name: 'outreach_update_campaign',
+        arguments: { id: campaignId, patch: { enabled: true } },
+      });
+      const updatedCampaign = firstJson(updated as never) as { enabled: boolean };
+      expect(updatedCampaign.enabled).toBe(true);
+
+      const populated = await c.callTool({ name: 'outreach_list_campaigns', arguments: {} });
+      const populatedList = firstJson(populated as never) as Array<{ id: string }>;
+      expect(populatedList.map((r) => r.id)).toContain(campaignId);
+
+      const proposed = await c.callTool({
+        name: 'outreach_propose_initial',
+        arguments: {
+          campaignId,
+          contactId,
+          draftSubject: 'Hi Jane',
+          draftBody: 'We just shipped X — would you like a quick demo?',
+        },
+      });
+      const proposal = firstJson(proposed as never) as { id: string; status: string; kind: string };
+      expect(proposal.id).toMatch(/^oprp_/);
+      expect(proposal.status).toBe('pending');
+      expect(proposal.kind).toBe('initial');
+      proposalId = proposal.id;
+
+      const listed = await c.callTool({
+        name: 'outreach_list_proposals',
+        arguments: { status: 'pending' },
+      });
+      const proposals = firstJson(listed as never) as Array<{
+        id: string;
+        contact?: { email?: string };
+      }>;
+      expect(proposals.map((p) => p.id)).toContain(proposalId);
+      const ours = proposals.find((p) => p.id === proposalId);
+      expect(ours?.contact?.email).toBe('jane@acme.com');
+    });
+  });
+
+  it('propose_reply requires a conversation with outreachCampaignId set', async () => {
+    const [convContact] = await db
+      .insert(schema.convContacts)
+      .values({
+        orgId,
+        email: 'jane@acme.com',
+        name: 'Jane Doe',
+      })
+      .returning();
+    const nextDisplay = await db.execute<{ next: number }>(
+      sql`SELECT conv_next_display_id(${orgId}) AS next`,
+    );
+    const [conv] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        channelId,
+        contactId: convContact!.id,
+        displayId: nextDisplay[0]!.next,
+        status: 'open',
+        outreachCampaignId: null,
+      })
+      .returning();
+    conversationId = conv!.id;
+
+    await withClient(adminKey, async (c) => {
+      const noCampaign = await c.callTool({
+        name: 'outreach_propose_reply',
+        arguments: {
+          conversationId,
+          draftBody: 'Thanks for replying!',
+        },
+      });
+      expect(noCampaign.isError).toBe(true);
+    });
+
+    const [outreachCampaign] = await db
+      .insert(schema.outreachCampaigns)
+      .values({
+        orgId,
+        name: 'reply-flow',
+        brief: 'Reply flow test',
+        segmentId,
+        channelId,
+        enabled: true,
+        unsubscribeRequired: true,
+        createdByActorType: 'admin_agent',
+        createdByActorId: 'outreach-it-setup',
+      })
+      .returning();
+    await db
+      .update(schema.convConversations)
+      .set({ outreachCampaignId: outreachCampaign!.id })
+      .where(sql`id = ${conversationId}`);
+
+    await withClient(adminKey, async (c) => {
+      const proposed = await c.callTool({
+        name: 'outreach_propose_reply',
+        arguments: {
+          conversationId,
+          draftBody: 'Following up with a tailored offer.',
+        },
+      });
+      const raw = JSON.stringify(proposed);
+      const proposal = firstJson(proposed as never) as
+        | { id: string; kind?: string; status?: string }
+        | null;
+      expect(proposed.isError, `expected success, got: ${raw}`).not.toBe(true);
+      expect(proposal?.kind).toBe('reply');
+      expect(proposal?.status).toBe('pending');
+    });
+  });
+
+  it('create_campaign rejects a non-email channel', async () => {
+    const [chatCh] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'chat',
+        vendor: 'munin',
+        name: 'web-widget-reject',
+        active: true,
+        config: {},
+      })
+      .returning();
+
+    await withClient(adminKey, async (c) => {
+      const result = await c.callTool({
+        name: 'outreach_create_campaign',
+        arguments: {
+          name: 'wrong-channel',
+          brief: 'Should fail',
+          segmentId,
+          channelId: chatCh!.id,
+        },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three new integration test files; no production code changes. All gated on \`TEST_DATABASE_URL\` (skipped without a Postgres test DB, same harness pattern as the existing \`crm.integration.test.ts\` / \`cms.integration.test.ts\` / \`conv.integration.test.ts\`).

### 1. \`packages/backend-core/src/modules/outreach/outreach.integration.test.ts\` (4 tests)

The outreach module was the only module with **zero** MCP-surface or HTTP coverage — service-level unit tests only. Now exercises all 7 admin tools end-to-end:

- \`tools/list\` returns exactly the 7 expected outreach tools.
- Full admin flow: \`list_campaigns\` (empty) → \`create_campaign\` → \`get_campaign\` → \`update_campaign\` (toggle enabled) → \`list_campaigns\` (1) → \`propose_initial\` → \`list_proposals\`.
- \`propose_reply\` against a conversation with \`outreachCampaignId\` set — and rejects when it isn't.
- Error path: \`create_campaign\` rejects a non-email channel.

### 2. \`packages/backend-core/src/mcp/tools-smoke.integration.test.ts\` (19 tests)

Broad shape check using \`openAdminAgentMcpClient\` (in-process — no HTTP, no Nest boot per test). Boots the app once, then for every registered tool asserts:

- Non-empty \`name\` matching \`^[a-z][a-z0-9_]+$\`.
- Non-empty \`description\`.
- \`inputSchema.type === 'object'\`.
- Well-formed annotations (\`title\`, \`readOnlyHint\`, \`destructiveHint\`).
- Title starts with the matching module display label (\`KB:\`, \`Conv:\`, \`CRM:\`, \`CMS:\`, \`Outreach:\`).

Plus per-module minimum-count guardrails so accidental deletions are caught, plus 11 listing-style tools smoked against a fresh org to assert they return without \`isError\`.

### 3. \`packages/backend-core/src/modules/kb/kb.integration.test.ts\` (3 tests)

KB was the only module without its own integration test file — covered only via the cross-cutting \`mcp.integration.test.ts\`. Now covers the full doc lifecycle end-to-end:

- \`create_space\` → \`create_document\` → \`search\` (hits) → \`update_document\` with \`ifVersion\` (and stale \`ifVersion\` rejected) → \`list_versions\` → \`restore_version\`.
- \`get_document_by_slug\` round-trip.
- \`delete_document\` then \`search\` confirms doc no longer hits.

## Verification

- 26 new tests, 26/26 pass locally.
- Workspace typecheck clean across 15 packages.
- Neighbor integration suites (\`crm\`, \`cms\`, \`mcp\`, \`oauth-jwt-resolver\`, \`oauth-conformance\`, \`auth-factory\`) still green — no regression.

## Out of scope

- Per-tool argument-shape fuzzing — the smoke test just asserts schemas are well-formed objects; doesn't fuzz inputs.
- Conv channel-specific scenarios (already covered by 8 dedicated channel integration tests).
- CRM segment-then-list-members scenario — left for a follow-up; \`crm.integration.test.ts\` covers the headline workflow well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)