### PR TITLE
feat(conv/vapi): handle assistant-request — inject prompt + tools + caller context for inbound calls

### DIFF
--- a/.changeset/vapi-assistant-request.md
+++ b/.changeset/vapi-assistant-request.md
@@ -1,0 +1,27 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Handle Vapi `assistant-request` webhook: dynamically inject system prompt + tools + caller context for inbound PSTN calls.
+
+Before this change, inbound calls fell into the webhook's `default` branch and were ignored — Vapi used whatever assistant prompt was pre-configured in its dashboard, with no Munin context. The first Munin learned about the call was when the first transcript turn arrived (which triggers `findOrCreateConversation` lazily).
+
+Now, when Vapi fires `assistant-request` (it's the first event for any call, fired before the assistant speaks), the adapter:
+
+1. **Pre-creates the conversation** by reusing `findOrCreateConversation`, so subsequent transcript / tool-calls events have a known conversationId in `assistantOverrides.metadata`.
+2. **Auto-creates the conv contact + end_user** from the caller's phone (same `findOrCreateContactByPhone` path used elsewhere).
+3. **Looks up the CRM contact** by phone (best-effort).
+4. **Fetches the channel's Vapi assistant config** via `VapiClientService.fetchAssistantConfig` to inherit voice / transcriber / voicemail / recording settings.
+5. **Builds an inline assistant** with:
+   - System prompt = KB `voice-system-prompt` + company profile + caller context (CRM name/email if found, otherwise "first-time caller" note).
+   - The voice opener prompt as a second system message.
+   - The MCP self-service tool surface (`VapiToolBridge.buildToolList()`).
+6. **Returns `{ assistant, assistantOverrides: { metadata: { conversationId, endUserId } } }`** so Vapi uses our inline config for this call and stamps our metadata onto subsequent webhook events.
+
+**Fail-soft:** if any step fails (Vapi API unreachable, KB read error, etc.), the handler returns `{}` and Vapi uses its default assistant. The conversation pre-create runs *before* the Vapi fetch so even on Vapi-fetch failure the conversation row still exists and subsequent transcripts resolve correctly.
+
+**Refactor:** moved `composeVoiceSystemPrompt`, `buildInlineAssistantConfig`, `OrgScopedKbDocReader`, `INHERITED_ASSISTANT_FIELDS` from `widget-voice.service.ts` to a new `vapi-assistant.ts` so both the widget path and the inbound PSTN path share one source. `composeVoiceSystemPrompt` gains an optional `extraContext` parameter for the caller context block.
+
+`runAsSystem` became generic `<T>` so the assistant-request handler can read DB state out of the transaction.
+
+Tests: extended `vapi.integration.test.ts` with two cases — assistant-request creates the conversation + contact + end_user even when the Vapi fetch fails; assistant-request with no `callId` is a no-op.

--- a/packages/backend-core/src/modules/conv/vapi/vapi-adapter.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-adapter.ts
@@ -3,7 +3,15 @@ import { sql, and, eq } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import {
   ActorIdentity,
+  AGENT_RUNTIME_PROMPT_SPACE_SLUG,
+  COMPANY_PROFILE_SLUG,
+  COMPANY_PROFILE_SPACE_SLUG,
+  DEFAULT_VOICE_OPENER_COLD,
+  DEFAULT_VOICE_SYSTEM_PROMPT,
+  VOICE_OPENER_COLD_SLUG,
+  VOICE_SYSTEM_PROMPT_SLUG,
   WebhookDispatcher,
+  createPromptCache,
   withContext,
   type RequestContext,
 } from '@getmunin/core';
@@ -26,6 +34,12 @@ import {
 } from './vapi-client.service.js';
 import { jsonbToStored } from './vapi.service.js';
 import { VapiToolBridge, type VapiToolCall } from './vapi-tool-bridge.js';
+import {
+  OrgScopedKbDocReader,
+  buildInlineAssistantConfig,
+  composeVoiceSystemPrompt,
+  type ChatMessageSeed,
+} from './vapi-assistant.js';
 
 interface VapiServerMessage {
   type: string;
@@ -98,6 +112,10 @@ export class VapiAdapter implements ChannelAdapter {
       'message' in envelope && envelope.message ? envelope.message : (envelope as VapiServerMessage);
 
     switch (msg.type) {
+      case 'assistant-request': {
+        const body = await this.handleAssistantRequest(channel, msg);
+        return { messages: [], responseOverride: body };
+      }
       case 'transcript':
         await this.handleTranscript(channel, msg);
         return { messages: [] };
@@ -120,6 +138,125 @@ export class VapiAdapter implements ChannelAdapter {
       default:
         this.logger.debug(`vapi event ignored: ${msg.type}`);
         return { messages: [] };
+    }
+  }
+
+  private async handleAssistantRequest(
+    channel: ChannelRow,
+    msg: VapiServerMessage,
+  ): Promise<WebhookResponse> {
+    const emptyBody = {
+      status: 200,
+      contentType: 'application/json; charset=utf-8',
+      body: '{}',
+    } satisfies WebhookResponse;
+    try {
+      const callId = msg.call?.id;
+      if (!callId) throw new Error('assistant_request_missing_call_id');
+
+      const { conversationId, endUserId, crmContact } = await this.runAsSystem(
+        channel,
+        async (tx) => {
+          const conversation = await this.findOrCreateConversation(
+            tx,
+            channel,
+            callId,
+            msg.call?.customer,
+          );
+          const phone = msg.call?.customer?.number;
+          let crm: { name: string | null; email: string | null } | null = null;
+          if (phone) {
+            const rows = await tx
+              .select({
+                name: schema.crmContacts.name,
+                email: schema.crmContacts.email,
+              })
+              .from(schema.crmContacts)
+              .where(
+                and(
+                  eq(schema.crmContacts.orgId, channel.orgId),
+                  eq(schema.crmContacts.phone, phone),
+                ),
+              )
+              .limit(1);
+            crm = rows[0] ?? null;
+          }
+          return {
+            conversationId: conversation.id,
+            endUserId: conversation.endUserId,
+            crmContact: crm,
+          };
+        },
+      );
+
+      const config = jsonbToStored(channel.config);
+      const apiKey = await this.client.loadSecret(config.encryptedApiKey);
+      const fetched = await this.client.fetchAssistantConfig({
+        apiKey,
+        assistantId: config.assistantId,
+      });
+      if (!fetched.ok) throw new Error(`fetch_assistant_failed:${fetched.error}`);
+
+      const reader = new OrgScopedKbDocReader(this.db, channel.orgId);
+      const prompts = await createPromptCache({
+        reader,
+        entries: {
+          [VOICE_SYSTEM_PROMPT_SLUG]: {
+            location: {
+              spaceSlug: AGENT_RUNTIME_PROMPT_SPACE_SLUG,
+              slug: VOICE_SYSTEM_PROMPT_SLUG,
+            },
+            fallback: DEFAULT_VOICE_SYSTEM_PROMPT,
+          },
+          [VOICE_OPENER_COLD_SLUG]: {
+            location: {
+              spaceSlug: AGENT_RUNTIME_PROMPT_SPACE_SLUG,
+              slug: VOICE_OPENER_COLD_SLUG,
+            },
+            fallback: DEFAULT_VOICE_OPENER_COLD,
+          },
+          [COMPANY_PROFILE_SLUG]: {
+            location: { spaceSlug: COMPANY_PROFILE_SPACE_SLUG, slug: COMPANY_PROFILE_SLUG },
+          },
+        },
+      });
+
+      const callerContext = formatCallerContext(msg.call?.customer, crmContact);
+      const systemPrompt = composeVoiceSystemPrompt(prompts, conversationId, callerContext);
+      const opener = prompts.get(VOICE_OPENER_COLD_SLUG);
+
+      const messages: ChatMessageSeed[] = [
+        { role: 'system', content: systemPrompt },
+        { role: 'system', content: opener },
+      ];
+
+      const inlineAssistant = buildInlineAssistantConfig({
+        baseConfig: fetched.config,
+        messages,
+        tools: this.tools.buildToolList(),
+      });
+
+      const body = JSON.stringify({
+        assistant: inlineAssistant,
+        assistantOverrides: {
+          metadata: { conversationId, endUserId },
+        },
+      });
+
+      this.logger.log(
+        `vapi assistant-request callId=${callId} convId=${conversationId} crmHit=${
+          crmContact ? 'yes' : 'no'
+        }`,
+      );
+
+      return { status: 200, contentType: 'application/json; charset=utf-8', body };
+    } catch (err) {
+      this.logger.warn(
+        `vapi assistant-request build failed; falling back to default assistant: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return emptyBody;
     }
   }
 
@@ -273,15 +410,15 @@ export class VapiAdapter implements ChannelAdapter {
     }
   }
 
-  private async runAsSystem(
+  private async runAsSystem<T = void>(
     channel: ChannelRow,
-    fn: (tx: Db | Tx) => Promise<void>,
-  ): Promise<void> {
+    fn: (tx: Db | Tx) => Promise<T>,
+  ): Promise<T> {
     const actor = new ActorIdentity('system', 'vapi-webhook', channel.orgId, ['*'], ['admin']);
-    await this.db.transaction(async (tx) => {
+    return this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
       const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
-      await withContext(ctx, () => fn(tx));
+      return withContext(ctx, () => fn(tx));
     });
   }
 
@@ -569,4 +706,24 @@ function jsonResponse(body: unknown): WebhookResponse {
     contentType: 'application/json; charset=utf-8',
     body: JSON.stringify(body),
   };
+}
+
+function formatCallerContext(
+  customer: VapiServerMessage['call'] extends infer C
+    ? C extends { customer?: infer X }
+      ? X
+      : undefined
+    : undefined,
+  crm: { name: string | null; email: string | null } | null,
+): string | undefined {
+  const phone = customer?.number;
+  const callerName = customer?.name ?? crm?.name ?? null;
+  const email = customer?.email ?? crm?.email ?? null;
+  if (!phone && !callerName && !email) return undefined;
+  const lines = ['[Caller]'];
+  if (callerName) lines.push(`Name: ${callerName}`);
+  if (phone) lines.push(`Phone: ${phone}`);
+  if (email) lines.push(`Email: ${email}`);
+  if (!crm) lines.push('Not in CRM yet — this is a first-time caller.');
+  return lines.join('\n');
 }

--- a/packages/backend-core/src/modules/conv/vapi/vapi-assistant.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-assistant.ts
@@ -1,0 +1,110 @@
+import { and, eq } from 'drizzle-orm';
+import { schema, type Db } from '@getmunin/db';
+import {
+  COMPANY_PROFILE_SLUG,
+  VOICE_SYSTEM_PROMPT_SLUG,
+  type KbDocLocation,
+  type KbDocReader,
+  type PromptCache,
+} from '@getmunin/core';
+import type { VapiFunctionTool } from './vapi-tool-bridge.js';
+
+export interface ChatMessageSeed {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export const INHERITED_ASSISTANT_FIELDS = [
+  'voice',
+  'transcriber',
+  'voicemailDetection',
+  'voicemailMessage',
+  'endCallMessage',
+  'endCallPhrases',
+  'maxDurationSeconds',
+  'silenceTimeoutSeconds',
+  'backgroundSound',
+  'backgroundDenoisingEnabled',
+  'modelOutputInMessagesEnabled',
+  'recordingEnabled',
+  'server',
+] as const;
+
+export function composeVoiceSystemPrompt(
+  prompts: PromptCache,
+  conversationId: string,
+  extraContext?: string,
+): string {
+  const base = prompts.get(VOICE_SYSTEM_PROMPT_SLUG);
+  const idLine = `When a tool asks for a conversationId, pass exactly: ${conversationId} — never substitute placeholders.`;
+  const companyContext = prompts.get(COMPANY_PROFILE_SLUG);
+  const head = `${base} ${idLine}`;
+  const parts = [head];
+  if (companyContext) parts.push(`[Company context]\n${companyContext}`);
+  if (extraContext) parts.push(extraContext);
+  return parts.join('\n\n');
+}
+
+export class OrgScopedKbDocReader implements KbDocReader {
+  constructor(
+    private readonly db: Db,
+    private readonly orgId: string,
+  ) {}
+
+  async getBody(location: KbDocLocation): Promise<string | null> {
+    const rows = await this.db
+      .select({ body: schema.kbDocuments.body })
+      .from(schema.kbDocuments)
+      .innerJoin(schema.kbSpaces, eq(schema.kbDocuments.spaceId, schema.kbSpaces.id))
+      .where(
+        and(
+          eq(schema.kbDocuments.orgId, this.orgId),
+          eq(schema.kbSpaces.slug, location.spaceSlug),
+          eq(schema.kbDocuments.slug, location.slug),
+        ),
+      )
+      .limit(1);
+    const body = rows[0]?.body?.trim() ?? null;
+    return body && body.length > 0 ? body : null;
+  }
+}
+
+export function buildInlineAssistantConfig(opts: {
+  baseConfig: Record<string, unknown>;
+  messages: ChatMessageSeed[];
+  tools: VapiFunctionTool[];
+}): Record<string, unknown> {
+  const inline: Record<string, unknown> = {};
+  for (const key of INHERITED_ASSISTANT_FIELDS) {
+    if (opts.baseConfig[key] !== undefined) inline[key] = opts.baseConfig[key];
+  }
+
+  const baseModel =
+    opts.baseConfig.model && typeof opts.baseConfig.model === 'object'
+      ? (opts.baseConfig.model as Record<string, unknown>)
+      : {};
+  const baseTools = Array.isArray(baseModel.tools) ? (baseModel.tools as unknown[]) : [];
+  const model: Record<string, unknown> = {
+    provider: typeof baseModel.provider === 'string' ? baseModel.provider : 'openai',
+    model: typeof baseModel.model === 'string' ? baseModel.model : 'gpt-4o-mini',
+    messages: opts.messages,
+    tools: [...baseTools, ...opts.tools],
+  };
+  if (typeof baseModel.temperature === 'number') model.temperature = baseModel.temperature;
+  if (typeof baseModel.maxTokens === 'number') model.maxTokens = baseModel.maxTokens;
+  if (typeof baseModel.emotionRecognitionEnabled === 'boolean') {
+    model.emotionRecognitionEnabled = baseModel.emotionRecognitionEnabled;
+  }
+  if (typeof baseModel.numFastTurns === 'number') model.numFastTurns = baseModel.numFastTurns;
+
+  inline.model = model;
+  inline.firstMessageMode = 'assistant-speaks-first-with-model-generated-message';
+  inline.serverMessages = [
+    'conversation-update',
+    'tool-calls',
+    'end-of-call-report',
+    'status-update',
+  ];
+
+  return inline;
+}

--- a/packages/backend-core/src/modules/conv/vapi/vapi.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi.integration.test.ts
@@ -192,6 +192,82 @@ const skipReason = TEST_URL
     expect(convs.length).toBe(0);
   });
 
+  it('handles assistant-request: pre-creates conversation + contact, returns fail-soft body when Vapi API unreachable', async () => {
+    const callId = 'call_vapi_inbound_first';
+    const callerNumber = '+14155556060';
+    const res = await postEvent({
+      type: 'assistant-request',
+      call: { id: callId, customer: { number: callerNumber } },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    const convs = await db
+      .select({
+        id: schema.convConversations.id,
+        contactId: schema.convConversations.contactId,
+        endUserId: schema.convConversations.endUserId,
+        metadata: schema.convConversations.metadata,
+      })
+      .from(schema.convConversations)
+      .where(
+        and(
+          eq(schema.convConversations.orgId, orgId),
+          sql`${schema.convConversations.metadata}->>'vapiCallId' = ${callId}`,
+        ),
+      );
+    expect(convs.length).toBe(1);
+    expect(convs[0]!.contactId).toBeTruthy();
+    expect(convs[0]!.endUserId).toBeTruthy();
+
+    const contacts = await db
+      .select({ phone: schema.convContacts.phone, endUserId: schema.convContacts.endUserId })
+      .from(schema.convContacts)
+      .where(
+        and(
+          eq(schema.convContacts.orgId, orgId),
+          eq(schema.convContacts.phone, callerNumber),
+        ),
+      );
+    expect(contacts.length).toBe(1);
+
+    const endUsers = await db
+      .select({ externalId: schema.endUsers.externalId, phone: schema.endUsers.phone })
+      .from(schema.endUsers)
+      .where(
+        and(
+          eq(schema.endUsers.orgId, orgId),
+          eq(schema.endUsers.externalId, `phone:${callerNumber}`),
+        ),
+      );
+    expect(endUsers.length).toBe(1);
+    expect(endUsers[0]!.phone).toBe(callerNumber);
+
+    expect(body).toEqual({});
+  });
+
+  it('assistant-request with no callId returns empty body and creates nothing new', async () => {
+    const beforeRows = await db
+      .select({ id: schema.convConversations.id })
+      .from(schema.convConversations)
+      .where(eq(schema.convConversations.orgId, orgId));
+    const before = beforeRows.length;
+
+    const res = await postEvent({
+      type: 'assistant-request',
+      call: { customer: { number: '+14155557070' } },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({});
+
+    const afterRows = await db
+      .select({ id: schema.convConversations.id })
+      .from(schema.convConversations)
+      .where(eq(schema.convConversations.orgId, orgId));
+    expect(afterRows.length).toBe(before);
+  });
+
   it('closes the conversation and stores artifact metadata on end-of-call-report', async () => {
     const callId = 'call_vapi_end';
     await postEvent({

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
@@ -29,7 +29,13 @@ import { DB } from '../../../common/db/db.module.js';
 import { DbListenerService, type EventRow } from '../../../realtime/db-listener.service.js';
 import { jsonbToStored } from '../vapi/vapi.service.js';
 import { VapiClientService } from '../vapi/vapi-client.service.js';
-import { VapiToolBridge, type VapiFunctionTool } from '../vapi/vapi-tool-bridge.js';
+import { VapiToolBridge } from '../vapi/vapi-tool-bridge.js';
+import {
+  OrgScopedKbDocReader,
+  buildInlineAssistantConfig,
+  composeVoiceSystemPrompt,
+  type ChatMessageSeed,
+} from '../vapi/vapi-assistant.js';
 import type {
   WidgetVoiceEventInputT,
   WidgetVoiceEventResult,
@@ -39,11 +45,6 @@ import type {
 
 const HISTORY_TURN_LIMIT = 20;
 const PROMPT_CACHE_TTL_MS = 60_000;
-
-interface ChatMessageSeed {
-  role: 'system' | 'user' | 'assistant';
-  content: string;
-}
 
 interface CachedPromptBundle {
   cache: PromptCache;
@@ -401,90 +402,3 @@ function mapAuthorToRole(authorType: string): 'user' | 'assistant' | null {
   return null;
 }
 
-function composeVoiceSystemPrompt(prompts: PromptCache, conversationId: string): string {
-  const base = prompts.get(VOICE_SYSTEM_PROMPT_SLUG);
-  const idLine = `When a tool asks for a conversationId, pass exactly: ${conversationId} — never substitute placeholders.`;
-  const companyContext = prompts.get(COMPANY_PROFILE_SLUG);
-  const head = `${base} ${idLine}`;
-  return companyContext ? `${head}\n\n[Company context]\n${companyContext}` : head;
-}
-
-class OrgScopedKbDocReader implements KbDocReader {
-  constructor(
-    private readonly db: Db,
-    private readonly orgId: string,
-  ) {}
-
-  async getBody(location: KbDocLocation): Promise<string | null> {
-    const rows = await this.db
-      .select({ body: schema.kbDocuments.body })
-      .from(schema.kbDocuments)
-      .innerJoin(schema.kbSpaces, eq(schema.kbDocuments.spaceId, schema.kbSpaces.id))
-      .where(
-        and(
-          eq(schema.kbDocuments.orgId, this.orgId),
-          eq(schema.kbSpaces.slug, location.spaceSlug),
-          eq(schema.kbDocuments.slug, location.slug),
-        ),
-      )
-      .limit(1);
-    const body = rows[0]?.body?.trim() ?? null;
-    return body && body.length > 0 ? body : null;
-  }
-}
-
-const INHERITED_ASSISTANT_FIELDS = [
-  'voice',
-  'transcriber',
-  'voicemailDetection',
-  'voicemailMessage',
-  'endCallMessage',
-  'endCallPhrases',
-  'maxDurationSeconds',
-  'silenceTimeoutSeconds',
-  'backgroundSound',
-  'backgroundDenoisingEnabled',
-  'modelOutputInMessagesEnabled',
-  'recordingEnabled',
-  'server',
-] as const;
-
-function buildInlineAssistantConfig(opts: {
-  baseConfig: Record<string, unknown>;
-  messages: ChatMessageSeed[];
-  tools: VapiFunctionTool[];
-}): Record<string, unknown> {
-  const inline: Record<string, unknown> = {};
-  for (const key of INHERITED_ASSISTANT_FIELDS) {
-    if (opts.baseConfig[key] !== undefined) inline[key] = opts.baseConfig[key];
-  }
-
-  const baseModel =
-    opts.baseConfig.model && typeof opts.baseConfig.model === 'object'
-      ? (opts.baseConfig.model as Record<string, unknown>)
-      : {};
-  const baseTools = Array.isArray(baseModel.tools) ? (baseModel.tools as unknown[]) : [];
-  const model: Record<string, unknown> = {
-    provider: typeof baseModel.provider === 'string' ? baseModel.provider : 'openai',
-    model: typeof baseModel.model === 'string' ? baseModel.model : 'gpt-4o-mini',
-    messages: opts.messages,
-    tools: [...baseTools, ...opts.tools],
-  };
-  if (typeof baseModel.temperature === 'number') model.temperature = baseModel.temperature;
-  if (typeof baseModel.maxTokens === 'number') model.maxTokens = baseModel.maxTokens;
-  if (typeof baseModel.emotionRecognitionEnabled === 'boolean') {
-    model.emotionRecognitionEnabled = baseModel.emotionRecognitionEnabled;
-  }
-  if (typeof baseModel.numFastTurns === 'number') model.numFastTurns = baseModel.numFastTurns;
-
-  inline.model = model;
-  inline.firstMessageMode = 'assistant-speaks-first-with-model-generated-message';
-  inline.serverMessages = [
-    'conversation-update',
-    'tool-calls',
-    'end-of-call-report',
-    'status-update',
-  ];
-
-  return inline;
-}


### PR DESCRIPTION
## Summary

Before: inbound Vapi PSTN calls used whatever assistant was configured in Vapi's dashboard, with no Munin context. The `assistant-request` webhook event (Vapi's pre-call hook) fell into the adapter's `default` branch and was ignored. Munin only learned about the call when the first transcript turn arrived.

Now: the adapter handles `assistant-request` to dynamically build an inline assistant for every inbound call. The same flow already exists for the in-browser widget path (`widget-voice.service.ts`); this PR shares the building blocks and applies them to PSTN.

### What happens on each inbound call

1. **Pre-create the conversation** via `findOrCreateConversation` (reused from the transcript path) — gives us a stable `conversationId` to thread through.
2. **Auto-create conv contact + end_user** from caller phone (same `findOrCreateContactByPhone` path used for transcript-first calls).
3. **CRM lookup** by phone (best-effort).
4. **Fetch the channel's Vapi assistant** to inherit `voice`, `transcriber`, `voicemailDetection`, `recordingEnabled`, etc.
5. **Build inline assistant** with: KB `voice-system-prompt` + company profile + caller context (CRM name/email if found, else "first-time caller" note) + voice opener + MCP self-service tools.
6. **Return** `{ assistant, assistantOverrides: { metadata: { conversationId, endUserId } } }` so Vapi uses the inline config and stamps our metadata onto subsequent webhooks.

### Fail-soft behavior

If any step fails (Vapi API unreachable, KB read error, decrypt error), the handler returns `{}` → Vapi uses its default assistant → call continues. The conversation pre-create runs **before** the Vapi fetch so even on fetch failure the conversation row still exists and subsequent transcripts resolve via `vapiCallId`.

### Refactor

Moved `composeVoiceSystemPrompt`, `buildInlineAssistantConfig`, `OrgScopedKbDocReader`, `INHERITED_ASSISTANT_FIELDS` from `widget-voice.service.ts` to a new `vapi-assistant.ts` so both widget and inbound PSTN paths share one source. `composeVoiceSystemPrompt` gains an optional `extraContext` parameter for the caller context block. `runAsSystem` became generic `<T>` so the handler can read DB state out of the transaction.

### Behavior change to flag

This **changes the assistant prompt for inbound PSTN calls**. Anyone who relied on their pre-configured Vapi assistant prompt verbatim will now see Munin's KB-backed prompt instead. The voice/transcriber/recording settings are inherited from Vapi, so the *call experience* (voice, latency, recording) is unchanged — only the *agent behavior* (system prompt + available tools) changes.

## Test plan

- [x] `pnpm typecheck` clean across 15 packages
- [x] `vapi.integration.test.ts` extended with two cases — 6/6 pass
  - assistant-request creates conversation + contact + end_user even when Vapi fetch fails (returns `{}` fail-soft body)
  - assistant-request with no `callId` is a no-op and creates nothing
- [ ] CI green
- [ ] Manual on cloud-dev: place a call to your Vapi number, verify the conversation appears in Munin before the first transcript turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)