### PR TITLE
feat(conv): explicit voice channel routing via channelId + widget voiceChannelId

### DIFF
--- a/.changeset/conv-channel-routing.md
+++ b/.changeset/conv-channel-routing.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/backend': patch
+---
+
+Explicit voice channel routing for orgs with multiple active Vapi voice channels.
+
+- `conv_voice_call_contact` MCP tool accepts an optional `channelId` to pick a specific voice channel; with a single channel the call falls back to it.
+- Widget channel config gains `voiceChannelId` so the chat widget's "call now" button routes deterministically when multiple voice channels exist.
+- When >1 voice channels are configured and no routing hint is provided, callers get `multiple_active_voice_channels` (tool) / `multiple_voice_channels_without_widget_routing` (widget) instead of an arbitrary pick.

--- a/packages/backend-core/src/modules/conv/voice-callback.channelid.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/voice-callback.channelid.integration.test.ts
@@ -1,0 +1,227 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql, eq } from 'drizzle-orm';
+import { AppModule } from '../../app.module.js';
+
+const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run voice-callback channelId tests.';
+
+(skipReason ? describe.skip : describe)('conv_voice_call_contact — optional channelId routing', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let adminKey: string;
+  let conversationId: string;
+  let channelAId: string;
+  let channelBId: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_ENCRYPTION_KEY ??=
+      'dGVzdC1lbmNyeXB0aW9uLWtleS1tdXN0LWJlLWxvbmctZW5vdWdoLWZvci1wZ2NyeXB0bw==';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Voice Routing IT Org' })
+      .returning();
+    orgId = org!.id;
+
+    adminKey = buildApiKey('admin');
+    await db.insert(schema.apiKeys).values({
+      orgId,
+      type: 'admin',
+      name: 'voice-routing-admin',
+      keyHash: hashSecret(adminKey),
+      keyPrefix: keyPrefix(adminKey),
+      scopes: ['*'],
+    });
+
+    const [contact] = await db
+      .insert(schema.convContacts)
+      .values({ orgId, name: 'Caller', phone: '+14155550100' })
+      .returning();
+
+    const [chatChannel] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'chat',
+        vendor: 'munin',
+        name: 'widget',
+        active: true,
+        config: {},
+      })
+      .returning();
+    const nextDisplay = await db.execute<{ next: number }>(
+      sql`SELECT conv_next_display_id(${orgId}) AS next`,
+    );
+    const [conv] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        channelId: chatChannel!.id,
+        contactId: contact!.id,
+        displayId: nextDisplay[0]!.next,
+        status: 'open',
+      })
+      .returning();
+    conversationId = conv!.id;
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  async function withClient<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+    const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+      requestInit: { headers: { Authorization: `Bearer ${adminKey}` } },
+    });
+    const c = new Client({ name: 'voice-routing-it', version: '0.0.0' });
+    await c.connect(transport);
+    try {
+      return await fn(c);
+    } finally {
+      await transport.close();
+      await c.close();
+    }
+  }
+
+  function firstText(result: { content: Array<{ type: string; text?: string }> }): string {
+    return result.content.find((c) => c.type === 'text')?.text ?? '';
+  }
+
+  async function insertVoiceChannel(name: string): Promise<string> {
+    const [row] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'voice',
+        vendor: 'vapi',
+        name,
+        active: true,
+        config: {
+          encryptedApiKey: 'fake',
+          encryptedWebhookSecret: 'fake',
+          assistantId: 'asst_x',
+          phoneNumberId: 'pn_x',
+        },
+      })
+      .returning();
+    return row!.id;
+  }
+
+  it('no voice channels → throws no_active_voice_channel', async () => {
+    await withClient(async (c) => {
+      const res = await c.callTool({
+        name: 'conv_voice_call_contact',
+        arguments: { conversationId },
+      });
+      expect(res.isError).toBe(true);
+      expect(firstText(res as never)).toContain('no_active_voice_channel');
+    });
+  });
+
+  it('one voice channel → calls it without channelId being required', async () => {
+    channelAId = await insertVoiceChannel('vapi-only');
+    await withClient(async (c) => {
+      const res = await c.callTool({
+        name: 'conv_voice_call_contact',
+        arguments: { conversationId },
+      });
+      const text = firstText(res as never);
+      expect(text, text).toMatch(/vapi_|fetch failed|placeCall|TypeError|invalid|pgp_sym_decrypt/i);
+    });
+  });
+
+  it('two voice channels without channelId → throws asking caller to pick', async () => {
+    channelBId = await insertVoiceChannel('vapi-second');
+    await withClient(async (c) => {
+      const res = await c.callTool({
+        name: 'conv_voice_call_contact',
+        arguments: { conversationId },
+      });
+      expect(res.isError).toBe(true);
+      expect(firstText(res as never)).toContain('multiple_active_voice_channels');
+    });
+  });
+
+  it('two voice channels with explicit channelId → routes to the named channel', async () => {
+    await withClient(async (c) => {
+      const res = await c.callTool({
+        name: 'conv_voice_call_contact',
+        arguments: { conversationId, channelId: channelBId },
+      });
+      const text = firstText(res as never);
+      expect(text, text).toMatch(/vapi_|fetch failed|placeCall|TypeError|invalid|pgp_sym_decrypt/i);
+    });
+  });
+
+  it('explicit channelId pointing at a non-voice channel → not found', async () => {
+    const [emailCh] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'email',
+        vendor: 'smtp',
+        name: 'support-email',
+        active: true,
+        config: {},
+      })
+      .returning();
+    await withClient(async (c) => {
+      const res = await c.callTool({
+        name: 'conv_voice_call_contact',
+        arguments: { conversationId, channelId: emailCh!.id },
+      });
+      expect(res.isError).toBe(true);
+      expect(firstText(res as never)).toContain('not found');
+    });
+  });
+
+  it('explicit channelId pointing at an archived channel → not found', async () => {
+    await db
+      .update(schema.convChannels)
+      .set({ active: false, archivedAt: new Date() })
+      .where(eq(schema.convChannels.id, channelAId));
+    await withClient(async (c) => {
+      const res = await c.callTool({
+        name: 'conv_voice_call_contact',
+        arguments: { conversationId, channelId: channelAId },
+      });
+      expect(res.isError).toBe(true);
+      expect(firstText(res as never)).toContain('not found');
+    });
+  });
+});

--- a/packages/backend-core/src/modules/conv/voice-callback.service.ts
+++ b/packages/backend-core/src/modules/conv/voice-callback.service.ts
@@ -29,6 +29,7 @@ export class VoiceCallbackService {
 
   async placeCallbackForConversation(input: {
     conversationId: string;
+    channelId?: string;
   }): Promise<VoiceCallbackResult> {
     const ctx = getCurrentContext();
     const orgId = ctx.actor!.orgId;
@@ -65,22 +66,41 @@ export class VoiceCallbackService {
 
     return this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
-      const channelRows = await tx
-        .select()
-        .from(schema.convChannels)
-        .where(
-          and(
-            eq(schema.convChannels.orgId, orgId),
-            eq(schema.convChannels.type, 'voice'),
-            eq(schema.convChannels.vendor, 'vapi'),
-            eq(schema.convChannels.active, true),
-            isNull(schema.convChannels.archivedAt),
-          ),
-        )
-        .limit(1);
-      const channel = channelRows[0];
-      if (!channel) {
-        throw new ConflictException('no_active_voice_channel');
+      const baseConditions = [
+        eq(schema.convChannels.orgId, orgId),
+        eq(schema.convChannels.type, 'voice'),
+        eq(schema.convChannels.vendor, 'vapi'),
+        eq(schema.convChannels.active, true),
+        isNull(schema.convChannels.archivedAt),
+      ];
+      let channel: typeof schema.convChannels.$inferSelect | undefined;
+      if (input.channelId) {
+        const explicit = await tx
+          .select()
+          .from(schema.convChannels)
+          .where(and(...baseConditions, eq(schema.convChannels.id, input.channelId)))
+          .limit(1);
+        channel = explicit[0];
+        if (!channel) {
+          throw new NotFoundException(
+            `voice channel ${input.channelId} not found, inactive, archived, or wrong type`,
+          );
+        }
+      } else {
+        const candidates = await tx
+          .select()
+          .from(schema.convChannels)
+          .where(and(...baseConditions))
+          .limit(2);
+        if (candidates.length === 0) {
+          throw new ConflictException('no_active_voice_channel');
+        }
+        if (candidates.length > 1) {
+          throw new ConflictException(
+            'multiple_active_voice_channels — pass channelId to pick one',
+          );
+        }
+        channel = candidates[0]!;
       }
       const config = jsonbToStored(channel.config);
       if (!config.phoneNumberId) {

--- a/packages/backend-core/src/modules/conv/voice-callback.tools.ts
+++ b/packages/backend-core/src/modules/conv/voice-callback.tools.ts
@@ -5,6 +5,7 @@ import { VoiceCallbackService, type VoiceCallbackResult } from './voice-callback
 
 const CallbackInput = z.object({
   conversationId: z.string(),
+  channelId: z.string().min(1).max(64).optional(),
 });
 
 @Injectable()
@@ -32,7 +33,7 @@ export class VoiceCallbackTools {
     name: 'conv_voice_call_contact',
     title: "Conv: Place a voice call to this conversation's contact",
     description:
-      "Place an outbound voice call to the contact attached to a conversation. Resolves the phone number from the conversation's contact and picks the org's active Vapi voice channel automatically. For arbitrary destinations, use `conv_voice_call_initiate` instead.",
+      "Place an outbound voice call to the contact attached to a conversation. Resolves the phone number from the conversation's contact. If your org has more than one active Vapi voice channel, pass `channelId` to pick one; with a single channel the call falls back to it. For arbitrary destinations, use `conv_voice_call_initiate` instead.",
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: CallbackInput,

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
@@ -261,4 +261,112 @@ const skipReason = TEST_URL
         .where(eq(schema.convChannels.id, voiceChannelId));
     }
   });
+
+  it('returns multiple_voice_channels_without_widget_routing when 2 voice channels and widget has no voiceChannelId', async () => {
+    const [extra] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'voice',
+        vendor: 'vapi',
+        name: 'extra-vapi',
+        active: true,
+        config: {
+          encryptedApiKey: 'fake',
+          encryptedWebhookSecret: 'fake',
+          assistantId: 'asst_extra',
+          phoneNumberId: 'pn_extra',
+          publicKey: 'pk_extra',
+        },
+      })
+      .returning();
+    try {
+      const { status, json } = await call({
+        channelId: widgetChannelId,
+        conversationId: aliceConvId,
+      });
+      expect(status).toBe(201);
+      expect(json).toEqual({
+        available: false,
+        reason: 'multiple_voice_channels_without_widget_routing',
+      });
+    } finally {
+      await db.delete(schema.convChannels).where(eq(schema.convChannels.id, extra!.id));
+    }
+  });
+
+  it('routes to the configured voiceChannelId when widget has one set and multiple voice channels exist', async () => {
+    const vapiSvc = app.get(VapiService);
+    const actor = new ActorIdentity('user', 'usr_test_wv', orgId, ['*'], ['admin']);
+    const extra = await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+      await tx.execute(
+        sql`SELECT set_config('app.crypt_key', ${process.env.MUNIN_ENCRYPTION_KEY ?? ''}, true)`,
+      );
+      const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+      return withContext(ctx, () =>
+        vapiSvc.createChannel({
+          name: 'Vapi voice 2',
+          config: {
+            apiKey: 'vapi-api-key-wv-2',
+            webhookSecret: 'vapi-webhook-secret-wv-2',
+            assistantId: 'asst_extra2',
+            phoneNumberId: 'pn_extra2',
+            publicKey: 'pk_target',
+          },
+        }),
+      );
+    });
+    await db
+      .update(schema.convChannels)
+      .set({
+        config: sql`config || ${JSON.stringify({ provider: 'widget', voiceChannelId: extra.id })}::jsonb`,
+      })
+      .where(eq(schema.convChannels.id, widgetChannelId));
+    try {
+      const { status, json } = await call({
+        channelId: widgetChannelId,
+        conversationId: aliceConvId,
+      });
+      expect(status).toBe(201);
+      const body = json as {
+        available: boolean;
+        descriptor?: { publicKey: string; assistantId: string };
+      };
+      expect(body.available).toBe(true);
+      expect(body.descriptor?.publicKey).toBe('pk_target');
+      expect(body.descriptor?.assistantId).toBe('asst_extra2');
+    } finally {
+      await db
+        .update(schema.convChannels)
+        .set({ config: sql`config - 'voiceChannelId' - 'provider'` })
+        .where(eq(schema.convChannels.id, widgetChannelId));
+      await db.delete(schema.convChannels).where(eq(schema.convChannels.id, extra.id));
+    }
+  });
+
+  it('returns widget_voice_channel_id_not_found_or_inactive when voiceChannelId points at an unknown channel', async () => {
+    await db
+      .update(schema.convChannels)
+      .set({
+        config: sql`config || ${JSON.stringify({ provider: 'widget', voiceChannelId: 'cch_does_not_exist' })}::jsonb`,
+      })
+      .where(eq(schema.convChannels.id, widgetChannelId));
+    try {
+      const { status, json } = await call({
+        channelId: widgetChannelId,
+        conversationId: aliceConvId,
+      });
+      expect(status).toBe(201);
+      expect(json).toEqual({
+        available: false,
+        reason: 'widget_voice_channel_id_not_found_or_inactive',
+      });
+    } finally {
+      await db
+        .update(schema.convChannels)
+        .set({ config: sql`config - 'voiceChannelId' - 'provider'` })
+        .where(eq(schema.convChannels.id, widgetChannelId));
+    }
+  });
 });

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
@@ -36,6 +36,7 @@ import {
   composeVoiceSystemPrompt,
   type ChatMessageSeed,
 } from '../vapi/vapi-assistant.js';
+import { WidgetChannelConfig } from './widget.types.js';
 import type {
   WidgetVoiceEventInputT,
   WidgetVoiceEventResult,
@@ -130,22 +131,50 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
         return { available: false, reason: 'conversation_has_no_end_user' };
       }
 
-      const channelRows = await tx
-        .select()
+      const widgetChannelRows = await tx
+        .select({ config: schema.convChannels.config })
         .from(schema.convChannels)
-        .where(
-          and(
-            eq(schema.convChannels.orgId, orgId),
-            eq(schema.convChannels.type, 'voice'),
-            eq(schema.convChannels.vendor, 'vapi'),
-            eq(schema.convChannels.active, true),
-            isNull(schema.convChannels.archivedAt),
-          ),
-        )
+        .where(eq(schema.convChannels.id, input.channelId))
         .limit(1);
-      const channel = channelRows[0];
-      if (!channel) {
-        return { available: false, reason: 'no_active_voice_channel' };
+      const widgetConfig = widgetChannelRows[0]
+        ? WidgetChannelConfig.safeParse(widgetChannelRows[0].config)
+        : null;
+      const voiceChannelId = widgetConfig?.success ? widgetConfig.data.voiceChannelId : undefined;
+
+      const voiceBaseConditions = [
+        eq(schema.convChannels.orgId, orgId),
+        eq(schema.convChannels.type, 'voice'),
+        eq(schema.convChannels.vendor, 'vapi'),
+        eq(schema.convChannels.active, true),
+        isNull(schema.convChannels.archivedAt),
+      ];
+      let channel: typeof schema.convChannels.$inferSelect | undefined;
+      if (voiceChannelId) {
+        const explicit = await tx
+          .select()
+          .from(schema.convChannels)
+          .where(and(...voiceBaseConditions, eq(schema.convChannels.id, voiceChannelId)))
+          .limit(1);
+        channel = explicit[0];
+        if (!channel) {
+          return { available: false, reason: 'widget_voice_channel_id_not_found_or_inactive' };
+        }
+      } else {
+        const candidates = await tx
+          .select()
+          .from(schema.convChannels)
+          .where(and(...voiceBaseConditions))
+          .limit(2);
+        if (candidates.length === 0) {
+          return { available: false, reason: 'no_active_voice_channel' };
+        }
+        if (candidates.length > 1) {
+          return {
+            available: false,
+            reason: 'multiple_voice_channels_without_widget_routing',
+          };
+        }
+        channel = candidates[0]!;
       }
       const storedConfig = jsonbToStored(channel.config);
       if (!storedConfig.publicKey) {

--- a/packages/backend-core/src/modules/conv/widget/widget.types.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.types.ts
@@ -6,6 +6,7 @@ export const WidgetChannelConfig = z.object({
   webhookOnEscalation: z.string().url().optional(),
   identityVerificationSecret: z.string().min(32).max(256).optional(),
   requireVerifiedIdentity: z.boolean().default(false),
+  voiceChannelId: z.string().min(1).max(64).optional(),
 });
 
 export type WidgetChannelConfigT = z.infer<typeof WidgetChannelConfig>;


### PR DESCRIPTION
## Summary
- `conv_voice_call_contact` MCP tool accepts an optional `channelId` so admins can pick a specific voice channel when the org has more than one active Vapi voice channel; with a single channel the call falls back to it.
- Widget channel config gains `voiceChannelId` so the chat widget's "call now" routes deterministically when multiple voice channels exist.
- When >1 voice channels are active and no routing hint is provided, callers get an explicit error (`multiple_active_voice_channels` / `multiple_voice_channels_without_widget_routing`) instead of an arbitrary implicit pick.

This replaces the abandoned `is_default` flag approach — routing is now decided at the call site (tool arg or widget config) rather than via a global per-channel default.

## Test plan
- [x] 6 new integration tests in `voice-callback.channelid.integration.test.ts` covering no/one/multi voice channels, explicit channelId routing, non-voice channel rejection, archived channel rejection
- [x] 3 new integration tests appended to `widget-voice.integration.test.ts` covering multi-channel without `voiceChannelId`, with `voiceChannelId`, and with invalid `voiceChannelId`
- [x] Full `pnpm -F @getmunin/backend-core test` suite green (194 conv tests)
- [x] `pnpm -F @getmunin/backend-core typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)