### PR TITLE
chore(changeset): drop ignored @getmunin/backend bump from conv-channel-routing

### DIFF
--- a/.changeset/conv-channel-routing.md
+++ b/.changeset/conv-channel-routing.md
@@ -1,6 +1,5 @@
 ---
 '@getmunin/backend-core': minor
-'@getmunin/backend': patch
 ---
 
 Explicit voice channel routing for orgs with multiple active Vapi voice channels.


### PR DESCRIPTION
## Summary
Post-merge Release workflow for PR #223 failed because the changeset listed both `@getmunin/backend-core` (released) and `@getmunin/backend` (ignored in `.changeset/config.json`). Drop the ignored entry.

## Test plan
- [x] CI's Release (Changesets) step proceeds past `changeset version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)