### PR TITLE
chore: drop api.munin.eu / docs.getmunin.com hardcodes

### DIFF
--- a/.changeset/dynamic-public-urls.md
+++ b/.changeset/dynamic-public-urls.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/docs-pages': minor
+'@getmunin/dashboard-pages': minor
+'@getmunin/core': minor
+---
+
+Make public-facing URLs configurable instead of hardcoding `api.munin.eu` / `docs.getmunin.com`.
+
+- `packages/docs-pages/src/page.tsx` and `_components/rest-endpoint.tsx`: the example `curl` URL is built from `process.env.NEXT_PUBLIC_API_URL` (defaulting to `http://localhost:3001`), matching the existing pattern in `guides/chat-widget/page.tsx`.
+- `packages/backend-core/scripts/generate-openapi.ts`: the OpenAPI spec's `servers[0]` is built from `MUNIN_OPENAPI_SERVER_URL` / `MUNIN_OPENAPI_SERVER_DESCRIPTION` (defaulting to `http://localhost:3001` / `local dev`). Cloud deploys set these at build time to render docs against the right host.
+- `packages/dashboard-pages/src/data/mcp-setups.ts`: `buildMcpSetups` takes an optional second `docsHost` argument; `MCP_SETUPS` keeps using the cloud-prod default. `get-started.tsx` reads `process.env.NEXT_PUBLIC_DOCS_URL` so dev points at `docs.dev.getmunin.com` and prod at `docs.getmunin.com`.
+
+Brand-attribution links (`getmunin.com` in the chat-widget "Powered by" footer, the web-crawler User-Agent) stay hardcoded — they identify Munin itself, not the deployment.

--- a/packages/backend-core/scripts/generate-openapi.ts
+++ b/packages/backend-core/scripts/generate-openapi.ts
@@ -37,7 +37,10 @@ async function main() {
     .setVersion('1')
     .addBearerAuth({ type: 'http', scheme: 'bearer' }, 'bearer')
     .addCookieAuth('munin_session', { type: 'apiKey', in: 'cookie', name: 'munin_session' }, 'session')
-    .addServer('https://api.munin.eu', 'EU production')
+    .addServer(
+      process.env.MUNIN_OPENAPI_SERVER_URL ?? 'http://localhost:3001',
+      process.env.MUNIN_OPENAPI_SERVER_DESCRIPTION ?? 'local dev',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/packages/dashboard-pages/src/components/dashboard/get-started.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/get-started.tsx
@@ -34,7 +34,11 @@ export function GetStarted() {
     };
   }, []);
 
-  const setups = useMemo(() => (mcpHost ? buildMcpSetups(mcpHost) : MCP_SETUPS), [mcpHost]);
+  const docsHost = process.env.NEXT_PUBLIC_DOCS_URL;
+  const setups = useMemo(
+    () => (mcpHost ? buildMcpSetups(mcpHost, docsHost) : MCP_SETUPS),
+    [mcpHost, docsHost],
+  );
   const setup = setups.find((s) => s.id === activeId) ?? setups[0]!;
 
   function copySnippet() {

--- a/packages/dashboard-pages/src/data/mcp-setups.ts
+++ b/packages/dashboard-pages/src/data/mcp-setups.ts
@@ -16,8 +16,14 @@ const TOKEN_PLACEHOLDER = 'mn_live_••••••••';
  * so self-host instances render `http://localhost:3001` (or whatever
  * `MUNIN_MCP_URL` is set to) and cloud renders `mcp.getmunin.com`
  * without a rebuild.
+ *
+ * `docsHost` is the public docs site (e.g. `https://docs.getmunin.com`
+ * for prod, `https://docs.dev.getmunin.com` for dev). Defaults to the
+ * cloud-prod URL when omitted.
  */
-export function buildMcpSetups(host: string): McpSetup[] {
+export function buildMcpSetups(host: string, docsHost: string = DEFAULT_DOCS_HOST): McpSetup[] {
+  const docs = docsHost.replace(/\/+$/, '');
+  const docsBare = docs.replace(/^https?:\/\//, '');
   return [
     {
       id: 'claude',
@@ -34,8 +40,8 @@ export function buildMcpSetups(host: string): McpSetup[] {
     }
   }
 }`,
-      docsHref: 'https://docs.getmunin.com/mcp/claude',
-      docsLabel: 'docs.getmunin.com/mcp/claude',
+      docsHref: `${docs}/mcp/claude`,
+      docsLabel: `${docsBare}/mcp/claude`,
     },
     {
       id: 'chatgpt',
@@ -51,8 +57,8 @@ export function buildMcpSetups(host: string): McpSetup[] {
     "token": "${TOKEN_PLACEHOLDER}"
   }
 }`,
-      docsHref: 'https://docs.getmunin.com/mcp/chatgpt',
-      docsLabel: 'docs.getmunin.com/mcp/chatgpt',
+      docsHref: `${docs}/mcp/chatgpt`,
+      docsLabel: `${docsBare}/mcp/chatgpt`,
     },
     {
       id: 'gemini',
@@ -69,11 +75,14 @@ export function buildMcpSetups(host: string): McpSetup[] {
     }
   }
 }`,
-      docsHref: 'https://docs.getmunin.com/mcp/gemini',
-      docsLabel: 'docs.getmunin.com/mcp/gemini',
+      docsHref: `${docs}/mcp/gemini`,
+      docsLabel: `${docsBare}/mcp/gemini`,
     },
   ];
 }
 
+const DEFAULT_MCP_HOST = 'https://mcp.getmunin.com';
+const DEFAULT_DOCS_HOST = 'https://docs.getmunin.com';
+
 /** Static fallback used before the runtime fetch resolves. */
-export const MCP_SETUPS: McpSetup[] = buildMcpSetups('https://mcp.getmunin.com');
+export const MCP_SETUPS: McpSetup[] = buildMcpSetups(DEFAULT_MCP_HOST, DEFAULT_DOCS_HOST);

--- a/packages/docs-pages/src/_components/rest-endpoint.tsx
+++ b/packages/docs-pages/src/_components/rest-endpoint.tsx
@@ -128,7 +128,7 @@ function schemaChipFor(r: NonNullable<Operation['responses']>[string]): string |
 }
 
 function curlFor(ep: EndpointEntry): string {
-  const base = 'https://api.munin.eu';
+  const base = (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
   let cmd = `curl -X ${ep.method.toUpperCase()} \\\n  '${base}${ep.path}'`;
   if (ep.authMode !== 'public') {
     cmd += ` \\\n  -H 'Authorization: Bearer $MUNIN_API_KEY'`;

--- a/packages/docs-pages/src/page.tsx
+++ b/packages/docs-pages/src/page.tsx
@@ -7,6 +7,7 @@ export default function DocsHome() {
   const restCount = listEndpoints().length;
   const mcpCount = mcpTools.length;
   const skillCount = skills.length;
+  const apiBase = (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
   return (
     <main className="docs-main">
       <header className="docs-hero">
@@ -124,7 +125,7 @@ export default function DocsHome() {
           <span>cURL · GET /api/v1/whoami</span>
           <span style={{ color: 'var(--docs-mute)' }}>copy &amp; run</span>
         </div>
-        <pre>{`curl 'https://api.munin.eu/api/v1/whoami' \\
+        <pre>{`curl '${apiBase}/api/v1/whoami' \\
   -H 'Authorization: Bearer $MUNIN_API_KEY'`}</pre>
       </div>
 


### PR DESCRIPTION
Cloud's docs site will live at `docs.getmunin.com` (prod) / `docs.dev.getmunin.com` (dev), and the API at `api.getmunin.com` / `api.dev.getmunin.com`. Several upstream surfaces still pointed at `https://api.munin.eu` and `https://docs.getmunin.com` literally, which would render wrong everywhere except OSS prod.

### Changes
- **`docs-pages/page.tsx`** + **`rest-endpoint.tsx`** — `curl` URL reads from `NEXT_PUBLIC_API_URL` (default `http://localhost:3001`), matching the pattern in `guides/chat-widget/page.tsx`.
- **`backend-core/scripts/generate-openapi.ts`** — `servers[0]` URL/description come from `MUNIN_OPENAPI_SERVER_URL` / `MUNIN_OPENAPI_SERVER_DESCRIPTION`. Cloud's docs build sets these at build time.
- **`dashboard-pages/data/mcp-setups.ts`** — `buildMcpSetups` accepts a second `docsHost` argument. Defaults to `https://docs.getmunin.com` so the pre-runtime-fetch fallback stays correct.
- **`dashboard-pages/components/dashboard/get-started.tsx`** — reads `NEXT_PUBLIC_DOCS_URL` and threads it through.

### Out of scope (intentionally hardcoded)
- `apps/chat-widget/src/ui.ts` — "Powered by Munin" footer points at the marketing site even on self-hosted instances.
- `packages/agent-runtime/src/web-crawl.ts` — the `+URL` in the bot's User-Agent identifies Munin, not the tenant deployment.