### PR TITLE
feat: rename feedback MCP tools and partner settings label

### DIFF
--- a/.changeset/feedback-tools-and-partner-label.md
+++ b/.changeset/feedback-tools-and-partner-label.md
@@ -1,0 +1,17 @@
+---
+'@getmunin/dashboard-pages': minor
+'@getmunin/backend-core': patch
+---
+
+Rename the Partner-access settings nav label key and adjust the MCP
+tool-name guard test.
+
+- `dashboard-pages`: `nav.partnerAccess` → `nav.partner` (en + nb). The
+  cloud overlay now uses `labelKey: 'partner'` and a shorter "Partner"
+  label, moved from the Workspace group to Access & integrations.
+- `backend-core`: the OSS MCP integration test's negative assertion is
+  updated to `feedback_create` to match the cloud-feedback module's
+  renamed tools (`suggestion_*` → `feedback_*`). OSS behavior is
+  unchanged — the guard still verifies cloud-only tools don't leak.
+
+No production users yet, so no backwards-compat aliasing.

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -111,7 +111,7 @@ const skipReason = TEST_URL
       expect(names).toContain('kb_create_document');
       expect(names).toContain('kb_search');
       expect(names).toContain('ping');
-      expect(names).not.toContain('suggestion_create');
+      expect(names).not.toContain('feedback_create');
 
       for (const t of tools) {
         expect(t.annotations, `tool ${t.name} missing annotations`).toBeDefined();
@@ -430,7 +430,7 @@ const skipReason = TEST_URL
         expect(names).toContain('kb_get_document');
         expect(names).not.toContain('kb_create_document');
         expect(names).not.toContain('kb_delete_document');
-        expect(names).not.toContain('suggestion_create');
+        expect(names).not.toContain('feedback_create');
 
         const hits = parseToolResult<Array<{ documentId: string; title: string }>>(
           await c.callTool({ name: 'kb_search', arguments: { query: 'widgets' } }),

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -125,7 +125,7 @@
     "activity": "Activity",
     "skills": "Skills",
     "suggestions": "Suggestions",
-    "partnerAccess": "Partner access",
+    "partner": "Partner",
     "openMenu": "Open menu",
     "closeMenu": "Close menu",
     "organization": "Organization"

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -125,7 +125,7 @@
     "activity": "Aktivitet",
     "skills": "Ferdigheter",
     "suggestions": "Forslag",
-    "partnerAccess": "Partnertilgang",
+    "partner": "Partner",
     "openMenu": "Åpne meny",
     "closeMenu": "Lukk meny",
     "organization": "Organisasjon"


### PR DESCRIPTION
## Summary
- `dashboard-pages`: `nav.partnerAccess` → `nav.partner` (en + nb). Lets the cloud overlay move the entry into Access & integrations with the shorter "Partner" label.
- `backend-core`: update MCP integration test guard from `suggestion_create` to `feedback_create` — pairs with the cloud-feedback rename of `suggestion_*` → `feedback_*` so the cloud-only tools stay aligned with the OSS `<module>_*` naming convention.

No production users yet, so no backwards-compat aliasing.

## Test plan
- [x] `pnpm -F @getmunin/backend-core typecheck`
- [x] `pnpm -F @getmunin/dashboard-pages typecheck`
- [ ] Cloud PR (https://github.com/getmunin/munin-cloud) consumes the renamed key once this releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)