### PR TITLE
fix(agent-runtime): stop logging 'created KB space' on every reconcile

### DIFF
--- a/.changeset/fix-agent-runtime-kb-space-log.md
+++ b/.changeset/fix-agent-runtime-kb-space-log.md
@@ -1,0 +1,17 @@
+---
+'@getmunin/agent-runtime': patch
+---
+
+Fix misleading `created KB space agent-runtime` log on every backend
+startup. `ensureSpace` and `ensureDocument` were using `try/catch` to
+detect "already exists" conflicts, but `mcp.callTool()` never throws on
+tool errors — the MCP dispatch layer converts thrown errors into
+`{ isError: true, content: [...] }` results. The catch was unreachable
+dead code, so the success log fired on every reconcile even when the
+space/document already existed (the row itself was not being recreated).
+
+Switch both helpers to inspect `result.isError` (the same pattern as
+`parseDocumentBody`). Conflict path returns silently; non-conflict
+errors now actually throw. Test fake MCP handle was also returning a
+rejected promise for the conflict case, which hid the bug — updated to
+match real dispatch behavior.

--- a/packages/agent-runtime/src/prompt-resolver.test.ts
+++ b/packages/agent-runtime/src/prompt-resolver.test.ts
@@ -41,7 +41,15 @@ function fakeMcp(opts: {
       calls.push({ name, args });
       if (name === 'kb_create_space') {
         if (spaceExists) {
-          return Promise.reject(new Error('conflict: slug already in use'));
+          return Promise.resolve({
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `kb_invalid: a space with slug "${args['slug'] as string}" already exists`,
+              },
+            ],
+          });
         }
         spaceExists = true;
         return Promise.resolve({ content: [{ type: 'text', text: '{}' }] });
@@ -106,15 +114,37 @@ describe('createPromptResolver', () => {
         [`${CHANNEL_PROMPT_PREFIX}email`]: 'OPERATOR_EDITED_EMAIL',
       },
     });
-    const resolver = await createPromptResolver({ mcp, logger: silentLogger });
+    const info = vi.fn();
+    const resolver = await createPromptResolver({
+      mcp,
+      logger: { info, warn: () => {}, error: () => {} },
+    });
 
     const created = mcp.calls.filter((c) => c.name === 'kb_create_document');
     const createdSlugs = created.map((c) => c.args['slug']);
     expect(createdSlugs).not.toContain(SYSTEM_PROMPT_SLUG);
     expect(createdSlugs).not.toContain(`${CHANNEL_PROMPT_PREFIX}email`);
 
+    const createdLogs = info.mock.calls.filter(([msg]) =>
+      String(msg).startsWith('created KB space'),
+    );
+    expect(createdLogs).toHaveLength(0);
+
     expect(resolver.system()).toBe('OPERATOR_EDITED_SYSTEM');
     expect(resolver.channel('email')).toBe('OPERATOR_EDITED_EMAIL');
+  });
+
+  it('logs "created KB space" exactly once on first boot', async () => {
+    const mcp = fakeMcp();
+    const info = vi.fn();
+    await createPromptResolver({
+      mcp,
+      logger: { info, warn: () => {}, error: () => {} },
+    });
+    const createdLogs = info.mock.calls.filter(([msg]) =>
+      String(msg).startsWith(`created KB space ${PROMPT_SPACE_SLUG}`),
+    );
+    expect(createdLogs).toHaveLength(1);
   });
 
   it('falls back to channel-default when an unknown channel kind is queried', async () => {

--- a/packages/agent-runtime/src/prompt-resolver.ts
+++ b/packages/agent-runtime/src/prompt-resolver.ts
@@ -140,18 +140,19 @@ async function ensureSpace(
   spaceSlug: string,
   log: { info: (m: string) => void; warn: (m: string) => void },
 ): Promise<void> {
-  try {
-    await mcp.callTool('kb_create_space', {
-      name: 'Agent runtime',
-      slug: spaceSlug,
-      description:
-        'Self-service AI runtime configuration. Edit the system prompt and per-channel descriptors here; the runner picks up changes within a few seconds via realtime events.',
-    });
+  const result = await mcp.callTool('kb_create_space', {
+    name: 'Agent runtime',
+    slug: spaceSlug,
+    description:
+      'Self-service AI runtime configuration. Edit the system prompt and per-channel descriptors here; the runner picks up changes within a few seconds via realtime events.',
+  });
+  if (!result.isError) {
     log.info(`created KB space ${spaceSlug}`);
-  } catch (err) {
-    if (looksLikeConflict(err)) return;
-    throw err;
+    return;
   }
+  const errorText = textFromResult(result);
+  if (looksLikeConflict(errorText)) return;
+  throw new Error(`kb_create_space failed: ${errorText || 'unknown error'}`);
 }
 
 async function ensureDocument(
@@ -162,14 +163,22 @@ async function ensureDocument(
   const existing = await readBySlug(mcp, AGENT_RUNTIME_PROMPT_SPACE_SLUG, seed.slug);
   if (existing !== null) return;
   const spaceId = await getSpaceId(mcp, AGENT_RUNTIME_PROMPT_SPACE_SLUG);
-  await mcp.callTool('kb_create_document', {
+  const result = await mcp.callTool('kb_create_document', {
     spaceId,
     slug: seed.slug,
     title: seed.title,
     body: seed.body,
     audiences: ['admin'],
   });
-  log.info(`seeded KB doc ${AGENT_RUNTIME_PROMPT_SPACE_SLUG}/${seed.slug} from defaults`);
+  if (!result.isError) {
+    log.info(`seeded KB doc ${AGENT_RUNTIME_PROMPT_SPACE_SLUG}/${seed.slug} from defaults`);
+    return;
+  }
+  const errorText = textFromResult(result);
+  if (looksLikeConflict(errorText)) return;
+  throw new Error(
+    `kb_create_document failed for ${seed.slug}: ${errorText || 'unknown error'}`,
+  );
 }
 
 async function readBySlug(
@@ -212,10 +221,7 @@ function textFromResult(result: McpToolResult): string {
   return '';
 }
 
-function looksLikeConflict(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const msg = 'message' in err && typeof err.message === 'string'
-    ? err.message.toLowerCase()
-    : '';
+function looksLikeConflict(text: string): boolean {
+  const msg = text.toLowerCase();
   return msg.includes('conflict') || msg.includes('already');
 }


### PR DESCRIPTION
## Summary

- `AgentHostRunner` logged `[AgentHostRunner] org_... prompts: created KB space agent-runtime` on every backend startup — not just first boot. The space row was *not* actually being recreated; only the log was wrong.
- Root cause: `ensureSpace` (and `ensureDocument`) in `packages/agent-runtime/src/prompt-resolver.ts` used `try/catch` to swallow the `KbInvalidError` "already exists" conflict. But `mcp.callTool()` never throws on tool errors — the MCP dispatch layer (`packages/mcp-toolkit/src/dispatch.ts:103-122`) converts thrown errors into `{ isError: true, content: [...] }` results. The catch was unreachable, `looksLikeConflict()` was dead code, and the success log fired unconditionally on every 30s reconcile.
- Fix: inspect `result.isError` (same pattern as `parseDocumentBody`). Conflict path returns silently; non-conflict errors now actually throw with the dispatch error text.
- Test fake MCP handle was rejecting on conflict, which hid the bug — updated to return `{ isError: true, ... }` matching real dispatch. Added an assertion that warm-boot logs zero `created KB space` lines and first-boot logs exactly one.

## Test plan

- [x] `pnpm -F @getmunin/agent-runtime test` — 93/93 pass, including new warm-boot assertion
- [x] `pnpm -F @getmunin/agent-runtime typecheck` — clean
- [ ] Restart backend twice against a persistent DB: first start logs `created KB space agent-runtime`, second start logs nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)