### PR TITLE
chore: align @getmunin/docs-pages version with fixed group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core", "@getmunin/agent-runtime", "@getmunin/agent-host"]],
+  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core", "@getmunin/agent-runtime", "@getmunin/agent-host", "@getmunin/docs-pages"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/.changeset/sync-docs-pages-version.md
+++ b/.changeset/sync-docs-pages-version.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/docs-pages': patch
+---
+
+Align `@getmunin/docs-pages` version with the rest of the fixed-group public packages and add it to the changesets `fixed` set so future releases keep all OSS package versions in lockstep.

--- a/packages/docs-pages/package.json
+++ b/packages/docs-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/docs-pages",
-  "version": "1.3.2",
+  "version": "4.19.1",
   "license": "MIT",
   "description": "Munin developer-portal route components shared between OSS and cloud Next apps.",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump \`@getmunin/docs-pages\` from \`1.3.2\` → \`4.19.1\` to match the rest of the public OSS packages.
- Add \`@getmunin/docs-pages\` to the changesets \`fixed\` group so future releases bump all public packages together — no more drift.

## Test plan
- [ ] CI green
- [ ] Confirm changesets release PR generated post-merge bumps the whole fixed group (including docs-pages) to the same next version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)