### PR TITLE
chore: publish @getmunin/chat-widget to GitHub Packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,11 +2,11 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core", "@getmunin/agent-runtime", "@getmunin/agent-host", "@getmunin/docs-pages"]],
+  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core", "@getmunin/agent-runtime", "@getmunin/agent-host", "@getmunin/docs-pages", "@getmunin/chat-widget"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@getmunin/backend", "@getmunin/chat-widget", "@getmunin/web", "@getmunin/eslint-config", "@getmunin/tsconfig"]
+  "ignore": ["@getmunin/backend", "@getmunin/web", "@getmunin/eslint-config", "@getmunin/tsconfig"]
 }
 

--- a/.changeset/publish-chat-widget.md
+++ b/.changeset/publish-chat-widget.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/chat-widget': patch
+---
+
+Publish `@getmunin/chat-widget` to GitHub Packages so the cloud backend image can install the prebuilt widget bundle from the registry instead of needing a workspace link. Aligns its version with the rest of the public OSS packages and adds it to the changesets `fixed` group so future releases keep all OSS package versions in lockstep.

--- a/apps/chat-widget/package.json
+++ b/apps/chat-widget/package.json
@@ -1,9 +1,21 @@
 {
   "name": "@getmunin/chat-widget",
-  "version": "2.0.0",
+  "version": "4.19.1",
+  "license": "MIT",
   "description": "Drop-in browser chat widget for self-hosted Munin. Built as a single content-hashed IIFE bundle and served by the Munin backend.",
-  "private": true,
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getmunin/munin.git",
+    "directory": "apps/chat-widget"
+  },
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch --mode development",


### PR DESCRIPTION
## Summary
- Remove \`private: true\` from \`@getmunin/chat-widget\` and add \`publishConfig\` (npm.pkg.github.com, restricted), \`repository\`, \`license\`, and \`files: ["dist"]\` so the build output ships with the published tarball.
- Bump version \`2.0.0\` → \`4.19.1\` to align with the rest of the public OSS packages.
- Remove \`@getmunin/chat-widget\` from the changesets \`ignore\` list and add it to the \`fixed\` group so future releases keep all OSS package versions in lockstep.

## Why
The cloud backend image currently can't ship a working \`/widget.js\` endpoint because the chat-widget bundle isn't available outside the OSS monorepo (\`api.getmunin.com/widget.js\` returns 503 — manifest missing). Publishing the package lets the cloud backend install it from the registry and copy the bundle into its image at build time (\`apps/backend-cloud/scripts/copy-widget.mjs\`, follow-up PR in munin-cloud).

## Test plan
- [ ] CI green
- [ ] Confirm changesets release PR generated post-merge publishes \`@getmunin/chat-widget@<next>\` to GitHub Packages
- [ ] Follow-up PR in \`munin-cloud\` consumes the package, bakes the bundle into the backend image, and \`api.getmunin.com/widget.js\` starts returning the hashed redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)