### PR TITLE
fix(chat-widget): move @getmunin/widget-voice to devDependencies

### DIFF
--- a/.changeset/chat-widget-fix-widget-voice-dep.md
+++ b/.changeset/chat-widget-fix-widget-voice-dep.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/chat-widget': patch
+---
+
+Move `@getmunin/widget-voice` from `dependencies` to `devDependencies`. Vite already inlines it into the IIFE bundle at build time (`inlineDynamicImports: true`), so consumers should not try to resolve it at install time. As shipped in 4.19.2 the published package errored on `pnpm install` because `widget-voice` is a private workspace package not available on the registry.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -26782,29 +26782,7 @@ SOFTWARE.
 - Author: Jan Amann
 - License: MIT
 
-```
-MIT License
-
-Copyright (c) 2024 Jan Amann
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
+_No LICENSE file shipped in the package; refer to homepage above._
 
 ---
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -26782,7 +26782,29 @@ SOFTWARE.
 - Author: Jan Amann
 - License: MIT
 
-_No LICENSE file shipped in the package; refer to homepage above._
+```
+MIT License
+
+Copyright (c) 2024 Jan Amann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
 
 ---
 

--- a/apps/chat-widget/package.json
+++ b/apps/chat-widget/package.json
@@ -23,12 +23,10 @@
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests"
   },
-  "dependencies": {
-    "@getmunin/widget-voice": "workspace:*"
-  },
   "devDependencies": {
     "@getmunin/eslint-config": "workspace:*",
     "@getmunin/tsconfig": "workspace:*",
+    "@getmunin/widget-voice": "workspace:*",
     "@types/node": "^22.10.0",
     "eslint": "^9.10.0",
     "happy-dom": "^20.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,10 +151,6 @@ importers:
         version: 2.1.9(@types/node@22.19.17)(happy-dom@20.9.0)(jiti@1.21.7)(jsdom@24.1.3)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/chat-widget:
-    dependencies:
-      '@getmunin/widget-voice':
-        specifier: workspace:*
-        version: link:../../packages/widget-voice
     devDependencies:
       '@getmunin/eslint-config':
         specifier: workspace:*
@@ -162,6 +158,9 @@ importers:
       '@getmunin/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      '@getmunin/widget-voice':
+        specifier: workspace:*
+        version: link:../../packages/widget-voice
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.17
@@ -224,7 +223,7 @@ importers:
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl:
         specifier: ^4.12.0
-        version: 4.12.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 4.12.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -571,7 +570,7 @@ importers:
         version: 1.14.0(react@19.2.6)
       next-intl:
         specifier: ^4.12.0
-        version: 4.12.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 4.12.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react:
         specifier: ^19.0.0
         version: 19.2.6
@@ -654,7 +653,7 @@ importers:
         version: link:../backend-core
       next-intl:
         specifier: ^4.12.0
-        version: 4.12.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 4.12.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react:
         specifier: ^19.0.0
         version: 19.2.6
@@ -11192,7 +11191,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.12.0: {}
 
-  next-intl@4.12.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
+  next-intl@4.12.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.5
       '@parcel/watcher': 2.5.6


### PR DESCRIPTION
## Summary
- Move \`@getmunin/widget-voice\` from \`dependencies\` to \`devDependencies\` in \`apps/chat-widget/package.json\`.
- Vite already inlines widget-voice into the IIFE bundle at build time (\`inlineDynamicImports: true\`), so the published package does not need it at install time.

## Why
As shipped in 4.19.2 the published \`@getmunin/chat-widget\` package fails \`pnpm install\` in any consumer with:

\`\`\`
ERR_PNPM_FETCH_404  GET https://npm.pkg.github.com/@getmunin%2Fwidget-voice: Not Found - 404
This error happened while installing the dependencies of @getmunin/chat-widget@4.19.2
\`\`\`

\`@getmunin/widget-voice\` is a private workspace package (no publishConfig, \`private: true\`), so it's not resolvable from the registry. Since the IIFE bundle inlines it, consumers don't actually need it.

## Test plan
- [ ] CI green
- [ ] After merge + release, \`pnpm install\` of \`@getmunin/chat-widget@4.19.3\` succeeds in a fresh consumer (e.g. \`munin-cloud/apps/backend-cloud\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)