### PR TITLE
fix(agent-runtime): handover via REST and post a public fallback message

### DIFF
--- a/.changeset/agent-runtime-handover-public-message.md
+++ b/.changeset/agent-runtime-handover-public-message.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/agent-runtime': patch
+---
+
+Fix silent handover when the agent runtime exhausts retries against an unhealthy LLM provider.
+
+- `conversation-handler` now calls a new admin REST endpoint (`POST /v1/conversations/:id/request-handover` with `publicFallbackMessage`) instead of routing handover through an end-user MCP tool call. The MCP path required `conv:write` scope on the end-user agent actor, which the in-process agent host doesn't grant — so the call was being silently denied with an MCP `errorResult`, leaving the conversation un-flagged and the end user staring at an empty widget.
+- `convService.requestHandover()` now accepts an optional `publicFallbackMessage`. When set, it posts a user-visible agent message (`internal: false`, `metadata.kind = "handover_fallback"`) so the end user sees confirmation that a teammate is coming, even when the LLM never produced any reply. Mirrored on the admin `conv_request_handover` MCP tool and `POST /v1/conversations/:id/request-handover` HTTP route.
+- `MuninRestClient` gains a `requestHandover(conversationId, { reason, publicFallbackMessage })` method.

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -113,6 +113,7 @@ function buildRest(overrides: Partial<MuninRestClient> = {}): MuninRestClient {
       Promise.resolve({ acquired: true, leaseExpiresAt: new Date(Date.now() + 3600_000).toISOString() }),
     ),
     releaseConversationClaim: vi.fn(() => Promise.resolve({ released: true })),
+    requestHandover: vi.fn(() => Promise.resolve()),
     ...overrides,
   };
 }
@@ -365,48 +366,23 @@ describe('createConversationHandler', () => {
     expect(call[2]?.sinceMessageId).toBe(lastMessageId);
   });
 
-  it('calls handover tool after MAX_RETRIES provider failures', async () => {
-    const handoverCalls: string[] = [];
-    const buildFailingMcp = (): OpenedMcp => ({
-      listTools: vi.fn(() =>
-        Promise.resolve([
-          {
-            name: 'kb_search',
-            description: 'kb',
-            inputSchema: { type: 'object', properties: {} },
-          },
-        ]),
-      ),
-      callTool: vi.fn((name: string) => {
-        handoverCalls.push(name);
-        return Promise.resolve<McpToolResult>({ content: [] });
-      }),
-      close: vi.fn(() => Promise.resolve()),
-    });
+  it('calls rest.requestHandover with a public fallback message after MAX_RETRIES provider failures', async () => {
     const rest = buildRest();
     const postSpy = vi.fn(() => Promise.resolve());
     rest.postAgentMessage = postSpy;
+    const handoverSpy = vi.fn(() => Promise.resolve());
+    rest.requestHandover = handoverSpy;
 
-    // Provider always errors → runAgent rethrows from listTools→provider call.
-    // We simulate this by making the first call to listTools succeed but the
-    // openai provider call fail. Easiest: make openMcp return a handle whose
-    // listTools throws on the first three runs, then succeeds for handover.
-    let runCount = 0;
     const handler = createConversationHandler({
       config: baseConfig,
       rest,
       prompts: buildPrompts(),
-      openMcp: () => {
-        runCount += 1;
-        if (runCount <= 3) {
-          return Promise.resolve({
-            listTools: vi.fn(() => Promise.reject(new Error('provider boom'))),
-            callTool: vi.fn(() => Promise.resolve<McpToolResult>({ content: [] })),
-            close: vi.fn(() => Promise.resolve()),
-          });
-        }
-        return Promise.resolve(buildFailingMcp());
-      },
+      openMcp: () =>
+        Promise.resolve({
+          listTools: vi.fn(() => Promise.reject(new Error('provider boom'))),
+          callTool: vi.fn(() => Promise.resolve<McpToolResult>({ content: [] })),
+          close: vi.fn(() => Promise.resolve()),
+        }),
       logger: silentLogger,
       scheduler: noDelayScheduler,
     });
@@ -415,7 +391,14 @@ describe('createConversationHandler', () => {
     await handler.flush();
 
     expect(postSpy).not.toHaveBeenCalled();
-    expect(handoverCalls).toEqual(['conv_request_handover_in_my_conversation']);
+    expect(handoverSpy).toHaveBeenCalledTimes(1);
+    const [conversationId, args] = handoverSpy.mock.calls[0] as unknown as [
+      string,
+      { reason?: string; publicFallbackMessage?: string },
+    ];
+    expect(conversationId).toBe('conv_1');
+    expect(args.reason).toMatch(/retries exhausted/);
+    expect(args.publicFallbackMessage).toMatch(/teammate will follow up/);
   });
 
   it('passes endUserId to openMcp once per attempt and never calls rest.mintDelegatedToken', async () => {

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -24,6 +24,8 @@ export interface HandlerConfig {
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
 const HANDOVER_TOOL_NAME = 'conv_request_handover_in_my_conversation';
+const RUNTIME_HANDOVER_FALLBACK_MESSAGE =
+  "Thanks for your message — I'm having trouble responding right now. A teammate will follow up shortly.";
 
 export interface OpenedMcp extends McpToolHandle {
   close(): Promise<void>;
@@ -312,11 +314,16 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
       ? `provider unavailable (${providerErrorCode})`
       : `agent retries exhausted (${lastError?.message ?? 'unknown'})`;
     log.error(`${conversationId} handover: ${reason}`);
-    await requestHandover(conversationId, endUserId).catch((err) => {
-      log.error(
-        `${conversationId} handover request failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    });
+    await deps.rest
+      .requestHandover(conversationId, {
+        reason,
+        publicFallbackMessage: RUNTIME_HANDOVER_FALLBACK_MESSAGE,
+      })
+      .catch((err) => {
+        log.error(
+          `${conversationId} handover request failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
     } finally {
       stopTyping();
       await releaseClaim(conversationId);
@@ -417,18 +424,6 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
           err instanceof Error ? err.message : String(err)
         }`,
       );
-    }
-  }
-
-  async function requestHandover(conversationId: string, endUserId: string): Promise<void> {
-    const mcp = await deps.openMcp({ endUserId });
-    try {
-      await mcp.callTool(HANDOVER_TOOL_NAME, {
-        conversationId,
-        reason: 'agent retries exhausted',
-      });
-    } finally {
-      await mcp.close().catch(() => undefined);
     }
   }
 

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -116,6 +116,10 @@ export interface MuninRestClient {
     holder: string;
   }): Promise<{ released: boolean }>;
   postInternalNote(conversationId: string, body: string): Promise<void>;
+  requestHandover(
+    conversationId: string,
+    input: { reason?: string; publicFallbackMessage?: string },
+  ): Promise<void>;
   mintDelegatedToken(endUserId: string, ttlSeconds?: number): Promise<DelegatedToken>;
   toRuntimeHistory(detail: ConversationDetail): ConversationMessage[];
   changeStatus(conversationId: string, status: ConversationStatus, snoozeUntil?: string): Promise<void>;
@@ -199,6 +203,23 @@ export function createMuninRestClient(opts: CreateMuninRestClientOptions): Munin
         method: 'POST',
         body: JSON.stringify({ body, internal: true }),
       });
+    },
+    async requestHandover(
+      conversationId: string,
+      input: { reason?: string; publicFallbackMessage?: string },
+    ): Promise<void> {
+      await call<unknown>(
+        `/v1/conversations/${encodeURIComponent(conversationId)}/request-handover`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            ...(input.reason ? { reason: input.reason } : {}),
+            ...(input.publicFallbackMessage
+              ? { publicFallbackMessage: input.publicFallbackMessage }
+              : {}),
+          }),
+        },
+      );
     },
     async mintDelegatedToken(endUserId: string, ttlSeconds = 600): Promise<DelegatedToken> {
       return call<DelegatedToken>('/v1/tokens/delegated', {

--- a/packages/backend-core/src/agent/in-process-rest-client.ts
+++ b/packages/backend-core/src/agent/in-process-rest-client.ts
@@ -146,6 +146,19 @@ function buildClient(opts: BuildOptions): MuninRestClient {
       });
     },
 
+    async requestHandover(
+      conversationId: string,
+      input: { reason?: string; publicFallbackMessage?: string },
+    ): Promise<void> {
+      await audited('runner:requestHandover', async () => {
+        await opts.conv.requestHandover({
+          conversationId,
+          reason: input.reason,
+          publicFallbackMessage: input.publicFallbackMessage,
+        });
+      });
+    },
+
     async tryAcquireConversation(input: {
       conversationId: string;
       holder: string;

--- a/packages/backend-core/src/control/conversations.controller.ts
+++ b/packages/backend-core/src/control/conversations.controller.ts
@@ -66,6 +66,7 @@ const StatusBody = z.object({
 const HandoverBody = z
   .object({
     reason: z.string().max(500).optional(),
+    publicFallbackMessage: z.string().max(2000).optional(),
   })
   .partial();
 
@@ -259,7 +260,11 @@ export class ConversationsController {
     const parsed = HandoverBody.safeParse(body ?? {});
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return translate(() =>
-      this.conv.requestHandover({ conversationId: id, reason: parsed.data.reason }),
+      this.conv.requestHandover({
+        conversationId: id,
+        reason: parsed.data.reason,
+        publicFallbackMessage: parsed.data.publicFallbackMessage,
+      }),
     );
   }
 

--- a/packages/backend-core/src/modules/conv/conv.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.integration.test.ts
@@ -338,6 +338,48 @@ const skipReason = TEST_URL
     void flagged;
   }, 30_000);
 
+  it('admin handover with publicFallbackMessage posts a public agent message visible to end-user', async () => {
+    const startResp = await rest<{ id: string }>(endUserToken, 'POST', '/v1/end-users/me/conversations', {
+      body: 'Are you there?',
+    });
+    const conv = startResp.body;
+
+    type Detail = {
+      needsHumanAttention: boolean;
+      messages: Array<{
+        body: string;
+        authorType: string;
+        internal: boolean;
+        metadata?: Record<string, unknown> | null;
+      }>;
+    };
+
+    await withClient(adminKey, async (c) => {
+      await c.callTool({
+        name: 'conv_request_handover',
+        arguments: {
+          conversationId: conv.id,
+          reason: 'provider unavailable (provider_other)',
+          publicFallbackMessage:
+            "Thanks for your message — I'm having trouble responding right now. A teammate will follow up shortly.",
+        },
+      });
+    });
+
+    const endUserDetail = await rest<Detail>(
+      endUserToken,
+      'GET',
+      `/v1/end-users/me/conversations/${conv.id}`,
+    );
+
+    expect(endUserDetail.body.needsHumanAttention).toBe(true);
+    const publicAgentMessages = endUserDetail.body.messages.filter(
+      (m) => m.authorType === 'agent' && !m.internal,
+    );
+    expect(publicAgentMessages).toHaveLength(1);
+    expect(publicAgentMessages[0]!.body).toMatch(/teammate will follow up/);
+  }, 30_000);
+
   it('end-user agent can flag its own conversation via conv_request_handover_in_my_conversation (self-service)', async () => {
     const startResp = await rest<{ id: string }>(endUserToken, 'POST', '/v1/end-users/me/conversations', {
       body: 'I need to talk to a human about my contract.',

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -944,6 +944,7 @@ export class ConvService {
     conversationId: string;
     reason?: string;
     suggestedReply?: string;
+    publicFallbackMessage?: string;
     postSystemNote?: boolean;
   }): Promise<ConversationSummary> {
     const ctx = getCurrentContext();
@@ -986,6 +987,19 @@ export class ConvService {
         body: draft,
         internal: true,
         metadata: { kind: 'draft_reply' },
+      });
+    }
+
+    const publicFallback = input.publicFallbackMessage?.trim();
+    if (publicFallback) {
+      await ctx.db.insert(schema.convMessages).values({
+        orgId: actor.orgId,
+        conversationId: input.conversationId,
+        authorType: 'agent',
+        authorId: actor.id,
+        body: publicFallback,
+        internal: false,
+        metadata: { kind: 'handover_fallback' },
       });
     }
 

--- a/packages/backend-core/src/modules/conv/conv.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.tools.ts
@@ -38,6 +38,7 @@ const RequestHandoverInput = z.object({
   conversationId: z.string(),
   reason: z.string().max(500).optional(),
   suggestedReply: z.string().max(2000).optional(),
+  publicFallbackMessage: z.string().max(2000).optional(),
 });
 
 const SearchInput = z.object({


### PR DESCRIPTION
## Summary

When the in-process agent host exhausts retries against an unhealthy LLM provider, it should flag the conversation for human handover **and** post a user-visible "a teammate will follow up shortly" reply. Today neither happens — the widget shows "typing…" for a couple seconds, then nothing, and the conversation stays \`needs_human_attention = false\` on the backend.

## Root cause

\`conversation-handler.requestHandover()\` routed handover through the end-user MCP tool \`conv_request_handover_in_my_conversation\`, which requires the \`conv:write\` scope. The in-process \`openEndUserAgentMcpClient\` builds an end-user actor with **no scopes** (\`synth-agent-actor.ts:15\` defaults to \`[]\`), so the MCP dispatcher rejects the call at the scope gate (\`dispatch.ts:80\`) and returns an \`errorResult\` — which never throws. The runtime logs "handover: agent retries exhausted" and exits without ever flipping the flag or sending the user anything.

## Fix

The runtime-driven failure path is something the **host** is doing on its own (the LLM never even ran). There's no reason to round-trip through MCP under end-user identity. Switch it to a direct admin REST call:

\`\`\`
agent-host (in-process)
  └─ rest.requestHandover(conversationId, { reason, publicFallbackMessage })
       └─ convService.requestHandover({ ..., publicFallbackMessage })
                                       ← admin context, full scopes, public message posted
\`\`\`

- \`conv.service.requestHandover()\` accepts an optional \`publicFallbackMessage\`; when set, inserts a public \`agent\` message (\`internal: false\`, \`metadata.kind = "handover_fallback"\`).
- \`MuninRestClient\` gains \`requestHandover(conversationId, { reason, publicFallbackMessage })\`. HTTP impl + in-process factory both wired.
- \`conversation-handler.ts\` swaps the MCP call for \`deps.rest.requestHandover(...)\` and passes a standardized fallback string. Removes the now-unused inner helper.
- Admin MCP tool \`conv_request_handover\` and HTTP endpoint \`POST /v1/conversations/:id/request-handover\` both accept \`publicFallbackMessage\`.

## Not in scope (follow-up)

The **LLM-driven** self-service handover path — when the LLM itself calls \`conv_request_handover_in_my_conversation\` mid-conversation — still goes through MCP and has the same \`conv:write\` scope mismatch. Will be addressed in a separate PR by either dropping the scope requirement on self-service-audience tools (audience is already the access gate) or granting the in-process end-user actor the appropriate scopes.

## Test plan

- [x] \`pnpm -F @getmunin/agent-runtime test\` — 93/93
- [x] \`pnpm -F @getmunin/backend-core test\` (integration) — 551/551, including new "admin handover with publicFallbackMessage posts a public agent message visible to end-user" test
- [x] \`pnpm -F @getmunin/agent-runtime typecheck\` / \`@getmunin/backend-core typecheck\`
- [ ] Reproduce locally: bogus provider key → send widget message → verify (a) widget shows fallback reply within a few seconds, (b) conversation flagged in dashboard "Live now"

🤖 Generated with [Claude Code](https://claude.com/claude-code)