### PR TITLE
fix(agent-host): grant in-process end-user actor the self-service scopes it needs

### DIFF
--- a/.changeset/in-process-end-user-actor-scopes.md
+++ b/.changeset/in-process-end-user-actor-scopes.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/agent-host': patch
+'@getmunin/agent-runtime': patch
+'@getmunin/mcp-toolkit': patch
+---
+
+Fix the in-process end-user agent actor having no scopes, which silently disabled every self-service-audience tool that requires a write scope (handover, phone-call request, my-contact update, log-activity-self).
+
+- `agent-host`'s `openMcp` factory now passes a default scope set to `openEndUserAgentMcpClient` covering the full self-service surface: `conv:read`, `conv:write`, `kb:read`, `crm:read`, `crm:write`. Previously the actor was built with `[]`, so the MCP dispatcher rejected every gated tool call with a structured `errorResult('Missing required scope: …')` — silently, because tool errors do not throw — and the LLM's call was a no-op.
+- `agent-runtime`'s HTTP `mintDelegatedToken` default now includes `crm:write` for parity, so delegated end-user tokens minted by the runtime can call the same self-service surface.
+- Adds a regression test asserting a self-service actor with broad scopes is still blocked from admin-audience tools — the audience gate runs before the scope check, so granting an end-user agent `conv:write` does *not* unlock admin conv tools.

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -68,6 +68,14 @@ const RECONCILE_INTERVAL_MS = 30_000;
 const CURATOR_LEASE_SECONDS = 600;
 const CURATOR_MAX_SCHEDULED_DELAY_MS = 24 * 60 * 60 * 1000;
 
+const DEFAULT_END_USER_AGENT_SCOPES: readonly string[] = [
+  'conv:read',
+  'conv:write',
+  'kb:read',
+  'crm:read',
+  'crm:write',
+];
+
 export interface AgentHostRunnerOptions {
   databaseUrl?: string;
 }
@@ -334,6 +342,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
             endUserId,
             registry: this.mcpRegistry,
             skills: this.mcpSkills,
+            scopes: DEFAULT_END_USER_AGENT_SCOPES,
           }),
         ),
       holderId: this.holderId,

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -206,7 +206,7 @@ export function createMuninRestClient(opts: CreateMuninRestClientOptions): Munin
         body: JSON.stringify({
           endUserId,
           audiences: ['self_service'],
-          scopes: ['conv:read', 'conv:write', 'kb:read', 'crm:read'],
+          scopes: ['conv:read', 'conv:write', 'kb:read', 'crm:read', 'crm:write'],
           ttlSeconds,
         }),
       });

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -117,6 +117,36 @@ describe('openInProcessMcpClient', () => {
     );
   });
 
+  it('self-service actor with broad scopes is still blocked by audience gate on admin tools', async () => {
+    fakeAudit.record.mockClear();
+    const selfServiceWithBroadScopes = new ActorIdentity(
+      'end_user_agent',
+      'agent:eu_1',
+      'org_test',
+      ['kb:write', 'kb:read', 'conv:write', 'crm:write'],
+      ['self_service'],
+      'eu_1',
+    );
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: selfServiceWithBroadScopes,
+      audience: 'self_service',
+      audit: fakeAudit,
+    });
+
+    const tools = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toEqual(['self_only']);
+    expect(names).not.toContain('echo');
+    expect(names).not.toContain('kb_write');
+
+    const out = await client.callTool('kb_write', {});
+    expect(out.isError).toBe(true);
+    expect(fakeAudit.record).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: 'kb_write', result: 'denied', error: 'audience_mismatch' }),
+    );
+  });
+
   it('callTool enforces scopes against the actor', async () => {
     fakeAudit.record.mockClear();
     const scopedActor = new ActorIdentity(


### PR DESCRIPTION
## Summary

Follow-up to #250. The runtime-driven auto-handover path is now fixed (PR #250 routes it through admin REST). This PR fixes the parallel hole for the **LLM-driven** self-service tool calls inside the agent loop — the LLM calling \`conv_request_handover_in_my_conversation\`, \`crm_update_my_contact\`, \`crm_log_activity_self\`, \`conv_request_phone_call_for_my_conversation\` mid-conversation.

## Root cause

\`packages/agent-host/src/runner.service.ts:329\` opens the in-process end-user MCP client without passing any \`scopes\`. \`packages/core/src/request/synth-agent-actor.ts:15\` defaults \`scopes\` to \`[]\`. The dispatcher (\`packages/mcp-toolkit/src/dispatch.ts:77-81\`) rejects any tool call requiring a scope the actor doesn't have, returning a structured \`errorResult('Missing required scope: …')\` — which **does not throw** — so every gated self-service tool call from the LLM has been a silent no-op.

## Fix

Pass a default scope set covering the full self-service-audience surface to \`openEndUserAgentMcpClient\`:

\`conv:read · conv:write · kb:read · crm:read · crm:write\`

Updates \`agent-runtime\`'s HTTP \`mintDelegatedToken\` default (\`munin-rest.ts:209\`) to match (it was missing \`crm:write\`, so delegated end-user tokens served over the network had the same silent-fail behavior for \`crm_update_my_contact\` / \`crm_log_activity_self\`).

## Safety

The **audience gate runs before the scope check** (\`dispatch.ts:72\` → \`:77\`). Granting the end-user agent \`conv:write\` does **not** unlock admin-audience tools like \`conv_send_message\`, \`conv_assign_conversation\`, \`conv_change_status\`. The audience system is the primary access control; scopes are the secondary fine-grained gate.

This is asserted by a new regression test in \`packages/mcp-toolkit/src/in-process-client.test.ts\`: a self-service actor with broad scopes (\`kb:write\`, \`conv:write\`, \`crm:write\`, …) listing tools only sees self-service-audience tools, and calling an admin-audience tool returns \`isError: true\` with \`audience_mismatch\` — even when the actor has the required scope.

Self-service-audience tools have layered defense at the data level too:

- RLS pins all reads/writes to the calling \`app_end_user_id()\` (\`conv.sql\` + crm policies).
- Tool input schemas restrict fields (\`crm_update_my_contact\` only allows \`name\`/\`phone\`/\`address\`).

## Test plan

- [x] \`pnpm -F @getmunin/mcp-toolkit test\` — 12/12 (including new regression test for self-service → admin denial)
- [x] \`pnpm -F @getmunin/agent-runtime test\` — 93/93
- [x] \`pnpm -F @getmunin/agent-host test\` — 12/12
- [x] Typechecks across all three packages
- [ ] Manual: reproduce LLM-driven handover (the LLM calls \`conv_request_handover_in_my_conversation\` mid-conversation) and verify \`needs_human_attention\` flips on the conversation row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)