### PR TITLE
feat(feedback): MCP tools for global roadmap search and voting

### DIFF
--- a/.changeset/feedback-search-and-vote-tools.md
+++ b/.changeset/feedback-search-and-vote-tools.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': patch
+---
+
+Extend the feedback MCP surface with global roadmap search and voting.
+
+- `feedback_search` queries the public Munin roadmap (`GET /v1/public/feedback`) so agents can find an existing item to vote on before filing a duplicate. Supports `q`, `appScope`, `status`, `sort` (`votes`|`recent`), and `limit` (≤100).
+- `feedback_vote` casts the instance's vote on a published item via the HMAC-signed `POST /v1/public/feedback/:id/vote` endpoint. Idempotent on `(feedbackId, instanceId)`; surfaces 404 (item missing or not public) and 429 (per-instance quota) as typed errors.
+- `FeedbackForwarder` keeps a single HTTP entry point for submit/search/vote; reuses the existing `munin-feedback-intake-v1` HMAC derivation so both directions share one key and constant.
+- OSS landing page gains a "Read the docs →" link under the Get started / Sign in buttons (en + nb).

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -35,6 +35,13 @@ export default function HomePage() {
               {t('signIn')}
             </Button>
           </div>
+          <Link
+            href="/docs"
+            className="inline-flex items-center gap-1 text-sm text-ink-soft dark:text-foreground/80 hover:text-ink dark:hover:text-foreground"
+          >
+            {t('readTheDocs')}
+            <span aria-hidden="true">→</span>
+          </Link>
         </div>
       </div>
     </main>

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -4664,5 +4664,89 @@
       ],
       "additionalProperties": false
     }
+  },
+  {
+    "name": "feedback_search",
+    "title": "Feedback: Search global roadmap",
+    "description": "Search the public Munin roadmap for items matching a query. Call this before feedback_create to find an existing item to vote on instead of filing a duplicate. Returns only items the Munin team has published; pending and rejected items are hidden. sort defaults to votes (highest first); use \"recent\" for newest. limit is capped at 100.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "q": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "appScope": {
+          "type": "string",
+          "enum": [
+            "kb",
+            "conv",
+            "crm",
+            "cms",
+            "core"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "open",
+            "planned",
+            "in_progress",
+            "done",
+            "wontfix",
+            "duplicate"
+          ]
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "votes",
+            "recent"
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "feedback_vote",
+    "title": "Feedback: Vote on roadmap item",
+    "description": "Cast this instance's vote on a published roadmap item, optionally attaching a short comment. Idempotent: a second call from the same instance returns { alreadyVoted: true } without inflating the count. Throws feedback_item_not_found if the id is unknown or the item is not public, and feedback_vote_quota_exceeded if the per-instance quota has been hit.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": "writes",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string",
+          "maxLength": 2000
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    }
   }
 ]

--- a/packages/backend-core/src/modules/feedback/feedback.forwarder.test.ts
+++ b/packages/backend-core/src/modules/feedback/feedback.forwarder.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { signHmac } from '@getmunin/core';
+import { canonicalVoteBody } from './feedback.forwarder.ts';
+
+const HMAC_KEY_CONSTANT = 'munin-feedback-intake-v1';
+
+describe('canonicalVoteBody', () => {
+  it('serializes keys in the order the cloud verifier expects', () => {
+    const body = canonicalVoteBody({
+      feedbackId: 'fb-123',
+      instanceId: '00000000-0000-0000-0000-000000000001',
+      comment: null,
+      votedAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(body).toBe(
+      '{"feedbackId":"fb-123","instanceId":"00000000-0000-0000-0000-000000000001","comment":null,"votedAt":"2026-01-01T00:00:00.000Z"}',
+    );
+  });
+
+  it('coalesces missing comment to null', () => {
+    const body = canonicalVoteBody({
+      feedbackId: 'fb-123',
+      instanceId: '00000000-0000-0000-0000-000000000001',
+      comment: null,
+      votedAt: '2026-01-01T00:00:00.000Z',
+    });
+    const parsed = JSON.parse(body) as { comment: unknown };
+    expect(parsed.comment).toBeNull();
+  });
+
+  it('produces a signature the cloud verifier will accept', () => {
+    const instanceId = '00000000-0000-0000-0000-000000000001';
+    const body = canonicalVoteBody({
+      feedbackId: 'fb-123',
+      instanceId,
+      comment: 'looks great',
+      votedAt: '2026-01-01T00:00:00.000Z',
+    });
+    const ossKey = signHmac(instanceId, HMAC_KEY_CONSTANT);
+    const ossSignature = signHmac(body, ossKey);
+
+    const cloudKey = signHmac(instanceId, HMAC_KEY_CONSTANT);
+    const cloudExpected = signHmac(body, cloudKey);
+
+    expect(ossSignature).toBe(cloudExpected);
+  });
+});

--- a/packages/backend-core/src/modules/feedback/feedback.forwarder.ts
+++ b/packages/backend-core/src/modules/feedback/feedback.forwarder.ts
@@ -19,6 +19,51 @@ export interface ForwardResult {
   error?: string;
 }
 
+export interface PublicFeedbackItem {
+  id: string;
+  title: string;
+  body: string;
+  appScope: string | null;
+  status: string;
+  voteCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SearchParams {
+  q?: string;
+  appScope?: string;
+  status?: string;
+  sort?: 'votes' | 'recent';
+  limit?: number;
+}
+
+export interface VoteResult {
+  voteCount: number;
+  alreadyVoted: boolean;
+}
+
+export class FeedbackItemNotFoundError extends Error {
+  readonly code = 'feedback_item_not_found';
+  constructor(id: string) {
+    super(`feedback_item_not_found: no public roadmap item with id ${id}`);
+  }
+}
+
+export class FeedbackVoteQuotaExceededError extends Error {
+  readonly code = 'feedback_vote_quota_exceeded';
+  constructor() {
+    super('feedback_vote_quota_exceeded: per-instance vote quota exhausted');
+  }
+}
+
+export class FeedbackRemoteError extends Error {
+  readonly code = 'feedback_remote_error';
+  constructor(status: number, detail: string) {
+    super(`feedback_remote_error: cloud responded ${status} ${detail}`);
+  }
+}
+
 @Injectable()
 export class FeedbackForwarder {
   private readonly logger = new Logger(FeedbackForwarder.name);
@@ -28,9 +73,8 @@ export class FeedbackForwarder {
   ) {}
 
   async forward(input: ForwardPayload): Promise<ForwardResult> {
-    const intakeUrl = process.env.MUNIN_FEEDBACK_INTAKE_URL ?? DEFAULT_INTAKE_URL;
     const instanceId = await this.instanceId.get();
-    const body = canonicalBody({
+    const body = canonicalSubmitBody({
       title: input.title,
       body: input.body,
       appScope: input.appScope ?? null,
@@ -42,7 +86,7 @@ export class FeedbackForwarder {
     const signature = `v1=${signHmac(body, key)}`;
 
     try {
-      const res = await fetch(intakeUrl, {
+      const res = await fetch(this.intakeBaseUrl(), {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
@@ -69,9 +113,64 @@ export class FeedbackForwarder {
       };
     }
   }
+
+  async search(params: SearchParams): Promise<PublicFeedbackItem[]> {
+    const qs = new URLSearchParams();
+    if (params.q) qs.set('q', params.q);
+    if (params.appScope) qs.set('appScope', params.appScope);
+    if (params.status) qs.set('status', params.status);
+    if (params.sort) qs.set('sort', params.sort);
+    if (params.limit !== undefined) qs.set('limit', String(params.limit));
+    const query = qs.toString();
+    const url = query ? `${this.intakeBaseUrl()}?${query}` : this.intakeBaseUrl();
+
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '');
+      throw new FeedbackRemoteError(res.status, errText.slice(0, 300));
+    }
+    return (await res.json()) as PublicFeedbackItem[];
+  }
+
+  async vote(input: { feedbackId: string; comment?: string }): Promise<VoteResult> {
+    const instanceId = await this.instanceId.get();
+    const votedAt = new Date().toISOString();
+    const body = canonicalVoteBody({
+      feedbackId: input.feedbackId,
+      instanceId,
+      comment: input.comment ?? null,
+      votedAt,
+    });
+    const key = signHmac(instanceId, HMAC_KEY_CONSTANT);
+    const signature = `v1=${signHmac(body, key)}`;
+
+    const url = `${this.intakeBaseUrl()}/${encodeURIComponent(input.feedbackId)}/vote`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-munin-signature': signature,
+      },
+      body,
+    });
+    if (res.ok) {
+      return (await res.json()) as VoteResult;
+    }
+    const errText = await res.text().catch(() => '');
+    if (res.status === 404) throw new FeedbackItemNotFoundError(input.feedbackId);
+    if (res.status === 429) throw new FeedbackVoteQuotaExceededError();
+    throw new FeedbackRemoteError(res.status, errText.slice(0, 300));
+  }
+
+  private intakeBaseUrl(): string {
+    return process.env.MUNIN_FEEDBACK_INTAKE_URL ?? DEFAULT_INTAKE_URL;
+  }
 }
 
-function canonicalBody(p: {
+function canonicalSubmitBody(p: {
   title: string;
   body: string;
   appScope: string | null;
@@ -86,5 +185,19 @@ function canonicalBody(p: {
     attribution: p.attribution,
     instanceId: p.instanceId,
     submittedAt: p.submittedAt,
+  });
+}
+
+export function canonicalVoteBody(p: {
+  feedbackId: string;
+  instanceId: string;
+  comment: string | null;
+  votedAt: string;
+}): string {
+  return JSON.stringify({
+    feedbackId: p.feedbackId,
+    instanceId: p.instanceId,
+    comment: p.comment,
+    votedAt: p.votedAt,
   });
 }

--- a/packages/backend-core/src/modules/feedback/feedback.service.ts
+++ b/packages/backend-core/src/modules/feedback/feedback.service.ts
@@ -2,7 +2,12 @@ import { Inject, Injectable } from '@nestjs/common';
 import { desc, eq } from 'drizzle-orm';
 import { schema } from '@getmunin/db';
 import { getCurrentContext } from '@getmunin/core';
-import { FeedbackForwarder } from './feedback.forwarder.ts';
+import {
+  FeedbackForwarder,
+  type PublicFeedbackItem,
+  type SearchParams,
+  type VoteResult,
+} from './feedback.forwarder.ts';
 
 const APP_SCOPES = ['kb', 'conv', 'crm', 'cms', 'core'] as const;
 export type FeedbackAppScope = (typeof APP_SCOPES)[number];
@@ -123,6 +128,14 @@ export class FeedbackService {
         .where(eq(schema.feedbackOutbox.id, id));
     }
     throw new FeedbackForwardFailedError(result.status, errorText);
+  }
+
+  search(params: SearchParams): Promise<PublicFeedbackItem[]> {
+    return this.forwarder.search(params);
+  }
+
+  vote(input: { feedbackId: string; comment?: string }): Promise<VoteResult> {
+    return this.forwarder.vote(input);
   }
 
   private async findById(id: string) {

--- a/packages/backend-core/src/modules/feedback/feedback.tools.ts
+++ b/packages/backend-core/src/modules/feedback/feedback.tools.ts
@@ -17,6 +17,22 @@ const IdInput = z.object({ id: z.string() });
 
 const EmptyInput = z.object({});
 
+const StatusSchema = z.enum(['open', 'planned', 'in_progress', 'done', 'wontfix', 'duplicate']);
+const SortSchema = z.enum(['votes', 'recent']);
+
+const SearchInput = z.object({
+  q: z.string().min(1).max(200).optional(),
+  appScope: AppScopeSchema.optional(),
+  status: StatusSchema.optional(),
+  sort: SortSchema.optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+const VoteInput = z.object({
+  id: z.string(),
+  comment: z.string().max(2000).optional(),
+});
+
 @Injectable()
 export class FeedbackTools {
   constructor(@Inject(FeedbackService) private readonly service: FeedbackService) {}
@@ -86,5 +102,32 @@ export class FeedbackTools {
   async reject(args: z.infer<typeof IdInput>) {
     await this.service.reject(args.id);
     return { ok: true };
+  }
+
+  @McpTool({
+    name: 'feedback_search',
+    title: 'Feedback: Search global roadmap',
+    description:
+      'Search the public Munin roadmap for items matching a query. Call this before feedback_create to find an existing item to vote on instead of filing a duplicate. Returns only items the Munin team has published; pending and rejected items are hidden. sort defaults to votes (highest first); use "recent" for newest. limit is capped at 100.',
+    audiences: ['admin'],
+    scopes: [],
+    input: SearchInput,
+    readOnlyHint: true,
+  })
+  async search(args: z.infer<typeof SearchInput>) {
+    return { items: await this.service.search(args) };
+  }
+
+  @McpTool({
+    name: 'feedback_vote',
+    title: 'Feedback: Vote on roadmap item',
+    description:
+      'Cast this instance\'s vote on a published roadmap item, optionally attaching a short comment. Idempotent: a second call from the same instance returns { alreadyVoted: true } without inflating the count. Throws feedback_item_not_found if the id is unknown or the item is not public, and feedback_vote_quota_exceeded if the per-instance quota has been hit.',
+    audiences: ['admin'],
+    scopes: [],
+    input: VoteInput,
+  })
+  async vote(args: z.infer<typeof VoteInput>) {
+    return this.service.vote({ feedbackId: args.id, comment: args.comment });
   }
 }

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -39,7 +39,8 @@
     "title": "The open source customer platform for the <accent>agentic</accent> era.",
     "subtitle": "CRM, knowledge, content, outreach, and conversations in one MCP-first system. Agents work against the same tools and data as your team — with review and handover where it matters.",
     "getStarted": "Get started",
-    "signIn": "Sign in"
+    "signIn": "Sign in",
+    "readTheDocs": "Read the docs"
   },
   "auth": {
     "signIn": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -39,7 +39,8 @@
     "title": "Kundeplattformen med åpen kildekode – for den <accent>agentiske</accent> æraen.",
     "subtitle": "CRM, kunnskap, innhold, oppsøk og samtaler i ett MCP-først-system. Agenter jobber mot de samme verktøyene og dataene som teamet ditt — med vurdering og overlevering der det betyr noe.",
     "getStarted": "Kom i gang",
-    "signIn": "Logg inn"
+    "signIn": "Logg inn",
+    "readTheDocs": "Les dokumentasjonen"
   },
   "auth": {
     "signIn": {


### PR DESCRIPTION
## Summary

- `feedback_search` MCP tool — wraps `GET /v1/public/feedback` so agents can find an existing roadmap item before filing a duplicate. Forwards `q`, `appScope`, `status`, `sort` (`votes`|`recent`), `limit` (≤100).
- `feedback_vote` MCP tool — HMAC-signs and POSTs to `/v1/public/feedback/:id/vote`. Idempotent per `(instanceId, feedbackId)`; surfaces 404 (missing or unpublished) and 429 (per-instance quota) as typed errors.
- `FeedbackForwarder` is the single HTTP entry point for submit / search / vote and reuses the existing `munin-feedback-intake-v1` HMAC derivation so both directions share one canonical-body discipline.
- Locks the canonical vote body shape against the cloud verifier with a unit test.
- Adds a small "Read the docs →" link under the buttons on the OSS landing page (en + nb).

## Test plan

- [ ] CI green (typecheck, unit, integration, openapi generation).
- [ ] `feedback_search { q: "..." }` returns items from a dev cloud.
- [ ] `feedback_vote { id }` returns `{ alreadyVoted: false }` then `{ alreadyVoted: true }` on the second call.
- [ ] `feedback_vote { id: "<missing>" }` raises `feedback_item_not_found`.
- [ ] Landing page shows "Read the docs →" below the buttons in both en and nb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)