### PR TITLE
feat(quotas): gate row-count caps behind MUNIN_QUOTAS_ENABLED

### DIFF
--- a/.changeset/oss-quotas-opt-in.md
+++ b/.changeset/oss-quotas-opt-in.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Make row-count quotas opt-in via `MUNIN_QUOTAS_ENABLED`.
+
+OSS self-hosters on their own hardware were being capped at the cloud free-tier ceilings (10K KB docs, 100 KB spaces, 50 CMS collections, 10K CMS entries, 1K CMS assets) because `QuotasService.assertCanAdd` ran unconditionally. The defaults make sense for a tiered SaaS but not for someone running Munin on their own box.
+
+`assertCanAdd` now no-ops unless `MUNIN_QUOTAS_ENABLED=true`. Set it in cloud deployments to keep the existing behavior; leave it unset (or `false`) on self-hosted instances. The per-org `orgs.settings.quotas.<resource>` override path is unchanged.

--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,15 @@ MUNIN_FEEDBACK_ENABLED=false
 # end-to-end testing). Defaults to Munin's production roadmap intake.
 # MUNIN_FEEDBACK_INTAKE_URL=https://feedback.getmunin.com/v1/public/feedback
 
+# --- Quotas (tier caps) -------------------------------------------------
+# Per-resource row caps (KB docs/spaces, CMS collections/entries/assets)
+# enforced at write time. Off by default so OSS self-hosters aren't capped
+# on their own hardware. Set to `true` in tiered/SaaS deployments. When
+# enabled, defaults come from FREE_TIER_QUOTAS in
+# packages/backend-core/src/common/quotas/quotas.service.ts; per-org
+# overrides live at `orgs.settings.quotas.<resource>`.
+MUNIN_QUOTAS_ENABLED=false
+
 # --- Curator scheduler (backend-side cron) ------------------------------
 # The backend enqueues curator sweep jobs on these cadences via
 # @nestjs/schedule. Standard cron expressions (minute hour dom mon dow).

--- a/packages/backend-core/src/common/quotas/quotas.service.test.ts
+++ b/packages/backend-core/src/common/quotas/quotas.service.test.ts
@@ -18,6 +18,7 @@ const skipReason = TEST_URL
   let actor: ActorIdentity;
 
   beforeAll(async () => {
+    process.env.MUNIN_QUOTAS_ENABLED = 'true';
     await runMigrations(TEST_URL!);
     db = createDb(TEST_URL!, { serviceRole: true });
     const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');

--- a/packages/backend-core/src/common/quotas/quotas.service.ts
+++ b/packages/backend-core/src/common/quotas/quotas.service.ts
@@ -37,17 +37,22 @@ const TABLE_FOR: Record<QuotaResource, string> = {
   cms_assets: 'cms_assets',
 };
 
+function isEnabled(): boolean {
+  const raw = process.env.MUNIN_QUOTAS_ENABLED;
+  if (raw === undefined) return false;
+  return raw.toLowerCase() === 'true' || raw === '1';
+}
+
 /**
- * Free-tier row caps. Counted at write time inside the request transaction;
- * the count and the insert see the same MVCC snapshot, so two concurrent
- * inserts cannot both pass when the org is one row from the cap (the second
- * will block on lock acquisition or fail at insert with a serialization error
- * if the table is heavily contended — neither is worse than rejecting at
- * the cap edge).
+ * Row caps for tiered deployments. Opt-in via MUNIN_QUOTAS_ENABLED so OSS
+ * self-hosters aren't capped on their own hardware. When enabled, the count
+ * runs inside the request transaction, so the count and the insert see the
+ * same MVCC snapshot and concurrent inserts at the cap edge can't both pass.
  */
 @Injectable()
 export class QuotasService {
   async assertCanAdd(resource: QuotaResource): Promise<void> {
+    if (!isEnabled()) return;
     const ctx = getCurrentContext();
     const orgId = ctx.actor!.orgId;
     if (!orgId) return;

--- a/packages/backend-core/src/modules/cms/cms.service.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.test.ts
@@ -609,6 +609,16 @@ class StubStorage implements AssetStorage {
   // ─── Quotas / RLS ────────────────────────────────────────────────────
 
   describe('quotas and RLS', () => {
+    let previousQuotasEnv: string | undefined;
+    beforeAll(() => {
+      previousQuotasEnv = process.env.MUNIN_QUOTAS_ENABLED;
+      process.env.MUNIN_QUOTAS_ENABLED = 'true';
+    });
+    afterAll(() => {
+      if (previousQuotasEnv === undefined) delete process.env.MUNIN_QUOTAS_ENABLED;
+      else process.env.MUNIN_QUOTAS_ENABLED = previousQuotasEnv;
+    });
+
     it('createCollection respects org quota cap', async () => {
       await db
         .update(schema.orgs)

--- a/packages/backend-core/src/modules/kb/kb.service.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.test.ts
@@ -158,7 +158,8 @@ const skipReason = TEST_URL
   });
 
   it('createDocument throws QuotaExceededError at the org cap and writes no row', async () => {
-    // Tighten the cap for this test only.
+    const previous = process.env.MUNIN_QUOTAS_ENABLED;
+    process.env.MUNIN_QUOTAS_ENABLED = 'true';
     await db
       .update(schema.orgs)
       .set({ settings: { quotas: { kb_documents: 1 } } })
@@ -175,6 +176,8 @@ const skipReason = TEST_URL
       expect(rows[0]!.count).toBe(1);
     } finally {
       await db.update(schema.orgs).set({ settings: {} }).where(sql`id = ${orgId}`);
+      if (previous === undefined) delete process.env.MUNIN_QUOTAS_ENABLED;
+      else process.env.MUNIN_QUOTAS_ENABLED = previous;
     }
   });
 


### PR DESCRIPTION
## Summary

- `QuotasService.assertCanAdd` now no-ops unless `MUNIN_QUOTAS_ENABLED=true`. OSS self-hosters were being capped at the cloud free-tier ceilings (10K KB docs, 100 KB spaces, 50 CMS collections, 10K CMS entries, 1K CMS assets) on their own hardware, which is wrong.
- Cloud deployments set `MUNIN_QUOTAS_ENABLED=true`. The per-org `orgs.settings.quotas.<resource>` override path is unchanged.
- The three tests that verify enforcement (quotas, kb, cms) opt the env in explicitly so the at-cap rejection path still gets coverage.

## Out of scope

Usage-based metering for MCP calls, API calls, and contacts will live in cloud and uses a different mechanism (period-windowed counters) than this row-count cap.

## Test plan

- [ ] CI green.
- [ ] With `MUNIN_QUOTAS_ENABLED` unset, creating the 10001st KB document on a self-hosted instance succeeds.
- [ ] With `MUNIN_QUOTAS_ENABLED=true` and a per-org cap of 1 on `kb_documents`, the second document creation rejects with `quota_exceeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)