### PR TITLE
feat(quotas): tier-aware foundation (abstract service + crm_contacts + call seams)

### DIFF
--- a/.changeset/quotas-tier-aware-foundation.md
+++ b/.changeset/quotas-tier-aware-foundation.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Lay groundwork for tier-aware quotas: split `QuotasService` into an abstract base + DI token + `DefaultQuotasService` so cloud can swap in a tier-aware implementation.
+
+- New injection token `QUOTAS_SERVICE`; consumers (`KbService`, `CmsService`, `CrmService`) now inject via the token.
+- `crm_contacts` joins the row-count quota set (`QuotaResource`, `FREE_TIER_QUOTAS`, `TABLE_FOR`) and `CrmService.createContact` gates on it. Still off by default — `MUNIN_QUOTAS_ENABLED=true` to enable.
+- New `recordCall(kind, key?)` method on `QuotasService` for call-count metering (MCP tool invocations, REST requests). Default impl is a no-op; cloud will override to do tier-aware soft/hard caps with windowed counters.
+- Seams: MCP dispatch wires `recordCall('mcp_tool', toolName)` through the existing `rateLimit` hook on the controller; a globally-registered `CallQuotaInterceptor` calls `recordCall('api_request', "<verb> <route>")` for `/v1` traffic.
+
+OSS behavior unchanged: `recordCall` is a no-op everywhere on the default impl, and `assertCanAdd` still respects the `MUNIN_QUOTAS_ENABLED` gate.

--- a/packages/backend-core/src/app.module.ts
+++ b/packages/backend-core/src/app.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { DbModule } from './common/db/db.module.ts';
 import { HealthController } from './common/health.controller.ts';
 import { WhoamiController } from './common/whoami.controller.ts';
 import { AuthGuard } from './common/auth/auth.guard.ts';
 import { TenancyInterceptor } from './common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from './common/audit/audit.interceptor.ts';
+import { CallQuotaInterceptor } from './common/quotas/call-quota.interceptor.ts';
 import { McpModule } from './mcp/mcp.module.ts';
 import { ControlModule } from './control/control.module.ts';
 import { KbModule } from './modules/kb/kb.module.ts';
@@ -39,7 +41,12 @@ export const BACKEND_FEATURE_MODULES = [
 ];
 
 export const BACKEND_BASE_CONTROLLERS = [HealthController, WhoamiController];
-export const BACKEND_BASE_PROVIDERS = [AuthGuard, TenancyInterceptor, AuditInterceptor];
+export const BACKEND_BASE_PROVIDERS = [
+  AuthGuard,
+  TenancyInterceptor,
+  AuditInterceptor,
+  { provide: APP_INTERCEPTOR, useExisting: CallQuotaInterceptor },
+];
 
 @Module({
   imports: BACKEND_FEATURE_MODULES,

--- a/packages/backend-core/src/common/quotas/call-quota.interceptor.ts
+++ b/packages/backend-core/src/common/quotas/call-quota.interceptor.ts
@@ -1,0 +1,55 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, from, mergeMap } from 'rxjs';
+import { getCurrentContext } from '@getmunin/core';
+import { QUOTAS_SERVICE, type QuotasService } from './quotas.service.ts';
+
+/**
+ * Counts `/v1` REST traffic toward the org's call quota. Runs inside the
+ * tenancy transaction (via getCurrentContext()) so the cloud override's
+ * counter upsert lives in the same Postgres tx as the request's work; if
+ * the handler errors after the upsert, the counter rolls back with it.
+ *
+ * Default `QuotasService` no-ops `recordCall`, so this is a free pass on
+ * OSS — only registered globally so cloud's overridden provider gets
+ * called without touching every controller's @UseInterceptors line.
+ *
+ * Skips routes without a tenancy context (anonymous endpoints) and the
+ * `/mcp` controller, which has its own per-tool seam through the
+ * dispatcher's rateLimit hook.
+ */
+@Injectable()
+export class CallQuotaInterceptor implements NestInterceptor {
+  constructor(@Inject(QUOTAS_SERVICE) private readonly quotas: QuotasService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    try {
+      getCurrentContext();
+    } catch {
+      return next.handle();
+    }
+
+    const request = context
+      .switchToHttp()
+      .getRequest<{ method: string; url: string; route?: { path?: string } }>();
+    const path = request.url.split('?')[0] ?? request.url;
+    if (path === '/mcp' || path.startsWith('/mcp/')) {
+      return next.handle();
+    }
+    const verb = request.method.toUpperCase();
+    if (verb === 'HEAD' || verb === 'OPTIONS') {
+      return next.handle();
+    }
+
+    const route = request.route?.path ?? path;
+    const key = `${verb} ${route}`;
+    return from(this.quotas.recordCall('api_request', key)).pipe(
+      mergeMap(() => next.handle()),
+    );
+  }
+}

--- a/packages/backend-core/src/common/quotas/quotas.module.ts
+++ b/packages/backend-core/src/common/quotas/quotas.module.ts
@@ -1,9 +1,13 @@
 import { Global, Module } from '@nestjs/common';
-import { QuotasService } from './quotas.service.ts';
+import { CallQuotaInterceptor } from './call-quota.interceptor.ts';
+import { DefaultQuotasService, QUOTAS_SERVICE } from './quotas.service.ts';
 
 @Global()
 @Module({
-  providers: [QuotasService],
-  exports: [QuotasService],
+  providers: [
+    { provide: QUOTAS_SERVICE, useClass: DefaultQuotasService },
+    CallQuotaInterceptor,
+  ],
+  exports: [QUOTAS_SERVICE, CallQuotaInterceptor],
 })
 export class QuotasModule {}

--- a/packages/backend-core/src/common/quotas/quotas.service.test.ts
+++ b/packages/backend-core/src/common/quotas/quotas.service.test.ts
@@ -3,7 +3,8 @@ import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core'
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
-import { QuotaExceededError, QuotasService } from './quotas.service.ts';
+import type { QuotasService } from './quotas.service.ts';
+import { DefaultQuotasService, QuotaExceededError } from './quotas.service.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
 const skipReason = TEST_URL
@@ -35,7 +36,7 @@ const skipReason = TEST_URL
       .returning();
     orgId = org!.id;
     actor = new ActorIdentity('admin_agent', 'agt_q', orgId, ['*'], ['admin']);
-    svc = new QuotasService();
+    svc = new DefaultQuotasService();
   });
 
   afterAll(async () => {
@@ -73,6 +74,30 @@ const skipReason = TEST_URL
       { orgId, name: 'B', slug: 'b' },
     ]);
     await expect(run(() => svc.assertCanAdd('kb_spaces'))).rejects.toThrow(QuotaExceededError);
+  });
+
+  it('throws QuotaExceededError on crm_contacts at cap', async () => {
+    await db
+      .update(schema.orgs)
+      .set({ settings: { quotas: { crm_contacts: 1 } } })
+      .where(sql`id = ${orgId}`);
+    try {
+      await db
+        .insert(schema.crmContacts)
+        .values({ orgId, name: 'A', email: 'a@example.com' });
+      await expect(run(() => svc.assertCanAdd('crm_contacts'))).rejects.toThrow(
+        QuotaExceededError,
+      );
+    } finally {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.crmContacts).where(sql`org_id = ${orgId}`);
+      await db.update(schema.orgs).set({ settings: { quotas: { kb_spaces: 2 } } }).where(sql`id = ${orgId}`);
+    }
+  });
+
+  it('recordCall is a no-op on the default impl', async () => {
+    await expect(run(() => svc.recordCall('mcp_tool', 'kb_search'))).resolves.toBeUndefined();
+    await expect(run(() => svc.recordCall('api_request', 'GET /v1/orgs'))).resolves.toBeUndefined();
   });
 
   it('falls back to free-tier defaults when settings.quotas is absent', async () => {

--- a/packages/backend-core/src/common/quotas/quotas.service.ts
+++ b/packages/backend-core/src/common/quotas/quotas.service.ts
@@ -3,6 +3,8 @@ import { schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
 
+export const QUOTAS_SERVICE = Symbol('QUOTAS_SERVICE');
+
 export class QuotaExceededError extends Error {
   readonly code = 'quota_exceeded';
   constructor(public readonly resource: string, public readonly cap: number) {
@@ -15,7 +17,10 @@ export type QuotaResource =
   | 'kb_spaces'
   | 'cms_collections'
   | 'cms_entries'
-  | 'cms_assets';
+  | 'cms_assets'
+  | 'crm_contacts';
+
+export type QuotaCallKind = 'mcp_tool' | 'api_request';
 
 const FREE_TIER_QUOTAS: Record<QuotaResource, number> = {
   kb_documents: 10_000,
@@ -23,6 +28,7 @@ const FREE_TIER_QUOTAS: Record<QuotaResource, number> = {
   cms_collections: 50,
   cms_entries: 10_000,
   cms_assets: 1_000,
+  crm_contacts: 1_000,
 };
 
 interface OrgSettings {
@@ -35,6 +41,7 @@ const TABLE_FOR: Record<QuotaResource, string> = {
   cms_collections: 'cms_collections',
   cms_entries: 'cms_entries',
   cms_assets: 'cms_assets',
+  crm_contacts: 'crm_contacts',
 };
 
 function isEnabled(): boolean {
@@ -43,14 +50,22 @@ function isEnabled(): boolean {
   return raw.toLowerCase() === 'true' || raw === '1';
 }
 
+export abstract class QuotasService {
+  abstract assertCanAdd(resource: QuotaResource): Promise<void>;
+  abstract recordCall(kind: QuotaCallKind, key?: string): Promise<void>;
+  abstract cap(orgId: string, resource: QuotaResource): Promise<number>;
+  abstract count(resource: QuotaResource): Promise<number>;
+}
+
 /**
- * Row caps for tiered deployments. Opt-in via MUNIN_QUOTAS_ENABLED so OSS
- * self-hosters aren't capped on their own hardware. When enabled, the count
- * runs inside the request transaction, so the count and the insert see the
- * same MVCC snapshot and concurrent inserts at the cap edge can't both pass.
+ * Default row-count quota implementation. Opt-in via MUNIN_QUOTAS_ENABLED so
+ * OSS self-hosters aren't capped on their own hardware. When enabled, the
+ * count runs inside the request transaction so the count and the insert see
+ * the same MVCC snapshot. `recordCall` is a no-op here — call-count quotas
+ * require a counter table and live in the cloud override.
  */
 @Injectable()
-export class QuotasService {
+export class DefaultQuotasService extends QuotasService {
   async assertCanAdd(resource: QuotaResource): Promise<void> {
     if (!isEnabled()) return;
     const ctx = getCurrentContext();
@@ -59,6 +74,10 @@ export class QuotasService {
     const cap = await this.cap(orgId, resource);
     const used = await this.count(resource);
     if (used >= cap) throw new QuotaExceededError(resource, cap);
+  }
+
+  recordCall(_kind: QuotaCallKind, _key?: string): Promise<void> {
+    return Promise.resolve();
   }
 
   async cap(orgId: string, resource: QuotaResource): Promise<number> {
@@ -72,10 +91,6 @@ export class QuotasService {
     return settings.quotas?.[resource] ?? FREE_TIER_QUOTAS[resource];
   }
 
-  /**
-   * Count rows for the resource in the calling org. Table name comes from a
-   * fixed enum-mapped lookup (no user input), interpolated as an identifier.
-   */
   async count(resource: QuotaResource): Promise<number> {
     const ctx = getCurrentContext();
     const orgId = ctx.actor!.orgId;

--- a/packages/backend-core/src/mcp/mcp.controller.ts
+++ b/packages/backend-core/src/mcp/mcp.controller.ts
@@ -19,6 +19,7 @@ import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 import { McpRegistryService } from './mcp.registry.ts';
 import { McpSkillRegistryService } from './mcp.skill-registry.service.ts';
 import { RateLimitService } from '../common/rate-limit/rate-limit.service.ts';
+import { QUOTAS_SERVICE, type QuotasService } from '../common/quotas/quotas.service.ts';
 
 /**
  * Streamable HTTP entry point for the MCP server.
@@ -41,6 +42,7 @@ export class McpController {
     @Inject(McpRegistryService) private readonly registry: McpRegistryService,
     @Inject(McpSkillRegistryService) private readonly skills: McpSkillRegistryService,
     @Inject(RateLimitService) private readonly rateLimit: RateLimitService,
+    @Inject(QUOTAS_SERVICE) private readonly quotas: QuotasService,
   ) {}
 
   @Post()
@@ -71,7 +73,10 @@ export class McpController {
       audience,
       actor,
       audit: this.audit,
-      rateLimit: () => this.rateLimit.consume(),
+      rateLimit: async (toolName: string) => {
+        await this.rateLimit.consume();
+        await this.quotas.recordCall('mcp_tool', toolName);
+      },
       skills: this.skills,
       instructions: this.skills.instructions(),
     });

--- a/packages/backend-core/src/modules/cms/cms.service.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.test.ts
@@ -17,7 +17,7 @@ import {
   CmsInvalidError,
 } from './cms.service.ts';
 import { EmbeddingProviderHolder } from '../kb/embedding.provider.ts';
-import { QuotaExceededError, QuotasService } from '../../common/quotas/quotas.service.ts';
+import { DefaultQuotasService, QuotaExceededError } from '../../common/quotas/quotas.service.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
 const skipReason = TEST_URL
@@ -71,7 +71,7 @@ class StubStorage implements AssetStorage {
       }
     })();
     storage = new StubStorage();
-    svc = new CmsService(new QuotasService(), new WebhookDispatcher(), storage, holder);
+    svc = new CmsService(new DefaultQuotasService(), new WebhookDispatcher(), storage, holder);
   });
 
   afterAll(async () => {

--- a/packages/backend-core/src/modules/cms/cms.service.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.ts
@@ -12,7 +12,7 @@ import {
   WebhookDispatcher,
   type AssetStorage,
 } from '@getmunin/core';
-import { QuotasService } from '../../common/quotas/quotas.service.ts';
+import { QUOTAS_SERVICE, type QuotasService } from '../../common/quotas/quotas.service.ts';
 import { STORAGE } from '../../common/storage/storage.token.ts';
 import {
   buildSearchText,
@@ -109,7 +109,7 @@ export interface LocaleDto {
 @Injectable()
 export class CmsService {
   constructor(
-    @Inject(QuotasService) private readonly quotas: QuotasService,
+    @Inject(QUOTAS_SERVICE) private readonly quotas: QuotasService,
     @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
     @Inject(STORAGE) private readonly storage: AssetStorage,
     @Inject(EmbeddingProviderHolder) private readonly embeddings: EmbeddingProviderHolder,

--- a/packages/backend-core/src/modules/crm/crm.service.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.test.ts
@@ -5,6 +5,7 @@ import { eq, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { NotFoundException, ConflictException } from '@nestjs/common';
 import { CrmService, CrmInvalidError } from './crm.service.ts';
+import { DefaultQuotasService } from '../../common/quotas/quotas.service.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
 const skipReason = TEST_URL
@@ -38,7 +39,7 @@ const skipReason = TEST_URL
     endUserId = eu!.id;
     actor = new ActorIdentity('admin_agent', 'agt_crm_test', orgId, ['*'], ['admin']);
 
-    svc = new CrmService(new WebhookDispatcher());
+    svc = new CrmService(new WebhookDispatcher(), new DefaultQuotasService());
   });
 
   afterAll(async () => {
@@ -75,6 +76,31 @@ const skipReason = TEST_URL
   // ─── Contacts ────────────────────────────────────────────────────────
 
   describe('contacts', () => {
+    it('createContact respects org quota cap and writes no row', async () => {
+      const previousEnv = process.env.MUNIN_QUOTAS_ENABLED;
+      process.env.MUNIN_QUOTAS_ENABLED = 'true';
+      await db
+        .update(schema.orgs)
+        .set({ settings: { quotas: { crm_contacts: 1 } } })
+        .where(sql`id = ${orgId}`);
+      try {
+        await run(() => svc.createContact({ name: 'first', email: 'first@example.com' }));
+        await expect(
+          run(() => svc.createContact({ name: 'second', email: 'second@example.com' })),
+        ).rejects.toThrow(/quota_exceeded/);
+        const rows = await db.execute<{ count: number }>(
+          sql`SELECT COUNT(*)::int AS count FROM crm_contacts WHERE org_id = ${orgId}`,
+        );
+        expect(rows[0]!.count).toBe(1);
+      } finally {
+        await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+        await db.delete(schema.crmContacts).where(sql`org_id = ${orgId}`);
+        await db.update(schema.orgs).set({ settings: {} }).where(sql`id = ${orgId}`);
+        if (previousEnv === undefined) delete process.env.MUNIN_QUOTAS_ENABLED;
+        else process.env.MUNIN_QUOTAS_ENABLED = previousEnv;
+      }
+    });
+
     it('createContact persists with the requested fields', async () => {
       const c = await run(() =>
         svc.createContact({

--- a/packages/backend-core/src/modules/crm/crm.service.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.ts
@@ -2,6 +2,7 @@ import { ConflictException, Inject, Injectable, NotFoundException } from '@nestj
 import { schema } from '@getmunin/db';
 import { and, asc, desc, eq, ilike, or, sql, type SQL } from 'drizzle-orm';
 import { getCurrentContext, WebhookDispatcher } from '@getmunin/core';
+import { QUOTAS_SERVICE, type QuotasService } from '../../common/quotas/quotas.service.ts';
 
 export class CrmInvalidError extends Error {
   readonly code = 'crm_invalid';
@@ -163,6 +164,7 @@ export interface MergeProposalDto {
 export class CrmService {
   constructor(
     @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
+    @Inject(QUOTAS_SERVICE) private readonly quotas: QuotasService,
   ) {}
 
   // ─── Contacts ───────────────────────────────────────────────────────────
@@ -239,6 +241,7 @@ export class CrmService {
     tags?: string[];
     customFields?: Record<string, unknown>;
   }): Promise<ContactDto> {
+    await this.quotas.assertCanAdd('crm_contacts');
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     const [row] = await ctx.db

--- a/packages/backend-core/src/modules/kb/kb.search.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.search.test.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { KbService } from './kb.service.ts';
 import { KbSearchService } from './kb.search.ts';
 import { EmbeddingProviderHolder } from './embedding.provider.ts';
-import { QuotasService } from '../../common/quotas/quotas.service.ts';
+import { DefaultQuotasService } from '../../common/quotas/quotas.service.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
 const skipReason = TEST_URL
@@ -64,7 +64,7 @@ const skipReason = TEST_URL
         return new StubEmbeddingProvider();
       }
     })();
-    kb = new KbService(holder, new QuotasService(), new WebhookDispatcher());
+    kb = new KbService(holder, new DefaultQuotasService(), new WebhookDispatcher());
     search = new KbSearchService(holder);
   });
 

--- a/packages/backend-core/src/modules/kb/kb.service.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.test.ts
@@ -11,7 +11,7 @@ import { sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { CURATION_INBOX_SLUG, KbService, KbConflictError, KbNotFoundError, KbInvalidError } from './kb.service.ts';
 import { EmbeddingProviderHolder } from './embedding.provider.ts';
-import { QuotaExceededError, QuotasService } from '../../common/quotas/quotas.service.ts';
+import { DefaultQuotasService, QuotaExceededError } from '../../common/quotas/quotas.service.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
 const skipReason = TEST_URL
@@ -44,7 +44,7 @@ const skipReason = TEST_URL
         return new StubEmbeddingProvider();
       }
     })();
-    svc = new KbService(holder, new QuotasService(), new WebhookDispatcher());
+    svc = new KbService(holder, new DefaultQuotasService(), new WebhookDispatcher());
   });
 
   afterAll(async () => {

--- a/packages/backend-core/src/modules/kb/kb.service.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.ts
@@ -4,7 +4,7 @@ import { schema } from '@getmunin/db';
 import { chunkDocument, contentHash, getCurrentContext, WebhookDispatcher } from '@getmunin/core';
 import type { ActorIdentity, Audience } from '@getmunin/core';
 import { EmbeddingProviderHolder } from './embedding.provider.ts';
-import { QuotasService } from '../../common/quotas/quotas.service.ts';
+import { QUOTAS_SERVICE, type QuotasService } from '../../common/quotas/quotas.service.ts';
 
 const AUDIENCES: readonly Audience[] = ['admin', 'self_service'];
 
@@ -100,7 +100,7 @@ export interface VersionDto {
 export class KbService {
   constructor(
     @Inject(EmbeddingProviderHolder) private readonly embeddings: EmbeddingProviderHolder,
-    @Inject(QuotasService) private readonly quotas: QuotasService,
+    @Inject(QUOTAS_SERVICE) private readonly quotas: QuotasService,
     @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
   ) {}
 

--- a/packages/backend-core/src/modules/outreach/outreach.service.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.test.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'node:crypto';
 import { ConflictException } from '@nestjs/common';
 import { OutreachService, OutreachInvalidError } from './outreach.service.ts';
 import { CrmService } from '../crm/crm.service.ts';
+import { DefaultQuotasService } from '../../common/quotas/quotas.service.ts';
 import { ConvService } from '../conv/conv.service.ts';
 import { VapiClientService } from '../conv/vapi/vapi-client.service.ts';
 import { VapiService } from '../conv/vapi/vapi.service.ts';
@@ -51,7 +52,7 @@ const skipReason = TEST_URL
     actor = new ActorIdentity('admin_agent', 'agt_outreach_test', orgId, ['*'], ['admin']);
 
     const dispatcher = new WebhookDispatcher();
-    crm = new CrmService(dispatcher);
+    crm = new CrmService(dispatcher, new DefaultQuotasService());
     const claims = new ConversationClaimsService(dispatcher);
     const curatorJobs = new CuratorJobsService(dispatcher);
     conv = new ConvService(dispatcher, claims, curatorJobs);


### PR DESCRIPTION
**Stacked on #261** — set base to `oss-quotas-opt-in` so the diff shows only this layer. Merge #261 first, then GitHub will retarget this to `main`.

## Summary

Lays the groundwork for cloud to ship tier-aware quotas (hard caps for free, soft caps + metered overage for premium) without further OSS changes. No behavior change for OSS — `recordCall` is a no-op on the default impl and `assertCanAdd` still respects the `MUNIN_QUOTAS_ENABLED` gate from #261.

- **`QuotasService` → abstract base + DI token.** `DefaultQuotasService` is today's row-count behavior. Cloud overrides the `QUOTAS_SERVICE` token in its `AppModule` to swap in a tier-aware implementation.
- **`crm_contacts`** joins the row-count quota set; `CrmService.createContact` gates on it (bulk path inherits via the loop).
- **`recordCall(kind, key?)` method** added for call-count metering — no-op default; cloud will do windowed counter upserts. Two seams wired in `backend-core` so cloud doesn't need to monkey-patch:
  - **MCP**: `mcp.controller` composes `recordCall('mcp_tool', toolName)` into the existing `rateLimit` hook. No `mcp-toolkit` API change.
  - **REST**: globally-registered `CallQuotaInterceptor` calls `recordCall('api_request', "<verb> <route>")` inside the tenancy tx for every `/v1` request. Skips anonymous routes and `/mcp` (which has its own seam).

## Follow-up

Stage 2 (in `munin-cloud`) — new `cloud-quotas` package with `org_usage_events` + `org_call_counters` tables, tier × kind policy map, `CloudQuotasService` override — needs this PR released as a `@getmunin/backend-core` version cloud can pin to. Will be its own PR after release.

Plan: `/Users/kjell/.claude/plans/tier-aware-quotas.md`

## Test plan

- [ ] CI green (workspace typecheck, lint, tests).
- [ ] On OSS with `MUNIN_QUOTAS_ENABLED=true`: `crm_contacts` cap rejects past the cap.
- [ ] On OSS: MCP and `/v1` calls still work; `recordCall` is no-op (no extra writes).
- [ ] Smoke-test the cloud override path locally before opening the Stage 2 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)