### PR TITLE
feat(quotas): export tier-aware primitives from backend-core barrel

### DIFF
--- a/.changeset/quotas-exports.md
+++ b/.changeset/quotas-exports.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Export the tier-aware quota primitives so cloud builds can override the service.
+
+Adds `QUOTAS_SERVICE` (DI token), `QuotasService` (abstract base), `DefaultQuotasService` (default impl), `QuotaExceededError`, the `QuotaResource` and `QuotaCallKind` types, and `CallQuotaInterceptor` to the public surface of `@getmunin/backend-core`. The implementations shipped in 4.23.0; only the index barrel changes here.

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -89,6 +89,15 @@ export { CrmModule } from './modules/crm/crm.module.ts';
 export { CmsModule } from './modules/cms/cms.module.ts';
 export { RateLimitModule } from './common/rate-limit/rate-limit.module.ts';
 export { QuotasModule } from './common/quotas/quotas.module.ts';
+export {
+  QUOTAS_SERVICE,
+  QuotasService,
+  DefaultQuotasService,
+  QuotaExceededError,
+  type QuotaResource,
+  type QuotaCallKind,
+} from './common/quotas/quotas.service.ts';
+export { CallQuotaInterceptor } from './common/quotas/call-quota.interceptor.ts';
 export { WebhookModule } from './common/webhooks/webhook.module.ts';
 export { OAuthModule } from './oauth/oauth.module.ts';
 export {


### PR DESCRIPTION
## Summary

Stage 1 (#262) shipped the abstract `QuotasService` + DI token + `CallQuotaInterceptor` internally but only exported `QuotasModule` from the package barrel. Cloud's planned `cloud-quotas` package can't build against `@getmunin/backend-core@4.23.0` without these symbols.

Adds to the barrel:

- `QUOTAS_SERVICE` (DI token)
- `QuotasService` (abstract base)
- `DefaultQuotasService` (default impl)
- `QuotaExceededError`
- `QuotaResource`, `QuotaCallKind` (types)
- `CallQuotaInterceptor`

Patch-bump only — no behavior change, no new code, just exports.

## Test plan

- [ ] CI green.
- [ ] Cloud's upcoming PR builds against the resulting `@getmunin/backend-core` version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)