### PR TITLE
fix(backend-core): include MCP resource URL in OAuth validAudiences

### DIFF
--- a/.changeset/oauth-mcp-audience-cloud.md
+++ b/.changeset/oauth-mcp-audience-cloud.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Accept the MCP resource URL in OAuth `validAudiences` when it differs from the authorization-server host. On cloud (`api.getmunin.com` + `mcp.getmunin.com`), Claude's token exchange was failing with `invalid_request: requested resource invalid` from `@better-auth/oauth-provider`'s `checkResource` — the token endpoint had `validAudiences = [<AS origin>]` only, so the `resource=https://mcp.getmunin.com` parameter (advertised by `/.well-known/oauth-protected-resource` and required because `resource_indicators_supported: true`) was rejected. Externally this surfaced as "Authorization with the MCP server failed" right after the user clicked Authorize.
+
+`createMuninAuthCore` now passes both the AS base URL and `mcpResourceUrl()` (from `NEXT_PUBLIC_MCP_URL`) into `computeValidAudiences`, which returns the union of URL-variant sets for both. OSS single-host topologies (where the two URLs share an origin) dedupe to the same audience list as before. No config changes needed in `munin-cloud` — it already sets both env vars; just bump the lockfile and redeploy.

--- a/packages/backend-core/src/auth/auth-factory.test.ts
+++ b/packages/backend-core/src/auth/auth-factory.test.ts
@@ -39,4 +39,42 @@ describe('computeValidAudiences', () => {
   it('falls back to canonical-only when the input is not a parseable URL', () => {
     expect(computeValidAudiences('not-a-url')).toEqual(['not-a-url', 'not-a-url/']);
   });
+
+  it('accepts the MCP resource URL when it lives on a different host than the AS (cloud topology)', () => {
+    expect(
+      computeValidAudiences('https://api.getmunin.com', 'https://mcp.getmunin.com'),
+    ).toEqual(
+      expect.arrayContaining([
+        'https://api.getmunin.com',
+        'https://api.getmunin.com/',
+        'https://mcp.getmunin.com',
+        'https://mcp.getmunin.com/',
+      ]),
+    );
+  });
+
+  it('strips trailing slashes on the MCP resource and emits both variants', () => {
+    const audiences = computeValidAudiences('https://api.example.com', 'https://mcp.example.com/');
+    expect(audiences).toContain('https://mcp.example.com');
+    expect(audiences).toContain('https://mcp.example.com/');
+    expect(audiences).not.toContain('https://mcp.example.com//');
+  });
+
+  it('dedupes when MCP and AS share the same origin (OSS single-host topology)', () => {
+    expect(
+      computeValidAudiences('http://localhost:3001/mcp', 'http://localhost:3001/mcp'),
+    ).toEqual([
+      'http://localhost:3001/mcp',
+      'http://localhost:3001/mcp/',
+      'http://localhost:3001',
+      'http://localhost:3001/',
+    ]);
+  });
+
+  it('ignores nullish or empty MCP resource', () => {
+    const asOnly = ['https://api.example.com', 'https://api.example.com/'];
+    expect(computeValidAudiences('https://api.example.com', null)).toEqual(asOnly);
+    expect(computeValidAudiences('https://api.example.com', undefined)).toEqual(asOnly);
+    expect(computeValidAudiences('https://api.example.com', '')).toEqual(asOnly);
+  });
 });

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -3,7 +3,10 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { jwt } from 'better-auth/plugins';
 import { oauthProvider } from '@better-auth/oauth-provider';
 import { schema, type Db } from '@getmunin/db';
-import { SUPPORTED_SCOPES as MUNIN_SUPPORTED_SCOPES } from '../oauth/oauth.constants.ts';
+import {
+  SUPPORTED_SCOPES as MUNIN_SUPPORTED_SCOPES,
+  mcpResourceUrl,
+} from '../oauth/oauth.constants.ts';
 
 type BetterAuthInstance = ReturnType<typeof betterAuth>;
 
@@ -68,7 +71,7 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
     /\/+$/,
     '',
   );
-  const validAudiences = computeValidAudiences(opts.baseUrl);
+  const validAudiences = computeValidAudiences(opts.baseUrl, mcpResourceUrl());
   const issuer = opts.baseUrl.replace(/\/+$/, '');
 
   const socialProviders = buildSocialProviders(opts.socialProviders);
@@ -153,20 +156,31 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
   }));
 }
 
-export function computeValidAudiences(baseUrl: string): string[] {
-  const canonical = baseUrl.replace(/\/+$/, '');
-  const variants = new Set<string>([canonical, `${canonical}/`]);
+export function computeValidAudiences(
+  baseUrl: string,
+  mcpResourceUrl?: string | null,
+): string[] {
+  const variants = new Set<string>();
+  addUrlVariants(variants, baseUrl);
+  if (mcpResourceUrl) addUrlVariants(variants, mcpResourceUrl);
+  return Array.from(variants);
+}
+
+function addUrlVariants(variants: Set<string>, url: string): void {
+  const canonical = url.replace(/\/+$/, '');
+  if (!canonical) return;
+  variants.add(canonical);
+  variants.add(`${canonical}/`);
   try {
     const origin = new URL(canonical).origin;
     variants.add(origin);
     variants.add(`${origin}/`);
   } catch (err) {
-    console.warn('[auth-factory] computeValidAudiences: baseUrl is not a parseable URL', {
-      baseUrl,
+    console.warn('[auth-factory] computeValidAudiences: url is not a parseable URL', {
+      url,
       err,
     });
   }
-  return Array.from(variants);
 }
 
 function uniqueOrigins(values: string[]): string[] {


### PR DESCRIPTION
## Summary

- `@better-auth/oauth-provider`'s `checkResource` was rejecting Claude's token exchange with `invalid_request: requested resource invalid` on cloud, because `validAudiences` was built only from the AS base URL (`https://api.getmunin.com`). The MCP host (`https://mcp.getmunin.com`) — the value advertised in `/.well-known/oauth-protected-resource` and sent by Claude as the RFC 8707 `resource` parameter — was missing from the whitelist, so `/auth/oauth2/token` 400'd. End-user symptom: "Authorization with the MCP server failed" right after pressing Authorize on the consent screen.
- `computeValidAudiences` now takes an optional second `mcpResourceUrl` and returns the union of URL-variant sets for both inputs. `createMuninAuthCore` plumbs `mcpResourceUrl()` (reads `NEXT_PUBLIC_MCP_URL`) through. OSS single-host topologies dedupe to the same list as before.
- Same-issue precedent: PR #208 fixed the OSS-side variant of this for the single-host case ("token aud must equal baseUrl verbatim"). That patch didn't extend to cloud's split-host topology — this one does.

## Why Sentry showed nothing

The error is raised inside `@better-auth/oauth-provider` as an `APIError`, serialized straight to the HTTP response by better-auth's request handler. It never propagates through Nest's exception filter, so Sentry's interceptor never sees it. (Sentry instrumentation in cloud also looks broader-broken — zero events across both projects for 7d — worth a separate look, but not this PR's scope.)

## Cloud follow-up

No code changes needed in `munin-cloud`. Both env vars are already set in `terraform/containers.tf:42,48,127,128`. After release, bump `@getmunin/backend-core` in `munin-cloud/pnpm-lock.yaml` and redeploy `backend-cloud`.

## Test plan

- [x] `pnpm -F @getmunin/backend-core exec vitest run src/auth/auth-factory.test.ts` — 9/9 pass, includes new cases for the cloud split-host topology, trailing-slash normalization, OSS same-origin dedupe, and nullish/empty MCP input.
- [x] `pnpm -F @getmunin/backend-core typecheck` — clean.
- [ ] After merge + release + cloud bump: connect Claude to https://mcp.getmunin.com end-to-end and confirm the OAuth flow completes through token exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)