### PR TITLE
fix(core): verify OAuth JWTs against NEXT_PUBLIC_AUTH_URL, not MCP origin

### DIFF
--- a/.changeset/oauth-jwt-issuer-split-host.md
+++ b/.changeset/oauth-jwt-issuer-split-host.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/core': patch
+---
+
+Fix `jwtIssuer()` for split MCP/auth host topologies — verify JWTs against `NEXT_PUBLIC_AUTH_URL`, not the MCP origin.
+
+`oauth-jwt.ts`'s `jwtIssuer()` derived the expected `iss` claim from `NEXT_PUBLIC_MCP_URL`. After PR #238 split `NEXT_PUBLIC_AUTH_URL` from `NEXT_PUBLIC_MCP_URL`, cloud's `mcp.getmunin.com` no longer matched the actual issuer (`https://api.getmunin.com`, set by `betterAuth({ baseURL: NEXT_PUBLIC_AUTH_URL, ... }).plugins[jwt({ issuer })]`). `jwtVerify(..., { issuer: jwtIssuer() })` rejected every valid Claude-issued token, so the OAuth dance completed cleanly but the first `/mcp` request 401'd. End-user symptom: "Authorization with the MCP server failed" reappearing after consent.
+
+`jwtIssuer()` now reads `NEXT_PUBLIC_AUTH_URL` (trim trailing slash) when set, falling back to the MCP origin only for OSS single-host deployments where AS and MCP share an origin.

--- a/packages/core/src/request/oauth-jwt.test.ts
+++ b/packages/core/src/request/oauth-jwt.test.ts
@@ -22,25 +22,43 @@ describe('looksLikeJwt', () => {
 });
 
 describe('jwtIssuer + acceptedJwtAudiences', () => {
-  let original: string | undefined;
+  let originalMcp: string | undefined;
+  let originalAuth: string | undefined;
 
   beforeEach(() => {
-    original = process.env.NEXT_PUBLIC_MCP_URL;
+    originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+    originalAuth = process.env.NEXT_PUBLIC_AUTH_URL;
   });
 
   afterEach(() => {
-    if (original === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
-    else process.env.NEXT_PUBLIC_MCP_URL = original;
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+    if (originalAuth === undefined) delete process.env.NEXT_PUBLIC_AUTH_URL;
+    else process.env.NEXT_PUBLIC_AUTH_URL = originalAuth;
   });
 
-  it('uses origin of NEXT_PUBLIC_MCP_URL as issuer when it has a path', () => {
+  it('uses origin of NEXT_PUBLIC_MCP_URL as issuer when it has a path and AUTH_URL is unset', () => {
+    delete process.env.NEXT_PUBLIC_AUTH_URL;
     process.env.NEXT_PUBLIC_MCP_URL = 'https://api.example.com/mcp';
     expect(jwtIssuer()).toBe('https://api.example.com');
   });
 
-  it('uses origin of NEXT_PUBLIC_MCP_URL as issuer when it has no path', () => {
+  it('uses origin of NEXT_PUBLIC_MCP_URL as issuer when it has no path and AUTH_URL is unset', () => {
+    delete process.env.NEXT_PUBLIC_AUTH_URL;
     process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.com';
     expect(jwtIssuer()).toBe('https://mcp.example.com');
+  });
+
+  it('uses NEXT_PUBLIC_AUTH_URL verbatim when set (split MCP/auth host topology)', () => {
+    process.env.NEXT_PUBLIC_AUTH_URL = 'https://api.getmunin.com';
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.getmunin.com';
+    expect(jwtIssuer()).toBe('https://api.getmunin.com');
+  });
+
+  it('strips trailing slash from NEXT_PUBLIC_AUTH_URL', () => {
+    process.env.NEXT_PUBLIC_AUTH_URL = 'https://api.getmunin.com/';
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.getmunin.com';
+    expect(jwtIssuer()).toBe('https://api.getmunin.com');
   });
 
   it('accepts canonical URL plus trailing-slash, origin, and origin-with-slash when URL has a path', () => {

--- a/packages/core/src/request/oauth-jwt.ts
+++ b/packages/core/src/request/oauth-jwt.ts
@@ -121,6 +121,8 @@ function publicUrl(): string {
 }
 
 export function jwtIssuer(): string {
+  const explicit = process.env.NEXT_PUBLIC_AUTH_URL;
+  if (explicit) return explicit.replace(/\/+$/, '');
   try {
     return new URL(publicUrl()).origin;
   } catch {


### PR DESCRIPTION
## Summary

Fixes `Authorization with the MCP server failed` on claude.ai (and any MCP client) when connecting to `https://mcp.getmunin.com`.

`packages/core/src/request/oauth-jwt.ts:123` derived the expected JWT `iss` claim from `NEXT_PUBLIC_MCP_URL`. PR #238 split `NEXT_PUBLIC_AUTH_URL` from `NEXT_PUBLIC_MCP_URL` for cloud's two-subdomain layout (`api.*` for auth, `mcp.*` for MCP). After the split, better-auth signs tokens with `iss=https://api.getmunin.com` (from `apps/backend/src/auth/auth.controller.ts:29-32` → `baseUrl = NEXT_PUBLIC_AUTH_URL`) but the verifier was still expecting `iss=https://mcp.getmunin.com`. `jose.jwtVerify` threw on every valid token. The OAuth dance completes through `/token` cleanly (PR #266's `validAudiences` fix is in place) but the first `/mcp` request 401s.

`jwtIssuer()` now mirrors the same fallback ladder used by `apps/backend/src/auth/auth.controller.ts`: prefer `NEXT_PUBLIC_AUTH_URL`, fall back to MCP origin (for OSS single-host setups where AS and MCP share an origin). `acceptedJwtAudiences()` is unchanged — that's the resource audience, which still correctly points at the MCP URL.

## Verification

- [x] Unit tests added for the split-host case (`packages/core/src/request/oauth-jwt.test.ts` — 11 tests pass)
- [x] Workspace typecheck clean (25/25 packages)
- [ ] After this lands + cloud bump: confirm claude.ai → `https://mcp.getmunin.com` OAuth flow completes end-to-end

## Why the regression went unnoticed

- Local `pnpm dev` typically has neither env var set → both default → single-host → bug doesn't manifest.
- The OAuth conformance integration test (`apps/backend/src/auth/oauth-conformance.integration.test.ts`) only exercises discovery + dynamic registration, never the verify path on an issued token in a split-host config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)