### PR TITLE
fix(dashboard-pages): keep settings Sign out reachable under agent-health banner

### DIFF
--- a/.changeset/agent-banner-sidebar-layout.md
+++ b/.changeset/agent-banner-sidebar-layout.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Stop the agent-health banner from pushing the settings-page Sign out button below the viewport. The banner now sticks to viewport top alongside the topbar, has a fixed `h-12` (with `truncate` on the message so long provider-error reasons ellipsize instead of wrapping), and exposes its presence via a stable `.agent-banner` marker class that downstream layout reads with Tailwind's `group-has-[]:` modifier. The `DashboardShell` wrapper gets a `group` class; both topbar variants and the settings sidebar shift down by exactly `3rem` (the banner height) only when the banner is rendered — no JavaScript measurement, no `ResizeObserver`, no CSS custom properties. Pure CSS, so the layout shift happens in the same paint that mounts the banner.

--- a/packages/dashboard-pages/src/components/agent-health-banner.tsx
+++ b/packages/dashboard-pages/src/components/agent-health-banner.tsx
@@ -66,14 +66,14 @@ export function AgentHealthBanner() {
     <div
       role="alert"
       aria-live="polite"
-      className="border-b-[0.5px] border-ink bg-amber-100 text-ink dark:bg-amber-200/90 dark:text-ink"
+      className="agent-banner sticky top-0 z-50 h-12 border-b-[0.5px] border-ink bg-amber-100 text-ink dark:bg-amber-200/90 dark:text-ink"
     >
-      <div className="mx-auto flex items-center gap-4 px-10 py-2.5">
+      <div className="mx-auto flex h-full items-center gap-4 px-10">
         <span className="flex shrink-0 items-center gap-2 whitespace-nowrap border-r border-ink/25 pr-3.5 font-mono text-[10px] uppercase tracking-[0.16em]">
           <span className="size-[7px] animate-pulse rounded-full bg-ink" aria-hidden />
           {state.tag}
         </span>
-        <span className="min-w-0 flex-1 font-sans text-[13px] leading-[1.4]">{state.message}</span>
+        <span className="min-w-0 flex-1 truncate font-sans text-[13px] leading-[1.4]">{state.message}</span>
         {state.cta && (
           <Link
             href={state.cta.href}

--- a/packages/dashboard-pages/src/components/munin-topbar.tsx
+++ b/packages/dashboard-pages/src/components/munin-topbar.tsx
@@ -26,7 +26,7 @@ export function DashboardTopbar({
   settingsLabel,
 }: DashboardTopbarProps) {
   return (
-    <header className="sticky top-0 z-40 flex h-14 items-stretch gap-6 border-b-[0.5px] border-ink bg-paper px-4 dark:border-rule-on-dark dark:bg-card md:px-10">
+    <header className="sticky top-0 z-40 group-has-[.agent-banner]:top-12 flex h-14 items-stretch gap-6 border-b-[0.5px] border-ink bg-paper px-4 dark:border-rule-on-dark dark:bg-card md:px-10">
       <Link
         href={brandHref}
         className="flex items-center gap-1 self-center text-ink dark:text-foreground"
@@ -84,7 +84,7 @@ export function SettingsTopbar({
   openMenuLabel,
 }: SettingsTopbarProps) {
   return (
-    <header className="sticky top-0 z-40 flex h-14 items-stretch gap-4 border-b-[0.5px] border-ink bg-paper px-4 dark:border-rule-on-dark dark:bg-card md:gap-5 md:px-10">
+    <header className="sticky top-0 z-40 group-has-[.agent-banner]:top-12 flex h-14 items-stretch gap-4 border-b-[0.5px] border-ink bg-paper px-4 dark:border-rule-on-dark dark:bg-card md:gap-5 md:px-10">
       <Link
         href={backHref}
         aria-label={backLabel}

--- a/packages/dashboard-pages/src/shells/dashboard-shell.tsx
+++ b/packages/dashboard-pages/src/shells/dashboard-shell.tsx
@@ -37,7 +37,7 @@ export function DashboardShell({
   const inSettings = pathname.startsWith('/dashboard/settings');
 
   const content = (
-    <div className="flex min-h-screen flex-col bg-bone dark:bg-background">
+    <div className="group flex min-h-screen flex-col bg-bone dark:bg-background">
       <AgentHealthBanner />
       {!inSettings && (
         <DashboardTopbar

--- a/packages/dashboard-pages/src/shells/settings-shell.tsx
+++ b/packages/dashboard-pages/src/shells/settings-shell.tsx
@@ -87,7 +87,7 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
   );
 
   return (
-    <div className="flex min-h-screen flex-col bg-paper dark:bg-background">
+    <div className="flex min-h-screen flex-col bg-paper group-has-[.agent-banner]:min-h-[calc(100vh_-_3rem)] dark:bg-background">
       <SettingsTopbar
         title={tNav('settings')}
         backLabel={tCommon('back')}
@@ -96,8 +96,8 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
         openMenuLabel={tNav('openMenu')}
       />
 
-      <div className="flex min-h-[calc(100vh-3.5rem)]">
-        <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-72 shrink-0 flex-col self-start border-r-[0.5px] border-rule-soft bg-bone md:flex dark:border-rule-on-dark dark:bg-secondary">
+      <div className="flex min-h-[calc(100vh_-_3.5rem)] group-has-[.agent-banner]:min-h-[calc(100vh_-_6.5rem)]">
+        <aside className="sticky top-14 hidden h-[calc(100vh_-_3.5rem)] w-72 shrink-0 flex-col self-start border-r-[0.5px] border-rule-soft bg-bone group-has-[.agent-banner]:top-[6.5rem] group-has-[.agent-banner]:h-[calc(100vh_-_6.5rem)] md:flex dark:border-rule-on-dark dark:bg-secondary">
           <div className="flex-1 overflow-y-auto px-6 py-10">{navTree}</div>
           <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
             {signOutButton}


### PR DESCRIPTION
## Summary

- The settings sidebar's sticky `h-[calc(100vh-3.5rem)]` assumed only the 56px topbar sat above it. When the agent-health banner rendered above the topbar (degraded provider, realtime drop), the bottom of the sidebar — including Sign out — was pushed below the viewport and required scrolling to reach.
- Banner is now `sticky top-0 h-12` with `truncate` on the message span, so long provider-error reasons ellipsize instead of wrapping to two lines.
- Banner element carries a stable `.agent-banner` marker class. `DashboardShell` wrapper carries `group`. Both topbar variants (`DashboardTopbar`, `SettingsTopbar`) and the settings sidebar (`top`, `min-h`, `height`) react via `group-has-[.agent-banner]:` and shift down by `3rem` only when the banner is mounted.
- Zero JS — no `ResizeObserver`, no CSS custom properties, no inline-style mutations on `<html>`. Pure CSS, so the layout shift lands in the same paint that mounts the banner (no flash on first measurement).

## Trade-off

Long provider-error messages get ellipsized on narrow viewports instead of wrapping. The tag and the "Open AI settings" CTA stay visible, which is what users actually need to act on; the full message remains in the DOM and can be inspected.

## Test plan

- [x] `pnpm -F @getmunin/dashboard-pages typecheck` — clean.
- [x] Visual smoke at `/dashboard/settings/team` with a degraded agent (banner visible): Sign out lands above the fold; scrolling the right column keeps banner + topbar + sidebar pinned together with no dead-space below the sidebar.
- [x] Visual smoke with the banner hidden: layout is byte-identical to pre-PR behavior (`top-0` on topbars, `top-14` on aside, `min-h-screen` on the wrapper).
- [ ] Verify mobile (≤md) sidebar drawer still opens/closes correctly via `SettingsTopbar`'s menu toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)