### PR TITLE
fix(emails): declare react-dom as a direct dependency

### DIFF
--- a/.changeset/emails-react-dom-peer.md
+++ b/.changeset/emails-react-dom-peer.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/emails': patch
+---
+
+Add `react-dom` as a direct dependency of `@getmunin/emails`.
+
+`@react-email/render` declares it as a peer (used internally for `renderToStaticMarkup`). The package's own tests passed because the workspace hoists `react-dom` into the root, but consumer Docker images that install only production deps for a single workspace target (cloud's `backend-cloud`) never pulled it in, so `render()` threw at runtime and BetterAuth swallowed the failure — end-user symptom: forgot-password / verify / delete-account / partner-claim emails silently dropped on prod after the 4.23.4 cutover.
+
+Now declared explicitly so every consumer gets it transitively.

--- a/packages/emails/package.json
+++ b/packages/emails/package.json
@@ -35,13 +35,15 @@
   "dependencies": {
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.8",
-    "react": "^19.2.0"
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
     "@getmunin/eslint-config": "workspace:*",
     "@getmunin/tsconfig": "workspace:*",
     "@types/node": "^22.7.0",
     "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
     "eslint": "^9.10.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,6 +706,9 @@ importers:
       react:
         specifier: ^19.2.0
         version: 19.2.6
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.6(react@19.2.6)
     devDependencies:
       '@getmunin/eslint-config':
         specifier: workspace:*
@@ -719,6 +722,9 @@ importers:
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.15)
       eslint:
         specifier: ^9.10.0
         version: 9.39.4(jiti@1.21.7)


### PR DESCRIPTION
## Summary

Fixes silently-dropped emails on prod after 4.23.4. `@react-email/render` declares `react-dom` as a peer (uses `renderToStaticMarkup` from `react-dom/server` internally). `@getmunin/emails`'s own tests passed because pnpm hoists `react-dom` into the workspace root via other packages (Next.js apps), but **cloud's `backend-cloud` Docker image** installs only production deps for a single workspace target — `react-dom` was never pulled in, so `render()` threw at runtime and BetterAuth swallowed the failure.

End-user symptom: forgot-password (and verify-email / delete-account / partner-claim) silently dropped on prod after the 4.23.4 cutover. UI still shows "we sent a link" because BetterAuth doesn't propagate `sendResetPassword` errors.

## Fix

- `packages/emails/package.json` now declares `react-dom` (and `@types/react-dom`) directly.

## Test plan

- [x] `pnpm install` — lockfile updated cleanly
- [x] `pnpm -F @getmunin/emails test` — 16 cases pass
- [ ] CI on this PR
- [ ] Post-release: bump cloud to 4.23.5, redeploy prod, retry forgot-password — email should arrive with HTML body

🤖 Generated with [Claude Code](https://claude.com/claude-code)