### PR TITLE
feat(auth): forward BetterAuth log errors to Sentry

### DIFF
--- a/.changeset/better-auth-sentry-logger.md
+++ b/.changeset/better-auth-sentry-logger.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/backend': minor
+---
+
+Forward BetterAuth log errors to Sentry.
+
+`createMuninAuthCore` now accepts a `logger` option (passthrough to BetterAuth). The OSS `apps/backend` wires it up with `sentryForwardingLogger(Sentry.captureException)`, which captures every `level === 'error'` log entry — including the background-task failures BetterAuth catches internally (e.g. SMTP errors during `sendResetPassword`).
+
+Without this, BetterAuth's `try { … } catch (err) { logger.error('Failed to run background task', err) }` pattern swallowed real failures: the error never reached Sentry's unhandled-exception/rejection hooks, so issues like the recent `551 5.5.3 Domain name must be added` SMTP rejection were invisible to alerting.
+
+Consumers passing a custom `logger` can either omit the helper or extend it; the option type matches `BetterAuthOptions['logger']` directly.

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -1,4 +1,5 @@
 import { APIError } from 'better-auth/api';
+import type { BetterAuthOptions } from 'better-auth';
 import {
   createMuninAuthCore,
   type MuninAuthInstance,
@@ -22,6 +23,7 @@ export interface MuninAuthOptions {
   allowedEmailDomains?: string[];
   google?: { clientId: string; clientSecret: string };
   github?: { clientId: string; clientSecret: string };
+  logger?: BetterAuthOptions['logger'];
 }
 
 export function createMuninAuth({
@@ -34,6 +36,7 @@ export function createMuninAuth({
   allowedEmailDomains = [],
   google,
   github,
+  logger,
 }: MuninAuthOptions): MuninAuthInstance {
   return createMuninAuthCore({
     db,
@@ -41,6 +44,7 @@ export function createMuninAuth({
     authSecret,
     trustedOrigins,
     webBaseUrl,
+    logger,
     socialProviders: google || github ? { google, github } : undefined,
     sendResetPassword: mailer
       ? async ({ user, url }) => {
@@ -150,4 +154,30 @@ export function readAllowedEmailDomainsFromEnv(): string[] {
     .split(',')
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean);
+}
+
+type CaptureExceptionFn = (
+  err: unknown,
+  hint?: { tags?: Record<string, string>; extra?: Record<string, unknown> },
+) => unknown;
+
+export function sentryForwardingLogger(
+  captureException: CaptureExceptionFn,
+): NonNullable<BetterAuthOptions['logger']> {
+  return {
+    log(level, message, ...args) {
+      const safeArgs = args as unknown[];
+      const out = level === 'error' || level === 'warn' ? console.error : console.log;
+      out(`[Better Auth] [${level}] ${message}`, ...safeArgs);
+      if (level !== 'error') return;
+      const err = safeArgs.find((a): a is Error => a instanceof Error);
+      captureException(err ?? new Error(`[BetterAuth] ${message}`), {
+        tags: { source: 'better-auth' },
+        extra: {
+          message,
+          args: err ? safeArgs.filter((a) => a !== err) : safeArgs,
+        },
+      });
+    },
+  };
 }

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -10,9 +10,11 @@ import {
   readTrustedOriginsFromEnv,
   requireAuthSecret,
 } from '@getmunin/backend-core';
+import * as Sentry from '@sentry/nestjs';
 import {
   createMuninAuth,
   readAllowedEmailDomainsFromEnv,
+  sentryForwardingLogger,
   type MuninAuth,
 } from './auth.config.ts';
 
@@ -37,6 +39,7 @@ export class AuthController {
       allowedEmailDomains: readAllowedEmailDomainsFromEnv(),
       google: readGoogleProviderFromEnv(),
       github: readGithubProviderFromEnv(),
+      logger: sentryForwardingLogger(Sentry.captureException),
     });
   }
 

--- a/apps/backend/src/auth/sentry-forwarding-logger.test.ts
+++ b/apps/backend/src/auth/sentry-forwarding-logger.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sentryForwardingLogger } from './auth.config.ts';
+
+type CaptureHint = { tags?: Record<string, string>; extra?: Record<string, unknown> };
+type CaptureCall = [unknown, CaptureHint?];
+
+describe('sentryForwardingLogger', () => {
+  let calls: CaptureCall[];
+  let capture: (err: unknown, hint?: CaptureHint) => unknown;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  let consoleLog: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    calls = [];
+    capture = (err, hint) => {
+      calls.push([err, hint]);
+      return undefined;
+    };
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    consoleLog.mockRestore();
+  });
+
+  it('forwards Errors from error-level logs to captureException', () => {
+    const logger = sentryForwardingLogger(capture);
+    const err = new Error('boom');
+    logger.log!('error', 'Failed to run background task', err);
+
+    expect(calls).toHaveLength(1);
+    const [reported, hint] = calls[0]!;
+    expect(reported).toBe(err);
+    expect(hint).toEqual({
+      tags: { source: 'better-auth' },
+      extra: { message: 'Failed to run background task', args: [] },
+    });
+  });
+
+  it('synthesises an Error when error-level logs carry none', () => {
+    const logger = sentryForwardingLogger(capture);
+    logger.log!('error', 'something went sideways', { detail: 42 });
+
+    expect(calls).toHaveLength(1);
+    const [reported, hint] = calls[0]!;
+    expect(reported).toBeInstanceOf(Error);
+    expect((reported as Error).message).toBe('[BetterAuth] something went sideways');
+    expect(hint).toEqual({
+      tags: { source: 'better-auth' },
+      extra: { message: 'something went sideways', args: [{ detail: 42 }] },
+    });
+  });
+
+  it('does not capture non-error log levels', () => {
+    const logger = sentryForwardingLogger(capture);
+    logger.log!('warn', 'heads up', new Error('still ignored'));
+    logger.log!('info', 'just info');
+    logger.log!('debug', 'debug');
+
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -59,6 +59,8 @@ export interface MuninAuthCoreOptions {
   crossSubDomainCookies?: { domain: string };
 
   rateLimit?: BetterAuthOptions['rateLimit'];
+
+  logger?: BetterAuthOptions['logger'];
 }
 
 export type MuninAuthInstance = BetterAuthInstance;
@@ -81,6 +83,7 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
     basePath: '/auth',
     secret: opts.authSecret,
     rateLimit: opts.rateLimit,
+    logger: opts.logger,
     database: drizzleAdapter(opts.db, {
       provider: 'pg',
       schema: {


### PR DESCRIPTION
## Summary
- `createMuninAuthCore` now accepts a `logger` option (passthrough to BetterAuth's logger).
- `apps/backend` wires `sentryForwardingLogger(Sentry.captureException)` — every `level === 'error'` log call (the first `Error` in args, or a synthesised one) gets reported to Sentry with `tags.source = 'better-auth'`.

## Why
BetterAuth wraps `sendResetPassword`, `sendVerificationEmail`, `sendDeleteAccountVerification`, and other background tasks in `try { … } catch (err) { logger.error(...) }`. Errors become logger calls and never throw, so Sentry's unhandled-exception integration never sees them.

Surfaced during this weekend's incident: a missing TEM blackhole MX in cloud caused every forgot-password to fail with `551 5.5.3 Domain name must be added` — invisible to Sentry. Only found by tailing container stdout via Cockpit Loki. This PR makes the same class of failure self-report next time.

## Test plan
- [x] `pnpm typecheck` (workspace) clean.
- [x] 3-case vitest covering: Error in args → forwarded, no Error → synthesised, non-error levels → no capture.
- [ ] Local `pnpm dev`: trigger a forced BetterAuth error (e.g. mailer stub that throws), confirm a Sentry event with `tags.source: better-auth` lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)