### PR TITLE
chore(tests): require TEST_DATABASE_URL strictly + clean up JWK fixture

### DIFF
--- a/.changeset/integration-test-strict-gating.md
+++ b/.changeset/integration-test-strict-gating.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Integration tests now strictly require `TEST_DATABASE_URL` instead of silently falling back to `DATABASE_URL`. Yesterday's "Failed to decrypt private key" boot loop on dev was caused by `oauth-jwt-resolver.integration.test` running against the dev database (because `TEST_DATABASE_URL` was unset and the fallback let it use `DATABASE_URL`), writing an unencrypted JWK row directly via Drizzle, and never cleaning it up — so the next `pnpm dev` boot tried to read it through BetterAuth's encrypted-key code path and crashed.
+
+Two changes close the loop:
+
+- Every integration + database-touching test in this package (and elsewhere across the workspace) now reads `process.env.TEST_DATABASE_URL` only. When unset, `describe.skip` runs cleanly with a clear "Set TEST_DATABASE_URL" message instead of pointing the test at whatever DB happens to be in `process.env.DATABASE_URL` (typically dev).
+- `oauth-jwt-resolver.integration.test` now `afterAll`-deletes its fixture JWK row by `kid`, so even within the dedicated test database no plaintext key lingers between runs.
+
+CI already sets `TEST_DATABASE_URL` in `.github/workflows/ci.yml`, so the pipeline is unaffected. For local development, `.env.example` now declares the variable (default: `postgres://munin_app:munin_app@localhost:5432/munin_test`).

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,13 @@ MUNIN_MIGRATE_URL=postgres://munin:munin@localhost:5432/munin
 # policies actually apply (superusers bypass RLS, regardless of FORCE).
 DATABASE_URL=postgres://munin_app:munin_app@localhost:5432/munin
 
+# --- Test database (required for integration tests) --------------------
+# Integration tests refuse to run unless this is set, and they will wipe
+# fixture rows in the database it points at. Use a *separate* Postgres
+# database from DATABASE_URL so a stray `vitest` run never pollutes dev
+# data (e.g. JWKS keys written by oauth-jwt-resolver.integration.test).
+TEST_DATABASE_URL=postgres://munin_app:munin_app@localhost:5432/munin_test
+
 # --- Backend ------------------------------------------------------------
 BACKEND_PORT=3001
 # Generate with: openssl rand -base64 48

--- a/apps/backend/src/auth/oauth-conformance.integration.test.ts
+++ b/apps/backend/src/auth/oauth-conformance.integration.test.ts
@@ -6,10 +6,10 @@ import { createApp } from '@getmunin/backend-core';
 import { runMigrations } from '@getmunin/db';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run OAuth AS conformance tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run OAuth AS conformance tests.';
 
 const FIXED_PORT = 17345;
 const PRESET_BASE_URL = `http://127.0.0.1:${FIXED_PORT}`;

--- a/apps/backend/src/auth/oss-signup.integration.test.ts
+++ b/apps/backend/src/auth/oss-signup.integration.test.ts
@@ -8,10 +8,10 @@ import { hashSecret, randomToken } from '@getmunin/core';
 import { createApp } from '@getmunin/backend-core';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run OSS signup tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run OSS signup tests.';
 
 (skipReason ? describe.skip : describe)('Singleton org + invite-only signup', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/common/quotas/quotas.service.test.ts
+++ b/packages/backend-core/src/common/quotas/quotas.service.test.ts
@@ -6,10 +6,10 @@ import { randomUUID } from 'node:crypto';
 import type { QuotasService } from './quotas.service.ts';
 import { DefaultQuotasService, QuotaExceededError } from './quotas.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run quotas tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run quotas tests.';
 
 (skipReason ? describe.skip : describe)('QuotasService', () => {
   let db: ReturnType<typeof createDb>;

--- a/packages/backend-core/src/common/rate-limit/rate-limit.service.test.ts
+++ b/packages/backend-core/src/common/rate-limit/rate-limit.service.test.ts
@@ -5,10 +5,10 @@ import { sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { RateLimitExceededError, RateLimitService } from './rate-limit.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run rate-limit tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run rate-limit tests.';
 
 (skipReason ? describe.skip : describe)('RateLimitService', () => {
   let db: ReturnType<typeof createDb>;

--- a/packages/backend-core/src/common/webhooks/webhook.worker.test.ts
+++ b/packages/backend-core/src/common/webhooks/webhook.worker.test.ts
@@ -10,10 +10,10 @@ import { sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.ts';
 import { WebhookWorker } from './webhook.worker.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run webhook worker tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run webhook worker tests.';
 
 interface ReceivedRequest {
   body: string;

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -9,10 +9,10 @@ import { eq, sql } from 'drizzle-orm';
 import { createApp } from '../bootstrap-app.ts';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run control-plane controller tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run control-plane controller tests.';
 
 interface OrgFixture {
   id: string;

--- a/packages/backend-core/src/control/conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/conversations.controller.integration.test.ts
@@ -10,10 +10,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run conversations REST integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run conversations REST integration tests.';
 
 (skipReason ? describe.skip : describe)('Conversations REST controller', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
@@ -8,10 +8,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run end-user conversations REST integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run end-user conversations REST integration tests.';
 
 (skipReason ? describe.skip : describe)('End-user conversations REST controller', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/control/outreach-unsubscribe.controller.integration.test.ts
+++ b/packages/backend-core/src/control/outreach-unsubscribe.controller.integration.test.ts
@@ -8,10 +8,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run unsubscribe integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run unsubscribe integration tests.';
 
 (skipReason ? describe.skip : describe)('Outreach unsubscribe controller', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/control/overview.controller.integration.test.ts
+++ b/packages/backend-core/src/control/overview.controller.integration.test.ts
@@ -10,10 +10,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run overview integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run overview integration tests.';
 
 (skipReason ? describe.skip : describe)('Overview backlog controller', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -10,10 +10,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run MCP integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run MCP integration tests.';
 
 (skipReason ? describe.skip : describe)('MCP integration: KB end-to-end', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
+++ b/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
@@ -11,10 +11,10 @@ import { DB } from '../common/db/db.module.ts';
 import { openAdminAgentMcpClient, type AgentMcpClient } from '../agent/in-process-context.ts';
 import type { Db } from '@getmunin/db';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run MCP tools smoke tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run MCP tools smoke tests.';
 
 const EXPECTED_BY_MODULE: Record<string, RegExp> = {
   kb: /^kb_/,

--- a/packages/backend-core/src/modules/cms/cms.integration.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.integration.test.ts
@@ -14,10 +14,10 @@ import { createApp } from '../../bootstrap-app.ts';
 import { AppModule } from '../../app.module.ts';
 import { CmsScheduleWorker } from './cms.schedule.worker.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run CMS integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run CMS integration tests.';
 
 (skipReason ? describe.skip : describe)('CMS integration: admin authoring + public delivery', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/cms/cms.service.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.test.ts
@@ -19,10 +19,10 @@ import {
 import { EmbeddingProviderHolder } from '../kb/embedding.provider.ts';
 import { DefaultQuotasService, QuotaExceededError } from '../../common/quotas/quotas.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run CMS service tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run CMS service tests.';
 
 class StubStorage implements AssetStorage {
   readonly provider = 'local' as const;

--- a/packages/backend-core/src/modules/conv/conv.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.integration.test.ts
@@ -10,10 +10,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run conv integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run conv integration tests.';
 
 (skipReason ? describe.skip : describe)('Conversations integration: end-user + admin flow', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/conv/conv.runner-claim.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.runner-claim.integration.test.ts
@@ -8,10 +8,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { eq, sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to run conv runner-claim integration tests.';
+  : 'Set TEST_DATABASE_URL to run conv runner-claim integration tests.';
 
 (skipReason ? describe.skip : describe)('conv runner-claim ownership', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/conv/conv.service.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.test.ts
@@ -13,10 +13,10 @@ import { ConvService, ConvInvalidError } from './conv.service.ts';
 import { ConversationClaimsService } from './conv.claims.service.ts';
 import { CuratorJobsService } from '../curator/curator-jobs.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run conv service tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run conv service tests.';
 
 (skipReason ? describe.skip : describe)('ConvService', () => {
   let db: ReturnType<typeof createDb>;

--- a/packages/backend-core/src/modules/conv/email/email.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email.integration.test.ts
@@ -15,10 +15,10 @@ import { InboundPollWorker } from '../channels/inbound-poll.worker.ts';
 import { OutboundDeliveryWorker } from '../channels/outbound-delivery.worker.ts';
 import { MAILER } from '../../../common/mail/mail.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run email integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run email integration tests.';
 
 const REPLY_DOMAIN = 'reply.example.test';
 

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.integration.test.ts
@@ -10,10 +10,10 @@ import { createApp } from '../../../bootstrap-app.ts';
 import { MessageBirdSmsService } from './messagebird-sms.service.ts';
 import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run MessageBird SMS integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run MessageBird SMS integration tests.';
 
 (skipReason ? describe.skip : describe)('MessageBird SMS inbound webhook integration', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms.integration.test.ts
@@ -11,10 +11,10 @@ import { TwilioSmsService } from './twilio-sms.service.ts';
 import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
 import { randomUUID } from 'node:crypto';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run Twilio SMS integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run Twilio SMS integration tests.';
 
 (skipReason ? describe.skip : describe)('Twilio SMS inbound webhook integration', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/conv/vapi/vapi.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi.integration.test.ts
@@ -10,10 +10,10 @@ import { createApp } from '../../../bootstrap-app.ts';
 import { VapiService } from './vapi.service.ts';
 import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run Vapi integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run Vapi integration tests.';
 
 (skipReason ? describe.skip : describe)('Vapi voice channel integration', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/conv/voice-callback.channelid.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/voice-callback.channelid.integration.test.ts
@@ -10,10 +10,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql, eq } from 'drizzle-orm';
 import { AppModule } from '../../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run voice-callback channelId tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run voice-callback channelId tests.';
 
 (skipReason ? describe.skip : describe)('conv_voice_call_contact — optional channelId routing', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/conv/voice-callback.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/voice-callback.integration.test.ts
@@ -13,10 +13,10 @@ import { AppModule } from '../../app.module.ts';
 import { createApp } from '../../bootstrap-app.ts';
 import { VapiService } from './vapi/vapi.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run voice-callback integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run voice-callback integration tests.';
 
 (skipReason ? describe.skip : describe)('Voice callback MCP tools', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/conv/widget/widget-email-fallback.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-email-fallback.integration.test.ts
@@ -9,10 +9,10 @@ import { AppModule } from '../../../app.module.ts';
 import { MAILER } from '../../../common/mail/mail.module.ts';
 import { WidgetEmailFallbackWorker } from './widget-email-fallback.worker.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run widget fallback integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run widget fallback integration tests.';
 
 const REPLY_DOMAIN = 'reply.example.test';
 

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
@@ -12,10 +12,10 @@ import { createApp } from '../../../bootstrap-app.ts';
 import { VapiService } from '../vapi/vapi.service.ts';
 import { VapiClientService } from '../vapi/vapi-client.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run widget-voice integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run widget-voice integration tests.';
 
 (skipReason ? describe.skip : describe)('Widget voice/start endpoint', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -13,10 +13,10 @@ import { sql, eq, and } from 'drizzle-orm';
 import { AppModule } from '../../../app.module.ts';
 import { createApp } from '../../../bootstrap-app.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run widget integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run widget integration tests.';
 
 (skipReason ? describe.skip : describe)('Chat-widget channel integration', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/crm/crm.integration.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.integration.test.ts
@@ -10,10 +10,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run CRM integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run CRM integration tests.';
 
 (skipReason ? describe.skip : describe)('CRM integration: admin + self-service', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/crm/crm.service.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.test.ts
@@ -7,10 +7,10 @@ import { NotFoundException, ConflictException } from '@nestjs/common';
 import { CrmService, CrmInvalidError } from './crm.service.ts';
 import { DefaultQuotasService } from '../../common/quotas/quotas.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run CRM service tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run CRM service tests.';
 
 (skipReason ? describe.skip : describe)('CrmService', () => {
   let db: ReturnType<typeof createDb>;

--- a/packages/backend-core/src/modules/curator/curator-jobs.integration.test.ts
+++ b/packages/backend-core/src/modules/curator/curator-jobs.integration.test.ts
@@ -8,10 +8,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to run curator-jobs integration tests.';
+  : 'Set TEST_DATABASE_URL to run curator-jobs integration tests.';
 
 (skipReason ? describe.skip : describe)('curator_jobs queue', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/kb/kb.integration.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.integration.test.ts
@@ -10,10 +10,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run KB integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run KB integration tests.';
 
 (skipReason ? describe.skip : describe)('KB integration: document lifecycle via /mcp', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/kb/kb.search.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.search.test.ts
@@ -14,10 +14,10 @@ import { KbSearchService } from './kb.search.ts';
 import { EmbeddingProviderHolder } from './embedding.provider.ts';
 import { DefaultQuotasService } from '../../common/quotas/quotas.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run KB search tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run KB search tests.';
 
 (skipReason ? describe.skip : describe)('KbSearchService', () => {
   let db: ReturnType<typeof createDb>;

--- a/packages/backend-core/src/modules/kb/kb.service.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.test.ts
@@ -13,10 +13,10 @@ import { CURATION_INBOX_SLUG, KbService, KbConflictError, KbNotFoundError, KbInv
 import { EmbeddingProviderHolder } from './embedding.provider.ts';
 import { DefaultQuotasService, QuotaExceededError } from '../../common/quotas/quotas.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run KB service tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run KB service tests.';
 
 (skipReason ? describe.skip : describe)('KbService', () => {
   let db: ReturnType<typeof createDb>;

--- a/packages/backend-core/src/modules/outreach/outreach.integration.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.integration.test.ts
@@ -10,10 +10,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run Outreach integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run Outreach integration tests.';
 
 (skipReason ? describe.skip : describe)('Outreach integration: admin tools via /mcp', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/modules/outreach/outreach.service.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.test.ts
@@ -19,10 +19,10 @@ import { ConversationClaimsService } from '../conv/conv.claims.service.ts';
 import { CuratorJobsService } from '../curator/curator-jobs.service.ts';
 import { EmailService } from '../conv/email/email.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run outreach service tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run outreach service tests.';
 
 (skipReason ? describe.skip : describe)('OutreachService', () => {
   let db: ReturnType<typeof createDb>;

--- a/packages/backend-core/src/oauth/oauth-conformance.integration.test.ts
+++ b/packages/backend-core/src/oauth/oauth-conformance.integration.test.ts
@@ -6,10 +6,10 @@ import { NestFactory } from '@nestjs/core';
 import { runMigrations } from '@getmunin/db';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run OAuth conformance tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run OAuth conformance tests.';
 
 (skipReason ? describe.skip : describe)('OAuth 2.1 / MCP resource-server conformance', () => {
   let app: INestApplication;

--- a/packages/backend-core/src/oauth/oauth-jwt-resolver.integration.test.ts
+++ b/packages/backend-core/src/oauth/oauth-jwt-resolver.integration.test.ts
@@ -6,13 +6,13 @@ import { NestFactory } from '@nestjs/core';
 import { exportJWK, generateKeyPair, SignJWT } from 'jose';
 import { randomUUID } from 'node:crypto';
 import { createDb, runMigrations, schema } from '@getmunin/db';
-import { sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run OAuth JWT resolver integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run OAuth JWT resolver integration tests.';
 
 (skipReason ? describe.skip : describe)('OAuth JWT resolver: end-to-end /mcp verification', () => {
   let app: INestApplication;
@@ -78,6 +78,7 @@ const skipReason = TEST_URL
 
   afterAll(async () => {
     if (app) await app.close();
+    if (db && kid) await db.delete(schema.jwks).where(eq(schema.jwks.id, kid));
     delete process.env.NEXT_PUBLIC_MCP_URL;
   });
 

--- a/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
+++ b/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
@@ -11,10 +11,10 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../app.module.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run widget WS integration tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run widget WS integration tests.';
 
 (skipReason ? describe.skip : describe)('Realtime widget subscriptions', () => {
   let app: INestApplication;

--- a/packages/core/src/crypto/primitives.test.ts
+++ b/packages/core/src/crypto/primitives.test.ts
@@ -63,8 +63,8 @@ describe('timingSafeEqual', () => {
   });
 });
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
-const skipPgcrypto = TEST_URL ? null : 'Set DATABASE_URL or TEST_DATABASE_URL to run pgcrypto tests';
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipPgcrypto = TEST_URL ? null : 'Set TEST_DATABASE_URL to run pgcrypto tests';
 
 (skipPgcrypto ? describe.skip : describe)('pgcrypto secret encryption', () => {
   let db: Db;

--- a/packages/core/src/request/credentials.test.ts
+++ b/packages/core/src/request/credentials.test.ts
@@ -6,10 +6,10 @@ import { CredentialResolver } from './credentials.ts';
 import { buildApiKey, keyPrefix } from '../crypto/keys.ts';
 import { hashSecret } from '../crypto/primitives.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run credential resolver tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run credential resolver tests.';
 
 (skipReason ? describe.skip : describe)('CredentialResolver.resolveApiKey', () => {
   let db: Db;

--- a/packages/db/src/rls.test.ts
+++ b/packages/db/src/rls.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import postgres from 'postgres';
 
-const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
   ? null
-  : 'Set DATABASE_URL or TEST_DATABASE_URL to a Postgres URL to run RLS tests.';
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run RLS tests.';
 
 (skipReason ? describe.skip : describe)('RLS isolation', () => {
   if (skipReason) it.skip(skipReason, () => {});


### PR DESCRIPTION
## Why

Twice in two days, dev backend boot crashed with `BetterAuthError: Failed to decrypt private key`. Root cause traced to `oauth-jwt-resolver.integration.test.ts`:

```ts
const TEST_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
// …
await db.insert(schema.jwks).values({
  id: kid,
  publicKey: JSON.stringify(publicJwk),
  privateKey: JSON.stringify(await exportJWK(privateKey)),  // ← unencrypted
});
```

When `TEST_DATABASE_URL` was unset locally, the fallback let the test point at the *dev* database. It then wrote a plaintext JWK row via Drizzle (bypassing BetterAuth's encryption) and never deleted it in `afterAll`. The next `pnpm dev` boot tried to read that row through BetterAuth's encrypted-key code path → `Failed to decrypt`.

## Changes

- **40 OSS test files**: dropped the `?? process.env.DATABASE_URL` fallback. Tests now `describe.skip` cleanly when `TEST_DATABASE_URL` is unset, with a skip-reason that no longer mentions `DATABASE_URL`.
- **`oauth-jwt-resolver.integration.test.ts`**: added `afterAll` cleanup that deletes the fixture JWK row by `kid`, so even within the dedicated test DB no plaintext key lingers between runs.
- **`.env.example`**: declares `TEST_DATABASE_URL` (default `postgres://munin_app:munin_app@localhost:5432/munin_test`) with a comment explaining what it's for.

CI already sets `TEST_DATABASE_URL` in `.github/workflows/ci.yml`, so the pipeline is unaffected.

A matching cloud PR will follow for the 6 cloud-side tests with the same pattern.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck` — clean.
- [x] `pnpm -F @getmunin/db typecheck` + `pnpm -F @getmunin/core typecheck` — clean.
- [x] Strict-gate smoke: ran `oauth-jwt-resolver.integration.test` with both `TEST_DATABASE_URL` and `DATABASE_URL` unset and `.env` moved aside — file cleanly skipped 8/8 tests instead of trying to migrate the dev DB.
- [ ] CI run on this branch to confirm the suite still passes against the configured `TEST_DATABASE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)