### PR TITLE
fix(feedback): require control-plane access for approve/reject

### DIFF
--- a/packages/backend-core/src/modules/feedback/feedback.controller.test.ts
+++ b/packages/backend-core/src/modules/feedback/feedback.controller.test.ts
@@ -1,0 +1,25 @@
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+import { ControlPlaneGuard } from '../../common/auth/control-plane.guard.ts';
+import { FeedbackController } from './feedback.controller.ts';
+
+const GUARDS_METADATA = '__guards__';
+
+function guardsOn(method: 'approve' | 'reject' | 'create'): unknown[] {
+  const fn = FeedbackController.prototype[method] as (...args: unknown[]) => unknown;
+  return (Reflect.getMetadata(GUARDS_METADATA, fn) as unknown[] | undefined) ?? [];
+}
+
+describe('FeedbackController guard wiring', () => {
+  it('approve has ControlPlaneGuard at the method level', () => {
+    expect(guardsOn('approve')).toContain(ControlPlaneGuard);
+  });
+
+  it('reject has ControlPlaneGuard at the method level', () => {
+    expect(guardsOn('reject')).toContain(ControlPlaneGuard);
+  });
+
+  it('create does NOT carry ControlPlaneGuard (broadly authenticated)', () => {
+    expect(guardsOn('create')).not.toContain(ControlPlaneGuard);
+  });
+});

--- a/packages/backend-core/src/modules/feedback/feedback.controller.ts
+++ b/packages/backend-core/src/modules/feedback/feedback.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import { z } from 'zod';
 import { AuthGuard } from '../../common/auth/auth.guard.ts';
+import { ControlPlaneGuard } from '../../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../../common/audit/audit.interceptor.ts';
 import {
@@ -44,6 +45,7 @@ export class FeedbackController {
   }
 
   @Post(':id/approve')
+  @UseGuards(ControlPlaneGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
   async approve(@Param('id') id: string): Promise<void> {
     try {
@@ -60,6 +62,7 @@ export class FeedbackController {
   }
 
   @Post(':id/reject')
+  @UseGuards(ControlPlaneGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
   async reject(@Param('id') id: string): Promise<void> {
     try {


### PR DESCRIPTION
## Summary

- `POST /v1/feedback/:id/approve` and `/reject` were guarded only by `AuthGuard`, so `widget_agent` and delegated actors could moderate feedback even though the MCP `feedback_approve` / `feedback_reject` tools are admin-only. The REST surface now matches.
- Apply `ControlPlaneGuard` at the method level on `approve` and `reject` in `FeedbackController`. `create` keeps the broadly-authenticated path so any signed-in actor can still submit feedback.
- Regression test asserts the guard metadata wiring on each route.

## Test plan

- [x] `pnpm -F @getmunin/backend-core test feedback` (3 wiring + 3 forwarder tests pass)
- [x] `pnpm -F @getmunin/backend-core typecheck`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)