### PR TITLE
fix(dashboard-pages): pin relativeTime to useNow on end-users

### DIFF
--- a/packages/dashboard-pages/src/pages/end-users.tsx
+++ b/packages/dashboard-pages/src/pages/end-users.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
-import { useFormatter, useTranslations } from 'next-intl';
+import { useFormatter, useNow, useTranslations } from 'next-intl';
 import { api } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 import { LoadFailed } from '../components/load-failed';
@@ -27,6 +27,7 @@ export function EndUsersPage() {
   const tCommon = useTranslations('common');
   const translate = useTranslateError();
   const format = useFormatter();
+  const now = useNow();
   const [items, setItems] = useState<EndUserDto[] | null>(null);
   const [revokingId, setRevokingId] = useState<string | null>(null);
   const [query, setQuery] = useState('');
@@ -145,7 +146,7 @@ export function EndUsersPage() {
                     {eu.externalId ?? '—'}
                   </td>
                   <td className="py-4 pr-4 font-mono text-xs text-ink-mute">
-                    {format.relativeTime(new Date(eu.updatedAt))}
+                    {format.relativeTime(new Date(eu.updatedAt), now)}
                   </td>
                   <td className="py-4 text-right">
                     <Button


### PR DESCRIPTION
## Summary

- next-intl logs `ENVIRONMENT_FALLBACK` when `format.relativeTime` is called without a `now` reference, because each render would otherwise use a fresh `Date()` (SSR/client divergence).
- Match `team.tsx`: read `useNow()` once and pass it as the second arg to `relativeTime` for the end-users updated-at column.

## Test plan

- [ ] Open Settings → End users in a logged-in session, confirm the "last contact" column renders without the console warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)