### PR TITLE
chore(changeset): drop ignored @getmunin/backend from sentry-logger entry

### DIFF
--- a/.changeset/better-auth-sentry-logger.md
+++ b/.changeset/better-auth-sentry-logger.md
@@ -1,6 +1,5 @@
 ---
 '@getmunin/backend-core': minor
-'@getmunin/backend': minor
 ---
 
 Forward BetterAuth log errors to Sentry.


### PR DESCRIPTION
## Summary

- Release (Changesets) workflow has been failing on main with `Mixed changesets that contain both ignored and not ignored packages are not allowed` (runs [26694969419](https://github.com/getmunin/munin/actions/runs/26694969419), [26694144290](https://github.com/getmunin/munin/actions/runs/26694144290)).
- `.changeset/better-auth-sentry-logger.md` (from #276) bumped both `@getmunin/backend-core` (released) and `@getmunin/backend` (in the `ignore` list in `.changeset/config.json`). Remove the ignored package.
- The OSS backend app is a deployment artifact, not a published package — it should never appear in a changeset.

## Test plan

- [ ] Release (Changesets) job on main turns green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)