### PR TITLE
chore(changeset): drop ignored @getmunin/web from shared-auth-pages entry

### DIFF
--- a/.changeset/shared-auth-pages.md
+++ b/.changeset/shared-auth-pages.md
@@ -1,6 +1,5 @@
 ---
 '@getmunin/dashboard-pages': minor
-'@getmunin/web': patch
 ---
 
 Promote the auth pages — `LoginForm`, `SignupForm`, `ForgotPasswordPage`, `ResetPasswordPage`, `VerifyEmailPage`, and `AuthLoading` — into `@getmunin/dashboard-pages` so OSS and cloud can share one implementation. Each accepts the brand footer as a prop (`OSS_AUTH_FOOTER` or `CLOUD_AUTH_FOOTER`); the signup form keeps OSS's invite-token lookup and gains OAuth provider buttons; the login form keeps `redirectTo` handling and moves the forgot-password link into the footnote next to "Create an account" (shortened from "Forgot your password?" to "Forgot password?"). The shared `useTranslateError` (and the pure `translateError` / `getErrorCode` helpers) are now re-exported from the package root, replacing the per-app duplicates.


### PR DESCRIPTION
## Summary

- Removes `@getmunin/web` (ignored in `.changeset/config.json`) from `.changeset/shared-auth-pages.md`, leaving only `@getmunin/dashboard-pages: minor`.
- Unblocks the Release (Changesets) step on `main`, which failed on run [26695567920](https://github.com/getmunin/munin/actions/runs/26695567920) with `Mixed changesets that contain both ignored and not ignored packages are not allowed`.
- Same class of fix as #281, which dropped `@getmunin/backend` from the `sentry-logger` entry; this one was missed. `@getmunin/web` will still bump transitively via its `@getmunin/dashboard-pages` dependency.

## Test plan

- [ ] Release job on main goes green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)