### PR TITLE
fix(web): center dashboard/settings loading spinners inside layout chrome

### DIFF
--- a/apps/web/app/[locale]/dashboard/loading.tsx
+++ b/apps/web/app/[locale]/dashboard/loading.tsx
@@ -1,5 +1,5 @@
 import { PageSpinner } from '@getmunin/ui';
 
 export default function DashboardLoading() {
-  return <PageSpinner className="min-h-screen bg-bone dark:bg-background" />;
+  return <PageSpinner />;
 }

--- a/apps/web/app/[locale]/dashboard/settings/loading.tsx
+++ b/apps/web/app/[locale]/dashboard/settings/loading.tsx
@@ -1,5 +1,5 @@
 import { PageSpinner } from '@getmunin/ui';
 
 export default function SettingsLoading() {
-  return <PageSpinner className="min-h-screen bg-bone dark:bg-background" />;
+  return <PageSpinner />;
 }


### PR DESCRIPTION
## Summary

- The Suspense fallbacks at `apps/web/app/[locale]/dashboard/loading.tsx` and `apps/web/app/[locale]/dashboard/settings/loading.tsx` render *inside* `DashboardShell` (and the settings sidebar/header). With `min-h-screen` on `PageSpinner`, the spinner box overflowed below the viewport and `items-center` then biased the spinner well below the visual center of the content well.
- The `bg-bone dark:bg-background` override also repainted the slot in a slightly different shade than the surrounding layout, making the loading state look like a floating panel.
- Drop the className overrides and use `PageSpinner`'s defaults (`min-h-[60vh]`, no background), so the spinner sits centered inside the content well and inherits the layout's background.

Left untouched on purpose:
- `apps/web/app/[locale]/loading.tsx` — outermost locale boundary, no chrome above; `min-h-screen` is correct.
- `apps/web/app/[locale]/setup/page.tsx` — full-screen setup wizard, no dashboard chrome.

## Test plan

- [ ] Visit `/en/dashboard` and `/en/dashboard/settings/*` while the page is loading — spinner is vertically centered inside the content well and the background matches the surrounding layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)