### PR TITLE
feat(embedding): make vector dimension a deploy-time parameter

### DIFF
--- a/.changeset/embedding-dimensions.md
+++ b/.changeset/embedding-dimensions.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/core': minor
+'@getmunin/db': minor
+---
+
+Make the embedding vector dimension a deploy-time parameter.
+
+`OpenAIEmbeddingProvider` now accepts an optional `dimensions` field that is sent in the request body (honored by `text-embedding-3-*` and Scaleway's `qwen3-embedding-8b`) and enforced on the response — Matryoshka-truncated and L2-renormalized if the upstream returns a larger vector. The factory reads `OPENAI_EMBEDDING_DIMENSIONS` and cross-validates against `MUNIN_EMBEDDING_DIMENSIONS` so a mismatched deploy fails at boot rather than corrupting the index.
+
+`packages/db/src/schema.ts` reads `MUNIN_EMBEDDING_DIMENSIONS` (default 1536, range 32..4000). The embedding column is `vector(dim)` when `dim <= 2000` and `halfvec(dim)` above that, so deployments wanting near-native Qwen3 quality can pick `halfvec(4000)` and still index with HNSW. OSS defaults are unchanged — leaving the env var unset keeps the existing `vector(1536)` schema and 1536-dim provider.
+
+OSS migrations stay pinned to `vector(1536)`; bumping the dimension requires a fresh database or a deployment-specific ALTER. Self-hosters on the default see no behavior change.

--- a/.env.example
+++ b/.env.example
@@ -104,12 +104,22 @@ RESEND_API_KEY=
 MUNIN_MAIL_FROM=Munin <no-reply@example.com>
 
 # --- Embedding provider (optional, defaults to deterministic stub) -----
-# Set OPENAI_API_KEY to use OpenAI text-embedding-3-small.
-# Or point OPENAI_BASE_URL at a local LM Studio / vLLM / llama.cpp server
-# that speaks the OpenAI protocol for fully-local embeddings.
+# Set OPENAI_API_KEY to use OpenAI text-embedding-3-small (1536 dim).
+# Or point OPENAI_BASE_URL at any OpenAI-compatible server — local
+# (LM Studio, vLLM, llama.cpp) or hosted (Scaleway Generative APIs, etc.).
 OPENAI_API_KEY=
 # OPENAI_BASE_URL=http://localhost:11434/v1
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+#
+# Scaleway Generative APIs (qwen3-embedding-8b, Matryoshka 32..4000):
+#   OPENAI_BASE_URL=https://api.scaleway.ai/v1
+#   OPENAI_EMBEDDING_MODEL=qwen3-embedding-8b
+#   OPENAI_EMBEDDING_DIMENSIONS=1536           # must match MUNIN_EMBEDDING_DIMENSIONS
+#
+# Changing the vector dimension requires a fresh DB (no live ALTER path in OSS
+# migrations). MUNIN_EMBEDDING_DIMENSIONS=1536 is the default and matches the
+# OSS-shipped migrations; values >2000 switch the schema to pgvector halfvec.
+# MUNIN_EMBEDDING_DIMENSIONS=1536
 
 # --- Social sign-in (optional) -----------------------------------------
 # Configure either provider (or both) to expose the buttons on the login

--- a/packages/core/src/providers/embedding.test.ts
+++ b/packages/core/src/providers/embedding.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { StubEmbeddingProvider } from './embedding.ts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  OpenAIEmbeddingProvider,
+  StubEmbeddingProvider,
+  readEmbeddingProviderFromEnv,
+} from './embedding.ts';
 
 describe('StubEmbeddingProvider', () => {
   it('returns one vector per input in order', async () => {
@@ -32,5 +36,155 @@ describe('StubEmbeddingProvider', () => {
   it('handles empty input array', async () => {
     const p = new StubEmbeddingProvider();
     expect(await p.embed([])).toEqual([]);
+  });
+});
+
+describe('OpenAIEmbeddingProvider', () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function mockEmbeddingResponse(vec: number[]): void {
+    globalThis.fetch = () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ data: [{ embedding: vec, index: 0 }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+  }
+
+  function installFetchSpy(responseVec: number[]): {
+    lastCall(): { url: string; body: Record<string, unknown> };
+  } {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = ((url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: [{ embedding: responseVec, index: 0 }] }), {
+          status: 200,
+        }),
+      );
+    }) as unknown as typeof fetch;
+    return {
+      lastCall: () => {
+        const c = calls.at(-1);
+        if (!c) throw new Error('fetch was not called');
+        return { url: c.url, body: JSON.parse(c.init.body as string) as Record<string, unknown> };
+      },
+    };
+  }
+
+  it('omits the dimensions field by default and reports 1536', async () => {
+    const spy = installFetchSpy(new Array<number>(1536).fill(0.1));
+    const p = new OpenAIEmbeddingProvider({ apiKey: 'sk-test' });
+    expect(p.dimensions).toBe(1536);
+    expect(p.name).toBe('openai:text-embedding-3-small');
+    await p.embed(['hi']);
+    expect(spy.lastCall().body.dimensions).toBeUndefined();
+  });
+
+  it('sends the dimensions field when configured and names itself accordingly', async () => {
+    const spy = installFetchSpy(new Array<number>(4000).fill(0.5));
+    const p = new OpenAIEmbeddingProvider({
+      apiKey: 'sk-test',
+      model: 'qwen3-embedding-8b',
+      baseUrl: 'https://api.scaleway.ai/v1',
+      dimensions: 4000,
+    });
+    expect(p.dimensions).toBe(4000);
+    expect(p.name).toBe('openai:qwen3-embedding-8b@4000');
+    await p.embed(['hi']);
+    expect(spy.lastCall().body).toMatchObject({
+      model: 'qwen3-embedding-8b',
+      dimensions: 4000,
+      input: ['hi'],
+    });
+  });
+
+  it('truncates and renormalizes an oversize response (Matryoshka fallback)', async () => {
+    const oversize = [3, 4, 0, 0, 0, 0];
+    mockEmbeddingResponse(oversize);
+    const p = new OpenAIEmbeddingProvider({ apiKey: 'sk-test', dimensions: 2 });
+    const [v] = await p.embed(['hi']);
+    expect(v).toHaveLength(2);
+    expect(v![0]!).toBeCloseTo(0.6, 9);
+    expect(v![1]!).toBeCloseTo(0.8, 9);
+    const mag = Math.sqrt(v!.reduce((s, x) => s + x * x, 0));
+    expect(Math.abs(mag - 1)).toBeLessThan(1e-9);
+  });
+
+  it('throws when the response is shorter than requested (cannot upsize)', async () => {
+    mockEmbeddingResponse([1, 2, 3]);
+    const p = new OpenAIEmbeddingProvider({ apiKey: 'sk-test', dimensions: 8 });
+    await expect(p.embed(['hi'])).rejects.toThrow(/returned 3 dims, expected 8/);
+  });
+
+  it('uses the configured baseUrl (strips trailing slashes)', async () => {
+    const spy = installFetchSpy(new Array<number>(1536).fill(0));
+    const p = new OpenAIEmbeddingProvider({ apiKey: 'sk-test', baseUrl: 'https://api.scaleway.ai/v1//' });
+    await p.embed(['hi']);
+    expect(spy.lastCall().url).toBe('https://api.scaleway.ai/v1/embeddings');
+  });
+});
+
+describe('readEmbeddingProviderFromEnv', () => {
+  const snapshot = { ...process.env };
+  beforeEach(() => {
+    delete process.env.MUNIN_EMBEDDING_PROVIDER;
+    delete process.env.MUNIN_EMBEDDING_DIMENSIONS;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_BASE_URL;
+    delete process.env.OPENAI_EMBEDDING_MODEL;
+    delete process.env.OPENAI_EMBEDDING_DIMENSIONS;
+  });
+  afterEach(() => {
+    Object.assign(process.env, snapshot);
+  });
+
+  it('returns the stub when no API key is set and no provider is forced', () => {
+    const p = readEmbeddingProviderFromEnv();
+    expect(p).toBeInstanceOf(StubEmbeddingProvider);
+    expect(p.dimensions).toBe(1536);
+  });
+
+  it('honors MUNIN_EMBEDDING_DIMENSIONS for the stub when no key is set', () => {
+    process.env.MUNIN_EMBEDDING_DIMENSIONS = '4000';
+    const p = readEmbeddingProviderFromEnv();
+    expect(p).toBeInstanceOf(StubEmbeddingProvider);
+    expect(p.dimensions).toBe(4000);
+  });
+
+  it('throws when OPENAI_EMBEDDING_DIMENSIONS disagrees with MUNIN_EMBEDDING_DIMENSIONS', () => {
+    process.env.MUNIN_EMBEDDING_DIMENSIONS = '1536';
+    process.env.OPENAI_API_KEY = 'sk-test';
+    process.env.OPENAI_EMBEDDING_DIMENSIONS = '4000';
+    expect(() => readEmbeddingProviderFromEnv()).toThrow(/must equal/);
+  });
+
+  it('throws on out-of-range dimensions env values', () => {
+    process.env.MUNIN_EMBEDDING_DIMENSIONS = '8';
+    expect(() => readEmbeddingProviderFromEnv()).toThrow(/32\.\.4000/);
+  });
+
+  it('builds an OpenAI provider with matching dimensions when both env vars agree', () => {
+    process.env.MUNIN_EMBEDDING_DIMENSIONS = '4000';
+    process.env.OPENAI_API_KEY = 'sk-test';
+    process.env.OPENAI_BASE_URL = 'https://api.scaleway.ai/v1';
+    process.env.OPENAI_EMBEDDING_MODEL = 'qwen3-embedding-8b';
+    process.env.OPENAI_EMBEDDING_DIMENSIONS = '4000';
+    const p = readEmbeddingProviderFromEnv();
+    expect(p).toBeInstanceOf(OpenAIEmbeddingProvider);
+    expect(p.dimensions).toBe(4000);
+    expect(p.name).toBe('openai:qwen3-embedding-8b@4000');
+  });
+
+  it('keeps the OSS default (no env vars) producing a 1536-dim OpenAI provider', () => {
+    process.env.OPENAI_API_KEY = 'sk-test';
+    const p = readEmbeddingProviderFromEnv();
+    expect(p).toBeInstanceOf(OpenAIEmbeddingProvider);
+    expect(p.dimensions).toBe(1536);
+    expect(p.name).toBe('openai:text-embedding-3-small');
   });
 });

--- a/packages/core/src/providers/embedding.ts
+++ b/packages/core/src/providers/embedding.ts
@@ -2,9 +2,10 @@
  * Embedding providers used by KB hybrid search.
  *
  * Pluggable so self-hosters can swap OpenAI for a local model (Ollama,
- * Llamafile) without forking. The interface returns vectors of a known
- * dimension; the KB schema commits to 1536 (OpenAI text-embedding-3-small,
- * BGE-large, et al). A different dimension means a different schema.
+ * Llamafile) or an OpenAI-compatible vendor (Scaleway Generative APIs,
+ * vLLM) without forking. The interface returns vectors of a known
+ * dimension; the KB / CMS schema commits to a single dim per deployment,
+ * controlled by `MUNIN_EMBEDDING_DIMENSIONS` (default 1536).
  */
 
 export interface EmbeddingProvider {
@@ -22,43 +23,71 @@ export interface OpenAIEmbeddingOptions {
   apiKey: string;
   model?: string;
   baseUrl?: string;
+  /**
+   * Request a specific vector dimension. When set:
+   *   1. sent as `dimensions` in the request body (honored by
+   *      text-embedding-3-* and by Scaleway's `qwen3-embedding-8b`),
+   *   2. used as the canonical `this.dimensions`,
+   *   3. enforced after the response: vectors longer than this are
+   *      Matryoshka-truncated and L2-renormalized, vectors shorter
+   *      throw a clear error.
+   */
+  dimensions?: number;
 }
 
 const DEFAULT_OPENAI_MODEL = 'text-embedding-3-small';
 const DEFAULT_OPENAI_BASE = 'https://api.openai.com/v1';
+const DEFAULT_DIMENSIONS = 1536;
 
 export class OpenAIEmbeddingProvider implements EmbeddingProvider {
-  readonly dimensions = 1536;
+  readonly dimensions: number;
   readonly name: string;
   private readonly apiKey: string;
   private readonly model: string;
   private readonly baseUrl: string;
+  private readonly sendDimensions: boolean;
 
   constructor(opts: OpenAIEmbeddingOptions) {
     this.apiKey = opts.apiKey;
     this.model = opts.model ?? DEFAULT_OPENAI_MODEL;
     this.baseUrl = (opts.baseUrl ?? DEFAULT_OPENAI_BASE).replace(/\/+$/, '');
-    this.name = `openai:${this.model}`;
+    this.dimensions = opts.dimensions ?? DEFAULT_DIMENSIONS;
+    this.sendDimensions = opts.dimensions !== undefined;
+    this.name = this.sendDimensions
+      ? `openai:${this.model}@${this.dimensions}`
+      : `openai:${this.model}`;
   }
 
   async embed(texts: readonly string[]): Promise<number[][]> {
     if (texts.length === 0) return [];
+    const body: Record<string, unknown> = { model: this.model, input: texts };
+    if (this.sendDimensions) body.dimensions = this.dimensions;
     const res = await fetch(`${this.baseUrl}/embeddings`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
         authorization: `Bearer ${this.apiKey}`,
       },
-      body: JSON.stringify({ model: this.model, input: texts }),
+      body: JSON.stringify(body),
     });
     if (!res.ok) {
-      const body = await res.text();
-      throw new Error(`openai embeddings failed: ${res.status} ${body}`);
+      const errBody = await res.text();
+      throw new Error(`openai embeddings failed: ${res.status} ${errBody}`);
     }
     const json = (await res.json()) as { data: { embedding: number[]; index: number }[] };
-    // Sort by index defensively — OpenAI returns in-order today, but the
-    // contract is explicit.
-    return [...json.data].sort((a, b) => a.index - b.index).map((d) => d.embedding);
+    const ordered = [...json.data].sort((a, b) => a.index - b.index).map((d) => d.embedding);
+    return ordered.map((v) => this.conformDimension(v));
+  }
+
+  private conformDimension(vec: number[]): number[] {
+    if (vec.length === this.dimensions) return vec;
+    if (vec.length < this.dimensions) {
+      throw new Error(
+        `embedding provider returned ${vec.length} dims, expected ${this.dimensions} ` +
+          `(${this.name} — upstream cannot satisfy the requested dimension)`,
+      );
+    }
+    return l2Normalize(vec.slice(0, this.dimensions));
   }
 }
 
@@ -73,7 +102,7 @@ export class StubEmbeddingProvider implements EmbeddingProvider {
   readonly dimensions: number;
   readonly name = 'stub';
 
-  constructor(dimensions = 1536) {
+  constructor(dimensions = DEFAULT_DIMENSIONS) {
     this.dimensions = dimensions;
   }
 
@@ -97,11 +126,15 @@ function stubVector(text: string, dim: number): number[] {
     const v = ((h1 ^ h2) >>> 0) / 0xffffffff - 0.5;
     out[i] = v;
   }
-  // L2-normalize so cosine similarity is well-defined.
+  return l2Normalize(out);
+}
+
+function l2Normalize(vec: number[]): number[] {
   let mag = 0;
-  for (let i = 0; i < dim; i++) mag += out[i]! * out[i]!;
+  for (let i = 0; i < vec.length; i++) mag += vec[i]! * vec[i]!;
   mag = Math.sqrt(mag) || 1;
-  for (let i = 0; i < dim; i++) out[i] = out[i]! / mag;
+  const out = new Array<number>(vec.length);
+  for (let i = 0; i < vec.length; i++) out[i] = vec[i]! / mag;
   return out;
 }
 
@@ -111,27 +144,62 @@ function stubVector(text: string, dim: number): number[] {
  * Resolve an EmbeddingProvider from environment.
  *
  * `MUNIN_EMBEDDING_PROVIDER`:
- *   `openai` (default if `OPENAI_API_KEY` is set) — uses OpenAI.
+ *   `openai` (default if `OPENAI_API_KEY` is set) — uses OpenAI-compatible API.
  *   `stub`   (default if no key) — deterministic in-process embeddings.
  *
  * `OPENAI_API_KEY` / `OPENAI_EMBEDDING_MODEL` / `OPENAI_BASE_URL` configure
- * the OpenAI provider. Self-hosters pointing at a local model (LM Studio,
- * vLLM, llama.cpp server) usually only need to set `OPENAI_BASE_URL` since
- * those servers speak the OpenAI protocol.
+ * the OpenAI-compatible provider. Point `OPENAI_BASE_URL` at any
+ * OpenAI-protocol server (LM Studio, vLLM, Scaleway Generative APIs, etc.).
+ *
+ * `OPENAI_EMBEDDING_DIMENSIONS` requests a specific output dimension when
+ * the upstream model supports Matryoshka truncation (text-embedding-3-*,
+ * qwen3-embedding-*). Must match the schema's `EMBEDDING_DIMENSIONS`
+ * (the `MUNIN_EMBEDDING_DIMENSIONS` env var) — the factory cross-validates
+ * to surface mismatches at boot rather than as silent corruption later.
  */
 export function readEmbeddingProviderFromEnv(): EmbeddingProvider {
   const explicit = process.env.MUNIN_EMBEDDING_PROVIDER?.toLowerCase();
-  if (explicit === 'stub') return new StubEmbeddingProvider();
+  const expectedDim = readSchemaDimensionsFromEnv();
+  if (explicit === 'stub') return new StubEmbeddingProvider(expectedDim);
   const apiKey = process.env.OPENAI_API_KEY;
   if (apiKey || explicit === 'openai') {
     if (!apiKey) {
       throw new Error('MUNIN_EMBEDDING_PROVIDER=openai requires OPENAI_API_KEY');
     }
+    const dimensions = parseOptionalDimensions('OPENAI_EMBEDDING_DIMENSIONS');
+    if (dimensions !== undefined && dimensions !== expectedDim) {
+      throw new Error(
+        `OPENAI_EMBEDDING_DIMENSIONS (${dimensions}) must equal ` +
+          `MUNIN_EMBEDDING_DIMENSIONS (${expectedDim}); the embedding provider's ` +
+          `output dimension has to match the DB schema.`,
+      );
+    }
     return new OpenAIEmbeddingProvider({
       apiKey,
       model: process.env.OPENAI_EMBEDDING_MODEL,
       baseUrl: process.env.OPENAI_BASE_URL,
+      dimensions,
     });
   }
-  return new StubEmbeddingProvider();
+  return new StubEmbeddingProvider(expectedDim);
+}
+
+function parseOptionalDimensions(envName: string): number | undefined {
+  const raw = process.env[envName];
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 32 || n > 4000) {
+    throw new Error(`${envName} must be an integer in 32..4000, got ${raw}`);
+  }
+  return n;
+}
+
+function readSchemaDimensionsFromEnv(): number {
+  const raw = process.env.MUNIN_EMBEDDING_DIMENSIONS;
+  if (!raw) return DEFAULT_DIMENSIONS;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 32 || n > 4000) {
+    throw new Error(`MUNIN_EMBEDDING_DIMENSIONS must be an integer in 32..4000, got ${raw}`);
+  }
+  return n;
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -12,6 +12,7 @@ import { sql } from 'drizzle-orm';
 import {
   bigint,
   boolean,
+  customType,
   index,
   integer,
   jsonb,
@@ -26,7 +27,28 @@ import {
 } from 'drizzle-orm/pg-core';
 import { makeId } from './id.ts';
 
-export const EMBEDDING_DIMENSIONS = 1536;
+export const EMBEDDING_DIMENSIONS = readEmbeddingDimensionsFromEnv();
+
+function readEmbeddingDimensionsFromEnv(): number {
+  const raw = process.env.MUNIN_EMBEDDING_DIMENSIONS;
+  if (!raw) return 1536;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 32 || n > 4000) {
+    throw new Error(`MUNIN_EMBEDDING_DIMENSIONS must be an integer in 32..4000, got ${raw}`);
+  }
+  return n;
+}
+
+const halfvec = customType<{ data: number[]; driverData: string; config: { dimensions: number } }>({
+  dataType: (config) => `halfvec(${config?.dimensions ?? EMBEDDING_DIMENSIONS})`,
+  toDriver: (v) => `[${v.join(',')}]`,
+  fromDriver: (v) => JSON.parse(v) as number[],
+});
+
+const embeddingColumn = (name: string) =>
+  EMBEDDING_DIMENSIONS <= 2000
+    ? vector(name, { dimensions: EMBEDDING_DIMENSIONS })
+    : halfvec(name, { dimensions: EMBEDDING_DIMENSIONS });
 
 const id = (prefix: string) =>
   text('id')
@@ -668,7 +690,7 @@ export const kbDocumentChunks = pgTable(
     chunkIndex: integer('chunk_index').notNull(),
     content: text('content').notNull(),
     tokenCount: integer('token_count').notNull(),
-    embedding: vector('embedding', { dimensions: EMBEDDING_DIMENSIONS }),
+    embedding: embeddingColumn('embedding'),
     createdAt,
   },
   (t) => ({
@@ -1348,7 +1370,7 @@ export const cmsEntries = pgTable(
     version: integer('version').notNull().default(1),
     contentHash: varchar('content_hash', { length: 64 }).notNull(),
     searchText: text('search_text').notNull().default(''),
-    embedding: vector('embedding', { dimensions: EMBEDDING_DIMENSIONS }),
+    embedding: embeddingColumn('embedding'),
     scheduledAt: timestamp('scheduled_at', { withTimezone: true }),
     publishedAt: timestamp('published_at', { withTimezone: true }),
     createdByType: varchar('created_by_type', { length: 16 }).notNull(),


### PR DESCRIPTION
## Summary

- `OpenAIEmbeddingProvider` accepts an optional `dimensions` field that is sent in the request body (honored by `text-embedding-3-*` and Scaleway's `qwen3-embedding-8b`) and enforced on the response — Matryoshka-truncated and L2-renormalized if the upstream returns a larger vector. Verified against Scaleway: `dimensions:4000` returns exactly 4000, `dimensions:1536` returns exactly 1536, omitting it returns 4096 (native).
- Factory reads `OPENAI_EMBEDDING_DIMENSIONS` and cross-validates against `MUNIN_EMBEDDING_DIMENSIONS` so a mismatched deploy fails at boot rather than corrupting the index.
- `packages/db/src/schema.ts` reads `MUNIN_EMBEDDING_DIMENSIONS` (default 1536, range 32..4000). Embedding column is `vector(dim)` when `dim <= 2000` and `halfvec(dim)` above that, so deployments wanting near-native Qwen3 quality can pick `halfvec(4000)` and still index with HNSW (pgvector cap).
- OSS defaults unchanged: no env vars → `vector(1536)` + `text-embedding-3-small`. Migrations stay pinned to `vector(1536)`; non-default dim requires a fresh DB or a deployment-specific ALTER.

Sets up Munin Cloud to swap OpenAI for Scaleway's `qwen3-embedding-8b` via env vars only, no code change on the cloud side.

## Test plan

- [x] `pnpm -F @getmunin/core test` — 114 pass (16 in `embedding.test.ts`, incl. new `dimensions` request-body, truncation, factory cross-validation cases).
- [x] `pnpm typecheck` workspace-wide.
- [x] `pnpm -F @getmunin/backend-core test kb` — 24 pass with real Postgres + default schema.
- [x] `pnpm -F @getmunin/backend-core test cms` — 45 pass.
- [ ] CI green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)