### PR TITLE
fix(db): make embedding HNSW index opclass-aware (vector vs halfvec)

### DIFF
--- a/.changeset/embedding-opclass-aware-index.md
+++ b/.changeset/embedding-opclass-aware-index.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/db': patch
+---
+
+Make the embedding HNSW index creation in `kb.sql` and `cms.sql` opclass-aware.
+
+Postgres `CREATE INDEX IF NOT EXISTS` parses and validates the operator class against the column type *before* the name-existence check fires, so once a deployment had switched the embedding column to `halfvec` (via `MUNIN_EMBEDDING_DIMENSIONS > 2000`), every subsequent `runMigrations` call errored with `operator class "vector_cosine_ops" does not accept data type halfvec` — even though the index already existed. That includes every `pnpm migrate` on container redeploy.
+
+Wrap each index creation in a `DO` block that inspects `information_schema.columns` for the actual `udt_name` (`vector` vs `halfvec`) and picks the matching opclass (`vector_cosine_ops` or `halfvec_cosine_ops`). The result is identical for the default OSS schema (`vector(1536)`) and unblocks deployments running at `halfvec(dim)`.

--- a/packages/db/src/sql/cms.sql
+++ b/packages/db/src/sql/cms.sql
@@ -18,9 +18,24 @@ CREATE INDEX IF NOT EXISTS cms_entries_fts_idx
 
 -- ───────────────────────── HNSW vector index ──────────────────────────────
 -- Cosine similarity for hybrid search. Pairs with the embedding column on
--- cms_entries; reads use `1 - (embedding <=> q)` for similarity.
-CREATE INDEX IF NOT EXISTS cms_entries_embedding_hnsw_idx
-  ON cms_entries USING hnsw (embedding vector_cosine_ops);
+-- cms_entries; reads use `1 - (embedding <=> q)` for similarity. Picks the
+-- opclass that matches the column type (see kb.sql for the why).
+DO $$
+DECLARE
+  col_udt text;
+BEGIN
+  SELECT udt_name INTO col_udt FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'cms_entries'
+      AND column_name = 'embedding';
+  IF col_udt = 'halfvec' THEN
+    CREATE INDEX IF NOT EXISTS cms_entries_embedding_hnsw_idx
+      ON cms_entries USING hnsw (embedding halfvec_cosine_ops);
+  ELSE
+    CREATE INDEX IF NOT EXISTS cms_entries_embedding_hnsw_idx
+      ON cms_entries USING hnsw (embedding vector_cosine_ops);
+  END IF;
+END $$;
 
 -- ───────────────────────── CMS RLS ────────────────────────────────────────
 -- Collections, locales, assets, references: org-scoped, admin-only. End-

--- a/packages/db/src/sql/kb.sql
+++ b/packages/db/src/sql/kb.sql
@@ -31,9 +31,29 @@ CREATE INDEX IF NOT EXISTS kb_chunks_fts_idx
 -- ───────────────────────── HNSW vector index ───────────────────────────────
 -- Cosine distance — pairs with `1 - (embedding <=> query)` similarity in
 -- queries. m=16, ef_construction=64 are pgvector defaults (good enough for
--- corpus sizes we expect through v0.5).
-CREATE INDEX IF NOT EXISTS kb_chunks_embedding_hnsw_idx
-  ON kb_document_chunks USING hnsw (embedding vector_cosine_ops);
+-- corpus sizes we expect through v0.5). Picks the opclass that matches the
+-- column type, which differs per deployment when MUNIN_EMBEDDING_DIMENSIONS
+-- pushes the schema past pgvector's 2000-dim `vector` HNSW cap into halfvec.
+-- `CREATE INDEX IF NOT EXISTS` would otherwise validate the opclass against
+-- the column type *before* the name-existence check, so a re-run after the
+-- column has been switched to halfvec would error out even though the index
+-- already exists.
+DO $$
+DECLARE
+  col_udt text;
+BEGIN
+  SELECT udt_name INTO col_udt FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'kb_document_chunks'
+      AND column_name = 'embedding';
+  IF col_udt = 'halfvec' THEN
+    CREATE INDEX IF NOT EXISTS kb_chunks_embedding_hnsw_idx
+      ON kb_document_chunks USING hnsw (embedding halfvec_cosine_ops);
+  ELSE
+    CREATE INDEX IF NOT EXISTS kb_chunks_embedding_hnsw_idx
+      ON kb_document_chunks USING hnsw (embedding vector_cosine_ops);
+  END IF;
+END $$;
 
 -- ───────────────────────── KB RLS policies ─────────────────────────────────
 -- All KB tables are org-scoped. Documents have an `audiences` jsonb array


### PR DESCRIPTION
## Summary

Follow-up to #285 (\`feat(embedding): make vector dimension a deploy-time parameter\`). The schema now switches between \`vector(dim)\` and \`halfvec(dim)\` based on \`MUNIN_EMBEDDING_DIMENSIONS\`, but the post-migration SQL in \`kb.sql\` / \`cms.sql\` still hardcoded \`vector_cosine_ops\` for the HNSW index.

That looked harmless because of \`CREATE INDEX IF NOT EXISTS\`, but **PostgreSQL parses and validates the operator class against the column type _before_ the name-existence check fires**:

\`\`\`sql
-- Existing halfvec index, halfvec column. Then:
CREATE INDEX IF NOT EXISTS kb_chunks_embedding_hnsw_idx
  ON kb_document_chunks USING hnsw (embedding vector_cosine_ops);
-- → ERROR: operator class "vector_cosine_ops" does not accept data type halfvec
\`\`\`

So every \`runMigrations\` call (including \`pnpm migrate\` on each cloud container redeploy) would have crashed once a deployment had switched the column to halfvec. Caught by munin-cloud CI on the Scaleway qwen3 embedding rollout.

## Fix

Wrap each embedding HNSW \`CREATE INDEX\` in a \`DO\` block that inspects \`information_schema.columns.udt_name\` and picks the matching opclass:

\`\`\`sql
DO $$
DECLARE col_udt text;
BEGIN
  SELECT udt_name INTO col_udt FROM information_schema.columns
    WHERE table_schema = 'public' AND table_name = 'kb_document_chunks' AND column_name = 'embedding';
  IF col_udt = 'halfvec' THEN
    CREATE INDEX IF NOT EXISTS kb_chunks_embedding_hnsw_idx
      ON kb_document_chunks USING hnsw (embedding halfvec_cosine_ops);
  ELSE
    CREATE INDEX IF NOT EXISTS kb_chunks_embedding_hnsw_idx
      ON kb_document_chunks USING hnsw (embedding vector_cosine_ops);
  END IF;
END $$;
\`\`\`

Same shape for \`cms_entries\`. Behaviour on the default OSS schema (\`vector(1536)\`) is identical — the index still ends up using \`vector_cosine_ops\`.

## Test plan

- [x] Repro locally: \`CREATE INDEX IF NOT EXISTS ... vector_cosine_ops\` against an existing halfvec index errors. With the new DO block, it skips with \`NOTICE: relation already exists\`.
- [x] \`pnpm -F @getmunin/backend-core test kb\` — 24 pass against real Postgres + default \`vector(1536)\`.
- [x] \`pnpm -F @getmunin/backend-core test cms\` — 45 pass.
- [ ] CI green.
- [ ] Cloud's munin-cloud#179 CI passes once it bumps to the new patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)