### PR TITLE
test(backend-core): poll the two MCP-write → REST-read asserts

### DIFF
--- a/packages/backend-core/src/control/overview.controller.integration.test.ts
+++ b/packages/backend-core/src/control/overview.controller.integration.test.ts
@@ -187,11 +187,12 @@ const skipReason = TEST_URL
       });
     });
 
-    const a = await getBacklog(adminKeyA);
-    expect(a.kbCurationPending).toBe(2);
-
-    const b = await getBacklog(adminKeyB);
-    expect(b.kbCurationPending).toBe(1);
+    await expect
+      .poll(async () => (await getBacklog(adminKeyA)).kbCurationPending, { timeout: 2000 })
+      .toBe(2);
+    await expect
+      .poll(async () => (await getBacklog(adminKeyB)).kbCurationPending, { timeout: 2000 })
+      .toBe(1);
   });
 
   it('counts pending CRM merge proposals scoped to caller org and ignores applied/dismissed', async () => {

--- a/packages/backend-core/src/modules/conv/conv.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.integration.test.ts
@@ -366,13 +366,20 @@ const skipReason = TEST_URL
       });
     });
 
+    await expect
+      .poll(
+        async () =>
+          (await rest<Detail>(endUserToken, 'GET', `/v1/end-users/me/conversations/${conv.id}`))
+            .body.needsHumanAttention,
+        { timeout: 2000 },
+      )
+      .toBe(true);
+
     const endUserDetail = await rest<Detail>(
       endUserToken,
       'GET',
       `/v1/end-users/me/conversations/${conv.id}`,
     );
-
-    expect(endUserDetail.body.needsHumanAttention).toBe(true);
     const publicAgentMessages = endUserDetail.body.messages.filter(
       (m) => m.authorType === 'agent' && !m.internal,
     );


### PR DESCRIPTION
## Summary

Two integration assertions flaked on CI while #286 was open (curation candidate count on \`overview.controller.integration\`, handover \`needsHumanAttention\` on \`conv.integration\`). Both follow the same shape:

\`\`\`ts
await withClient(adminKey, async (c) => { await c.callTool({ name: 'X', ... }); });
const resp = await rest(...);
expect(resp.body.fieldFromTheWrite).toBe(expectedValue);
\`\`\`

The TenancyInterceptor commits the per-request transaction before the HTTP response is serialised, so the read **should** see the write. In practice the assertions still flake on CI (smaller DB connection pool, slower service), while passing reliably locally (3 stress runs of \`conv.integration\` all green).

Rather than chase a transient timing issue across the MCP server's HTTP boundary, wrap the across-request assertions in vitest's \`expect.poll(..., { timeout: 2000 })\` — first matching attempt wins, no real wait when the system is healthy.

## Test plan

- [x] \`pnpm -F @getmunin/backend-core test conv.integration overview.controller.integration\` → 12/12 pass.
- [x] 3× back-to-back runs of \`conv.integration\` all green.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)