### PR TITLE
fix(security): close audit findings across MCP, widget, webhooks, SMS, email, crawler

### DIFF
--- a/apps/chat-widget/src/api.ts
+++ b/apps/chat-widget/src/api.ts
@@ -238,10 +238,19 @@ export function createApiClient(deps: ApiClientDeps): ApiClient {
     },
 
     async voiceStart(conversationId) {
+      const payload: Record<string, unknown> = {
+        channelId: deps.channelId,
+        conversationId,
+        sessionId,
+      };
+      if (deps.identity) {
+        payload.verifiedExternalId = deps.identity.externalId;
+        payload.userHash = deps.identity.userHash;
+      }
       const res = await fetchImpl(`${base}/voice/start`, {
         method: 'POST',
         headers: authHeaders(),
-        body: JSON.stringify({ channelId: deps.channelId, conversationId }),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) throw new WidgetApiError(res.status, await safeJson(res));
       return (await res.json()) as VoiceStartResult;
@@ -251,8 +260,13 @@ export function createApiClient(deps: ApiClientDeps): ApiClient {
       const payload: Record<string, unknown> = {
         channelId: deps.channelId,
         conversationId,
+        sessionId,
         kind,
       };
+      if (deps.identity) {
+        payload.verifiedExternalId = deps.identity.externalId;
+        payload.userHash = deps.identity.userHash;
+      }
       if (typeof durationSeconds === 'number') payload.durationSeconds = durationSeconds;
       const res = await fetchImpl(`${base}/voice/event`, {
         method: 'POST',

--- a/packages/agent-runtime/src/web-crawl.ts
+++ b/packages/agent-runtime/src/web-crawl.ts
@@ -4,6 +4,7 @@ const USER_AGENT = 'MuninOnboardingBot/1.0 (+https://getmunin.com/bot)';
 const DEFAULT_MAX_PAGES = 25;
 const HARD_MAX_PAGES = 50;
 const FETCH_TIMEOUT_MS = 5000;
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
 const FETCH_CONCURRENCY = 8;
 const MIN_BODY_CHARS = 200;
 const BFS_MAX_DEPTH = 2;
@@ -513,7 +514,12 @@ const defaultFetcher: HtmlFetcher = async (url) => {
         'accept-encoding': 'gzip, deflate, br',
       },
     });
-    const body = await res.text();
+    const declared = Number(res.headers.get('content-length') ?? '');
+    if (Number.isFinite(declared) && declared > MAX_RESPONSE_BYTES) {
+      await res.body?.cancel().catch(() => {});
+      throw new Error(`response_too_large: content-length ${declared} > ${MAX_RESPONSE_BYTES}`);
+    }
+    const body = await readBodyCapped(res, MAX_RESPONSE_BYTES);
     return {
       finalUrl: res.url || url,
       status: res.status,
@@ -524,6 +530,30 @@ const defaultFetcher: HtmlFetcher = async (url) => {
     clearTimeout(timer);
   }
 };
+
+async function readBodyCapped(res: { body: ReadableStream<Uint8Array> | null }, cap: number): Promise<string> {
+  if (!res.body) return '';
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder('utf-8', { fatal: false });
+  let total = 0;
+  let out = '';
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > cap) {
+        await reader.cancel().catch(() => {});
+        throw new Error(`response_too_large: streamed ${total} > ${cap}`);
+      }
+      out += decoder.decode(value, { stream: true });
+    }
+    out += decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+  return out;
+}
 
 const DEFUDDLE_NOISE = /^Initial parse returned very little content/;
 

--- a/packages/backend-core/src/bootstrap-app.test.ts
+++ b/packages/backend-core/src/bootstrap-app.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
 import {
+  corsMiddleware,
   hostAllowlistMiddleware,
   isPublicCorsPath,
   publicUrlRewriteMiddleware,
@@ -78,6 +79,70 @@ describe('isPublicCorsPath', () => {
     expect(isPublicCorsPath('/v1/kb/spaces')).toBe(false);
     expect(isPublicCorsPath('/auth/sign-in')).toBe(false);
     expect(isPublicCorsPath('/healthz')).toBe(false);
+  });
+});
+
+describe('corsMiddleware', () => {
+  function runCors(
+    strict: string[] | true,
+    init: { method?: string; path: string; origin?: string },
+  ): { headers: Record<string, string>; status: number | null; nextCalled: boolean } {
+    const headers: Record<string, string> = {};
+    let status: number | null = null;
+    const req = {
+      method: init.method ?? 'GET',
+      path: init.path,
+      headers: init.origin ? { origin: init.origin } : {},
+    } as unknown as Request;
+    const res = {
+      setHeader: (k: string, v: string) => {
+        headers[k] = v;
+      },
+      status: (code: number) => {
+        status = code;
+        return { end: () => undefined };
+      },
+    } as unknown as Response;
+    const next = vi.fn() as NextFunction;
+    corsMiddleware(strict)(req, res, next);
+    return { headers, status, nextCalled: (next as { mock?: { calls: unknown[] } }).mock!.calls.length > 0 };
+  }
+
+  it('reflects strict-origin requests with credentials', () => {
+    const { headers } = runCors(['https://app.example.com'], {
+      path: '/v1/kb/spaces',
+      origin: 'https://app.example.com',
+    });
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://app.example.com');
+    expect(headers['Access-Control-Allow-Credentials']).toBe('true');
+  });
+
+  it('does NOT set Allow-Credentials on /mcp even when origin is reflected', () => {
+    const { headers } = runCors(['https://app.example.com'], {
+      path: '/mcp',
+      origin: 'https://evil.example',
+    });
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://evil.example');
+    expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+  });
+
+  it('does NOT set Allow-Credentials on other public CORS paths', () => {
+    for (const path of ['/widget.js', '/v1/widget/messages', '/.well-known/oauth-authorization-server']) {
+      const { headers } = runCors(['https://app.example.com'], {
+        path,
+        origin: 'https://anything.example',
+      });
+      expect(headers['Access-Control-Allow-Origin']).toBe('https://anything.example');
+      expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+    }
+  });
+
+  it('rejects strict-only paths from non-allowlisted origins (no CORS headers set)', () => {
+    const { headers } = runCors(['https://app.example.com'], {
+      path: '/v1/kb/spaces',
+      origin: 'https://evil.example',
+    });
+    expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
   });
 });
 

--- a/packages/backend-core/src/bootstrap-app.test.ts
+++ b/packages/backend-core/src/bootstrap-app.test.ts
@@ -144,6 +144,15 @@ describe('corsMiddleware', () => {
     });
     expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
   });
+
+  it('does NOT set Allow-Credentials when strictOrigins is wildcard, even for non-public paths', () => {
+    const { headers } = runCors(true, {
+      path: '/v1/kb/spaces',
+      origin: 'https://anywhere.example',
+    });
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://anywhere.example');
+    expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+  });
 });
 
 describe('publicUrlRewriteMiddleware', () => {

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -18,7 +18,7 @@ const DEFAULT_DEV_WEB_ORIGINS = ['http://localhost:3000', 'http://127.0.0.1:3000
  */
 const HASHED_WIDGET_FILE_RE = /^widget\.[a-f0-9]{12}\.js(\.map)?$/;
 
-function readAllowedOrigins(): string[] | true {
+export function readAllowedOrigins(): string[] | true {
   const env = process.env.MUNIN_CORS_ORIGINS;
   if (!env) return DEFAULT_DEV_WEB_ORIGINS;
   if (env === '*') return true;
@@ -194,7 +194,7 @@ export function hostAllowlistMiddleware(allowedHosts: string[]) {
   };
 }
 
-function corsMiddleware(strictOrigins: string[] | true) {
+export function corsMiddleware(strictOrigins: string[] | true) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
     const allowAny = isPublicCorsPath(req.path);
@@ -205,7 +205,9 @@ function corsMiddleware(strictOrigins: string[] | true) {
     if (allowed && origin) {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader('Vary', 'Origin');
-      res.setHeader('Access-Control-Allow-Credentials', 'true');
+      if (!allowAny) {
+        res.setHeader('Access-Control-Allow-Credentials', 'true');
+      }
       res.setHeader('Access-Control-Expose-Headers', 'x-request-id');
     }
 

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -205,7 +205,8 @@ export function corsMiddleware(strictOrigins: string[] | true) {
     if (allowed && origin) {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader('Vary', 'Origin');
-      if (!allowAny) {
+      const explicitlyAllowed = !allowAny && Array.isArray(strictOrigins) && strictOrigins.includes(origin);
+      if (explicitlyAllowed) {
         res.setHeader('Access-Control-Allow-Credentials', 'true');
       }
       res.setHeader('Access-Control-Expose-Headers', 'x-request-id');

--- a/packages/backend-core/src/common/auth/auth.guard.test.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.test.ts
@@ -1,0 +1,71 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { describe, expect, it, vi } from 'vitest';
+import type { ResolvedCredential } from '@getmunin/core';
+import { AuthGuard, type AuthenticatedRequest } from './auth.guard.ts';
+
+function makeContext(req: AuthenticatedRequest & { url?: string; path?: string }) {
+  const res = { setHeader: vi.fn() };
+  return {
+    getHandler: () => () => undefined,
+    getClass: () => class {},
+    switchToHttp: () => ({
+      getRequest: () => req,
+      getResponse: () => res,
+    }),
+  } as unknown as Parameters<AuthGuard['canActivate']>[0];
+}
+
+function makeGuard(resolverStubs: {
+  resolveSessionToken?: ReturnType<typeof vi.fn>;
+  resolveBearerToken?: ReturnType<typeof vi.fn>;
+  resolveApiKey?: ReturnType<typeof vi.fn>;
+}): AuthGuard {
+  const guard = new AuthGuard({} as never, new Reflector());
+  Object.assign((guard as unknown as { resolver: Record<string, unknown> }).resolver, {
+    resolveSessionToken: resolverStubs.resolveSessionToken ?? vi.fn(),
+    resolveBearerToken: resolverStubs.resolveBearerToken ?? vi.fn(),
+    resolveApiKey: resolverStubs.resolveApiKey ?? vi.fn(),
+  });
+  return guard;
+}
+
+const SESSION_COOKIE = 'better-auth.session_token=raw.signature';
+
+describe('AuthGuard cookie fallback', () => {
+  it('accepts session cookie on a non-MCP path', async () => {
+    const resolveSessionToken = vi.fn().mockResolvedValue({ actor: { type: 'user' } });
+    const guard = makeGuard({ resolveSessionToken });
+    const ctx = makeContext({
+      headers: { cookie: SESSION_COOKIE },
+      url: '/v1/kb/spaces',
+      path: '/v1/kb/spaces',
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(resolveSessionToken).toHaveBeenCalledWith('raw');
+  });
+
+  it('rejects session cookie on /mcp — bearer required', async () => {
+    const resolveSessionToken = vi.fn();
+    const guard = makeGuard({ resolveSessionToken });
+    const ctx = makeContext({
+      headers: { cookie: SESSION_COOKIE },
+      url: '/mcp',
+      path: '/mcp',
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(resolveSessionToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects session cookie on /mcp/* subpaths too', async () => {
+    const resolveSessionToken = vi.fn();
+    const guard = makeGuard({ resolveSessionToken });
+    const ctx = makeContext({
+      headers: { cookie: SESSION_COOKIE },
+      url: '/mcp/session/abc',
+      path: '/mcp/session/abc',
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(resolveSessionToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -87,7 +87,7 @@ export class AuthGuard implements CanActivate {
       } else {
         credential = await this.resolver.resolveBearerToken(raw);
       }
-    } else {
+    } else if (!isMcpRequest(request)) {
       const cookieHeader = request.headers['cookie'];
       const cookieValue = Array.isArray(cookieHeader) ? cookieHeader[0] : cookieHeader;
       const sessionToken = readSessionCookie(cookieValue);

--- a/packages/backend-core/src/common/webhooks/webhook.worker.test.ts
+++ b/packages/backend-core/src/common/webhooks/webhook.worker.test.ts
@@ -4,7 +4,7 @@ import { NestFactory } from '@nestjs/core';
 import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
-import { buildApiKey, hashSecret, keyPrefix, verifyHmac } from '@getmunin/core';
+import { randomToken, verifyHmac } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
 import { AppModule } from '../../app.module.ts';
@@ -24,10 +24,8 @@ interface ReceivedRequest {
 
 (skipReason ? describe.skip : describe)('WebhookWorker', () => {
   let app: INestApplication;
-  let baseUrl: string;
   let db: ReturnType<typeof createDb>;
   let orgId: string;
-  let adminKey: string;
   let receiver: Server;
   let received: ReceivedRequest[];
   let receiverShouldFail: boolean;
@@ -39,6 +37,7 @@ interface ReceivedRequest {
     process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
     process.env.MUNIN_MAIL_PROVIDER = 'stub';
     process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_SSRF_ALLOW_PRIVATE = '1';
 
     await runMigrations(TEST_URL!);
 
@@ -48,22 +47,11 @@ interface ReceivedRequest {
     db = createDb(TEST_URL!, { serviceRole: true });
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
 
-    const ts = Date.now();
     const [org] = await db
       .insert(schema.orgs)
       .values({ name: 'Webhook Org' })
       .returning();
     orgId = org!.id;
-
-    adminKey = buildApiKey('admin');
-    await db.insert(schema.apiKeys).values({
-      orgId,
-      type: 'admin',
-      name: 'wh-admin',
-      keyHash: hashSecret(adminKey),
-      keyPrefix: keyPrefix(adminKey),
-      scopes: ['*'],
-    });
 
     received = [];
     receiverShouldFail = false;
@@ -90,11 +78,7 @@ interface ReceivedRequest {
     receiverUrl = `http://127.0.0.1:${recvAddr.port}`;
 
     app = await NestFactory.create(AppModule, { logger: false });
-    await app.listen(0, '127.0.0.1');
-    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
-    const address = server.address();
-    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
-    baseUrl = `http://127.0.0.1:${address.port}`;
+    await app.init();
   });
 
   afterAll(async () => {
@@ -106,21 +90,18 @@ interface ReceivedRequest {
     }
   });
 
-  async function rest(method: string, path: string, body?: unknown): Promise<Response> {
-    return fetch(`${baseUrl}${path}`, {
-      method,
-      headers: { Authorization: `Bearer ${adminKey}`, 'content-type': 'application/json' },
-      body: body === undefined ? undefined : JSON.stringify(body),
-    });
-  }
-
   it('emits + delivers a signed conversation.created event', async () => {
-    const create = await rest('POST', '/v1/webhooks', {
-      url: receiverUrl,
-      events: ['conversation.created', 'conversation.message.received'],
-    });
-    expect(create.status).toBe(201);
-    const webhook = (await create.json()) as { id: string; secret: string };
+    const [webhookRow] = await db
+      .insert(schema.webhooks)
+      .values({
+        orgId,
+        url: receiverUrl,
+        secret: `whsec_${randomToken(24)}`,
+        events: ['conversation.created', 'conversation.message.received'],
+        active: true,
+      })
+      .returning();
+    const webhook = { id: webhookRow!.id, secret: webhookRow!.secret };
 
     // Set up a chat channel so end-user start_conversation can pick one up.
     const [channel] = await db
@@ -186,11 +167,17 @@ interface ReceivedRequest {
   }, 30_000);
 
   it('retries on non-2xx and stops after MAX_ATTEMPTS', async () => {
-    const create = await rest('POST', '/v1/webhooks', {
-      url: receiverUrl,
-      events: ['failure.test'],
-    });
-    const webhook = (await create.json()) as { id: string };
+    const [webhookRow] = await db
+      .insert(schema.webhooks)
+      .values({
+        orgId,
+        url: receiverUrl,
+        secret: `whsec_${randomToken(24)}`,
+        events: ['failure.test'],
+        active: true,
+      })
+      .returning();
+    const webhook = { id: webhookRow!.id };
 
     const [event] = await db
       .insert(schema.events)

--- a/packages/backend-core/src/common/webhooks/webhook.worker.ts
+++ b/packages/backend-core/src/common/webhooks/webhook.worker.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, isNull, lt, lte } from 'drizzle-orm';
-import { WebhookDispatcher } from '@getmunin/core';
+import { safeFetch, WebhookDispatcher } from '@getmunin/core';
 import { DB } from '../db/db.module.ts';
 import { withSchedulerLock } from '../scheduler-lock/index.ts';
 
@@ -135,7 +135,7 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
     let statusCode: number | null = null;
     let error: string | null = null;
     try {
-      const res = await fetch(webhookRow.url, {
+      const res = await safeFetch(webhookRow.url, {
         method: 'POST',
         headers: {
           'content-type': 'application/json',

--- a/packages/backend-core/src/control/delegated-token.controller.test.ts
+++ b/packages/backend-core/src/control/delegated-token.controller.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { MintDto } from './delegated-token.controller.ts';
+
+describe('Delegated token MintDto', () => {
+  it('accepts a self_service mint with a known scope', () => {
+    const r = MintDto.safeParse({
+      externalId: 'u_123',
+      audiences: ['self_service'],
+      scopes: ['crm:read'],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('defaults audiences to [self_service] when omitted', () => {
+    const r = MintDto.safeParse({ externalId: 'u_123' });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data.audiences).toEqual(['self_service']);
+  });
+
+  it('rejects audience=admin', () => {
+    const r = MintDto.safeParse({
+      externalId: 'u_123',
+      audiences: ['admin'],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects wildcard scope *', () => {
+    const r = MintDto.safeParse({
+      externalId: 'u_123',
+      scopes: ['*'],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an admin-only scope like kb:write', () => {
+    const r = MintDto.safeParse({
+      externalId: 'u_123',
+      scopes: ['kb:write'],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('requires at least one of endUserId/externalId/email/phone', () => {
+    const r = MintDto.safeParse({});
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/backend-core/src/control/delegated-token.controller.ts
+++ b/packages/backend-core/src/control/delegated-token.controller.ts
@@ -16,7 +16,9 @@ import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 
-const MintDto = z
+export const SELF_SERVICE_SCOPES = ['conv:write', 'crm:read', 'crm:write'] as const;
+
+export const MintDto = z
   .object({
     endUserId: z.string().optional(),
     externalId: z.string().optional(),
@@ -25,8 +27,10 @@ const MintDto = z
     name: z.string().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
     ttlSeconds: z.number().int().min(60).max(60 * 60 * 24).default(30 * 60),
-    audiences: z.array(z.enum(['admin', 'self_service'])).default(['self_service']),
-    scopes: z.array(z.string()).default([]),
+    audiences: z
+      .array(z.literal('self_service'))
+      .default(['self_service']),
+    scopes: z.array(z.enum(SELF_SERVICE_SCOPES)).default([]),
   })
   .refine((v) => v.endUserId || v.externalId || v.email || v.phone, {
     message: 'at least one of endUserId, externalId, email, phone is required',

--- a/packages/backend-core/src/control/delegated-token.controller.ts
+++ b/packages/backend-core/src/control/delegated-token.controller.ts
@@ -16,7 +16,15 @@ import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 
-export const SELF_SERVICE_SCOPES = ['conv:write', 'crm:read', 'crm:write'] as const;
+export const SELF_SERVICE_SCOPES = [
+  'cms:read',
+  'conv:read',
+  'conv:write',
+  'crm:read',
+  'crm:write',
+  'kb:read',
+  'outreach:read',
+] as const;
 
 export const MintDto = z
   .object({

--- a/packages/backend-core/src/control/webhooks.controller.test.ts
+++ b/packages/backend-core/src/control/webhooks.controller.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { WebhookUrl } from './webhooks.controller.ts';
+
+describe('Webhook URL schema', () => {
+  it('accepts a public https URL', () => {
+    expect(WebhookUrl.safeParse('https://hooks.example.com/munin').success).toBe(true);
+  });
+
+  it('rejects plain http://', () => {
+    expect(WebhookUrl.safeParse('http://hooks.example.com/munin').success).toBe(false);
+  });
+
+  it('rejects non-http(s) schemes', () => {
+    expect(WebhookUrl.safeParse('ftp://hooks.example.com/').success).toBe(false);
+    expect(WebhookUrl.safeParse('file:///etc/passwd').success).toBe(false);
+    expect(WebhookUrl.safeParse('gopher://evil/').success).toBe(false);
+  });
+
+  it('rejects malformed input', () => {
+    expect(WebhookUrl.safeParse('not a url').success).toBe(false);
+  });
+
+  it('passes schema check for http localhost (private-IP block enforced by safeFetch at delivery)', () => {
+    expect(WebhookUrl.safeParse('http://localhost/').success).toBe(false);
+    expect(WebhookUrl.safeParse('http://127.0.0.1/').success).toBe(false);
+    expect(WebhookUrl.safeParse('https://127.0.0.1/').success).toBe(true);
+  });
+});

--- a/packages/backend-core/src/control/webhooks.controller.ts
+++ b/packages/backend-core/src/control/webhooks.controller.ts
@@ -21,14 +21,25 @@ import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 
+export const WebhookUrl = z
+  .string()
+  .url()
+  .refine((u) => {
+    try {
+      return new URL(u).protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }, 'webhook URL must use https://');
+
 const CreateDto = z.object({
-  url: z.string().url(),
+  url: WebhookUrl,
   events: z.array(z.string().min(1).max(64)).default([]),
   active: z.boolean().optional(),
 });
 
 const PatchDto = z.object({
-  url: z.string().url().optional(),
+  url: WebhookUrl.optional(),
   events: z.array(z.string().min(1).max(64)).optional(),
   active: z.boolean().optional(),
 });

--- a/packages/backend-core/src/mcp/mcp.controller.ts
+++ b/packages/backend-core/src/mcp/mcp.controller.ts
@@ -64,9 +64,8 @@ export class McpController {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
 
-    // For now: admin agents see admin tools, end-user agents see self_service.
-    // If a token has both audiences (rare; mainly admin keys), prefer 'admin'.
-    const audience: Audience = actor.audiences.includes('admin') ? 'admin' : 'self_service';
+    const audience: Audience =
+      actor.type === 'admin_agent' && actor.audiences.includes('admin') ? 'admin' : 'self_service';
 
     const server = createMcpServer({
       registry: this.registry,

--- a/packages/backend-core/src/modules/conv/conv.module.ts
+++ b/packages/backend-core/src/modules/conv/conv.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { CuratorModule } from '../curator/curator.module.ts';
 import { McpModule } from '../../mcp/mcp.module.ts';
 import { RealtimeModule } from '../../realtime/realtime.module.ts';
+import { PublicThrottleModule } from '../../common/rate-limit/public-throttle.module.ts';
 import { ConvService } from './conv.service.ts';
 import { ConversationClaimsService } from './conv.claims.service.ts';
 import { ConvAdminTools } from './conv.tools.ts';
@@ -37,7 +38,7 @@ import { WidgetEmailFallbackWorker } from './widget/widget-email-fallback.worker
 import { WidgetAdminTools } from './widget/widget.tools.ts';
 
 @Module({
-  imports: [CuratorModule, McpModule, RealtimeModule],
+  imports: [CuratorModule, McpModule, RealtimeModule, PublicThrottleModule],
   controllers: [WidgetController, ChannelWebhookController],
   providers: [
     ConvService,

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -4,7 +4,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import {
   ActorIdentity,
   WebhookDispatcher,
-  assertPublicHost,
+  resolvePublicHost,
   signEmailOpenToken,
   withContext,
   type Mailer,
@@ -80,13 +80,16 @@ class ImapFlowFetcher implements ImapFetcher {
     sinceUid: number | null;
     limit: number;
   }): Promise<ImapMessageMin[]> {
-    await assertPublicHost(opts.host);
+    const resolved = await resolvePublicHost(opts.host);
     const client = new ImapFlow({
-      host: opts.host,
+      host: resolved?.address ?? opts.host,
       port: opts.port,
       secure: opts.secure,
       auth: { user: opts.username, pass: opts.password },
       logger: false,
+      ...(resolved && resolved.address !== opts.host
+        ? { tls: { servername: opts.host } }
+        : {}),
     });
     await client.connect();
     try {
@@ -172,7 +175,7 @@ export class EmailAdapter implements ChannelAdapter {
     });
 
     if (config.outbound.provider === 'smtp') {
-      await assertPublicHost(config.outbound.host);
+      const resolved = await resolvePublicHost(config.outbound.host);
       const password = await this.db.transaction(async (tx) => {
         return this.emailService.decryptSmtpPassword(
           tx,
@@ -180,10 +183,13 @@ export class EmailAdapter implements ChannelAdapter {
         );
       });
       const transport: Transporter = createTransport(
-        smtpTransportOptions(config.outbound.host, config.outbound.port, config.outbound.secure, {
-          user: config.outbound.username,
-          pass: password,
-        }),
+        smtpTransportOptions(
+          config.outbound.host,
+          config.outbound.port,
+          config.outbound.secure,
+          { user: config.outbound.username, pass: password },
+          resolved?.address,
+        ),
       );
       await transport.sendMail({
         envelope: { from: config.addressing.fromAddress, to: recipient },

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -4,6 +4,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import {
   ActorIdentity,
   WebhookDispatcher,
+  assertPublicHost,
   signEmailOpenToken,
   withContext,
   type Mailer,
@@ -79,6 +80,7 @@ class ImapFlowFetcher implements ImapFetcher {
     sinceUid: number | null;
     limit: number;
   }): Promise<ImapMessageMin[]> {
+    await assertPublicHost(opts.host);
     const client = new ImapFlow({
       host: opts.host,
       port: opts.port,
@@ -170,6 +172,7 @@ export class EmailAdapter implements ChannelAdapter {
     });
 
     if (config.outbound.provider === 'smtp') {
+      await assertPublicHost(config.outbound.host);
       const password = await this.db.transaction(async (tx) => {
         return this.emailService.decryptSmtpPassword(
           tx,

--- a/packages/backend-core/src/modules/conv/email/email.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email.integration.test.ts
@@ -68,6 +68,7 @@ class StubImapFetcher implements ImapFetcher {
     process.env.MUNIN_MAIL_PROVIDER = 'stub';
     process.env.MUNIN_ENCRYPTION_KEY ??= 'integration-test-encryption-key';
     process.env.MUNIN_EMAIL_REPLY_DOMAIN = REPLY_DOMAIN;
+    process.env.MUNIN_SSRF_ALLOW_PRIVATE = '1';
 
     await runMigrations(TEST_URL!);
 

--- a/packages/backend-core/src/modules/conv/email/email.service.ts
+++ b/packages/backend-core/src/modules/conv/email/email.service.ts
@@ -7,6 +7,7 @@ import {
 import { schema, type Db, type Tx } from '@getmunin/db';
 import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
 import {
+  assertPublicHost,
   decryptSecretSql,
   encryptSecretSql,
   getCurrentContext,
@@ -98,6 +99,12 @@ export type StoredEmailChannelConfig = z.infer<typeof StoredEmailChannelConfigSc
 @Injectable()
 export class EmailService {
   async toStored(input: EmailChannelConfigInputT): Promise<StoredEmailChannelConfig> {
+    if (input.outbound.provider === 'smtp') {
+      await assertPublicHost(input.outbound.host);
+    }
+    if (input.inbound) {
+      await assertPublicHost(input.inbound.host);
+    }
     const out: StoredEmailChannelConfig = {
       addressing: { ...input.addressing },
       outbound:

--- a/packages/backend-core/src/modules/conv/email/email.tools.ts
+++ b/packages/backend-core/src/modules/conv/email/email.tools.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
 import { schema, type Db } from '@getmunin/db';
 import { eq } from 'drizzle-orm';
-import { assertPublicHost, getCurrentContext, type Mailer } from '@getmunin/core';
+import { getCurrentContext, resolvePublicHost, type Mailer } from '@getmunin/core';
 import { renderChannelTestEmail } from '@getmunin/emails';
 import { createTransport } from 'nodemailer';
 import { ImapFlow } from 'imapflow';
@@ -124,14 +124,18 @@ export class EmailAdminTools {
 
     try {
       if (config.outbound.provider === 'smtp') {
+        const resolved = await resolvePublicHost(config.outbound.host);
         const password = await this.serviceDb.transaction((tx) =>
           this.email.decryptSmtpPassword(tx, config.outbound.provider === 'smtp' ? config.outbound.encryptedPassword : ''),
         );
         const transport = createTransport(
-          smtpTransportOptions(config.outbound.host, config.outbound.port, config.outbound.secure, {
-            user: config.outbound.username,
-            pass: password,
-          }),
+          smtpTransportOptions(
+            config.outbound.host,
+            config.outbound.port,
+            config.outbound.secure,
+            { user: config.outbound.username, pass: password },
+            resolved?.address,
+          ),
         );
         try {
           await transport.sendMail({
@@ -164,7 +168,7 @@ export class EmailAdminTools {
   private async testSmtp(config: StoredEmailChannelConfig): Promise<string> {
     if (config.outbound.provider === 'mailer') return 'ok';
     try {
-      await assertPublicHost(config.outbound.host);
+      const resolved = await resolvePublicHost(config.outbound.host);
       const password = await this.serviceDb.transaction((tx) =>
         this.email.decryptSmtpPassword(
           tx,
@@ -172,10 +176,13 @@ export class EmailAdminTools {
         ),
       );
       const transport = createTransport({
-        ...smtpTransportOptions(config.outbound.host, config.outbound.port, config.outbound.secure, {
-          user: config.outbound.username,
-          pass: password,
-        }),
+        ...smtpTransportOptions(
+          config.outbound.host,
+          config.outbound.port,
+          config.outbound.secure,
+          { user: config.outbound.username, pass: password },
+          resolved?.address,
+        ),
         connectionTimeout: 5000,
         greetingTimeout: 5000,
       });
@@ -192,19 +199,20 @@ export class EmailAdminTools {
 
   private async testImap(config: StoredEmailChannelConfig): Promise<string> {
     if (!config.inbound) return 'not configured';
-    // imapflow is loaded lazily so the dependency stays out of code paths that
-    // don't need it. See M8.3 for the inbound worker that uses it for real.
     try {
-      await assertPublicHost(config.inbound.host);
+      const resolved = await resolvePublicHost(config.inbound.host);
       const password = await this.serviceDb.transaction((tx) =>
         this.email.decryptImapPassword(tx, config.inbound!.encryptedPassword),
       );
       const client = new ImapFlow({
-        host: config.inbound.host,
+        host: resolved?.address ?? config.inbound.host,
         port: config.inbound.port,
         secure: config.inbound.secure,
         auth: { user: config.inbound.username, pass: password },
         logger: false,
+        ...(resolved && resolved.address !== config.inbound.host
+          ? { tls: { servername: config.inbound.host } }
+          : {}),
       });
       try {
         await client.connect();
@@ -232,12 +240,14 @@ export function smtpTransportOptions(
   port: number,
   secureHint: boolean,
   auth: { user: string; pass: string },
+  resolvedAddress?: string,
 ): {
   host: string;
   port: number;
   secure: boolean;
   requireTLS: boolean;
   auth: { user: string; pass: string };
+  tls?: { servername: string };
 } {
   let secure: boolean;
   let requireTLS: boolean;
@@ -250,6 +260,9 @@ export function smtpTransportOptions(
   } else {
     secure = secureHint;
     requireTLS = !secureHint;
+  }
+  if (resolvedAddress && resolvedAddress !== host) {
+    return { host: resolvedAddress, port, secure, requireTLS, auth, tls: { servername: host } };
   }
   return { host, port, secure, requireTLS, auth };
 }

--- a/packages/backend-core/src/modules/conv/email/email.tools.ts
+++ b/packages/backend-core/src/modules/conv/email/email.tools.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
 import { schema, type Db } from '@getmunin/db';
 import { eq } from 'drizzle-orm';
-import { getCurrentContext, type Mailer } from '@getmunin/core';
+import { assertPublicHost, getCurrentContext, type Mailer } from '@getmunin/core';
 import { renderChannelTestEmail } from '@getmunin/emails';
 import { createTransport } from 'nodemailer';
 import { ImapFlow } from 'imapflow';
@@ -164,6 +164,7 @@ export class EmailAdminTools {
   private async testSmtp(config: StoredEmailChannelConfig): Promise<string> {
     if (config.outbound.provider === 'mailer') return 'ok';
     try {
+      await assertPublicHost(config.outbound.host);
       const password = await this.serviceDb.transaction((tx) =>
         this.email.decryptSmtpPassword(
           tx,
@@ -194,6 +195,7 @@ export class EmailAdminTools {
     // imapflow is loaded lazily so the dependency stays out of code paths that
     // don't need it. See M8.3 for the inbound worker that uses it for real.
     try {
+      await assertPublicHost(config.inbound.host);
       const password = await this.serviceDb.transaction((tx) =>
         this.email.decryptImapPassword(tx, config.inbound!.encryptedPassword),
       );

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-adapter.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-adapter.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { sql, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { schema, type Db } from '@getmunin/db';
 import { DB } from '../../../common/db/db.module.ts';
 import type {
@@ -118,7 +118,13 @@ export class MessageBirdSmsAdapter implements ChannelAdapter {
       await tx
         .update(schema.convMessageDeliveries)
         .set(update)
-        .where(eq(schema.convMessageDeliveries.messageIdHeader, id));
+        .where(
+          and(
+            eq(schema.convMessageDeliveries.orgId, channel.orgId),
+            eq(schema.convMessageDeliveries.channelId, channel.id),
+            eq(schema.convMessageDeliveries.messageIdHeader, id),
+          ),
+        );
     });
     this.logger.log(`messagebird status report id=${id} status=${params.status} → ${mapped}`);
   }

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms-adapter.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms-adapter.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { sql, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { schema, type Db } from '@getmunin/db';
 import { DB } from '../../../common/db/db.module.ts';
 import type {
@@ -122,7 +122,13 @@ export class TwilioSmsAdapter implements ChannelAdapter {
       await tx
         .update(schema.convMessageDeliveries)
         .set(update)
-        .where(eq(schema.convMessageDeliveries.messageIdHeader, sid));
+        .where(
+          and(
+            eq(schema.convMessageDeliveries.orgId, channel.orgId),
+            eq(schema.convMessageDeliveries.channelId, channel.id),
+            eq(schema.convMessageDeliveries.messageIdHeader, sid),
+          ),
+        );
     });
     this.logger.log(`twilio status callback sid=${sid} status=${params.MessageStatus} → ${status}`);
   }

--- a/packages/backend-core/src/modules/conv/widget/widget-email-fallback.worker.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-email-fallback.worker.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, sql } from 'drizzle-orm';
 import { createTransport, type Transporter } from 'nodemailer';
-import { type Mailer } from '@getmunin/core';
+import { resolvePublicHost, type Mailer } from '@getmunin/core';
 import { DB } from '../../../common/db/db.module.ts';
 import { MAILER } from '../../../common/mail/mail.module.ts';
 import { EmailService, jsonbToStored, type StoredEmailChannelConfig } from '../email/email.service.ts';
@@ -433,6 +433,7 @@ export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy 
     built: BuiltMessage,
   ): Promise<void> {
     if (config.outbound.provider === 'smtp') {
+      const resolved = await resolvePublicHost(config.outbound.host);
       const password = await this.db.transaction((tx) =>
         this.emailService.decryptSmtpPassword(
           tx,
@@ -445,6 +446,7 @@ export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy 
           config.outbound.port,
           config.outbound.secure,
           { user: config.outbound.username, pass: password },
+          resolved?.address,
         ),
       );
       try {

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -686,24 +686,7 @@ export class WidgetIngestService {
     orgId: string,
     channelId: string,
   ): Promise<typeof schema.convChannels.$inferSelect> {
-    const rows = await tx
-      .select()
-      .from(schema.convChannels)
-      .where(and(eq(schema.convChannels.id, channelId), eq(schema.convChannels.orgId, orgId)))
-      .limit(1);
-    const channel = rows[0];
-    if (!channel) throw new NotFoundException(`channel ${channelId} not found`);
-    if (channel.type !== 'chat') {
-      throw new BadRequestException(`channel ${channelId} is not a chat channel`);
-    }
-    if (!channel.active) {
-      throw new ForbiddenException(`channel ${channelId} is inactive`);
-    }
-    const parsed = WidgetChannelConfig.safeParse(channel.config);
-    if (!parsed.success) {
-      throw new BadRequestException(`channel ${channelId} is not configured as a widget channel`);
-    }
-    return channel;
+    return loadWidgetChannel(tx, orgId, channelId);
   }
 
   private async findOrCreateEndUser(
@@ -943,6 +926,31 @@ export function enforceOriginAllowlist(
   if (!origin) throw new ForbiddenException('origin_required');
   const allowed = list.some((entry) => originMatches(entry, origin));
   if (!allowed) throw new ForbiddenException('origin_not_allowed');
+}
+
+export async function loadWidgetChannel(
+  tx: Tx,
+  orgId: string,
+  channelId: string,
+): Promise<typeof schema.convChannels.$inferSelect> {
+  const rows = await tx
+    .select()
+    .from(schema.convChannels)
+    .where(and(eq(schema.convChannels.id, channelId), eq(schema.convChannels.orgId, orgId)))
+    .limit(1);
+  const channel = rows[0];
+  if (!channel) throw new NotFoundException(`channel ${channelId} not found`);
+  if (channel.type !== 'chat') {
+    throw new BadRequestException(`channel ${channelId} is not a chat channel`);
+  }
+  if (!channel.active) {
+    throw new ForbiddenException(`channel ${channelId} is inactive`);
+  }
+  const parsed = WidgetChannelConfig.safeParse(channel.config);
+  if (!parsed.success) {
+    throw new BadRequestException(`channel ${channelId} is not configured as a widget channel`);
+  }
+  return channel;
 }
 
 function originMatches(allowlistEntry: string, origin: string): boolean {

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -591,8 +591,8 @@ export class WidgetIngestService {
       if (input.url) meta.url = input.url;
       if (input.providerThreadId) meta.providerThreadId = input.providerThreadId;
 
-      const authorType = msg.role;
-      const authorId = authorType === 'end_user' ? contact.id : 'widget-agent';
+      const authorType = 'end_user';
+      const authorId = contact.id;
 
       let insertedId: string | null = null;
       let dup = false;
@@ -938,9 +938,9 @@ export function enforceOriginAllowlist(
   channelConfig: { originAllowlist: string[] },
   origin: string | undefined,
 ): void {
-  if (!origin) return;
   const list = channelConfig.originAllowlist ?? [];
   if (list.length === 0) return;
+  if (!origin) throw new ForbiddenException('origin_required');
   const allowed = list.some((entry) => originMatches(entry, origin));
   if (!allowed) throw new ForbiddenException('origin_not_allowed');
 }

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
@@ -18,6 +18,7 @@ const skipReason = TEST_URL
   : 'Set TEST_DATABASE_URL to a Postgres URL to run widget-voice integration tests.';
 
 (skipReason ? describe.skip : describe)('Widget voice/start endpoint', () => {
+  const ALICE_SESSION_ID = 'voice_alice_session';
   let app: INestApplication;
   let baseUrl: string;
   let db: ReturnType<typeof createDb>;
@@ -87,6 +88,7 @@ const skipReason = TEST_URL
         contactId: aliceContact!.id,
         endUserId: alice!.id,
         status: 'open',
+        metadata: { sessionId: ALICE_SESSION_ID },
       })
       .returning();
     aliceConvId = aliceConv!.id;
@@ -162,6 +164,7 @@ const skipReason = TEST_URL
     const { status, json } = await call({
       channelId: widgetChannelId,
       conversationId: aliceConvId,
+      sessionId: ALICE_SESSION_ID,
     });
     expect(status).toBe(201);
     const body = json as {
@@ -191,6 +194,7 @@ const skipReason = TEST_URL
     const { status, json } = await call({
       channelId: 'cch_someone_elses',
       conversationId: aliceConvId,
+      sessionId: ALICE_SESSION_ID,
     });
     expect(status).toBe(403);
     expect(JSON.stringify(json)).toContain('widget_channel_mismatch');
@@ -204,18 +208,30 @@ const skipReason = TEST_URL
         displayId: 99,
         channelId: voiceChannelId,
         status: 'open',
+        metadata: { sessionId: ALICE_SESSION_ID },
       })
       .returning();
     try {
       const { status, json } = await call({
         channelId: widgetChannelId,
         conversationId: otherConv!.id,
+        sessionId: ALICE_SESSION_ID,
       });
       expect(status).toBe(403);
       expect(JSON.stringify(json)).toContain('conversation_channel_mismatch');
     } finally {
       await db.delete(schema.convConversations).where(eq(schema.convConversations.id, otherConv!.id));
     }
+  });
+
+  it('rejects when sessionId does not match the conversation', async () => {
+    const { status, json } = await call({
+      channelId: widgetChannelId,
+      conversationId: aliceConvId,
+      sessionId: 'someone_elses_session',
+    });
+    expect(status).toBe(403);
+    expect(JSON.stringify(json)).toContain('conversation_session_mismatch');
   });
 
   it('returns available:false when voice channel has no publicKey', async () => {
@@ -229,6 +245,7 @@ const skipReason = TEST_URL
       const { status, json } = await call({
         channelId: widgetChannelId,
         conversationId: aliceConvId,
+        sessionId: ALICE_SESSION_ID,
       });
       expect(status).toBe(201);
       expect(json).toEqual({ available: false, reason: 'voice_channel_missing_public_key' });
@@ -251,6 +268,7 @@ const skipReason = TEST_URL
       const { status, json } = await call({
         channelId: widgetChannelId,
         conversationId: aliceConvId,
+        sessionId: ALICE_SESSION_ID,
       });
       expect(status).toBe(201);
       expect(json).toEqual({ available: false, reason: 'no_active_voice_channel' });
@@ -284,6 +302,7 @@ const skipReason = TEST_URL
       const { status, json } = await call({
         channelId: widgetChannelId,
         conversationId: aliceConvId,
+        sessionId: ALICE_SESSION_ID,
       });
       expect(status).toBe(201);
       expect(json).toEqual({
@@ -327,6 +346,7 @@ const skipReason = TEST_URL
       const { status, json } = await call({
         channelId: widgetChannelId,
         conversationId: aliceConvId,
+        sessionId: ALICE_SESSION_ID,
       });
       expect(status).toBe(201);
       const body = json as {
@@ -356,6 +376,7 @@ const skipReason = TEST_URL
       const { status, json } = await call({
         channelId: widgetChannelId,
         conversationId: aliceConvId,
+        sessionId: ALICE_SESSION_ID,
       });
       expect(status).toBe(201);
       expect(json).toEqual({

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
@@ -54,7 +54,13 @@ const skipReason = TEST_URL
 
     const [chatChannel] = await db
       .insert(schema.convChannels)
-      .values({ orgId, type: 'chat', vendor: 'munin', name: 'Web chat' })
+      .values({
+        orgId,
+        type: 'chat',
+        vendor: 'munin',
+        name: 'Web chat',
+        config: { provider: 'widget', originAllowlist: [], requireVerifiedIdentity: false },
+      })
       .returning();
     widgetChannelId = chatChannel!.id;
 
@@ -234,6 +240,27 @@ const skipReason = TEST_URL
     expect(JSON.stringify(json)).toContain('conversation_session_mismatch');
   });
 
+  it('rejects when the bound widget channel has been deactivated', async () => {
+    await db
+      .update(schema.convChannels)
+      .set({ active: false })
+      .where(eq(schema.convChannels.id, widgetChannelId));
+    try {
+      const { status, json } = await call({
+        channelId: widgetChannelId,
+        conversationId: aliceConvId,
+        sessionId: ALICE_SESSION_ID,
+      });
+      expect(status).toBe(403);
+      expect(JSON.stringify(json)).toContain('is inactive');
+    } finally {
+      await db
+        .update(schema.convChannels)
+        .set({ active: true })
+        .where(eq(schema.convChannels.id, widgetChannelId));
+    }
+  });
+
   it('returns available:false when voice channel has no publicKey', async () => {
     await db
       .update(schema.convChannels)
@@ -359,7 +386,7 @@ const skipReason = TEST_URL
     } finally {
       await db
         .update(schema.convChannels)
-        .set({ config: sql`config - 'voiceChannelId' - 'provider'` })
+        .set({ config: sql`config - 'voiceChannelId'` })
         .where(eq(schema.convChannels.id, widgetChannelId));
       await db.delete(schema.convChannels).where(eq(schema.convChannels.id, extra.id));
     }
@@ -386,7 +413,7 @@ const skipReason = TEST_URL
     } finally {
       await db
         .update(schema.convChannels)
-        .set({ config: sql`config - 'voiceChannelId' - 'provider'` })
+        .set({ config: sql`config - 'voiceChannelId'` })
         .where(eq(schema.convChannels.id, widgetChannelId));
     }
   });

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
@@ -43,6 +43,7 @@ import type {
   WidgetVoiceStartInputT,
   WidgetVoiceStartResult,
 } from './widget.types.ts';
+import { enforceOriginAllowlist, verifyIdentity } from './widget-ingest.service.ts';
 
 const HISTORY_TURN_LIMIT = 20;
 const PROMPT_CACHE_TTL_MS = 60_000;
@@ -101,6 +102,7 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
     orgId: string,
     boundChannelId: string,
     input: WidgetVoiceStartInputT,
+    requestContext: { origin?: string } = {},
   ): Promise<WidgetVoiceStartResult> {
     if (input.channelId !== boundChannelId) {
       throw new ForbiddenException('widget_channel_mismatch');
@@ -109,11 +111,31 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
     return this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
 
+      const widgetChannelRows = await tx
+        .select({ config: schema.convChannels.config })
+        .from(schema.convChannels)
+        .where(eq(schema.convChannels.id, input.channelId))
+        .limit(1);
+      const widgetConfigParsed = widgetChannelRows[0]
+        ? WidgetChannelConfig.safeParse(widgetChannelRows[0].config)
+        : null;
+      const widgetConfig = widgetConfigParsed?.success ? widgetConfigParsed.data : null;
+      if (widgetConfig) {
+        enforceOriginAllowlist(widgetConfig, requestContext.origin);
+      }
+      const identity = widgetConfig
+        ? verifyIdentity(widgetConfig, {
+            verifiedExternalId: input.verifiedExternalId,
+            userHash: input.userHash,
+          })
+        : { mode: 'anonymous' as const };
+
       const convRows = await tx
         .select({
           id: schema.convConversations.id,
           channelId: schema.convConversations.channelId,
           endUserId: schema.convConversations.endUserId,
+          contactId: schema.convConversations.contactId,
           orgId: schema.convConversations.orgId,
           metadata: schema.convConversations.metadata,
         })
@@ -127,19 +149,26 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
       if (conv.channelId !== input.channelId) {
         throw new ForbiddenException('conversation_channel_mismatch');
       }
+      const convSessionId = (conv.metadata as { sessionId?: unknown } | null)?.sessionId;
+      if (convSessionId !== input.sessionId) {
+        throw new ForbiddenException('conversation_session_mismatch');
+      }
+      if (identity.mode === 'verified' && conv.contactId) {
+        const [contactRow] = await tx
+          .select({ metadata: schema.convContacts.metadata })
+          .from(schema.convContacts)
+          .where(eq(schema.convContacts.id, conv.contactId))
+          .limit(1);
+        const contactExt = (contactRow?.metadata as { externalId?: unknown } | null)?.externalId;
+        if (contactExt !== identity.externalId) {
+          throw new ForbiddenException('conversation_identity_mismatch');
+        }
+      }
       if (!conv.endUserId) {
         return { available: false, reason: 'conversation_has_no_end_user' };
       }
 
-      const widgetChannelRows = await tx
-        .select({ config: schema.convChannels.config })
-        .from(schema.convChannels)
-        .where(eq(schema.convChannels.id, input.channelId))
-        .limit(1);
-      const widgetConfig = widgetChannelRows[0]
-        ? WidgetChannelConfig.safeParse(widgetChannelRows[0].config)
-        : null;
-      const voiceChannelId = widgetConfig?.success ? widgetConfig.data.voiceChannelId : undefined;
+      const voiceChannelId = widgetConfig?.voiceChannelId;
 
       const voiceBaseConditions = [
         eq(schema.convChannels.orgId, orgId),
@@ -258,6 +287,7 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
     orgId: string,
     boundChannelId: string,
     input: WidgetVoiceEventInputT,
+    requestContext: { origin?: string } = {},
   ): Promise<WidgetVoiceEventResult> {
     if (input.channelId !== boundChannelId) {
       throw new ForbiddenException('widget_channel_mismatch');
@@ -266,10 +296,30 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
     const messageId = await this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
 
+      const widgetChannelRows = await tx
+        .select({ config: schema.convChannels.config })
+        .from(schema.convChannels)
+        .where(eq(schema.convChannels.id, input.channelId))
+        .limit(1);
+      const widgetConfigParsed = widgetChannelRows[0]
+        ? WidgetChannelConfig.safeParse(widgetChannelRows[0].config)
+        : null;
+      const widgetConfig = widgetConfigParsed?.success ? widgetConfigParsed.data : null;
+      if (widgetConfig) {
+        enforceOriginAllowlist(widgetConfig, requestContext.origin);
+      }
+      const identity = widgetConfig
+        ? verifyIdentity(widgetConfig, {
+            verifiedExternalId: input.verifiedExternalId,
+            userHash: input.userHash,
+          })
+        : { mode: 'anonymous' as const };
+
       const [conv] = await tx
         .select({
           id: schema.convConversations.id,
           channelId: schema.convConversations.channelId,
+          contactId: schema.convConversations.contactId,
           orgId: schema.convConversations.orgId,
           assigneeUserId: schema.convConversations.assigneeUserId,
           metadata: schema.convConversations.metadata,
@@ -282,6 +332,21 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
       }
       if (conv.channelId !== input.channelId) {
         throw new ForbiddenException('conversation_channel_mismatch');
+      }
+      const convSessionId = (conv.metadata as { sessionId?: unknown } | null)?.sessionId;
+      if (convSessionId !== input.sessionId) {
+        throw new ForbiddenException('conversation_session_mismatch');
+      }
+      if (identity.mode === 'verified' && conv.contactId) {
+        const [contactRow] = await tx
+          .select({ metadata: schema.convContacts.metadata })
+          .from(schema.convContacts)
+          .where(eq(schema.convContacts.id, conv.contactId))
+          .limit(1);
+        const contactExt = (contactRow?.metadata as { externalId?: unknown } | null)?.externalId;
+        if (contactExt !== identity.externalId) {
+          throw new ForbiddenException('conversation_identity_mismatch');
+        }
       }
 
       let body: string;

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
@@ -43,7 +43,7 @@ import type {
   WidgetVoiceStartInputT,
   WidgetVoiceStartResult,
 } from './widget.types.ts';
-import { enforceOriginAllowlist, verifyIdentity } from './widget-ingest.service.ts';
+import { enforceOriginAllowlist, loadWidgetChannel, verifyIdentity } from './widget-ingest.service.ts';
 
 const HISTORY_TURN_LIMIT = 20;
 const PROMPT_CACHE_TTL_MS = 60_000;
@@ -111,24 +111,13 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
     return this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
 
-      const widgetChannelRows = await tx
-        .select({ config: schema.convChannels.config })
-        .from(schema.convChannels)
-        .where(eq(schema.convChannels.id, input.channelId))
-        .limit(1);
-      const widgetConfigParsed = widgetChannelRows[0]
-        ? WidgetChannelConfig.safeParse(widgetChannelRows[0].config)
-        : null;
-      const widgetConfig = widgetConfigParsed?.success ? widgetConfigParsed.data : null;
-      if (widgetConfig) {
-        enforceOriginAllowlist(widgetConfig, requestContext.origin);
-      }
-      const identity = widgetConfig
-        ? verifyIdentity(widgetConfig, {
-            verifiedExternalId: input.verifiedExternalId,
-            userHash: input.userHash,
-          })
-        : { mode: 'anonymous' as const };
+      const widgetChannel = await loadWidgetChannel(tx, orgId, input.channelId);
+      const widgetConfig = WidgetChannelConfig.parse(widgetChannel.config);
+      enforceOriginAllowlist(widgetConfig, requestContext.origin);
+      const identity = verifyIdentity(widgetConfig, {
+        verifiedExternalId: input.verifiedExternalId,
+        userHash: input.userHash,
+      });
 
       const convRows = await tx
         .select({
@@ -168,7 +157,7 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
         return { available: false, reason: 'conversation_has_no_end_user' };
       }
 
-      const voiceChannelId = widgetConfig?.voiceChannelId;
+      const voiceChannelId = widgetConfig.voiceChannelId;
 
       const voiceBaseConditions = [
         eq(schema.convChannels.orgId, orgId),
@@ -296,24 +285,13 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
     const messageId = await this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
 
-      const widgetChannelRows = await tx
-        .select({ config: schema.convChannels.config })
-        .from(schema.convChannels)
-        .where(eq(schema.convChannels.id, input.channelId))
-        .limit(1);
-      const widgetConfigParsed = widgetChannelRows[0]
-        ? WidgetChannelConfig.safeParse(widgetChannelRows[0].config)
-        : null;
-      const widgetConfig = widgetConfigParsed?.success ? widgetConfigParsed.data : null;
-      if (widgetConfig) {
-        enforceOriginAllowlist(widgetConfig, requestContext.origin);
-      }
-      const identity = widgetConfig
-        ? verifyIdentity(widgetConfig, {
-            verifiedExternalId: input.verifiedExternalId,
-            userHash: input.userHash,
-          })
-        : { mode: 'anonymous' as const };
+      const widgetChannel = await loadWidgetChannel(tx, orgId, input.channelId);
+      const widgetConfig = WidgetChannelConfig.parse(widgetChannel.config);
+      enforceOriginAllowlist(widgetConfig, requestContext.origin);
+      const identity = verifyIdentity(widgetConfig, {
+        verifiedExternalId: input.verifiedExternalId,
+        userHash: input.userHash,
+      });
 
       const [conv] = await tx
         .select({

--- a/packages/backend-core/src/modules/conv/widget/widget.controller.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.controller.ts
@@ -11,6 +11,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
 import { schema } from '@getmunin/db';
 import { eq } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
@@ -52,7 +53,7 @@ import { WidgetVoiceService } from './widget-voice.service.ts';
  * the bound org.
  */
 @Controller('v1/widget')
-@UseGuards(AuthGuard)
+@UseGuards(AuthGuard, ThrottlerGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 export class WidgetController {
   constructor(

--- a/packages/backend-core/src/modules/conv/widget/widget.controller.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.controller.ts
@@ -230,7 +230,10 @@ export class WidgetController {
   }
 
   @Post('voice/start')
-  async startVoice(@Body() rawBody: unknown): Promise<WidgetVoiceStartResult> {
+  async startVoice(
+    @Body() rawBody: unknown,
+    @Headers('origin') origin: string | undefined,
+  ): Promise<WidgetVoiceStartResult> {
     const ctx = getCurrentContext();
     const actor = ctx.actor;
     if (!actor) throw new ForbiddenException('widget_auth_required');
@@ -251,11 +254,14 @@ export class WidgetController {
     }
 
     const orgId = key.orgId ?? actor.orgId;
-    return this.voiceService.startSession(orgId, key.channelId, parsed.data);
+    return this.voiceService.startSession(orgId, key.channelId, parsed.data, { origin });
   }
 
   @Post('voice/event')
-  async voiceEvent(@Body() rawBody: unknown): Promise<WidgetVoiceEventResult> {
+  async voiceEvent(
+    @Body() rawBody: unknown,
+    @Headers('origin') origin: string | undefined,
+  ): Promise<WidgetVoiceEventResult> {
     const ctx = getCurrentContext();
     const actor = ctx.actor;
     if (!actor) throw new ForbiddenException('widget_auth_required');
@@ -276,6 +282,6 @@ export class WidgetController {
     }
 
     const orgId = key.orgId ?? actor.orgId;
-    return this.voiceService.recordEvent(orgId, key.channelId, parsed.data);
+    return this.voiceService.recordEvent(orgId, key.channelId, parsed.data, { origin });
   }
 }

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -143,8 +143,10 @@ const skipReason = TEST_URL
   ): Promise<{ status: number; json: unknown }> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
+      Origin: 'https://customer.example',
       ...extraHeaders,
     };
+    if (headers.Origin === '') delete headers.Origin;
     if (token) headers.Authorization = `Bearer ${token}`;
     const res = await fetch(`${baseUrl}${path}`, {
       method,
@@ -159,6 +161,33 @@ const skipReason = TEST_URL
       json = text;
     }
     return { status: res.status, json };
+  }
+
+  async function insertAgentMessage(
+    conversationId: string,
+    body: string,
+    sessionId?: string,
+    providerMessageId?: string,
+    extra: Partial<typeof schema.convMessages.$inferInsert> = {},
+  ): Promise<string> {
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    const meta: Record<string, unknown> = {};
+    if (sessionId) meta.sessionId = sessionId;
+    if (providerMessageId) meta.providerMessageId = providerMessageId;
+    const [row] = await db
+      .insert(schema.convMessages)
+      .values({
+        orgId,
+        conversationId,
+        authorType: 'agent',
+        authorId: 'widget-agent',
+        body,
+        internal: false,
+        metadata: meta,
+        ...extra,
+      })
+      .returning({ id: schema.convMessages.id });
+    return row!.id;
   }
 
   it('mints a widget key bound to a chat channel', async () => {
@@ -188,13 +217,14 @@ const skipReason = TEST_URL
       visitor: { name: 'Vita', email: 'vita@example.com' },
       messages: [
         { role: 'end_user', body: 'Where is my order?', providerMessageId: 'evt_1' },
-        { role: 'agent', body: 'Let me check…', providerMessageId: 'evt_2' },
       ],
     });
     expect(res.status).toBe(201);
     const out = res.json as { conversationId: string; inserted: number; skipped: number };
-    expect(out.inserted).toBe(2);
+    expect(out.inserted).toBe(1);
     expect(out.skipped).toBe(0);
+
+    await insertAgentMessage(out.conversationId, 'Let me check…', sessionId, 'evt_2');
 
     await waitFor(async () => {
       await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
@@ -660,26 +690,36 @@ const skipReason = TEST_URL
     );
     expect(allowed.status).toBe(201);
 
-    const noOrigin = await call('POST', '/v1/widget/messages', widgetKey, {
-      channelId,
-      sessionId: 'vis_origin_none',
-      messages: [{ role: 'end_user', body: 'no origin' }],
-    });
+    const noOrigin = await call(
+      'POST',
+      '/v1/widget/messages',
+      widgetKey,
+      {
+        channelId,
+        sessionId: 'vis_origin_none',
+        messages: [{ role: 'end_user', body: 'no origin' }],
+      },
+      { Origin: '' },
+    );
     expect(noOrigin.status).toBe(403);
   });
 
   it('lists messages ordered ascending and filters by since', async () => {
     const sessionId = 'vis_list_basic';
-    const t0 = await call('POST', '/v1/widget/messages', widgetKey, {
+    const first = await call('POST', '/v1/widget/messages', widgetKey, {
       channelId,
       sessionId,
-      messages: [
-        { role: 'end_user', body: 'one' },
-        { role: 'agent', body: 'two' },
-        { role: 'end_user', body: 'three' },
-      ],
+      messages: [{ role: 'end_user', body: 'one' }],
     });
-    expect(t0.status).toBe(201);
+    expect(first.status).toBe(201);
+    const conversationId = (first.json as { conversationId: string }).conversationId;
+    await insertAgentMessage(conversationId, 'two', sessionId);
+    const third = await call('POST', '/v1/widget/messages', widgetKey, {
+      channelId,
+      sessionId,
+      messages: [{ role: 'end_user', body: 'three' }],
+    });
+    expect(third.status).toBe(201);
 
     const all = await call(
       'GET',
@@ -888,15 +928,6 @@ const skipReason = TEST_URL
     expect(JSON.stringify(tooBig.json)).toMatch(/exceeds 1000 chars|too_big/i);
   });
 
-  it('still accepts long agent bodies (operator-pushed messages keep the 50K cap)', async () => {
-    const res = await call('POST', '/v1/widget/messages', widgetKey, {
-      channelId,
-      sessionId: 'vis_charcap_agent',
-      messages: [{ role: 'agent', body: 'b'.repeat(20_000) }],
-    });
-    expect(res.status).toBe(201);
-  });
-
   it('rejects an end_user bodyHtml over 4000 chars', async () => {
     const tooBig = await call('POST', '/v1/widget/messages', widgetKey, {
       channelId,
@@ -1013,14 +1044,13 @@ const skipReason = TEST_URL
 
   it('returns authorKind and authorName on listed agent messages', async () => {
     const sid = `vis_author_${Date.now()}`;
-    await call('POST', '/v1/widget/messages', widgetKey, {
+    const first = await call('POST', '/v1/widget/messages', widgetKey, {
       channelId,
       sessionId: sid,
-      messages: [
-        { role: 'end_user', body: 'help' },
-        { role: 'agent', body: 'sure thing' },
-      ],
+      messages: [{ role: 'end_user', body: 'help' }],
     });
+    expect(first.status).toBe(201);
+    await insertAgentMessage((first.json as { conversationId: string }).conversationId, 'sure thing', sid);
     const res = await call(
       'GET',
       `/v1/widget/messages?${qs({ channelId, sessionId: sid })}`,
@@ -1048,14 +1078,13 @@ const skipReason = TEST_URL
       });
     try {
       const sid = `vis_assistant_${Date.now()}`;
-      await call('POST', '/v1/widget/messages', widgetKey, {
+      const first = await call('POST', '/v1/widget/messages', widgetKey, {
         channelId,
         sessionId: sid,
-        messages: [
-          { role: 'end_user', body: 'hi' },
-          { role: 'agent', body: 'hello there' },
-        ],
+        messages: [{ role: 'end_user', body: 'hi' }],
       });
+      expect(first.status).toBe(201);
+      await insertAgentMessage((first.json as { conversationId: string }).conversationId, 'hello there', sid);
       const res = await call(
         'GET',
         `/v1/widget/messages?${qs({ channelId, sessionId: sid })}`,
@@ -1124,14 +1153,17 @@ const skipReason = TEST_URL
 
   it('returns readAt on listed messages, null until a conv_message_reads row exists', async () => {
     const sid = `vis_read_${Date.now()}`;
-    await call('POST', '/v1/widget/messages', widgetKey, {
+    const first = await call('POST', '/v1/widget/messages', widgetKey, {
       channelId,
       sessionId: sid,
-      messages: [
-        { role: 'end_user', body: 'hello there' },
-        { role: 'agent', body: 'an agent reply for read-state test' },
-      ],
+      messages: [{ role: 'end_user', body: 'hello there' }],
     });
+    expect(first.status).toBe(201);
+    await insertAgentMessage(
+      (first.json as { conversationId: string }).conversationId,
+      'an agent reply for read-state test',
+      sid,
+    );
 
     const firstRes = await call(
       'GET',

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -660,13 +660,12 @@ const skipReason = TEST_URL
     );
     expect(allowed.status).toBe(201);
 
-    // No Origin (server-to-server) still passes the allowlist gate.
     const noOrigin = await call('POST', '/v1/widget/messages', widgetKey, {
       channelId,
       sessionId: 'vis_origin_none',
       messages: [{ role: 'end_user', body: 'no origin' }],
     });
-    expect(noOrigin.status).toBe(201);
+    expect(noOrigin.status).toBe(403);
   });
 
   it('lists messages ordered ascending and filters by since', async () => {

--- a/packages/backend-core/src/modules/conv/widget/widget.types.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.types.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { WidgetIngestMessage } from './widget.types.ts';
+
+describe('WidgetIngestMessage role gate', () => {
+  it('accepts end_user (explicit)', () => {
+    const r = WidgetIngestMessage.safeParse({ role: 'end_user', body: 'hi' });
+    expect(r.success).toBe(true);
+  });
+
+  it('defaults role to end_user when omitted', () => {
+    const r = WidgetIngestMessage.safeParse({ body: 'hi' });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data.role).toBe('end_user');
+  });
+
+  it('rejects role=agent', () => {
+    const r = WidgetIngestMessage.safeParse({ role: 'agent', body: 'i am the AI' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects role=system', () => {
+    const r = WidgetIngestMessage.safeParse({ role: 'system', body: 'system msg' });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/backend-core/src/modules/conv/widget/widget.types.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.types.ts
@@ -14,44 +14,18 @@ export type WidgetChannelConfigT = z.infer<typeof WidgetChannelConfig>;
 export const WIDGET_END_USER_BODY_MAX_CHARS = 1_000;
 export const WIDGET_END_USER_BODY_HTML_MAX_CHARS = 4_000;
 
-export const WidgetIngestMessage = z
-  .object({
-    role: z.enum(['end_user', 'agent', 'system']),
-    body: z.string().min(1).max(50_000),
-    bodyHtml: z.string().max(200_000).optional(),
-    providerMessageId: z.string().min(1).max(200).optional(),
-    inReplyTo: z.string().min(1).max(200).optional(),
-    at: z
-      .string()
-      .datetime()
-      .optional()
-      .transform((s) => (s ? new Date(s) : undefined)),
-  })
-  .superRefine((msg, ctx) => {
-    if (msg.role !== 'end_user') return;
-    if (msg.body.length > WIDGET_END_USER_BODY_MAX_CHARS) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.too_big,
-        maximum: WIDGET_END_USER_BODY_MAX_CHARS,
-        type: 'string',
-        inclusive: true,
-        origin: 'string',
-        path: ['body'],
-        message: `end_user body exceeds ${WIDGET_END_USER_BODY_MAX_CHARS} chars`,
-      });
-    }
-    if (msg.bodyHtml && msg.bodyHtml.length > WIDGET_END_USER_BODY_HTML_MAX_CHARS) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.too_big,
-        maximum: WIDGET_END_USER_BODY_HTML_MAX_CHARS,
-        type: 'string',
-        inclusive: true,
-        origin: 'string',
-        path: ['bodyHtml'],
-        message: `end_user bodyHtml exceeds ${WIDGET_END_USER_BODY_HTML_MAX_CHARS} chars`,
-      });
-    }
-  });
+export const WidgetIngestMessage = z.object({
+  role: z.literal('end_user').default('end_user'),
+  body: z.string().min(1).max(WIDGET_END_USER_BODY_MAX_CHARS),
+  bodyHtml: z.string().max(WIDGET_END_USER_BODY_HTML_MAX_CHARS).optional(),
+  providerMessageId: z.string().min(1).max(200).optional(),
+  inReplyTo: z.string().min(1).max(200).optional(),
+  at: z
+    .string()
+    .datetime()
+    .optional()
+    .transform((s) => (s ? new Date(s) : undefined)),
+});
 
 export const WidgetIngestInput = z.object({
   channelId: z.string().min(1),

--- a/packages/backend-core/src/modules/conv/widget/widget.types.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.types.ts
@@ -61,6 +61,12 @@ export interface WidgetIngestResult {
 export const WidgetVoiceStartInput = z.object({
   channelId: z.string().min(1),
   conversationId: z.string().min(1),
+  sessionId: z.string().min(1).max(200),
+  verifiedExternalId: z.string().min(1).max(200).optional(),
+  userHash: z
+    .string()
+    .regex(/^[0-9a-f]{64}$/i, 'userHash must be a 64-char hex sha256 digest')
+    .optional(),
 });
 
 export type WidgetVoiceStartInputT = z.infer<typeof WidgetVoiceStartInput>;
@@ -68,6 +74,12 @@ export type WidgetVoiceStartInputT = z.infer<typeof WidgetVoiceStartInput>;
 export const WidgetVoiceEventInput = z.object({
   channelId: z.string().min(1),
   conversationId: z.string().min(1),
+  sessionId: z.string().min(1).max(200),
+  verifiedExternalId: z.string().min(1).max(200).optional(),
+  userHash: z
+    .string()
+    .regex(/^[0-9a-f]{64}$/i, 'userHash must be a 64-char hex sha256 digest')
+    .optional(),
   kind: z.enum(['started', 'ended']),
   durationSeconds: z.number().int().min(0).max(60 * 60 * 12).optional(),
 });

--- a/packages/backend-core/src/realtime/realtime.gateway.test.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { readBearerSubprotocol } from './realtime.gateway.ts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isOriginAllowedForCookieAuth, readBearerSubprotocol } from './realtime.gateway.ts';
 
 describe('readBearerSubprotocol', () => {
   it('returns null for undefined', () => {
@@ -28,5 +28,40 @@ describe('readBearerSubprotocol', () => {
 
   it('handles trailing commas and whitespace', () => {
     expect(readBearerSubprotocol('  bearer ,  mn_eu_xyz  , ')).toBe('mn_eu_xyz');
+  });
+});
+
+describe('isOriginAllowedForCookieAuth', () => {
+  const original = process.env.MUNIN_CORS_ORIGINS;
+
+  beforeEach(() => {
+    delete process.env.MUNIN_CORS_ORIGINS;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.MUNIN_CORS_ORIGINS;
+    else process.env.MUNIN_CORS_ORIGINS = original;
+  });
+
+  it('rejects when Origin header is missing', () => {
+    expect(isOriginAllowedForCookieAuth(undefined)).toBe(false);
+  });
+
+  it('accepts default dev origins when MUNIN_CORS_ORIGINS is unset', () => {
+    expect(isOriginAllowedForCookieAuth('http://localhost:3000')).toBe(true);
+  });
+
+  it('rejects non-allowlisted origins', () => {
+    process.env.MUNIN_CORS_ORIGINS = 'https://app.example.com';
+    expect(isOriginAllowedForCookieAuth('https://evil.example')).toBe(false);
+  });
+
+  it('accepts explicit allowlist matches', () => {
+    process.env.MUNIN_CORS_ORIGINS = 'https://app.example.com,https://www.example.com';
+    expect(isOriginAllowedForCookieAuth('https://app.example.com')).toBe(true);
+  });
+
+  it('accepts everything when MUNIN_CORS_ORIGINS is *', () => {
+    process.env.MUNIN_CORS_ORIGINS = '*';
+    expect(isOriginAllowedForCookieAuth('https://anywhere.example')).toBe(true);
   });
 });

--- a/packages/backend-core/src/realtime/realtime.gateway.test.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.test.ts
@@ -60,8 +60,9 @@ describe('isOriginAllowedForCookieAuth', () => {
     expect(isOriginAllowedForCookieAuth('https://app.example.com')).toBe(true);
   });
 
-  it('accepts everything when MUNIN_CORS_ORIGINS is *', () => {
+  it('rejects everything when MUNIN_CORS_ORIGINS is * (wildcard never grants cookie origins)', () => {
     process.env.MUNIN_CORS_ORIGINS = '*';
-    expect(isOriginAllowedForCookieAuth('https://anywhere.example')).toBe(true);
+    expect(isOriginAllowedForCookieAuth('https://anywhere.example')).toBe(false);
+    expect(isOriginAllowedForCookieAuth('http://localhost:3000')).toBe(false);
   });
 });

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -34,6 +34,7 @@ import {
   verifyIdentity,
 } from '../modules/conv/widget/widget-ingest.service.ts';
 import { WidgetChannelConfig } from '../modules/conv/widget/widget.types.ts';
+import { readAllowedOrigins } from '../bootstrap-app.ts';
 
 const PATH = '/v1/realtime';
 
@@ -157,14 +158,22 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     socket: Duplex,
     head: Buffer,
   ): Promise<void> {
-    let credential: ResolvedCredential | null = null;
+    let authResult: { credential: ResolvedCredential; fromCookie: boolean } | null = null;
     try {
-      credential = await this.authenticate(req);
+      authResult = await this.authenticate(req);
     } catch (err) {
       this.logger.debug(`upgrade auth failed: ${err instanceof Error ? err.message : String(err)}`);
     }
-    if (!credential) {
+    if (!authResult) {
       socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+    const credential = authResult.credential;
+
+    if (authResult.fromCookie && !isOriginAllowedForCookieAuth(readHeader(req, 'origin'))) {
+      this.logger.debug('upgrade rejected: cookie-authed WS origin not in allowlist');
+      socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
       socket.destroy();
       return;
     }
@@ -691,19 +700,24 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     };
   }
 
-  private async authenticate(req: IncomingMessage): Promise<ResolvedCredential | null> {
+  private async authenticate(
+    req: IncomingMessage,
+  ): Promise<{ credential: ResolvedCredential; fromCookie: boolean } | null> {
     const headerToken = readBearerToken(readHeader(req, 'authorization'));
     if (headerToken) {
-      return this.resolveToken(headerToken);
+      const credential = await this.resolveToken(headerToken);
+      return credential ? { credential, fromCookie: false } : null;
     }
     const subprotocolToken = readBearerSubprotocol(readHeader(req, 'sec-websocket-protocol'));
     if (subprotocolToken) {
-      return this.resolveToken(subprotocolToken);
+      const credential = await this.resolveToken(subprotocolToken);
+      return credential ? { credential, fromCookie: false } : null;
     }
     const cookieValue = readHeader(req, 'cookie');
     const sessionToken = readSessionCookie(cookieValue);
     if (sessionToken) {
-      return this.resolver.resolveSessionToken(sessionToken);
+      const credential = await this.resolver.resolveSessionToken(sessionToken);
+      return credential ? { credential, fromCookie: true } : null;
     }
     return null;
   }
@@ -774,6 +788,13 @@ function readSessionCookie(cookieHeader: string | undefined): string | null {
 
 function looksLikeApiKey(raw: string): boolean {
   return /^mn_[a-z]+_[A-Za-z0-9_-]+$/.test(raw);
+}
+
+export function isOriginAllowedForCookieAuth(origin: string | undefined): boolean {
+  if (!origin) return false;
+  const allowed = readAllowedOrigins();
+  if (allowed === true) return true;
+  return allowed.includes(origin);
 }
 
 function encodeChannel(msg: ClientMessage): string | null {

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -793,7 +793,7 @@ function looksLikeApiKey(raw: string): boolean {
 export function isOriginAllowedForCookieAuth(origin: string | undefined): boolean {
   if (!origin) return false;
   const allowed = readAllowedOrigins();
-  if (allowed === true) return true;
+  if (allowed === true) return false;
   return allowed.includes(origin);
 }
 

--- a/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
+++ b/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
@@ -249,15 +249,16 @@ const skipReason = TEST_URL
     ws.terminate();
   });
 
-  it('rejects upgrade with no Origin (browser keys must declare one)', async () => {
-    // Origin is required for browser-style widget keys; the upgrade gate
-    // calls enforceOriginAllowlist which only short-circuits when Origin
-    // is absent. We test absence-equals-pass at the REST layer; for WS
-    // we additionally don't expose any subprotocol hint that the caller
-    // is server-side, so the gate's permissive "no Origin" branch must
-    // still be exercised.
+  it('rejects upgrade with no Origin when an allowlist is configured', async () => {
     const ws = connectWs(widgetKey, {});
-    await waitForOpen(ws);
+    let err: Error | null = null;
+    try {
+      await waitForOpen(ws);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeTruthy();
+    expect(err!.message).toMatch(/upgrade rejected: 401/i);
     ws.terminate();
   });
 

--- a/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
+++ b/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
@@ -892,15 +892,23 @@ const skipReason = TEST_URL
       body: JSON.stringify({
         channelId,
         sessionId,
-        messages: [
-          { role: 'end_user', body: 'hello' },
-          { role: 'agent', body: 'first reply' },
-          { role: 'agent', body: 'second reply' },
-          { role: 'agent', body: 'third reply' },
-        ],
+        messages: [{ role: 'end_user', body: 'hello' }],
       }),
     });
     const conversationId = ((await ingestRes.json()) as { conversationId: string }).conversationId;
+
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    for (const body of ['first reply', 'second reply', 'third reply']) {
+      await db.insert(schema.convMessages).values({
+        orgId,
+        conversationId,
+        authorType: 'agent',
+        authorId: 'widget-agent',
+        body,
+        internal: false,
+        metadata: { sessionId },
+      });
+    }
 
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
     const agentRows = await db

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,7 @@ export {
 export {
   assertPublicHost,
   isPrivateIp,
+  resolvePublicHost,
   safeFetch,
   SsrfBlockedError,
   type SafeFetchOptions,

--- a/packages/core/src/net/safe-fetch.ts
+++ b/packages/core/src/net/safe-fetch.ts
@@ -160,7 +160,14 @@ export async function assertPublicHost(
   hostname: string,
   opts: AssertPublicHostOptions = {},
 ): Promise<void> {
-  if (envBool('MUNIN_SSRF_ALLOW_PRIVATE')) return;
+  await resolvePublicHost(hostname, opts);
+}
+
+export async function resolvePublicHost(
+  hostname: string,
+  opts: AssertPublicHostOptions = {},
+): Promise<{ address: string; family: number } | null> {
+  if (envBool('MUNIN_SSRF_ALLOW_PRIVATE')) return null;
   const host = hostname.toLowerCase();
   if (!host) throw new SsrfBlockedError('empty host');
   if (BLOCKED_HOSTNAMES.has(host)) {
@@ -173,7 +180,7 @@ export async function assertPublicHost(
     if (isPrivateIp(host)) {
       throw new SsrfBlockedError(`ip ${hostname} is private/reserved`);
     }
-    return;
+    return { address: host, family: isIp(host) === 6 ? 6 : 4 };
   }
   const resolver = opts.resolver ?? defaultResolver;
   let records: { address: string; family: number }[];
@@ -192,6 +199,7 @@ export async function assertPublicHost(
       throw new SsrfBlockedError(`host ${hostname} resolves to private ip ${r.address}`);
     }
   }
+  return records[0]!;
 }
 
 function makeBlockingAgent(): Agent {

--- a/packages/types/src/channels.ts
+++ b/packages/types/src/channels.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const HOST_RE =
-  /^(localhost|(?:\d{1,3}\.){3}\d{1,3}|[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+)$/;
+  /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$/;
 
 const HostSchema = z.string().min(1).max(253).regex(HOST_RE);
 


### PR DESCRIPTION
## Summary

Addresses nine security issues surfaced by a code review of the pre-production codebase. All confirmed real against the working tree before this branch. Per `CLAUDE.md` Munin has no production users, so these fixes ship without back-compat shims.

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | Critical | `/mcp` credentialed-CORS open + session-cookie auth fallback | `AuthGuard` skips cookie fallback on `/mcp`; CORS middleware drops `Access-Control-Allow-Credentials` on public paths |
| 2 | High | Realtime WS accepts session cookies without Origin check | `RealtimeGateway` tracks `fromCookie` and requires Origin to be in `MUNIN_CORS_ORIGINS` for cookie-authed upgrades |
| 3 | High | Public widget key could post `agent`/`system` messages | `WidgetIngestMessage.role` is `z.literal('end_user')`; service forces `authorType = 'end_user'` |
| 4 | High | Widget endpoints unthrottled + Origin-allowlist bypassed when header absent | `WidgetController` adds `ThrottlerGuard` via `PublicThrottleModule`; `enforceOriginAllowlist` fails closed |
| 5 | High | Delegated end-user tokens could be minted with `admin` audience / `*` scopes | `MintDto` restricts to `self_service` literal + `SELF_SERVICE_SCOPES`; `MCPController` requires `actor.type === 'admin_agent'` for admin audience |
| 6 | High | Outbound webhooks via raw `fetch`, accept `http://` | `webhook.worker.ts` uses `safeFetch`; controller schema requires `https://` |
| 7 | Medium | SMS status callbacks update by provider SID alone with `bypass_rls=on` | Twilio + MessageBird adapters now scope updates by `orgId + channelId` |
| 8 | Medium | Tenant SMTP/IMAP hosts can point at private/loopback | Hostname regex tightened (no `localhost`/IPv4 literal); `assertPublicHost` called at save (`email.service.ts`) and connect (`email-adapter.ts`, `email.tools.ts`) |
| 9 | Medium | Web crawler reads full response bodies, no size cap | `web-crawl.ts` checks `content-length` and streams bodies up to a 5 MB cap |

## Notable design choices

- **No new env vars.** Reuses the existing `MUNIN_SSRF_ALLOW_PRIVATE` (safeFetch) and `MUNIN_CORS_ORIGINS` (CORS allowlist) levers. Per repo memory, no preemptive fallback chains.
- **https-only webhooks.** Self-hosters in dev can use ngrok/cloudflared/self-signed certs; option to allow `http://` deferred until a concrete deployment asks.
- **Widget rate limits.** Reuses `PublicThrottleModule` (60/min, 1000/hr per IP) — same defaults as other public endpoints.
- **Delegated-token defense in depth.** Both the schema (`Mint​Dto`) and the audience picker (`MCPController`) refuse to grant admin to anything that isn't `actor.type === 'admin_agent'`.

## Test plan

- [x] `pnpm typecheck` — clean across workspace
- [x] `pnpm -F @getmunin/core test` — 114 passed
- [x] `pnpm -F @getmunin/agent-runtime test` — 94 passed (includes all `web-crawl` tests)
- [x] `pnpm -F @getmunin/backend-core test` — 175 unit tests pass; **new unit suites:**
  - `auth.guard.test.ts` (3) — MCP cookie rejection
  - `bootstrap-app.test.ts` (+4) — CORS no-credentials on public paths
  - `realtime.gateway.test.ts` (+5) — Origin allowlist for cookie-authed WS
  - `delegated-token.controller.test.ts` (6) — admin/wildcard rejected
  - `webhooks.controller.test.ts` (5) — https-only URL schema
  - `widget.types.test.ts` (4) — role enum locked
- [ ] Integration tests (`*.integration.test.ts`) — gated on a `munin_test` DB role with `CREATE SCHEMA` privilege; failing locally with `permission denied for database munin_test` independent of these changes. CI should pick them up.
- [ ] Manual smoke against `docker compose up` per the verification section in the plan file (`/Users/kjell/.claude/plans/pls-check-if-these-spicy-whisper.md`):
  - `/mcp` cookie request returns 401, no `Access-Control-Allow-Credentials`
  - Cross-origin WS with session cookie is refused
  - Widget POST with `role: 'agent'` returns 400
  - Widget loop hits 429 around 60 req/min
  - `POST /v1/tokens/delegated` with `audiences: ['admin']` returns 400
  - `POST /v1/webhooks` with `http://...` returns 400
  - SMS callback isolation across orgs
  - Email channel save with `host: 127.0.0.1` returns 400
  - Crawl of >5 MB response aborts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)