### PR TITLE
Security audit fixes (findings 1–N)

### DIFF
--- a/packages/backend-core/src/modules/conv/email/email.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email.integration.test.ts
@@ -176,6 +176,18 @@ class StubImapFetcher implements ImapFetcher {
       return rows.length === 1;
     });
 
+    const setupAudit = await db
+      .select({ args: schema.auditLog.args })
+      .from(schema.auditLog)
+      .where(
+        and(
+          eq(schema.auditLog.orgId, orgId),
+          eq(schema.auditLog.tool, 'conv_email_setup_channel'),
+        ),
+      );
+    expect(setupAudit).toHaveLength(1);
+    expect(JSON.stringify(setupAudit[0]!.args)).not.toContain('app-pw-stub');
+
     // 2. Push an inbound email from a brand-new sender.
     fetcher.push(rfc822({
       from: 'Customer One <c1@customer.test>',

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.tools.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.tools.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
+import { sensitive } from '@getmunin/types';
 import { schema } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
@@ -17,22 +18,26 @@ const ConfigureInput = z.object({
     .optional()
     .describe('Pass an existing channel id to update; omit to create a new channel.'),
   name: z.string().min(1).max(120).optional(),
-  accessKey: z
-    .string()
-    .min(1)
-    .max(256)
-    .optional()
-    .describe(
-      'MessageBird live or test Access Key (used to authorize outbound SMS). Required on create. On update, omit to keep the existing value.',
-    ),
-  signingKey: z
-    .string()
-    .min(1)
-    .max(256)
-    .optional()
-    .describe(
-      'MessageBird signing key (used to verify the JWT on incoming webhooks). Required on create. On update, omit to keep the existing value.',
-    ),
+  accessKey: sensitive(
+    z
+      .string()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe(
+        'MessageBird live or test Access Key (used to authorize outbound SMS). Required on create. On update, omit to keep the existing value.',
+      ),
+  ),
+  signingKey: sensitive(
+    z
+      .string()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe(
+        'MessageBird signing key (used to verify the JWT on incoming webhooks). Required on create. On update, omit to keep the existing value.',
+      ),
+  ),
   originator: z
     .string()
     .min(1)

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms.tools.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms.tools.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
+import { sensitive } from '@getmunin/types';
 import { schema, type Db } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
@@ -24,14 +25,16 @@ const ConfigureInput = z.object({
     .max(64)
     .optional()
     .describe('Twilio Account SID — starts with "AC". Required on create.'),
-  authToken: z
-    .string()
-    .min(1)
-    .max(256)
-    .optional()
-    .describe(
-      'Twilio Auth Token (plaintext). Required on create. On update, omit to keep the existing token, or pass a new value to rotate.',
-    ),
+  authToken: sensitive(
+    z
+      .string()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe(
+        'Twilio Auth Token (plaintext). Required on create. On update, omit to keep the existing token, or pass a new value to rotate.',
+      ),
+  ),
   fromNumber: z
     .string()
     .min(2)

--- a/packages/backend-core/src/modules/conv/vapi/vapi.tools.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi.tools.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
+import { sensitive } from '@getmunin/types';
 import { schema } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
@@ -19,20 +20,24 @@ const ConfigureInput = z.object({
     .optional()
     .describe('Pass an existing channel id to update; omit to create a new channel.'),
   name: z.string().min(1).max(120).optional(),
-  apiKey: z
-    .string()
-    .min(1)
-    .max(256)
-    .optional()
-    .describe('Vapi API key. Required on create. On update, omit to keep the existing value.'),
-  webhookSecret: z
-    .string()
-    .min(1)
-    .max(256)
-    .optional()
-    .describe(
-      'Shared secret used to authenticate inbound webhooks from Vapi. In the Vapi dashboard go to the assistant\'s Advanced → Webhook Server → HTTP Headers and add header `X-Webhook-Secret` with this value. Required on create.',
-    ),
+  apiKey: sensitive(
+    z
+      .string()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe('Vapi API key. Required on create. On update, omit to keep the existing value.'),
+  ),
+  webhookSecret: sensitive(
+    z
+      .string()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe(
+        'Shared secret used to authenticate inbound webhooks from Vapi. In the Vapi dashboard go to the assistant\'s Advanced → Webhook Server → HTTP Headers and add header `X-Webhook-Secret` with this value. Required on create.',
+      ),
+  ),
   assistantId: z
     .string()
     .min(1)

--- a/packages/backend-core/src/realtime/realtime.end-user.integration.test.ts
+++ b/packages/backend-core/src/realtime/realtime.end-user.integration.test.ts
@@ -1,0 +1,323 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { WebSocket } from 'ws';
+import { buildApiKey, hashSecret } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { AppModule } from '../app.module.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run end-user WS integration tests.';
+
+(skipReason ? describe.skip : describe)('Realtime end_user_agent subscription gate', () => {
+  let app: INestApplication;
+  let wsBase: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let channelId: string;
+  let endUserAId: string;
+  let endUserBId: string;
+  let contactBId: string;
+  let conversationAId: string;
+  let conversationBId: string;
+  let tokenA: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod-it-must-be-32-chars';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED = '1';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(
+      /(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/,
+      '$1munin_app:munin_app@',
+    );
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db.insert(schema.orgs).values({ name: 'EU RT Gate Org' }).returning();
+    orgId = org!.id;
+
+    const [chan] = await db
+      .insert(schema.convChannels)
+      .values({ orgId, type: 'chat', vendor: 'munin', name: 'Web chat', config: {} })
+      .returning();
+    channelId = chan!.id;
+
+    const [euA] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: 'eu-a', name: 'A' })
+      .returning();
+    const [euB] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: 'eu-b', name: 'B' })
+      .returning();
+    endUserAId = euA!.id;
+    endUserBId = euB!.id;
+
+    const [ctcA] = await db
+      .insert(schema.convContacts)
+      .values({ orgId, endUserId: endUserAId, name: 'A' })
+      .returning();
+    const [ctcB] = await db
+      .insert(schema.convContacts)
+      .values({ orgId, endUserId: endUserBId, name: 'B' })
+      .returning();
+    contactBId = ctcB!.id;
+
+    const [convA] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        displayId: 1,
+        channelId,
+        contactId: ctcA!.id,
+        endUserId: endUserAId,
+      })
+      .returning();
+    const [convB] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        displayId: 2,
+        channelId,
+        contactId: ctcB!.id,
+        endUserId: endUserBId,
+      })
+      .returning();
+    conversationAId = convA!.id;
+    conversationBId = convB!.id;
+
+    tokenA = buildApiKey('dlg');
+    await db.insert(schema.tokens).values({
+      orgId,
+      type: 'delegated_end_user',
+      tokenHash: hashSecret(tokenA),
+      scopes: ['conv:read', 'conv:write'],
+      audiences: ['self_service'],
+      endUserId: endUserAId,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    wsBase = `ws://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  function connectWs(token: string): WebSocket {
+    return new WebSocket(`${wsBase}/v1/realtime`, ['bearer', token]);
+  }
+
+  async function waitForOpen(ws: WebSocket, timeoutMs = 1500): Promise<void> {
+    if (ws.readyState === WebSocket.OPEN) return;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`ws never opened within ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+      ws.once('open', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      ws.once('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      ws.once('unexpected-response', (_req, res) => {
+        clearTimeout(timer);
+        reject(new Error(`upgrade rejected: ${res.statusCode}`));
+      });
+    });
+  }
+
+  async function emit(type: string, payload: Record<string, unknown>): Promise<void> {
+    const json = JSON.stringify({
+      id: `evt_${Math.random().toString(36).slice(2)}`,
+      org_id: orgId,
+      type,
+      actor_id: null,
+      correlation_id: null,
+      hop_count: 0,
+      payload,
+      created_at: new Date().toISOString(),
+    });
+    await db.execute(sql`SELECT pg_notify('munin_events', ${json})`);
+  }
+
+  function nextEvent(
+    ws: WebSocket,
+    predicate: (msg: { type: string; channel?: string; event?: { type: string } }) => boolean,
+    timeoutMs = 1500,
+  ): Promise<{ channel?: string; event?: { type: string; payload?: Record<string, unknown> } }> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`no matching event within ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+      const onMessage = (data: WebSocket.RawData) => {
+        try {
+          const text = decodeWsData(data);
+          const msg = JSON.parse(text) as {
+            type: string;
+            channel?: string;
+            event?: { type: string; payload?: Record<string, unknown> };
+          };
+          if (predicate(msg)) {
+            clearTimeout(timer);
+            ws.off('message', onMessage);
+            resolve(msg);
+          }
+        } catch {
+          // ignore
+        }
+      };
+      ws.on('message', onMessage);
+    });
+  }
+
+  function expectNoEvent(
+    ws: WebSocket,
+    predicate: (msg: { type: string; channel?: string }) => boolean,
+    withinMs = 600,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.off('message', onMessage);
+        resolve();
+      }, withinMs);
+      const onMessage = (data: WebSocket.RawData) => {
+        try {
+          const msg = JSON.parse(decodeWsData(data)) as { type: string; channel?: string };
+          if (predicate(msg)) {
+            clearTimeout(timer);
+            ws.off('message', onMessage);
+            reject(new Error(`unexpected event: ${JSON.stringify(msg)}`));
+          }
+        } catch {
+          // ignore
+        }
+      };
+      ws.on('message', onMessage);
+    });
+  }
+
+  it('rejects org-wide subscriptions for delegated end-user tokens', async () => {
+    const ws = connectWs(tokenA);
+    await waitForOpen(ws);
+    try {
+      ws.send(JSON.stringify({ type: 'subscribe', channel: 'org' }));
+      await new Promise((r) => setTimeout(r, 100));
+
+      const noEventP = expectNoEvent(ws, (m) => m.type === 'event', 600);
+      await emit('conversation.created', {
+        conversationId: conversationBId,
+        channelId,
+      });
+      await noEventP;
+    } finally {
+      ws.terminate();
+    }
+  });
+
+  it('rejects subscriptions to another end-user\'s conversation', async () => {
+    const ws = connectWs(tokenA);
+    await waitForOpen(ws);
+    try {
+      ws.send(
+        JSON.stringify({ type: 'subscribe', channel: 'conversation', id: conversationBId }),
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      const noEventP = expectNoEvent(
+        ws,
+        (m) => m.type === 'event' && m.channel === `conversation:${conversationBId}`,
+        600,
+      );
+      await emit('conversation.message.received', {
+        conversationId: conversationBId,
+        messageId: 'msg_fake',
+        authorType: 'end_user',
+        internal: false,
+      });
+      await noEventP;
+    } finally {
+      ws.terminate();
+    }
+  });
+
+  it('rejects subscriptions to another end-user\'s contact channel', async () => {
+    const ws = connectWs(tokenA);
+    await waitForOpen(ws);
+    try {
+      ws.send(JSON.stringify({ type: 'subscribe', channel: 'contact', id: contactBId }));
+      await new Promise((r) => setTimeout(r, 100));
+
+      const noEventP = expectNoEvent(
+        ws,
+        (m) => m.type === 'event' && m.channel === `contact:${contactBId}`,
+        600,
+      );
+      await emit('contact.updated', { contactId: contactBId });
+      await noEventP;
+    } finally {
+      ws.terminate();
+    }
+  });
+
+  it('accepts subscriptions to the end-user\'s own conversation', async () => {
+    const ws = connectWs(tokenA);
+    await waitForOpen(ws);
+    try {
+      ws.send(
+        JSON.stringify({ type: 'subscribe', channel: 'conversation', id: conversationAId }),
+      );
+      await new Promise((r) => setTimeout(r, 150));
+
+      const evP = nextEvent(
+        ws,
+        (m) =>
+          m.type === 'event' &&
+          m.channel === `conversation:${conversationAId}` &&
+          m.event?.type === 'conversation.message.received',
+      );
+      await emit('conversation.message.received', {
+        conversationId: conversationAId,
+        messageId: 'msg_real',
+        authorType: 'end_user',
+        internal: false,
+      });
+      const ev = await evP;
+      expect(ev.event!.type).toBe('conversation.message.received');
+    } finally {
+      ws.terminate();
+    }
+  });
+});
+
+function decodeWsData(data: WebSocket.RawData): string {
+  if (typeof data === 'string') return data;
+  if (Buffer.isBuffer(data)) return data.toString('utf8');
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf8');
+  return Buffer.from(data).toString('utf8');
+}

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -306,14 +306,6 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
 
     const unsubscribe = this.listener.subscribe((event) => {
       if (event.org_id !== actor.orgId) return;
-      if (
-        !isWidget &&
-        actor.type === 'end_user_agent' &&
-        actor.endUserId &&
-        !ownsEvent(event, actor.endUserId)
-      ) {
-        return;
-      }
       for (const channel of subscriptions) {
         if (isWidget) {
           void this.matchWidgetEvent(channel, event, conversationMetaCache, widgetCtx).then(
@@ -360,8 +352,21 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       if (isWidget) {
         if (!key.startsWith(`widget:${widgetCtx.channelId}:`)) return;
       }
-      if (msg.type === 'subscribe') addChannelSubscription(key);
-      else if (msg.type === 'unsubscribe') removeChannelSubscription(key);
+      if (msg.type === 'subscribe') {
+        if (isWidget) {
+          addChannelSubscription(key);
+        } else {
+          this.allowSubscription(actor, key)
+            .then((allowed) => {
+              if (allowed) addChannelSubscription(key);
+            })
+            .catch((err: unknown) =>
+              this.logger.warn(`subscription gate failed: ${describeError(err)}`),
+            );
+        }
+      } else if (msg.type === 'unsubscribe') {
+        removeChannelSubscription(key);
+      }
     });
 
     ws.on('close', () => {
@@ -700,6 +705,30 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     };
   }
 
+  private async allowSubscription(actor: ActorIdentity, key: string): Promise<boolean> {
+    if (actor.type !== 'end_user_agent') return true;
+    if (!actor.endUserId) return false;
+    if (key.startsWith('conversation:')) {
+      const conversationId = key.slice('conversation:'.length);
+      const rows = await this.db
+        .select({ endUserId: schema.convConversations.endUserId })
+        .from(schema.convConversations)
+        .where(eq(schema.convConversations.id, conversationId))
+        .limit(1);
+      return rows[0]?.endUserId === actor.endUserId;
+    }
+    if (key.startsWith('contact:')) {
+      const contactId = key.slice('contact:'.length);
+      const rows = await this.db
+        .select({ endUserId: schema.convContacts.endUserId })
+        .from(schema.convContacts)
+        .where(eq(schema.convContacts.id, contactId))
+        .limit(1);
+      return rows[0]?.endUserId === actor.endUserId;
+    }
+    return false;
+  }
+
   private async authenticate(
     req: IncomingMessage,
   ): Promise<{ credential: ResolvedCredential; fromCookie: boolean } | null> {
@@ -822,12 +851,6 @@ function channelMatches(channel: string, event: EventRow): boolean {
     return event.payload?.['contactId'] === id;
   }
   return false;
-}
-
-function ownsEvent(event: EventRow, endUserId: string): boolean {
-  const owner = event.payload?.['endUserId'];
-  if (typeof owner === 'string') return owner === endUserId;
-  return event.type.startsWith('conversation.');
 }
 
 function describeError(err: unknown): string {

--- a/packages/mcp-toolkit/src/dispatch.ts
+++ b/packages/mcp-toolkit/src/dispatch.ts
@@ -5,6 +5,7 @@ import {
   type Audience,
 } from '@getmunin/core';
 import type { McpToolRegistry } from './registry.ts';
+import { redactSensitive } from './sensitive.ts';
 import type { RegisteredSkill, SkillRegistry } from './skill-registry.ts';
 
 export interface DispatchContext {
@@ -123,7 +124,7 @@ export async function callTool(
   }
   await ctx.audit.record({
     tool: tool.meta.name,
-    args: parseResult.data,
+    args: redactSensitive(tool.meta.input, parseResult.data) as Record<string, unknown>,
     result: 'ok',
     durationMs: Date.now() - startedAt,
   });

--- a/packages/mcp-toolkit/src/index.ts
+++ b/packages/mcp-toolkit/src/index.ts
@@ -13,3 +13,5 @@ export {
   type ToolCallResult,
   type ToolListing,
 } from './dispatch.ts';
+export { redactSensitive } from './sensitive.ts';
+export { sensitive, isSensitiveSchema } from '@getmunin/types';

--- a/packages/mcp-toolkit/src/sensitive.test.ts
+++ b/packages/mcp-toolkit/src/sensitive.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { sensitive } from '@getmunin/types';
+import { redactSensitive } from './sensitive.ts';
+
+describe('redactSensitive', () => {
+  it('redacts a top-level sensitive field', () => {
+    const schema = z.object({
+      name: z.string(),
+      apiKey: sensitive(z.string()),
+    });
+    const out = redactSensitive(schema, { name: 'alice', apiKey: 'sk-live-abc' });
+    expect(out).toEqual({ name: 'alice', apiKey: '[REDACTED]' });
+  });
+
+  it('redacts inside nested objects', () => {
+    const schema = z.object({
+      config: z.object({
+        host: z.string(),
+        password: sensitive(z.string()),
+      }),
+    });
+    const out = redactSensitive(schema, {
+      config: { host: 'smtp.example.com', password: 'hunter2' },
+    });
+    expect(out).toEqual({ config: { host: 'smtp.example.com', password: '[REDACTED]' } });
+  });
+
+  it('redacts inside a discriminated union variant', () => {
+    const schema = z.object({
+      outbound: z.discriminatedUnion('provider', [
+        z.object({ provider: z.literal('smtp'), password: sensitive(z.string()) }),
+        z.object({ provider: z.literal('mailer') }),
+      ]),
+    });
+    const out = redactSensitive(schema, {
+      outbound: { provider: 'smtp', password: 'hunter2' },
+    });
+    expect(out).toEqual({ outbound: { provider: 'smtp', password: '[REDACTED]' } });
+  });
+
+  it('redacts inside arrays', () => {
+    const schema = z.object({
+      tokens: z.array(z.object({ value: sensitive(z.string()) })),
+    });
+    const out = redactSensitive(schema, {
+      tokens: [{ value: 'a' }, { value: 'b' }],
+    });
+    expect(out).toEqual({ tokens: [{ value: '[REDACTED]' }, { value: '[REDACTED]' }] });
+  });
+
+  it('preserves undefined for missing optional sensitive fields', () => {
+    const schema = z.object({
+      apiKey: sensitive(z.string().optional()),
+    });
+    expect(redactSensitive(schema, {})).toEqual({});
+  });
+
+  it('does not redact unmarked fields', () => {
+    const schema = z.object({ public: z.string(), authToken: z.string() });
+    const out = redactSensitive(schema, { public: 'p', authToken: 't' });
+    expect(out).toEqual({ public: 'p', authToken: 't' });
+  });
+
+  it('handles refined object schemas (top-level .refine)', () => {
+    const schema = z
+      .object({ apiKey: sensitive(z.string()), name: z.string() })
+      .refine((v) => v.name.length > 0);
+    const out = redactSensitive(schema, { apiKey: 'sk', name: 'ok' });
+    expect(out).toEqual({ apiKey: '[REDACTED]', name: 'ok' });
+  });
+});

--- a/packages/mcp-toolkit/src/sensitive.ts
+++ b/packages/mcp-toolkit/src/sensitive.ts
@@ -1,0 +1,105 @@
+import type { z } from 'zod';
+import { isSensitiveSchema } from '@getmunin/types';
+
+const REDACTED = '[REDACTED]';
+
+export function redactSensitive(schema: z.ZodType | undefined, value: unknown): unknown {
+  if (!schema) return value;
+  if (isSensitiveSchema(schema)) {
+    return value === undefined ? undefined : REDACTED;
+  }
+  const inner = unwrap(schema);
+  if (isSensitiveSchema(inner)) {
+    return value === undefined ? undefined : REDACTED;
+  }
+  const def = (inner as { _zod?: { def?: ZodDef } })._zod?.def;
+  if (!def) return value;
+  switch (def.type) {
+    case 'object': {
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) return value;
+      const shape = (def as ZodObjectDef).shape;
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        const childSchema = shape[k];
+        out[k] = childSchema ? redactSensitive(childSchema, v) : v;
+      }
+      return out;
+    }
+    case 'array': {
+      if (!Array.isArray(value)) return value;
+      const element = (def as ZodArrayDef).element;
+      return value.map((v) => redactSensitive(element, v));
+    }
+    case 'union':
+    case 'discriminated_union': {
+      if (value === null || typeof value !== 'object') return value;
+      const options = (def as ZodUnionDef).options ?? [];
+      const variant = pickUnionVariant(options, value);
+      return redactSensitive(variant ?? undefined, value);
+    }
+    case 'record': {
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) return value;
+      const valueSchema = (def as ZodRecordDef).valueType;
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        out[k] = redactSensitive(valueSchema, v);
+      }
+      return out;
+    }
+    default:
+      return value;
+  }
+}
+
+interface ZodDef {
+  type: string;
+  innerType?: z.ZodType;
+}
+interface ZodObjectDef extends ZodDef {
+  type: 'object';
+  shape: Record<string, z.ZodType>;
+}
+interface ZodArrayDef extends ZodDef {
+  type: 'array';
+  element: z.ZodType;
+}
+interface ZodUnionDef extends ZodDef {
+  type: 'union' | 'discriminated_union';
+  options: z.ZodType[];
+}
+interface ZodRecordDef extends ZodDef {
+  type: 'record';
+  valueType: z.ZodType;
+}
+
+function unwrap(schema: z.ZodType): z.ZodType {
+  let current = schema;
+  for (let i = 0; i < 8; i++) {
+    const def = (current as { _zod?: { def?: ZodDef } })._zod?.def;
+    if (!def) return current;
+    if (
+      (def.type === 'optional' ||
+        def.type === 'nullable' ||
+        def.type === 'default' ||
+        def.type === 'readonly' ||
+        def.type === 'pipe' ||
+        def.type === 'catch' ||
+        def.type === 'transform' ||
+        def.type === 'lazy') &&
+      def.innerType
+    ) {
+      current = def.innerType;
+      continue;
+    }
+    return current;
+  }
+  return current;
+}
+
+function pickUnionVariant(options: z.ZodType[], value: object): z.ZodType | null {
+  for (const opt of options) {
+    const result = opt.safeParse(value);
+    if (result.success) return opt;
+  }
+  return null;
+}

--- a/packages/types/src/channels.ts
+++ b/packages/types/src/channels.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { sensitive } from './sensitive.ts';
 
 const HOST_RE =
   /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$/;
@@ -11,7 +12,7 @@ export const SmtpOutboundSchema = z.object({
   port: z.number().int().min(1).max(65535),
   secure: z.boolean(),
   username: z.string().min(1),
-  password: z.string().min(1).optional(),
+  password: sensitive(z.string().min(1).optional()),
   trackOpens: z.boolean().optional(),
 });
 
@@ -31,7 +32,7 @@ export const ImapInboundSchema = z.object({
   port: z.number().int().min(1).max(65535),
   secure: z.boolean(),
   username: z.string().min(1),
-  password: z.string().min(1).optional(),
+  password: sensitive(z.string().min(1).optional()),
   mailbox: z.string().max(120).optional(),
 });
 
@@ -93,7 +94,7 @@ export const ConfigureTwilioSmsBody = z
     channelId: z.string().optional(),
     name: z.string().min(1).max(120).optional(),
     accountSid: z.string().min(2).max(64).optional(),
-    authToken: z.string().min(1).max(256).optional(),
+    authToken: sensitive(z.string().min(1).max(256).optional()),
     fromNumber: z.string().regex(E164, 'must be E.164').max(32).optional(),
     messagingServiceSid: z.string().min(2).max(64).optional(),
   })
@@ -123,8 +124,8 @@ export const ConfigureMessageBirdSmsBody = z
   .object({
     channelId: z.string().optional(),
     name: z.string().min(1).max(120).optional(),
-    accessKey: z.string().min(1).max(256).optional(),
-    signingKey: z.string().min(1).max(256).optional(),
+    accessKey: sensitive(z.string().min(1).max(256).optional()),
+    signingKey: sensitive(z.string().min(1).max(256).optional()),
     originator: z.string().min(1).max(32).optional(),
   })
   .refine(
@@ -150,8 +151,8 @@ export const ConfigureVapiBody = z
   .object({
     channelId: z.string().optional(),
     name: z.string().min(1).max(120).optional(),
-    apiKey: z.string().min(1).max(256).optional(),
-    webhookSecret: z.string().min(1).max(256).optional(),
+    apiKey: sensitive(z.string().min(1).max(256).optional()),
+    webhookSecret: sensitive(z.string().min(1).max(256).optional()),
     assistantId: z.string().min(1).max(128).optional(),
     phoneNumberId: z.string().min(1).max(128).optional(),
     publicKey: z.string().min(1).max(256).optional(),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,6 +30,7 @@ export {
   VapiCallInitiateBody,
   type VapiCallInitiateBodyT,
 } from './channels.ts';
+export { sensitive, isSensitiveSchema } from './sensitive.ts';
 export {
   KNOWN_SKILL_URIS,
   KNOWN_TASK_URIS,

--- a/packages/types/src/sensitive.ts
+++ b/packages/types/src/sensitive.ts
@@ -1,0 +1,12 @@
+import type { z } from 'zod';
+
+const SENSITIVE_SCHEMAS = new WeakSet<object>();
+
+export function sensitive<T extends z.ZodType>(schema: T): T {
+  SENSITIVE_SCHEMAS.add(schema);
+  return schema;
+}
+
+export function isSensitiveSchema(schema: unknown): boolean {
+  return typeof schema === 'object' && schema !== null && SENSITIVE_SCHEMAS.has(schema);
+}


### PR DESCRIPTION
## Summary

Closes findings 1 and 2 from the latest audit pass. Branch is now a single commit on top of `main` (earlier branch commits landed via #289).

**Finding 2 (high) — realtime gateway leaked conversation events across end-users within an org.** `ownsEvent()` returned `true` for any `conversation.*` event whose payload lacked `endUserId` (most don't carry it), so a delegated `end_user_agent` token could subscribe to `org` or any `conversation:<id>` and receive other users' conversation metadata.

Fix: subscriptions are now gated at subscribe time for `end_user_agent`. `conversation:<id>` requires `convConversations.endUserId` match; `contact:<id>` requires `convContacts.endUserId` match; `org` and other channels reject. Removed the unsafe `ownsEvent` fallback.

**Finding 1 (high) — MCP `audit_log.args` stored plaintext provider secrets.** Email/IMAP passwords, Twilio `authToken`, MessageBird `accessKey`/`signingKey`, Vapi `apiKey`/`webhookSecret` all reach the MCP boundary plaintext (they're encrypted into `conv_channels.config` later). The dispatcher was recording raw `parseResult.data` into the audit row.

Fix: added a `sensitive()` Zod marker in `@getmunin/types` and a `redactSensitive()` walker in `@getmunin/mcp-toolkit`. The walker handles object shapes, discriminated/regular unions, arrays, records, and `optional`/`default`/`pipe`/`transform`/`lazy` wrappers. The dispatcher redacts args before `audit.record`. Markers applied to every plaintext-secret field in the channel tools. Zod-to-JSON-Schema output is unchanged (the marker only flips a `WeakSet` bit).

## Test plan

- [x] `pnpm typecheck` clean on touched packages
- [x] `pnpm -F @getmunin/backend-core test` — 620/620 pass (with `TEST_DATABASE_URL`)
- [x] `pnpm -F @getmunin/mcp-toolkit test` — 19/19 (includes new `sensitive.test.ts`)
- [x] New `realtime.end-user.integration.test.ts` (4 cases): `org` rejection, cross-user `conversation:`/`contact:` rejection, positive own-conversation case
- [x] `email.integration.test.ts` asserts the `conv_email_setup_channel` audit row does not contain the plaintext IMAP password
- [ ] Reviewer: confirm no concern about not backfilling existing `audit_log.args` rows (project memory: no production users yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)