### PR TITLE
fix(kb): protect seeded agent-runtime docs from deletion

### DIFF
--- a/packages/backend-core/src/modules/kb/kb.service.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.test.ts
@@ -193,6 +193,48 @@ const skipReason = TEST_URL
     await expect(run(() => svc.getDocument(doc.id))).rejects.toThrow(KbNotFoundError);
   });
 
+  it('marks seeded agent-runtime docs as system and rejects deletion', async () => {
+    const space = await run(() =>
+      svc.createSpace({ name: 'Agent runtime', slug: 'agent-runtime' }),
+    );
+    const sysDoc = await run(() =>
+      svc.createDocument({
+        spaceId: space.id,
+        slug: 'system-prompt',
+        title: 'System prompt',
+        body: 'You are helpful.',
+      }),
+    );
+    expect(sysDoc.isSystem).toBe(true);
+
+    await expect(
+      run(() => svc.deleteDocument({ id: sysDoc.id, ifVersion: sysDoc.version })),
+    ).rejects.toThrow(KbInvalidError);
+
+    const edited = await run(() =>
+      svc.updateDocument({
+        id: sysDoc.id,
+        ifVersion: sysDoc.version,
+        body: 'You are very helpful.',
+      }),
+    );
+    expect(edited.body).toBe('You are very helpful.');
+    expect(edited.isSystem).toBe(true);
+
+    const userDoc = await run(() =>
+      svc.createDocument({
+        spaceId: space.id,
+        slug: 'team-handbook',
+        title: 'Team handbook',
+        body: 'Internal notes.',
+      }),
+    );
+    expect(userDoc.isSystem).toBe(false);
+    await run(() =>
+      svc.deleteDocument({ id: userDoc.id, ifVersion: userDoc.version }),
+    );
+  });
+
   it('round-trips a slug through createDocument and getDocumentBySlug', async () => {
     const space = await run(() =>
       svc.createSpace({ name: 'Agent runtime', slug: 'agent-runtime' }),

--- a/packages/backend-core/src/modules/kb/kb.service.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.ts
@@ -1,7 +1,13 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import { schema } from '@getmunin/db';
-import { chunkDocument, contentHash, getCurrentContext, WebhookDispatcher } from '@getmunin/core';
+import {
+  chunkDocument,
+  contentHash,
+  getCurrentContext,
+  isSystemRuntimeDoc,
+  WebhookDispatcher,
+} from '@getmunin/core';
 import type { ActorIdentity, Audience } from '@getmunin/core';
 import { EmbeddingProviderHolder } from './embedding.provider.ts';
 import { QUOTAS_SERVICE, type QuotasService } from '../../common/quotas/quotas.service.ts';
@@ -61,6 +67,7 @@ export interface DocumentDto {
   audiences: Audience[];
   version: number;
   tags: string[];
+  isSystem: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -207,13 +214,14 @@ export class KbService {
   }): Promise<DocumentDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await this.assertSpaceExists(input.spaceId);
+    const space = await this.loadSpace(input.spaceId);
     await this.quotas.assertCanAdd('kb_documents');
     if (input.slug !== undefined && !isValidSlug(input.slug)) {
       throw new KbInvalidError(`slug must match [a-z0-9][a-z0-9-]{0,63}`);
     }
     const audiences = normaliseAudiences(input.audiences);
     const hash = contentHash(input.title, input.body);
+    const isSystem = isSystemRuntimeDoc(space.slug, input.slug ?? null);
     const [doc] = await ctx.db
       .insert(schema.kbDocuments)
       .values({
@@ -226,6 +234,7 @@ export class KbService {
         version: 1,
         contentHash: hash,
         tags: input.tags ?? [],
+        isSystem,
         ...stampCreator(actor),
       })
       .returning();
@@ -315,6 +324,11 @@ export class KbService {
   async deleteDocument(input: { id: string; ifVersion: number }): Promise<{ deleted: true }> {
     const ctx = getCurrentContext();
     const existing = await this.loadForUpdate(input.id);
+    if (existing.isSystem) {
+      throw new KbInvalidError(
+        `document ${input.id} is system-managed and cannot be deleted (content can still be edited via kb_update_document)`,
+      );
+    }
     if (existing.version !== input.ifVersion) {
       throw new KbConflictError(existing.version, input.ifVersion);
     }
@@ -506,14 +520,16 @@ export class KbService {
 
   // ─── Internals ──────────────────────────────────────────────────────────
 
-  private async assertSpaceExists(spaceId: string): Promise<void> {
+  private async loadSpace(spaceId: string): Promise<typeof schema.kbSpaces.$inferSelect> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
-      .select({ id: schema.kbSpaces.id })
+      .select()
       .from(schema.kbSpaces)
       .where(eq(schema.kbSpaces.id, spaceId))
       .limit(1);
-    if (!rows[0]) throw new KbNotFoundError('space', spaceId);
+    const row = rows[0];
+    if (!row) throw new KbNotFoundError('space', spaceId);
+    return row;
   }
 
   private async assertDocumentExists(documentId: string): Promise<void> {
@@ -607,6 +623,7 @@ function toDocumentDto(row: typeof schema.kbDocuments.$inferSelect): DocumentDto
     audiences: row.audiences,
     version: row.version,
     tags: row.tags,
+    isSystem: row.isSystem,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };

--- a/packages/backend-core/src/modules/kb/kb.tools.ts
+++ b/packages/backend-core/src/modules/kb/kb.tools.ts
@@ -215,7 +215,7 @@ export class KbAdminTools {
     name: 'kb_delete_document',
     title: 'KB: Delete document',
     description:
-      'Delete a knowledge-base document. Pass `ifVersion` for optimistic concurrency. Cascades to chunks and versions.',
+      'Delete a knowledge-base document. Pass `ifVersion` for optimistic concurrency. Cascades to chunks and versions. System-managed docs (e.g. the seeded `agent-runtime` prompts) cannot be deleted — edit their content with `kb_update_document` instead.',
     audiences: ['admin'],
     scopes: ['kb:write'],
     input: DeleteDocumentInput,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ export {
   SEEDABLE_PROMPTS,
   type SeedablePrompt,
   getSeedablePrompt,
+  isSystemRuntimeDoc,
   type KbDocLocation,
   type KbDocReader,
   type PromptCache,

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -135,3 +135,13 @@ export const SEEDABLE_PROMPTS: readonly SeedablePrompt[] = [
 export function getSeedablePrompt(slug: string): SeedablePrompt | undefined {
   return SEEDABLE_PROMPTS.find((p) => p.slug === slug);
 }
+
+export function isSystemRuntimeDoc(
+  spaceSlug: string | null | undefined,
+  docSlug: string | null | undefined,
+): boolean {
+  if (!spaceSlug || !docSlug) return false;
+  if (spaceSlug !== AGENT_RUNTIME_PROMPT_SPACE_SLUG) return false;
+  if (SEEDABLE_PROMPTS.some((p) => p.slug === docSlug)) return true;
+  return docSlug.startsWith(CHANNEL_PROMPT_PREFIX);
+}

--- a/packages/db/drizzle/0033_kb_documents_is_system.sql
+++ b/packages/db/drizzle/0033_kb_documents_is_system.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "kb_documents"
+  ADD COLUMN IF NOT EXISTS "is_system" boolean NOT NULL DEFAULT false;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1780300000000,
       "tag": "0032_feedback_outbox",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1780400000000,
+      "tag": "0033_kb_documents_is_system",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -656,6 +656,7 @@ export const kbDocuments = pgTable(
     version: integer('version').notNull().default(1),
     contentHash: varchar('content_hash', { length: 64 }).notNull(),
     tags: jsonb('tags').$type<string[]>().notNull().default([]),
+    isSystem: boolean('is_system').notNull().default(false),
     createdByType: varchar('created_by_type', { length: 16 }).notNull(),
     // 'agent' | 'user'
     createdById: text('created_by_id').notNull(),


### PR DESCRIPTION
## Summary

- Adds an `is_system` flag to `kb_documents`, auto-set at create time for the seeded `agent-runtime/<seeded-slug>` and `agent-runtime/channel-*` documents via a new `isSystemRuntimeDoc` predicate in `@getmunin/core`.
- `kb_delete_document` now rejects system-managed docs outright with `KbInvalidError`. Content (title/body/audiences/tags) stays editable via `kb_update_document` so self-service runtime config keeps working.
- Surfaces `isSystem` on `DocumentDto` and updates the `kb_delete_document` tool description to spell out the constraint.

Without this, an admin agent calling `kb_delete_document` on the system prompt or a channel descriptor would silently break the runner — there was nothing on the API surface preventing it.

## Test plan
- [x] `pnpm -F @getmunin/backend-core exec vitest run src/modules/kb/kb.service.test.ts` — 18 tests pass, including a new case asserting: system doc gets `isSystem=true` on seed; delete rejected with `KbInvalidError`; content update still succeeds; non-system doc still deletable.
- [ ] After deploy, verify migration `0033_kb_documents_is_system.sql` applies cleanly (idempotent `ADD COLUMN IF NOT EXISTS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)