### PR TITLE
fix(dashboard): stabilize agent-health banner height and mobile layout

### DIFF
--- a/.changeset/agent-banner-height.md
+++ b/.changeset/agent-banner-height.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+fix(dashboard): keep agent-health banner at a stable 48px height across state changes, match topbar's mobile padding, and hide the CTA below `md` so the message text gets the freed width

--- a/packages/dashboard-pages/src/components/agent-health-banner.tsx
+++ b/packages/dashboard-pages/src/components/agent-health-banner.tsx
@@ -66,10 +66,10 @@ export function AgentHealthBanner() {
     <div
       role="alert"
       aria-live="polite"
-      className="agent-banner sticky top-0 z-50 h-12 border-b-[0.5px] border-ink bg-amber-100 text-ink dark:bg-amber-200/90 dark:text-ink"
+      className="agent-banner sticky top-0 z-50 h-12 overflow-hidden border-b-[0.5px] border-ink bg-amber-100 text-ink dark:bg-amber-200/90 dark:text-ink"
     >
-      <div className="mx-auto flex h-full items-center gap-4 px-10">
-        <span className="flex shrink-0 items-center gap-2 whitespace-nowrap border-r border-ink/25 pr-3.5 font-mono text-[10px] uppercase tracking-[0.16em]">
+      <div className="mx-auto flex h-full items-center gap-4 px-4 md:px-10">
+        <span className="flex shrink-0 items-center gap-2 whitespace-nowrap border-r border-ink/25 pr-3.5 font-mono text-[10px] uppercase leading-none tracking-[0.16em]">
           <span className="size-[7px] animate-pulse rounded-full bg-ink" aria-hidden />
           {state.tag}
         </span>
@@ -77,7 +77,7 @@ export function AgentHealthBanner() {
         {state.cta && (
           <Link
             href={state.cta.href}
-            className="whitespace-nowrap border border-ink bg-transparent px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-ink transition-colors hover:bg-ink hover:text-amber-100"
+            className="hidden h-7 shrink-0 items-center whitespace-nowrap border border-ink bg-transparent px-3 font-mono text-[10px] uppercase leading-none tracking-[0.14em] text-ink transition-colors hover:bg-ink hover:text-amber-100 md:inline-flex"
           >
             {state.cta.label}
           </Link>


### PR DESCRIPTION
## Summary
- Locks the agent-health banner to a fixed 48px (`h-12 overflow-hidden`) so the height no longer jumps when switching between the *disconnected* and *agent runner offline* states (the latter has a CTA whose intrinsic height previously depended on the browser default line-height).
- Gives the CTA an explicit `h-7 inline-flex items-center leading-none` so its rendered height is deterministic; applies `leading-none` to the tag for the same reason.
- Matches the topbar's mobile padding (`px-4 md:px-10`) so the banner aligns with the header.
- Hides the CTA below `md` so the message has room to truncate instead of being squeezed out on mobile. Settings remain reachable via the topbar gear icon.

## Test plan
- [ ] On desktop, trigger the banner in both states and confirm the height stays at 48px with no shift.
- [ ] On mobile width (<768px), confirm the CTA is hidden and the message truncates with ellipsis.
- [ ] Confirm left/right padding aligns with the topbar at both breakpoints.
- [ ] Confirm "Reconnecting…" descenders are not clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)