### PR TITLE
fix(security): mark public delivery, webhooks, health, and signed-URL uploads anonymous

### DIFF
--- a/.changeset/public-controller-helper.md
+++ b/.changeset/public-controller-helper.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Fix accidentally protected public endpoints in cloud builds. Cloud
+registers AuthGuard globally via `APP_GUARD`, so any controller without
+`@AllowAnonymous()` gets a 401 — that left `/v1/cms/...` delivery,
+provider webhooks (`POST /v1/conversations/channels/:id/webhook`),
+health probes (`/healthz`, `/readyz`, `/version`), and signed-URL
+uploads (`/static/assets/upload`) accidentally auth-gated.
+
+Adds a `@PublicController(path, { throttle? })` helper that bundles
+`@Controller` + `@AllowAnonymous` (and optionally `ThrottlerGuard`)
+so the "public" intent is a single greppable declaration.

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -1,9 +1,10 @@
-import { All, Controller, Inject, Req, Res } from '@nestjs/common';
+import { All, Inject, Req, Res } from '@nestjs/common';
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import type { Db } from '@getmunin/db';
 import { readMailerFromEnv } from '@getmunin/core';
 import {
   DB,
+  PublicController,
   handleAuthRequest,
   readGithubProviderFromEnv,
   readGoogleProviderFromEnv,
@@ -20,7 +21,7 @@ import {
 
 const AUTH_URL_FALLBACK = 'http://localhost:3001';
 
-@Controller('auth')
+@PublicController('auth')
 export class AuthController {
   private readonly auth: MuninAuth;
 

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -1,4 +1,16 @@
-import { CanActivate, ExecutionContext, Inject, Injectable, Optional, SetMetadata, UnauthorizedException } from '@nestjs/common';
+import {
+  CanActivate,
+  Controller,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  Optional,
+  SetMetadata,
+  UnauthorizedException,
+  UseGuards,
+  applyDecorators,
+} from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
 import { CredentialResolver, type ResolvedCredential } from '@getmunin/core';
 import type { Db } from '@getmunin/db';
 import { DB } from '../db/db.module.ts';
@@ -15,6 +27,26 @@ import { mcpResourceUrl, resourceMetadataUrl } from '../../oauth/oauth.constants
  */
 export const ALLOW_ANONYMOUS = 'munin:allow-anonymous';
 export const AllowAnonymous = () => SetMetadata(ALLOW_ANONYMOUS, true);
+
+export interface PublicControllerOpts {
+  throttle?: boolean;
+}
+
+/**
+ * Class decorator for controllers whose every route is intentionally
+ * anonymous. Bundles `@Controller(path)` + `@AllowAnonymous()` so the
+ * "public" intent is a single, greppable declaration — keeping a new
+ * public route from accidentally inheriting the cloud build's global
+ * AuthGuard. Pass `{ throttle: true }` to also wrap `ThrottlerGuard`.
+ */
+export function PublicController(
+  path: string,
+  opts: PublicControllerOpts = {},
+): ClassDecorator {
+  const decorators: ClassDecorator[] = [Controller(path), AllowAnonymous()];
+  if (opts.throttle) decorators.push(UseGuards(ThrottlerGuard));
+  return applyDecorators(...decorators);
+}
 
 /**
  * Extension point: try additional resolvers when the built-in resolver

--- a/packages/backend-core/src/common/health.controller.ts
+++ b/packages/backend-core/src/common/health.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get } from '@nestjs/common';
+import { Get } from '@nestjs/common';
+import { PublicController } from './auth/auth.guard.ts';
 
-@Controller()
+@PublicController('')
 export class HealthController {
   @Get('healthz')
   healthz() {

--- a/packages/backend-core/src/common/storage/static-assets.controller.ts
+++ b/packages/backend-core/src/common/storage/static-assets.controller.ts
@@ -1,6 +1,5 @@
 import {
   BadRequestException,
-  Controller,
   ForbiddenException,
   Inject,
   NotFoundException,
@@ -13,6 +12,7 @@ import {
 import { LocalFsStorage, type AssetStorage } from '@getmunin/core';
 import type { Request, Response } from 'express';
 
+import { PublicController } from '../auth/auth.guard.ts';
 import { STORAGE } from './storage.token.ts';
 
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024; // 50 MB; tighten via Org.settings later.
@@ -33,7 +33,7 @@ const MAX_UPLOAD_BYTES = 50 * 1024 * 1024; // 50 MB; tighten via Org.settings la
  * S3 URL, reads go to the bucket's public host (or a CDN front
  * configured via MUNIN_STORAGE_S3_PUBLIC_BASE_URL).
  */
-@Controller('static/assets')
+@PublicController('static/assets')
 export class StaticAssetsController {
   constructor(@Inject(STORAGE) private readonly storage: AssetStorage) {}
 

--- a/packages/backend-core/src/control/auth-providers.controller.ts
+++ b/packages/backend-core/src/control/auth-providers.controller.ts
@@ -1,6 +1,5 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
-import { AllowAnonymous } from '../common/auth/auth.guard.ts';
+import { Get } from '@nestjs/common';
+import { PublicController } from '../common/auth/auth.guard.ts';
 import {
   readGithubProviderFromEnv,
   readGoogleProviderFromEnv,
@@ -11,9 +10,7 @@ interface AuthProvidersResponse {
   github: boolean;
 }
 
-@Controller('v1/auth/providers')
-@AllowAnonymous()
-@UseGuards(ThrottlerGuard)
+@PublicController('v1/auth/providers', { throttle: true })
 export class AuthProvidersController {
   @Get()
   list(): AuthProvidersResponse {

--- a/packages/backend-core/src/control/cms-delivery.controller.ts
+++ b/packages/backend-core/src/control/cms-delivery.controller.ts
@@ -1,5 +1,4 @@
 import {
-  Controller,
   Get,
   Header,
   Inject,
@@ -8,12 +7,11 @@ import {
   Query,
   Req,
   Res,
-  UseGuards,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
-import { ThrottlerGuard } from '@nestjs/throttler';
 import { schema, type Db } from '@getmunin/db';
 import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
+import { PublicController } from '../common/auth/auth.guard.ts';
 import { DB } from '../common/db/db.module.ts';
 import { CmsSearchService } from '../modules/cms/cms.search.ts';
 import { projectData, type FieldDef } from '../modules/cms/cms.fields.ts';
@@ -30,8 +28,7 @@ import { projectData, type FieldDef } from '../modules/cms/cms.fields.ts';
  * context, and there's no auth here. Every SELECT hard-filters
  * `org_id` and `status='published'` so cross-org leakage is impossible.
  */
-@Controller('v1/cms')
-@UseGuards(ThrottlerGuard)
+@PublicController('v1/cms', { throttle: true })
 export class CmsDeliveryController {
   constructor(
     @Inject(DB) private readonly db: Db,

--- a/packages/backend-core/src/control/outreach-unsubscribe.controller.ts
+++ b/packages/backend-core/src/control/outreach-unsubscribe.controller.ts
@@ -1,8 +1,8 @@
-import { Controller, Get, Inject, Query, BadRequestException } from '@nestjs/common';
+import { Get, Inject, Query, BadRequestException } from '@nestjs/common';
 import { eq, and } from 'drizzle-orm';
 import { schema, type Db } from '@getmunin/db';
 import { UnsubscribeTokenError, verifyUnsubscribeToken } from '@getmunin/core';
-import { AllowAnonymous } from '../common/auth/auth.guard.ts';
+import { PublicController } from '../common/auth/auth.guard.ts';
 import { DB } from '../common/db/db.module.ts';
 
 interface UnsubscribeResult {
@@ -11,12 +11,11 @@ interface UnsubscribeResult {
   contactFound: boolean;
 }
 
-@Controller('v1/outreach/unsubscribe')
+@PublicController('v1/outreach/unsubscribe')
 export class OutreachUnsubscribeController {
   constructor(@Inject(DB) private readonly db: Db) {}
 
   @Get()
-  @AllowAnonymous()
   async unsubscribe(@Query('token') token?: string): Promise<UnsubscribeResult> {
     if (!token) throw new BadRequestException('token required');
     let payload;

--- a/packages/backend-core/src/control/public-mcp-tools.controller.ts
+++ b/packages/backend-core/src/control/public-mcp-tools.controller.ts
@@ -1,6 +1,5 @@
-import { Controller, Get, Inject, NotFoundException, Param, UseGuards } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
-import { AllowAnonymous } from '../common/auth/auth.guard.ts';
+import { Get, Inject, NotFoundException, Param } from '@nestjs/common';
+import { PublicController } from '../common/auth/auth.guard.ts';
 import { McpRegistryService } from '../mcp/mcp.registry.ts';
 import type { RegisteredMcpTool } from '@getmunin/mcp-toolkit';
 
@@ -18,9 +17,7 @@ interface PublicMcpToolDetail extends PublicMcpToolListItem {
   inputSchema: object;
 }
 
-@Controller('v1/public/mcp-tools')
-@AllowAnonymous()
-@UseGuards(ThrottlerGuard)
+@PublicController('v1/public/mcp-tools', { throttle: true })
 export class PublicMcpToolsController {
   constructor(@Inject(McpRegistryService) private readonly registry: McpRegistryService) {}
 

--- a/packages/backend-core/src/control/public-skills.controller.ts
+++ b/packages/backend-core/src/control/public-skills.controller.ts
@@ -1,6 +1,5 @@
-import { Controller, Get, Inject, NotFoundException, Param, UseGuards } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
-import { AllowAnonymous } from '../common/auth/auth.guard.ts';
+import { Get, Inject, NotFoundException, Param } from '@nestjs/common';
+import { PublicController } from '../common/auth/auth.guard.ts';
 import { McpSkillRegistryService } from '../mcp/mcp.skill-registry.service.ts';
 
 interface PublicSkillListItem {
@@ -16,9 +15,7 @@ interface PublicSkillDetail extends PublicSkillListItem {
   mimeType: string;
 }
 
-@Controller('v1/public/skills')
-@AllowAnonymous()
-@UseGuards(ThrottlerGuard)
+@PublicController('v1/public/skills', { throttle: true })
 export class PublicSkillsController {
   constructor(
     @Inject(McpSkillRegistryService) private readonly skills: McpSkillRegistryService,

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -41,6 +41,8 @@ export {
 export {
   AuthGuard,
   AllowAnonymous,
+  PublicController,
+  type PublicControllerOpts,
   type AuthenticatedRequest,
   ALLOW_ANONYMOUS,
   ADDITIONAL_CREDENTIAL_RESOLVERS,

--- a/packages/backend-core/src/modules/conv/channels/channel-webhook.controller.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-webhook.controller.ts
@@ -1,5 +1,4 @@
 import {
-  Controller,
   HttpException,
   HttpStatus,
   Inject,
@@ -13,6 +12,7 @@ import {
 import type { Request, Response } from 'express';
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, isNull } from 'drizzle-orm';
+import { PublicController } from '../../../common/auth/auth.guard.ts';
 import { DB } from '../../../common/db/db.module.ts';
 import {
   CHANNEL_ADAPTERS,
@@ -24,7 +24,7 @@ import {
 } from './adapter.ts';
 import { ChannelIngestService } from './channel-ingest.service.ts';
 
-@Controller('v1/conversations/channels')
+@PublicController('v1/conversations/channels')
 export class ChannelWebhookController {
   private readonly logger = new Logger(ChannelWebhookController.name);
   private readonly registry: ChannelAdapterRegistry;

--- a/packages/backend-core/src/oauth/oauth-as-alias.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-as-alias.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Header } from '@nestjs/common';
-import { AllowAnonymous } from '../common/auth/auth.guard.ts';
+import { Get, Header } from '@nestjs/common';
+import { PublicController } from '../common/auth/auth.guard.ts';
 import { authorizationServerUrl, SUPPORTED_SCOPES } from './oauth.constants.ts';
 
 interface AuthorizationServerMetadata {
@@ -19,10 +19,9 @@ interface AuthorizationServerMetadata {
   resource_indicators_supported: boolean;
 }
 
-@Controller('.well-known/oauth-authorization-server')
+@PublicController('.well-known/oauth-authorization-server')
 export class OAuthAsAliasController {
   @Get()
-  @AllowAnonymous()
   @Header('content-type', 'application/json; charset=utf-8')
   @Header('cache-control', 'public, max-age=300')
   metadata(): AuthorizationServerMetadata {

--- a/packages/backend-core/src/oauth/oauth-client-info.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-client-info.controller.ts
@@ -1,5 +1,4 @@
 import {
-  Controller,
   Get,
   Header,
   Inject,
@@ -8,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { schema, type Db } from '@getmunin/db';
-import { AllowAnonymous } from '../common/auth/auth.guard.ts';
+import { PublicController } from '../common/auth/auth.guard.ts';
 import { DB } from '../common/db/db.module.ts';
 
 interface OAuthClientInfo {
@@ -28,12 +27,11 @@ interface OAuthClientInfo {
  * Anonymous on purpose — the consent page is rendered for any user
  * mid-authorization, before the OAuth flow has issued any credential.
  */
-@Controller('v1/oauth/clients')
+@PublicController('v1/oauth/clients')
 export class OAuthClientInfoController {
   constructor(@Inject(DB) private readonly db: Db) {}
 
   @Get(':clientId')
-  @AllowAnonymous()
   @Header('cache-control', 'public, max-age=60')
   async lookup(@Param('clientId') clientId: string): Promise<OAuthClientInfo> {
     const rows = await this.db

--- a/packages/backend-core/src/oauth/oauth-resource.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Header } from '@nestjs/common';
-import { AllowAnonymous } from '../common/auth/auth.guard.ts';
+import { Get, Header } from '@nestjs/common';
+import { PublicController } from '../common/auth/auth.guard.ts';
 import {
   authorizationServerUrl,
   mcpResourceUrl,
@@ -15,10 +15,9 @@ interface ProtectedResourceMetadata {
   resource_indicators_supported: boolean;
 }
 
-@Controller('.well-known/oauth-protected-resource')
+@PublicController('.well-known/oauth-protected-resource')
 export class OAuthResourceController {
   @Get()
-  @AllowAnonymous()
   @Header('content-type', 'application/json; charset=utf-8')
   @Header('cache-control', 'public, max-age=3600')
   metadata(): ProtectedResourceMetadata {

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,8 @@
         ".next/**",
         "!.next/cache/**",
         "build/**",
-        "tsconfig.tsbuildinfo"
+        "tsconfig.tsbuildinfo",
+        "tsconfig.build.tsbuildinfo"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Summary

- Cloud registers `AuthGuard` as a global `APP_GUARD` in `backend-cloud/src/app.module.ts`. Every controller without `@AllowAnonymous()` returns 401 to anonymous callers. Four public-intent controllers were missing the bypass and were silently auth-gated in cloud:
  - `CmsDeliveryController` (`/v1/cms/...`)
  - `ChannelWebhookController` (`POST /v1/conversations/channels/:id/webhook`)
  - `HealthController` (`/healthz`, `/readyz`, `/version`)
  - `StaticAssetsController` (`PUT/POST /static/assets/upload`)
- Adds a `@PublicController(path, { throttle? })` helper that bundles `@Controller` + `@AllowAnonymous` (and optionally `ThrottlerGuard`) so the "public" intent is one greppable declaration.
- Migrates the existing class-level-anonymous controllers (OAuth discovery, public skills / mcp-tools, auth providers, outreach unsubscribe, OAuth client lookup) to the helper for consistency. Method-level mixed controllers (`email-opens`, `accept-invitation`) are intentionally left alone.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck`
- [x] `pnpm -F @getmunin/backend typecheck`
- [x] Migrations applied against local dev DB
- [ ] After merge + publish + bump in `munin-cloud`, hit `https://api.getmunin.com/v1/cms/<orgId>/<collection>` anonymously and confirm it returns published entries (not 401)
- [ ] Confirm `/healthz`, `/readyz`, `/version` return 200 anonymously in cloud
- [ ] Confirm `/v1/orgs/me` and `/mcp` are still 401 (no auth-gated regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)