### PR TITLE
fix(mcp): allow OAuth-authorized callers to reach admin tools

### DIFF
--- a/.changeset/mcp-oauth-admin-audience.md
+++ b/.changeset/mcp-oauth-admin-audience.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+fix(mcp): allow OAuth-authorized callers (`actor.type === 'user'`) to reach admin tools. The audience-derivation gate added in #289 required `actor.type === 'admin_agent'`, which excluded the OAuth bearer-token flow used by claude.ai-style MCP connectors and collapsed every admin tool to `self_service`. Replace the actor-type equality check with an allowlist (`'admin_agent'` + `'user'`) so the defense-in-depth against `widget_agent` / `end_user_agent` / `partner` / `system` actors with a forged admin audience stays in place while OAuth users get the admin surface their granted scopes already entitle them to.

--- a/packages/backend-core/src/mcp/mcp.audience.test.ts
+++ b/packages/backend-core/src/mcp/mcp.audience.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { ActorIdentity, type ActorType, type Audience } from '@getmunin/core';
+import { deriveMcpAudience } from './mcp.audience.ts';
+
+function actor(type: ActorType, audiences: Audience[]): ActorIdentity {
+  return new ActorIdentity(type, 'actor_test', 'org_test', ['*'], audiences);
+}
+
+describe('deriveMcpAudience', () => {
+  it('admin_agent with admin audience → admin', () => {
+    expect(deriveMcpAudience(actor('admin_agent', ['admin']))).toBe('admin');
+  });
+
+  it('OAuth user with admin audience → admin (claude.ai connector flow)', () => {
+    expect(deriveMcpAudience(actor('user', ['admin']))).toBe('admin');
+  });
+
+  it('end_user_agent with admin audience is clamped to self_service (defense-in-depth)', () => {
+    expect(deriveMcpAudience(actor('end_user_agent', ['admin']))).toBe('self_service');
+  });
+
+  it('widget_agent with admin audience is clamped to self_service (defense-in-depth)', () => {
+    expect(deriveMcpAudience(actor('widget_agent', ['admin']))).toBe('self_service');
+  });
+
+  it('admin_agent without admin in audiences → self_service', () => {
+    expect(deriveMcpAudience(actor('admin_agent', ['self_service']))).toBe('self_service');
+  });
+
+  it('admin_agent with both audiences → admin', () => {
+    expect(deriveMcpAudience(actor('admin_agent', ['admin', 'self_service']))).toBe('admin');
+  });
+
+  it('user with empty audiences → self_service', () => {
+    expect(deriveMcpAudience(actor('user', []))).toBe('self_service');
+  });
+
+  it('partner actor is not admin-eligible even with admin audience', () => {
+    expect(deriveMcpAudience(actor('partner', ['admin']))).toBe('self_service');
+  });
+
+  it('system actor is not admin-eligible even with admin audience', () => {
+    expect(deriveMcpAudience(actor('system', ['admin']))).toBe('self_service');
+  });
+});

--- a/packages/backend-core/src/mcp/mcp.audience.ts
+++ b/packages/backend-core/src/mcp/mcp.audience.ts
@@ -1,0 +1,9 @@
+import type { ActorIdentity, ActorType, Audience } from '@getmunin/core';
+
+const ADMIN_ELIGIBLE_ACTOR_TYPES: readonly ActorType[] = ['admin_agent', 'user'];
+
+export function deriveMcpAudience(actor: ActorIdentity): Audience {
+  return ADMIN_ELIGIBLE_ACTOR_TYPES.includes(actor.type) && actor.audiences.includes('admin')
+    ? 'admin'
+    : 'self_service';
+}

--- a/packages/backend-core/src/mcp/mcp.controller.ts
+++ b/packages/backend-core/src/mcp/mcp.controller.ts
@@ -11,7 +11,7 @@ import {
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { AuditLogger, getCurrentContext, type Audience } from '@getmunin/core';
+import { AuditLogger, getCurrentContext } from '@getmunin/core';
 import { createMcpServer } from '@getmunin/mcp-toolkit';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
@@ -20,6 +20,7 @@ import { McpRegistryService } from './mcp.registry.ts';
 import { McpSkillRegistryService } from './mcp.skill-registry.service.ts';
 import { RateLimitService } from '../common/rate-limit/rate-limit.service.ts';
 import { QUOTAS_SERVICE, type QuotasService } from '../common/quotas/quotas.service.ts';
+import { deriveMcpAudience } from './mcp.audience.ts';
 
 /**
  * Streamable HTTP entry point for the MCP server.
@@ -64,8 +65,7 @@ export class McpController {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
 
-    const audience: Audience =
-      actor.type === 'admin_agent' && actor.audiences.includes('admin') ? 'admin' : 'self_service';
+    const audience = deriveMcpAudience(actor);
 
     const server = createMcpServer({
       registry: this.registry,


### PR DESCRIPTION
## Summary

- **Regression fix for #289.** The audience-derivation check in `mcp.controller.ts` was tightened to require `actor.type === 'admin_agent'` AND `actor.audiences.includes('admin')`. OAuth bearer-token callers (claude.ai-style MCP connectors) resolve to `actor.type === 'user'`, so they were collapsed to `'self_service'` and only saw the 8 end-user tools — `cms_*`, `kb_create_document`, etc. were filtered out of `tools/list` even when the Authorize screen granted the matching scopes.
- Replace the equality check with an **allowlist** (`['admin_agent', 'user']`). OAuth users with admin-eligible audiences reach admin tools; `widget_agent` / `end_user_agent` / `partner` / `system` actors with a forged `'admin'` audience still get clamped to `'self_service'`, preserving the defense-in-depth #289 was after.
- Extract `deriveMcpAudience(actor)` into a tiny `mcp.audience.ts` and pin both branches with a 9-case unit test.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck` — clean
- [x] `pnpm -F @getmunin/backend-core exec vitest run src/mcp/mcp.audience.test.ts` — 9/9 pass
- [ ] CI green
- [ ] After deploy: reconnect Munin in claude.ai and confirm `tools/list` returns ~80 tools (incl. `cms_list_assets`, `cms_request_asset_upload`) instead of 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)