### PR TITLE
fix(security): role-gate sensitive routes, SSRF-harden provider URLs, add RLS for widget fallbacks

### DIFF
--- a/.changeset/security-role-guard-and-audit-fixes.md
+++ b/.changeset/security-role-guard-and-audit-fixes.md
@@ -1,0 +1,15 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/agent-host': patch
+'@getmunin/agent-runtime': patch
+'@getmunin/db': patch
+---
+
+**Security**: address four audit findings.
+
+- **High**: gate every sensitive control-plane endpoint on owner/admin role (webhooks, conversation channels, agent-config, org/assistant PATCH, etc.). Previously any signed-in member could rotate widget keys, change LLM provider credentials, or create event-exfiltrating webhooks.
+- **High**: agent provider URLs (`providerBaseUrl`) now route through `safeFetch` (blocks private/loopback/link-local hosts) and reject `http://` unless `MUNIN_SSRF_ALLOW_PRIVATE` is set. Closes the SSRF + credential-exfil path that let a misconfigured base URL leak the provider API key.
+- **High**: add RLS policy on `conv_widget_email_fallbacks` (the ledger had `org_id` but no policy). Plus a meta-test in `rls.test.ts` that fails when any `org_id`-bearing table is missing RLS.
+- **Medium**: expand role-coverage integration tests to cover the newly-gated endpoints (webhooks, conv channels, org/assistant PATCH).
+
+**Ergonomics**: introduce `@RequireRole(...)` / `@RequireActorType(...)` decorators + a single `RoleGuard` to replace inline `assertOwnerOrAdmin(...)` calls scattered across ~13 controllers. Conditional / body-dependent checks (`members:patch`) stay inline.

--- a/packages/agent-host/src/agent-health.controller.ts
+++ b/packages/agent-host/src/agent-health.controller.ts
@@ -1,31 +1,22 @@
+import { Controller, Get, Inject, UseGuards, UseInterceptors } from '@nestjs/common';
 import {
-  Controller,
-  ForbiddenException,
-  Get,
-  Inject,
-  UseGuards,
-  UseInterceptors,
-} from '@nestjs/common';
-import { getCurrentContext } from '@getmunin/core';
-import { AuditInterceptor, AuthGuard, TenancyInterceptor } from '@getmunin/backend-core';
+  AuditInterceptor,
+  AuthGuard,
+  TenancyInterceptor,
+  RoleGuard,
+  RequireActorType,
+} from '@getmunin/backend-core';
 import { AgentHealthService, type AgentHealthDto } from './agent-health.service.ts';
 
 @Controller('v1/agent-health')
-@UseGuards(AuthGuard)
+@UseGuards(AuthGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireActorType('user')
 export class AgentHealthController {
   constructor(@Inject(AgentHealthService) private readonly service: AgentHealthService) {}
 
   @Get()
   async get(): Promise<AgentHealthDto> {
-    requireUserActor();
     return this.service.getForCurrentActor();
-  }
-}
-
-function requireUserActor(): void {
-  const actor = getCurrentContext().actor;
-  if (!actor || actor.type !== 'user') {
-    throw new ForbiddenException('agent health is only readable from a signed-in dashboard session');
   }
 }

--- a/packages/agent-host/src/config.controller.test.ts
+++ b/packages/agent-host/src/config.controller.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { ProviderBaseUrl } from './config.controller.ts';
+
+describe('agent-config providerBaseUrl validation', () => {
+  it('accepts https:// urls', () => {
+    expect(ProviderBaseUrl.safeParse('https://provider.example/v1').success).toBe(true);
+  });
+
+  it('rejects http:// urls when MUNIN_SSRF_ALLOW_PRIVATE is unset', () => {
+    const prev = process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+    delete process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+    try {
+      expect(ProviderBaseUrl.safeParse('http://provider.example/v1').success).toBe(false);
+    } finally {
+      if (prev !== undefined) process.env.MUNIN_SSRF_ALLOW_PRIVATE = prev;
+    }
+  });
+
+  it('rejects http://localhost even with MUNIN_SSRF_ALLOW_PRIVATE unset', () => {
+    const prev = process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+    delete process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+    try {
+      expect(ProviderBaseUrl.safeParse('http://localhost:11434/v1').success).toBe(false);
+    } finally {
+      if (prev !== undefined) process.env.MUNIN_SSRF_ALLOW_PRIVATE = prev;
+    }
+  });
+
+  it('allows http:// when MUNIN_SSRF_ALLOW_PRIVATE=true (dev escape hatch for ollama etc.)', () => {
+    const prev = process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+    process.env.MUNIN_SSRF_ALLOW_PRIVATE = 'true';
+    try {
+      expect(ProviderBaseUrl.safeParse('http://localhost:11434/v1').success).toBe(true);
+    } finally {
+      if (prev !== undefined) process.env.MUNIN_SSRF_ALLOW_PRIVATE = prev;
+      else delete process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+    }
+  });
+
+  it('rejects non-http(s) protocols even with the escape hatch', () => {
+    const prev = process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+    process.env.MUNIN_SSRF_ALLOW_PRIVATE = 'true';
+    try {
+      expect(ProviderBaseUrl.safeParse('file:///etc/passwd').success).toBe(false);
+      expect(ProviderBaseUrl.safeParse('gopher://provider.example/').success).toBe(false);
+    } finally {
+      if (prev !== undefined) process.env.MUNIN_SSRF_ALLOW_PRIVATE = prev;
+      else delete process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+    }
+  });
+});

--- a/packages/agent-host/src/config.controller.ts
+++ b/packages/agent-host/src/config.controller.ts
@@ -2,7 +2,6 @@ import {
   BadRequestException,
   Body,
   Controller,
-  ForbiddenException,
   Get,
   Inject,
   Put,
@@ -10,15 +9,39 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { z } from 'zod';
-import { getCurrentContext } from '@getmunin/core';
-import { AuditInterceptor, AuthGuard, TenancyInterceptor } from '@getmunin/backend-core';
+import {
+  AuditInterceptor,
+  AuthGuard,
+  TenancyInterceptor,
+  RoleGuard,
+  RequireRole,
+  RequireActorType,
+} from '@getmunin/backend-core';
 import { AgentConfigService, type AgentConfigDto } from './config.service.ts';
 import { AgentModelsService, type ListModelsResult } from './models.service.ts';
+
+function allowPrivateProviderHosts(): boolean {
+  const v = process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+  return v === '1' || v === 'true';
+}
+
+export const ProviderBaseUrl = z
+  .string()
+  .url()
+  .refine((raw) => {
+    try {
+      const u = new URL(raw);
+      if (u.protocol === 'https:') return true;
+      return u.protocol === 'http:' && allowPrivateProviderHosts();
+    } catch {
+      return false;
+    }
+  }, 'provider base URL must use https:// (http:// only allowed when MUNIN_SSRF_ALLOW_PRIVATE is set)');
 
 const UpsertDto = z.object({
   fastModel: z.string().min(1).optional(),
   smartModel: z.string().min(1).nullable().optional(),
-  providerBaseUrl: z.string().url().optional(),
+  providerBaseUrl: ProviderBaseUrl.optional(),
   providerApiKey: z.string().min(1).nullable().optional(),
   maxHistoryChars: z.number().int().positive().optional(),
   maxToolIterations: z.number().int().positive().optional(),
@@ -26,8 +49,9 @@ const UpsertDto = z.object({
 });
 
 @Controller('v1/agent-config')
-@UseGuards(AuthGuard)
+@UseGuards(AuthGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireActorType('user')
 export class AgentConfigController {
   constructor(
     @Inject(AgentConfigService) private readonly service: AgentConfigService,
@@ -36,28 +60,20 @@ export class AgentConfigController {
 
   @Get()
   async get(): Promise<AgentConfigDto> {
-    requireUserActor();
     return this.service.getForCurrentActor();
   }
 
   @Put()
+  @RequireRole('owner', 'admin')
   async upsert(@Body() body: unknown): Promise<AgentConfigDto> {
-    requireUserActor();
     const parsed = UpsertDto.safeParse(body);
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return this.service.upsertForCurrentActor(parsed.data);
   }
 
   @Get('models')
+  @RequireRole('owner', 'admin')
   async listModels(): Promise<ListModelsResult> {
-    requireUserActor();
     return this.models.listForCurrentActor();
-  }
-}
-
-function requireUserActor(): void {
-  const actor = getCurrentContext().actor;
-  if (!actor || actor.type !== 'user') {
-    throw new ForbiddenException('agent config is only editable from a signed-in dashboard session');
   }
 }

--- a/packages/agent-host/src/models.service.test.ts
+++ b/packages/agent-host/src/models.service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as core from '@getmunin/core';
 import { AgentModelsService } from './models.service.ts';
 import type { AgentConfigRepository, AgentConfigRow } from './config.repository.ts';
 
@@ -28,20 +29,19 @@ function makeRepo(overrides: { apiKey?: string | null; row?: AgentConfigRow } = 
   };
 }
 
-function mockFetch(response: { status: number; body?: unknown }): void {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn().mockResolvedValue({
-      ok: response.status >= 200 && response.status < 300,
-      status: response.status,
-      json: () => Promise.resolve(response.body),
-    }),
-  );
+function mockSafeFetch(response: { status: number; body?: unknown }): ReturnType<typeof vi.fn> {
+  const fn = vi.fn().mockResolvedValue({
+    ok: response.status >= 200 && response.status < 300,
+    status: response.status,
+    json: () => Promise.resolve(response.body),
+  });
+  vi.spyOn(core, 'safeFetch').mockImplementation(fn);
+  return fn;
 }
 
 describe('AgentModelsService', () => {
   beforeEach(() => {
-    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   afterEach(() => {
@@ -57,7 +57,7 @@ describe('AgentModelsService', () => {
   });
 
   it('parses OpenRouter-shaped responses with context_length and pricing', async () => {
-    mockFetch({
+    mockSafeFetch({
       status: 200,
       body: {
         data: [
@@ -88,7 +88,7 @@ describe('AgentModelsService', () => {
   });
 
   it('handles entries without pricing or context_length (raw OpenAI shape)', async () => {
-    mockFetch({
+    mockSafeFetch({
       status: 200,
       body: {
         data: [
@@ -108,7 +108,7 @@ describe('AgentModelsService', () => {
   });
 
   it('returns supported:false when the provider returns 404', async () => {
-    mockFetch({ status: 404 });
+    mockSafeFetch({ status: 404 });
     const svc = new AgentModelsService(makeRepo());
     const result = await svc.listForCurrentActor();
     expect(result.supported).toBe(false);
@@ -116,19 +116,14 @@ describe('AgentModelsService', () => {
   });
 
   it('returns supported:false when the body is not the expected shape', async () => {
-    mockFetch({ status: 200, body: { unexpected: 'shape' } });
+    mockSafeFetch({ status: 200, body: { unexpected: 'shape' } });
     const svc = new AgentModelsService(makeRepo());
     const result = await svc.listForCurrentActor();
     expect(result.supported).toBe(false);
   });
 
   it('caches the response for the same (id, baseUrl) pair', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ data: [{ id: 'm-1' }] }),
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = mockSafeFetch({ status: 200, body: { data: [{ id: 'm-1' }] } });
     const svc = new AgentModelsService(makeRepo());
     await svc.listForCurrentActor();
     await svc.listForCurrentActor();
@@ -136,12 +131,7 @@ describe('AgentModelsService', () => {
   });
 
   it('strips trailing slashes from the base URL before appending /models', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ data: [] }),
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = mockSafeFetch({ status: 200, body: { data: [] } });
     const repo = makeRepo({
       row: { ...baseRow, providerBaseUrl: 'https://provider.example/v1//' },
     });
@@ -152,12 +142,7 @@ describe('AgentModelsService', () => {
   });
 
   it('uses Bearer auth for OAI-compat providers', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ data: [] }),
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = mockSafeFetch({ status: 200, body: { data: [] } });
     const svc = new AgentModelsService(makeRepo({ apiKey: 'sk-or-test' }));
     await svc.listForCurrentActor();
     const call = fetchMock.mock.calls[0] as [unknown, { headers: Record<string, string> }];
@@ -167,12 +152,7 @@ describe('AgentModelsService', () => {
   });
 
   it('uses x-api-key + anthropic-version on api.anthropic.com', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ data: [] }),
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = mockSafeFetch({ status: 200, body: { data: [] } });
     const repo = makeRepo({
       apiKey: 'sk-ant-test',
       row: { ...baseRow, providerBaseUrl: 'https://api.anthropic.com/v1' },

--- a/packages/agent-host/src/models.service.ts
+++ b/packages/agent-host/src/models.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { safeFetch } from '@getmunin/core';
 import { AGENT_CONFIG_REPOSITORY } from './injection-tokens.ts';
 import type { AgentConfigRepository } from './config.repository.ts';
 import { authHeaders } from './provider-auth.ts';
@@ -51,9 +52,9 @@ export class AgentModelsService {
 
   private async fetchModels(baseUrl: string, apiKey: string): Promise<ListModelsResult> {
     const url = `${baseUrl.replace(/\/+$/, '')}/models`;
-    let res: Response;
+    let res: Awaited<ReturnType<typeof safeFetch>>;
     try {
-      res = await fetch(url, {
+      res = await safeFetch(url, {
         method: 'GET',
         headers: authHeaders(baseUrl, apiKey),
       });

--- a/packages/agent-host/src/provider-auth.ts
+++ b/packages/agent-host/src/provider-auth.ts
@@ -1,9 +1,10 @@
 import { UnauthorizedException } from '@nestjs/common';
+import { safeFetch } from '@getmunin/core';
 
 export async function validateProviderCredentials(baseUrl: string, apiKey: string): Promise<void> {
   const root = baseUrl.replace(/\/+$/, '');
   if (/openrouter\.ai/i.test(baseUrl)) {
-    const res = await fetch(`${root}/auth/key`, {
+    const res = await safeFetch(`${root}/auth/key`, {
       headers: { authorization: `Bearer ${apiKey}`, accept: 'application/json' },
     });
     if (res.status === 401 || res.status === 403) {
@@ -11,7 +12,7 @@ export async function validateProviderCredentials(baseUrl: string, apiKey: strin
     }
     return;
   }
-  const res = await fetch(`${root}/models`, { headers: authHeaders(baseUrl, apiKey) });
+  const res = await safeFetch(`${root}/models`, { headers: authHeaders(baseUrl, apiKey) });
   if (res.status === 401 || res.status === 403) {
     throw new UnauthorizedException(`provider rejected the API key (${res.status})`);
   }

--- a/packages/agent-runtime/src/providers/openai-compatible.test.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import * as core from '@getmunin/core';
 import {
   shouldEnablePromptCache,
   withSystemPromptCache,
@@ -6,49 +7,60 @@ import {
 } from './openai-compatible.ts';
 import type { ChatMessage, ChatToolDefinition } from '../types.ts';
 
-import { vi } from 'vitest';
 import { openAiCompatibleProvider } from './openai-compatible.ts';
 
+function stubSafeFetch(
+  handler: (url: string, init: { body?: unknown }) => { status?: number; body: unknown },
+): ReturnType<typeof vi.fn> {
+  const fn = vi.fn((url: string, init: { body?: unknown }) => {
+    const out = handler(url, init);
+    const status = out.status ?? 200;
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(out.body),
+      text: () => Promise.resolve(typeof out.body === 'string' ? out.body : JSON.stringify(out.body)),
+    });
+  });
+  vi.spyOn(core, 'safeFetch').mockImplementation(fn as unknown as typeof core.safeFetch);
+  return fn;
+}
+
 describe('openAiCompatibleProvider request body', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('emits cache_control on system + last tool when targeting Anthropic', async () => {
     const captured: { url?: string; body?: Record<string, unknown> } = {};
-    const fakeFetch = vi.fn((url: string, init: RequestInit) => {
+    stubSafeFetch((url, init) => {
       captured.url = url;
       captured.body = JSON.parse(init.body as string) as Record<string, unknown>;
-      return Promise.resolve(new Response(
-        JSON.stringify({
+      return {
+        body: {
           choices: [
-            {
-              message: { role: 'assistant', content: 'ok' },
-              finish_reason: 'stop',
-            },
+            { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
           ],
           usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-        }),
-        { status: 200, headers: { 'content-type': 'application/json' } },
-      ));
-    });
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = fakeFetch as typeof fetch;
-    try {
-      await openAiCompatibleProvider({
-        config: {
-          provider: { baseUrl: 'https://api.anthropic.com/v1', apiKey: 'sk-ant-xxx' },
-          model: 'claude-haiku-4-5',
-          systemPrompt: 'sys',
         },
-        messages: [
-          { role: 'system', content: 'sys' },
-          { role: 'user', content: 'hi' },
-        ],
-        tools: [
-          { type: 'function', function: { name: 'a', description: 'a', parameters: {} } },
-          { type: 'function', function: { name: 'b', description: 'b', parameters: {} } },
-        ],
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+      };
+    });
+
+    await openAiCompatibleProvider({
+      config: {
+        provider: { baseUrl: 'https://api.anthropic.com/v1', apiKey: 'sk-ant-xxx' },
+        model: 'claude-haiku-4-5',
+        systemPrompt: 'sys',
+      },
+      messages: [
+        { role: 'system', content: 'sys' },
+        { role: 'user', content: 'hi' },
+      ],
+      tools: [
+        { type: 'function', function: { name: 'a', description: 'a', parameters: {} } },
+        { type: 'function', function: { name: 'b', description: 'b', parameters: {} } },
+      ],
+    });
 
     const messages = captured.body?.messages as Array<{ role: string; content: unknown }>;
     expect(messages[0]?.content).toEqual([
@@ -62,30 +74,25 @@ describe('openAiCompatibleProvider request body', () => {
 
   it('does NOT emit cache_control on plain OpenAI backend', async () => {
     const captured: { body?: Record<string, unknown> } = {};
-    const fakeFetch = vi.fn((_url: string, init: RequestInit) => {
+    stubSafeFetch((_url, init) => {
       captured.body = JSON.parse(init.body as string) as Record<string, unknown>;
-      return Promise.resolve(new Response(
-        JSON.stringify({
+      return {
+        body: {
           choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
-        }),
-        { status: 200, headers: { 'content-type': 'application/json' } },
-      ));
-    });
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = fakeFetch as typeof fetch;
-    try {
-      await openAiCompatibleProvider({
-        config: {
-          provider: { baseUrl: 'https://api.openai.com/v1', apiKey: 'sk-xxx' },
-          model: 'gpt-4o-mini',
-          systemPrompt: 'sys',
         },
-        messages: [{ role: 'system', content: 'sys' }],
-        tools: [{ type: 'function', function: { name: 'a', description: 'a', parameters: {} } }],
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+      };
+    });
+
+    await openAiCompatibleProvider({
+      config: {
+        provider: { baseUrl: 'https://api.openai.com/v1', apiKey: 'sk-xxx' },
+        model: 'gpt-4o-mini',
+        systemPrompt: 'sys',
+      },
+      messages: [{ role: 'system', content: 'sys' }],
+      tools: [{ type: 'function', function: { name: 'a', description: 'a', parameters: {} } }],
+    });
+
     const messages = captured.body?.messages as Array<{ content: unknown }>;
     expect(messages[0]?.content).toBe('sys');
     const tools = captured.body?.tools as Array<Record<string, unknown>>;

--- a/packages/agent-runtime/src/providers/openai-compatible.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.ts
@@ -1,3 +1,4 @@
+import { safeFetch } from '@getmunin/core';
 import type { ChatMessage, ChatToolDefinition, Provider, ProviderResponse } from '../types.ts';
 
 interface OpenAIChoice {
@@ -38,7 +39,7 @@ export const openAiCompatibleProvider: Provider = async ({
     body.response_format = { type: 'json_object' };
   }
 
-  const res = await fetch(url, {
+  const res = await safeFetch(url, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',

--- a/packages/backend-core/src/control/api-keys.controller.ts
+++ b/packages/backend-core/src/control/api-keys.controller.ts
@@ -20,7 +20,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
-import { assertOwnerOrAdmin } from './role-guard.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 const CreateApiKeyDto = z.object({
   name: z.string().min(1).max(128),
@@ -47,8 +48,9 @@ interface ApiKeySummary {
 }
 
 @Controller('v1/api-keys')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireRole('owner', 'admin')
 export class ApiKeysController {
   constructor(@Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher) {}
 
@@ -61,7 +63,6 @@ export class ApiKeysController {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     if (!actor.orgId) throw new BadRequestException('No org bound to caller');
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
 
     const rawKey = buildApiKey('admin');
     const [row] = await ctx.db
@@ -107,7 +108,6 @@ export class ApiKeysController {
   async list(): Promise<ApiKeySummary[]> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const rows = await ctx.db
       .select({
         id: schema.apiKeys.id,
@@ -136,7 +136,6 @@ export class ApiKeysController {
   async revoke(@Param('id') id: string): Promise<void> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const result = await ctx.db
       .update(schema.apiKeys)
       .set({ revokedAt: new Date() })

--- a/packages/backend-core/src/control/assistants.controller.ts
+++ b/packages/backend-core/src/control/assistants.controller.ts
@@ -15,6 +15,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 const PatchDto = z.object({
   name: z.string().max(64).nullable().optional(),
@@ -31,7 +33,7 @@ interface AssistantDto {
 }
 
 @Controller('v1/assistants/me')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 export class AssistantsController {
   @Get()
@@ -40,6 +42,7 @@ export class AssistantsController {
   }
 
   @Patch()
+  @RequireRole('owner', 'admin')
   async update(@Body() body: unknown): Promise<AssistantDto> {
     const parsed = PatchDto.safeParse(body);
     if (!parsed.success) throw new BadRequestException(parsed.error.message);

--- a/packages/backend-core/src/control/audit-log.controller.ts
+++ b/packages/backend-core/src/control/audit-log.controller.ts
@@ -6,7 +6,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
-import { assertOwnerOrAdmin } from './role-guard.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 interface AuditDto {
   id: string;
@@ -30,8 +31,9 @@ const PAGE_SIZE_DEFAULT = 50;
 const PAGE_SIZE_MAX = 200;
 
 @Controller('v1/admin/audit-logs')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireRole('owner', 'admin')
 export class AuditLogController {
   /**
    * Newest-first cursor pagination. `before` is the createdAt of the last
@@ -49,7 +51,6 @@ export class AuditLogController {
   ): Promise<{ items: AuditDto[]; nextCursor: string | null }> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const take = clampLimit(limit, PAGE_SIZE_DEFAULT, PAGE_SIZE_MAX);
 
     const filters: SQL[] = [eq(schema.auditLog.orgId, actor.orgId)];

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -774,6 +774,60 @@ interface OrgFixture {
       });
       expect(res.status).toBe(403);
     });
+
+    const WEBHOOK_MEMBER_DENIED = [
+      ['GET', '/v1/webhooks', undefined],
+      ['POST', '/v1/webhooks', { url: 'https://hook.example/x', events: [] }],
+    ] as const;
+    for (const [method, path, body] of WEBHOOK_MEMBER_DENIED) {
+      it(`member cannot ${method} ${path} (403)`, async () => {
+        const res = await fetch(`${baseUrl}${path}`, {
+          method,
+          headers: memberCookie,
+          body: body ? JSON.stringify(body) : undefined,
+        });
+        expect(res.status).toBe(403);
+      });
+    }
+
+    it('admin can list /v1/webhooks (200)', async () => {
+      const res = await fetch(`${baseUrl}/v1/webhooks`, { headers: adminCookie });
+      expect(res.status).toBe(200);
+    });
+
+    it('member cannot PATCH /v1/orgs/me (403)', async () => {
+      const res = await fetch(`${baseUrl}/v1/orgs/me`, {
+        method: 'PATCH',
+        headers: memberCookie,
+        body: JSON.stringify({ name: 'member-rename' }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('member cannot PATCH /v1/assistants/me (403)', async () => {
+      const res = await fetch(`${baseUrl}/v1/assistants/me`, {
+        method: 'PATCH',
+        headers: memberCookie,
+        body: JSON.stringify({ name: 'Hacky Hal' }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    const CONV_CHANNEL_MEMBER_DENIED = [
+      ['POST', '/v1/conversations/channels/widget', { name: 'w' }],
+      ['POST', '/v1/conversations/channels/widget/c_x/rotate-key', undefined],
+      ['POST', '/v1/conversations/channels/widget/c_x/rotate-identity-secret', undefined],
+    ] as const;
+    for (const [method, path, body] of CONV_CHANNEL_MEMBER_DENIED) {
+      it(`member cannot ${method} ${path} (403)`, async () => {
+        const res = await fetch(`${baseUrl}${path}`, {
+          method,
+          headers: memberCookie,
+          body: body ? JSON.stringify(body) : undefined,
+        });
+        expect(res.status).toBe(403);
+      });
+    }
   });
 
   // ─── realtime gateway (websocket auth) ──────────────────────────────

--- a/packages/backend-core/src/control/conv-channels.controller.ts
+++ b/packages/backend-core/src/control/conv-channels.controller.ts
@@ -15,6 +15,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 import { ConvService, type ChannelDto } from '../modules/conv/conv.service.ts';
 import { WidgetAdminTools } from '../modules/conv/widget/widget.tools.ts';
 import { EmailAdminTools } from '../modules/conv/email/email.tools.ts';
@@ -39,8 +41,9 @@ interface ChannelListResponse {
 }
 
 @Controller('v1/conversations/channels')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireRole('owner', 'admin')
 export class ConvChannelsController {
   constructor(
     private readonly conv: ConvService,

--- a/packages/backend-core/src/control/delegated-token.controller.ts
+++ b/packages/backend-core/src/control/delegated-token.controller.ts
@@ -15,6 +15,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireActorType } from './role.decorator.ts';
 
 export const SELF_SERVICE_SCOPES = [
   'cms:read',
@@ -62,8 +64,9 @@ interface MintResult {
  * is restricted to self-service tools, scoped to that one EndUser.
  */
 @Controller('v1/tokens/delegated')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireActorType('admin_agent')
 export class DelegatedTokenController {
   @Post()
   @HttpCode(201)
@@ -74,9 +77,6 @@ export class DelegatedTokenController {
 
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    if (actor.type !== 'admin_agent') {
-      throw new BadRequestException('only admin credentials may mint delegated tokens');
-    }
 
     // Resolve / upsert EndUser.
     let endUserId = input.endUserId;

--- a/packages/backend-core/src/control/end-users.controller.ts
+++ b/packages/backend-core/src/control/end-users.controller.ts
@@ -20,7 +20,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
-import { assertOwnerOrAdmin } from './role-guard.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 const EndUserPatchDto = z.object({
   externalId: z.string().optional(),
@@ -52,7 +53,7 @@ interface EndUserDto {
 }
 
 @Controller('v1/end-users')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 export class EndUsersController {
   constructor(@Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher) {}
@@ -78,10 +79,10 @@ export class EndUsersController {
   }
 
   @Get()
+  @RequireRole('owner', 'admin')
   async list(@Query('limit') limit?: string): Promise<EndUserDto[]> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const take = clampLimit(limit, 50, 200);
     const rows = await ctx.db
       .select()
@@ -94,10 +95,10 @@ export class EndUsersController {
 
   @Post(':id/revoke-tokens')
   @HttpCode(200)
+  @RequireRole('owner', 'admin')
   async revokeTokens(@Param('id') id: string): Promise<{ revoked: number }> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const result = await ctx.db
       .update(schema.tokens)
       .set({ revokedAt: new Date() })
@@ -119,10 +120,10 @@ export class EndUsersController {
   }
 
   @Get(':id')
+  @RequireRole('owner', 'admin')
   async get(@Param('id') id: string): Promise<EndUserDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const rows = await ctx.db
       .select()
       .from(schema.endUsers)

--- a/packages/backend-core/src/control/export.controller.ts
+++ b/packages/backend-core/src/control/export.controller.ts
@@ -6,7 +6,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
-import { assertOwnerOrAdmin } from './role-guard.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 interface ExportPayload {
   exportedAt: string;
@@ -26,15 +27,15 @@ interface ExportPayload {
  * not user content.
  */
 @Controller('v1/export')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireRole('owner', 'admin')
 export class ExportController {
   @Get()
   @Header('content-disposition', 'attachment; filename="munin-export.json"')
   async export(): Promise<ExportPayload> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
 
     const [org, endUsers, agents, kbSpaces, kbDocuments, kbDocumentVersions] =
       await Promise.all([

--- a/packages/backend-core/src/control/invitations.controller.ts
+++ b/packages/backend-core/src/control/invitations.controller.ts
@@ -16,6 +16,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireActorType, RequireRole } from './role.decorator.ts';
 import { InvitationsService } from './invitations.service.ts';
 
 const CreateInviteDto = z.object({
@@ -24,13 +26,15 @@ const CreateInviteDto = z.object({
 });
 
 @Controller('v1/orgs/me/invitations')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 export class InvitationsController {
   constructor(@Inject(InvitationsService) private readonly invites: InvitationsService) {}
 
   @Post()
   @HttpCode(201)
+  @RequireActorType('user')
+  @RequireRole('owner')
   async create(@Body() body: unknown) {
     const parsed = CreateInviteDto.safeParse(body);
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
@@ -38,12 +42,14 @@ export class InvitationsController {
   }
 
   @Get()
+  @RequireRole('owner', 'admin')
   list() {
     return this.invites.listPending();
   }
 
   @Delete(':id')
   @HttpCode(200)
+  @RequireRole('owner')
   revoke(@Param('id') id: string) {
     return this.invites.revoke(id);
   }

--- a/packages/backend-core/src/control/invitations.service.ts
+++ b/packages/backend-core/src/control/invitations.service.ts
@@ -1,10 +1,10 @@
 import {
   BadRequestException,
   ConflictException,
-  ForbiddenException,
   GoneException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
@@ -18,7 +18,7 @@ import {
 import { renderOrgInviteEmail } from '@getmunin/emails';
 import { DB } from '../common/db/db.module.ts';
 import { MAILER } from '../common/mail/mail.module.ts';
-import { assertOwner, assertOwnerOrAdmin, VALID_ROLES } from './role-guard.ts';
+import { VALID_ROLES } from './role-guard.ts';
 
 const INVITE_TTL_DAYS = 7;
 
@@ -43,19 +43,16 @@ export interface CreatedInvitation extends InvitationDto {
 
 @Injectable()
 export class InvitationsService {
+  private readonly logger = new Logger(InvitationsService.name);
+
   constructor(
     @Inject(DB) private readonly serviceDb: Db,
     @Inject(MAILER) private readonly mailer: Mailer,
   ) {}
 
-  /** Issued by an owner via the dashboard's session-cookie path. */
   async create(input: { email: string; role?: string }): Promise<CreatedInvitation> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    if (actor.type !== 'user') {
-      throw new ForbiddenException('only signed-in users can create invitations');
-    }
-    await assertOwner(actor.orgId, actor.userId ?? actor.id);
 
     const role = input.role ?? 'member';
     if (!VALID_ROLES.has(role)) {
@@ -66,7 +63,6 @@ export class InvitationsService {
       throw new BadRequestException('invalid email');
     }
 
-    // Already a member?
     const existingMember = await ctx.db
       .select({ userId: schema.orgMembers.userId })
       .from(schema.orgMembers)
@@ -77,7 +73,6 @@ export class InvitationsService {
       throw new ConflictException(`${email} is already a member of this org`);
     }
 
-    // Existing pending invite for the same email? Revoke it; re-issue.
     await ctx.db
       .update(schema.orgInvitations)
       .set({ revokedAt: new Date() })
@@ -118,7 +113,6 @@ export class InvitationsService {
   async listPending(): Promise<InvitationDto[]> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const rows = await ctx.db
       .select()
       .from(schema.orgInvitations)
@@ -136,7 +130,6 @@ export class InvitationsService {
   async revoke(invitationId: string): Promise<{ revoked: true }> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwner(actor.orgId, actor.userId ?? actor.id);
     const result = await ctx.db
       .update(schema.orgInvitations)
       .set({ revokedAt: new Date() })
@@ -209,7 +202,6 @@ export class InvitationsService {
 
     await this.serviceDb.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
-      // Insert membership; if already a member, no-op via ON CONFLICT.
       await tx
         .insert(schema.orgMembers)
         .values({
@@ -225,8 +217,6 @@ export class InvitationsService {
     });
     return { orgId: invitation.orgId, role: invitation.role };
   }
-
-  // ─── helpers ─────────────────────────────────────────────────────────
 
   private buildAcceptUrl(token: string): Promise<string> {
     const webBase = (process.env.MUNIN_WEB_URL ?? 'http://localhost:3000').replace(/\/+$/, '');
@@ -263,9 +253,10 @@ export class InvitationsService {
         text: tpl.text,
         html: tpl.html,
       });
-    } catch {
-      // Send failures must not block invite creation — the inviter sees the
-      // accept URL in the API response and can resend manually.
+    } catch (err) {
+      this.logger.warn(
+        `invite email send failed for ${email}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 }

--- a/packages/backend-core/src/control/members.controller.ts
+++ b/packages/backend-core/src/control/members.controller.ts
@@ -22,6 +22,8 @@ import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 import { assertOwner, assertOwnerOrAdmin } from './role-guard.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 const PatchMemberDto = z
   .object({
@@ -42,14 +44,14 @@ interface MemberDto {
 }
 
 @Controller('v1/orgs/me/members')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 export class MembersController {
   @Get()
+  @RequireRole('owner', 'admin')
   async list(): Promise<MemberDto[]> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const rows = await ctx.db
       .select({
         userId: schema.orgMembers.userId,
@@ -141,10 +143,10 @@ export class MembersController {
 
   @Delete(':userId')
   @HttpCode(204)
+  @RequireRole('owner')
   async remove(@Param('userId') userId: string): Promise<void> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwner(actor.orgId, actor.userId ?? actor.id);
 
     const target = await ctx.db
       .select({ role: schema.orgMembers.role })

--- a/packages/backend-core/src/control/orgs.controller.ts
+++ b/packages/backend-core/src/control/orgs.controller.ts
@@ -15,6 +15,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 const PatchDto = z.object({
   name: z.string().min(1).max(128).optional(),
@@ -29,7 +31,7 @@ interface OrgDto {
 }
 
 @Controller('v1/orgs/me')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 export class OrgsController {
   @Get()
@@ -51,6 +53,7 @@ export class OrgsController {
   }
 
   @Patch()
+  @RequireRole('owner', 'admin')
   async update(@Body() body: unknown): Promise<OrgDto> {
     const parsed = PatchDto.safeParse(body);
     if (!parsed.success) throw new BadRequestException(parsed.error.message);

--- a/packages/backend-core/src/control/role.decorator.ts
+++ b/packages/backend-core/src/control/role.decorator.ts
@@ -1,0 +1,22 @@
+import { SetMetadata } from '@nestjs/common';
+import type { ActorType } from '@getmunin/core';
+import type { OrgRole } from './role-guard.ts';
+
+export const REQUIRE_ROLE_KEY = 'munin:require-role';
+export const REQUIRE_ACTOR_TYPE_KEY = 'munin:require-actor-type';
+
+/**
+ * Require the calling user to hold one of the listed org roles. Admin API
+ * keys with unrestricted scope (`*`) and system actors pass automatically —
+ * matching `assertOwnerOrAdmin` semantics. To also block API keys, stack with
+ * `@RequireActorType('user')`.
+ */
+export const RequireRole = (...roles: OrgRole[]): MethodDecorator & ClassDecorator =>
+  SetMetadata(REQUIRE_ROLE_KEY, roles);
+
+/**
+ * Restrict the route to specific actor types (e.g. `'user'` for signed-in
+ * dashboard sessions only, `'end_user_agent'` for delegated end-user agents).
+ */
+export const RequireActorType = (...types: ActorType[]): MethodDecorator & ClassDecorator =>
+  SetMetadata(REQUIRE_ACTOR_TYPE_KEY, types);

--- a/packages/backend-core/src/control/role.guard.ts
+++ b/packages/backend-core/src/control/role.guard.ts
@@ -2,17 +2,29 @@ import {
   CanActivate,
   ExecutionContext,
   ForbiddenException,
+  Inject,
   Injectable,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import type { ActorType } from '@getmunin/core';
-import { getCurrentContext } from '@getmunin/core';
-import { assertOwner, assertOwnerOrAdmin, type OrgRole } from './role-guard.ts';
+import type { ActorIdentity, ActorType, ResolvedCredential } from '@getmunin/core';
+import { schema, type Db } from '@getmunin/db';
+import { and, eq, sql } from 'drizzle-orm';
+import { DB } from '../common/db/db.module.ts';
+import { type OrgRole } from './role-guard.ts';
 import { REQUIRE_ACTOR_TYPE_KEY, REQUIRE_ROLE_KEY } from './role.decorator.ts';
 
+/**
+ * Guards run BEFORE interceptors in Nest's pipeline, so this guard can't
+ * use the AsyncLocalStorage context set by TenancyInterceptor. Instead we
+ * pull the actor from `req.credential` (attached by AuthGuard) and use
+ * the injected service-role DB for the membership lookup.
+ */
 @Injectable()
 export class RoleGuard implements CanActivate {
-  constructor(private readonly reflector: Reflector) {}
+  constructor(
+    private readonly reflector: Reflector,
+    @Inject(DB) private readonly db: Db,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const handler = context.getHandler();
@@ -29,7 +41,8 @@ export class RoleGuard implements CanActivate {
 
     if (!requiredActorTypes && !requiredRoles) return true;
 
-    const actor = getCurrentContext().actor;
+    const req = context.switchToHttp().getRequest<{ credential?: ResolvedCredential }>();
+    const actor: ActorIdentity | undefined = req.credential?.actor;
     if (!actor) throw new ForbiddenException('unauthenticated');
 
     if (requiredActorTypes && requiredActorTypes.length > 0) {
@@ -41,23 +54,51 @@ export class RoleGuard implements CanActivate {
     }
 
     if (requiredRoles && requiredRoles.length > 0) {
-      const userId = actor.userId ?? actor.id;
-      const wantsOwner = requiredRoles.includes('owner');
-      const wantsAdmin = requiredRoles.includes('admin');
-      const wantsMember = requiredRoles.includes('member');
-      if (wantsMember) {
+      if (requiredRoles.includes('member')) {
         throw new Error(
           `RoleGuard: 'member' is not a meaningful gate (all org members pass). ` +
             `Use @RequireActorType('user') instead.`,
         );
       }
-      if (wantsOwner && !wantsAdmin) {
-        await assertOwner(actor.orgId, userId);
-      } else {
-        await assertOwnerOrAdmin(actor.orgId, userId);
+
+      if (actor.type === 'system') return true;
+      if (actor.type === 'admin_agent') {
+        if (!actor.hasScope('*')) {
+          throw new ForbiddenException('scoped admin keys cannot perform owner/admin actions');
+        }
+        return true;
+      }
+      if (actor.type !== 'user') {
+        throw new ForbiddenException('this action requires an owner or admin user');
+      }
+
+      const userId = actor.userId ?? actor.id;
+      const role = await this.readUserRole(actor.orgId, userId);
+      if (!role) {
+        throw new ForbiddenException('not a member of this org');
+      }
+      if (!requiredRoles.includes(role)) {
+        throw new ForbiddenException(
+          `this route requires role ${requiredRoles.join(' | ')}, got "${role}"`,
+        );
       }
     }
 
     return true;
+  }
+
+  /**
+   * Looks up the caller's role in `org_members`. The injected `db` is the
+   * service-role connection (which bypasses RLS via its connect-time option),
+   * so we don't need the request-scoped tenant transaction here.
+   */
+  private async readUserRole(orgId: string, userId: string): Promise<OrgRole | null> {
+    await this.db.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+    const rows = await this.db
+      .select({ role: schema.orgMembers.role })
+      .from(schema.orgMembers)
+      .where(and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.userId, userId)))
+      .limit(1);
+    return (rows[0]?.role as OrgRole | undefined) ?? null;
   }
 }

--- a/packages/backend-core/src/control/role.guard.ts
+++ b/packages/backend-core/src/control/role.guard.ts
@@ -1,0 +1,63 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { ActorType } from '@getmunin/core';
+import { getCurrentContext } from '@getmunin/core';
+import { assertOwner, assertOwnerOrAdmin, type OrgRole } from './role-guard.ts';
+import { REQUIRE_ACTOR_TYPE_KEY, REQUIRE_ROLE_KEY } from './role.decorator.ts';
+
+@Injectable()
+export class RoleGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const handler = context.getHandler();
+    const cls = context.getClass();
+
+    const requiredActorTypes = this.reflector.getAllAndOverride<ActorType[] | undefined>(
+      REQUIRE_ACTOR_TYPE_KEY,
+      [handler, cls],
+    );
+    const requiredRoles = this.reflector.getAllAndOverride<OrgRole[] | undefined>(
+      REQUIRE_ROLE_KEY,
+      [handler, cls],
+    );
+
+    if (!requiredActorTypes && !requiredRoles) return true;
+
+    const actor = getCurrentContext().actor;
+    if (!actor) throw new ForbiddenException('unauthenticated');
+
+    if (requiredActorTypes && requiredActorTypes.length > 0) {
+      if (!requiredActorTypes.includes(actor.type)) {
+        throw new ForbiddenException(
+          `this route requires actor type ${requiredActorTypes.join(' | ')}, got "${actor.type}"`,
+        );
+      }
+    }
+
+    if (requiredRoles && requiredRoles.length > 0) {
+      const userId = actor.userId ?? actor.id;
+      const wantsOwner = requiredRoles.includes('owner');
+      const wantsAdmin = requiredRoles.includes('admin');
+      const wantsMember = requiredRoles.includes('member');
+      if (wantsMember) {
+        throw new Error(
+          `RoleGuard: 'member' is not a meaningful gate (all org members pass). ` +
+            `Use @RequireActorType('user') instead.`,
+        );
+      }
+      if (wantsOwner && !wantsAdmin) {
+        await assertOwner(actor.orgId, userId);
+      } else {
+        await assertOwnerOrAdmin(actor.orgId, userId);
+      }
+    }
+
+    return true;
+  }
+}

--- a/packages/backend-core/src/control/tokens.controller.ts
+++ b/packages/backend-core/src/control/tokens.controller.ts
@@ -15,7 +15,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
-import { assertOwnerOrAdmin } from './role-guard.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 interface TokenDto {
   id: string;
@@ -30,14 +31,14 @@ interface TokenDto {
 }
 
 @Controller('v1/tokens')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireRole('owner', 'admin')
 export class TokensController {
   @Get()
   async list(): Promise<TokenDto[]> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const rows = await ctx.db
       .select()
       .from(schema.tokens)
@@ -51,7 +52,6 @@ export class TokensController {
   async revoke(@Param('id') id: string): Promise<void> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const result = await ctx.db
       .update(schema.tokens)
       .set({ revokedAt: new Date() })

--- a/packages/backend-core/src/control/usage-stats.controller.ts
+++ b/packages/backend-core/src/control/usage-stats.controller.ts
@@ -6,7 +6,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
-import { assertOwnerOrAdmin } from './role-guard.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 export interface UsageSummaryTile {
   current: number;
@@ -56,14 +57,14 @@ type DailyBigIntRow = {
 } & Record<string, unknown>;
 
 @Controller('v1/usage')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireRole('owner', 'admin')
 export class UsageStatsController {
   @Get('summary')
   async summary(): Promise<UsageSummaryDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const orgId = actor.orgId;
 
     const now = new Date();
@@ -93,7 +94,6 @@ export class UsageStatsController {
   async byAgent(@Query('days') daysRaw?: string): Promise<UsageByAgentDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     const orgId = actor.orgId;
 
     const days = clampDays(daysRaw, 30);

--- a/packages/backend-core/src/control/usage.controller.ts
+++ b/packages/backend-core/src/control/usage.controller.ts
@@ -1,22 +1,21 @@
 import { Controller, Get, Inject, UseGuards, UseInterceptors } from '@nestjs/common';
-import { getCurrentContext } from '@getmunin/core';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 import { RateLimitService } from '../common/rate-limit/rate-limit.service.ts';
-import { assertOwnerOrAdmin } from './role-guard.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 @Controller('v1/usage')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireRole('owner', 'admin')
 export class UsageController {
   constructor(@Inject(RateLimitService) private readonly rateLimit: RateLimitService) {}
 
   @Get()
   async current() {
-    const actor = getCurrentContext().actor!;
-    await assertOwnerOrAdmin(actor.orgId, actor.userId ?? actor.id);
     return this.rateLimit.usage();
   }
 }

--- a/packages/backend-core/src/control/webhooks.controller.ts
+++ b/packages/backend-core/src/control/webhooks.controller.ts
@@ -20,6 +20,8 @@ import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
+import { RoleGuard } from './role.guard.ts';
+import { RequireRole } from './role.decorator.ts';
 
 export const WebhookUrl = z
   .string()
@@ -56,8 +58,9 @@ interface WebhookDto {
 }
 
 @Controller('v1/webhooks')
-@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@RequireRole('owner', 'admin')
 export class WebhooksController {
   @Get()
   async list(): Promise<WebhookDto[]> {

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -48,6 +48,20 @@ export {
   ADDITIONAL_CREDENTIAL_RESOLVERS,
   type AdditionalCredentialResolver,
 } from './common/auth/auth.guard.ts';
+export { ControlPlaneGuard } from './common/auth/control-plane.guard.ts';
+export {
+  assertOwner,
+  assertOwnerOrAdmin,
+  VALID_ROLES,
+  type OrgRole,
+} from './control/role-guard.ts';
+export { RoleGuard } from './control/role.guard.ts';
+export {
+  RequireRole,
+  RequireActorType,
+  REQUIRE_ROLE_KEY,
+  REQUIRE_ACTOR_TYPE_KEY,
+} from './control/role.decorator.ts';
 export { TenancyInterceptor } from './common/tenancy/tenancy.interceptor.ts';
 export { AuditInterceptor } from './common/audit/audit.interceptor.ts';
 export { DB, DbModule } from './common/db/db.module.ts';

--- a/packages/db/src/rls.test.ts
+++ b/packages/db/src/rls.test.ts
@@ -115,4 +115,55 @@ const skipReason = TEST_URL
     expect(rows.length).toBe(1);
     expect(rows[0]!.id).toBe(aEu);
   });
+
+  // Meta-test: enforce the "every org-scoped table has RLS" invariant.
+  // If you add a new table with an `org_id` column, you must also enable
+  // row-level security on it and add a tenant_isolation policy (typically
+  // in packages/db/src/sql/<module>.sql). The few exempt tables are listed
+  // explicitly below — usually because tenancy is delegated to a parent
+  // table's policy via FK or the table is a system-level catalog.
+  it('every table with an org_id column has RLS enabled', async () => {
+    const exempt = new Set<string>([
+      // org_members: composite (org_id, user_id) primary key + service-role
+      // reads via assertOwnerOrAdmin. Documented in rls.sql.
+      'org_members',
+    ]);
+    const rows = await client.begin(async (sql) => {
+      await sql`SELECT set_config('app.bypass_rls', 'on', true)`;
+      return sql<{ table_name: string; relrowsecurity: boolean; relforcerowsecurity: boolean; policy_count: number }[]>`
+        SELECT
+          c.relname AS table_name,
+          c.relrowsecurity,
+          c.relforcerowsecurity,
+          (SELECT count(*) FROM pg_policies p
+            WHERE p.schemaname = 'public' AND p.tablename = c.relname)::int AS policy_count
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND EXISTS (
+            SELECT 1 FROM information_schema.columns col
+            WHERE col.table_schema = 'public'
+              AND col.table_name = c.relname
+              AND col.column_name = 'org_id'
+          )
+        ORDER BY c.relname`;
+    });
+
+    const offenders = rows
+      .filter((r) => !exempt.has(r.table_name))
+      .filter((r) => !r.relrowsecurity || !r.relforcerowsecurity || r.policy_count === 0);
+
+    if (offenders.length > 0) {
+      const detail = offenders
+        .map(
+          (r) =>
+            `  - ${r.table_name}: rls=${r.relrowsecurity} force=${r.relforcerowsecurity} policies=${r.policy_count}`,
+        )
+        .join('\n');
+      throw new Error(
+        `Tables with an org_id column are missing RLS:\n${detail}\n\nAdd a tenant_isolation policy to packages/db/src/sql/<module>.sql, or add the table to the exempt set with a comment justifying why.`,
+      );
+    }
+  });
 });

--- a/packages/db/src/sql/conv-channels.sql
+++ b/packages/db/src/sql/conv-channels.sql
@@ -61,3 +61,16 @@ CREATE POLICY tenant_isolation ON conv_message_reads
     OR (org_id = app_org_id() AND app_end_user_id() = '')
   )
   WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
+-- Widget → email fallback ledger. Org-scoped; the sweeper writes with
+-- app.bypass_rls=on. End-users never see these rows; admin dashboard
+-- callers see only their own org.
+ALTER TABLE conv_widget_email_fallbacks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE conv_widget_email_fallbacks FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON conv_widget_email_fallbacks;
+CREATE POLICY tenant_isolation ON conv_widget_email_fallbacks
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());


### PR DESCRIPTION
## Summary

Addresses four audit findings, plus an ergonomics refactor that introduces a `@RequireRole` / `@RequireActorType` decorator system to replace inline `assertOwnerOrAdmin` calls across ~13 controllers.

### Findings fixed

- **High — control-plane role gating.** Any signed-in *member* could previously rotate widget keys, change LLM provider credentials, create exfiltration webhooks, configure SMS/email/voice channels, or PATCH org/assistant settings. `ControlPlaneGuard` only checked actor type, not role, and the affected controllers didn't call `assertOwnerOrAdmin`. Now all sensitive routes require owner/admin via `@RequireRole('owner', 'admin')`. Affected: `webhooks`, `conv-channels`, `agent-config`, `orgs PATCH`, `assistants PATCH`.
- **High — SSRF / credential exfil via `providerBaseUrl`.** The agent-host fetched models/credentials via raw `fetch()` against an org-controlled URL, sending the provider API key in the auth header. A malicious or typo'd URL could probe internal infra (e.g. `169.254.169.254`) and leak the key. Now: `safeFetch` (blocks private/loopback/link-local hosts) in `provider-auth.ts`, `models.service.ts`, `openai-compatible.ts`, plus Zod-level rejection of `http://` unless `MUNIN_SSRF_ALLOW_PRIVATE` is set (dev escape hatch for ollama et al.).
- **High — missing RLS on `conv_widget_email_fallbacks`.** Org-scoped table with no policy. Sweeper bypasses RLS, but any future request-context read would have leaked across orgs. Added `tenant_isolation` policy mirroring `conv_message_reads`. Plus a meta-test in `rls.test.ts` that scans `pg_class` for `org_id`-bearing tables and fails when any lacks RLS (`org_members` is the only documented exemption).
- **Medium — role-coverage test gaps.** The existing role matrix omitted `/v1/webhooks`, `/v1/conversations/channels`, `/v1/orgs/me PATCH`, `/v1/assistants/me PATCH`. Added member-denial + admin-positive coverage. Agent-config tests live as unit tests in `agent-host` since the backend-core test app doesn't load `AgentHostModule`.

### Ergonomics

- New `@RequireRole(...roles)` and `@RequireActorType(...types)` decorators backed by a single `RoleGuard`.
- 13 controllers + 1 service migrated. Every previously-inline `assertOwnerOrAdmin` that was unconditional is now declarative — the role requirement sits next to `@Post` / `@Patch` / etc.
- `members:patch` keeps inline assertions because its gates depend on which body field is being patched.
- `ConvChannelsController.list` is now also owner/admin-gated (consistent with `tokens:list`, `audit-log:list`, `end-users:list`).

### Behavior changes worth flagging

- `delegated-token POST` for non-admin actors now returns **403** instead of **400** — semantically correct (auth, not malformed input).
- `conv-channels GET /v1/conversations/channels` now requires owner/admin. Members previously could list channel inventory.

## Test plan

- [x] `pnpm -F @getmunin/agent-host test` — 17/17
- [x] `pnpm -F @getmunin/agent-runtime test` — 94/94
- [x] `pnpm -F @getmunin/db test` — 6/6 (meta-test included)
- [x] `pnpm -F @getmunin/backend-core` typecheck + build clean
- [x] Backend-core control-plane integration suite — 72/72 against fresh test DB (verified before the decorator refactor; CI to re-run on this branch)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)