### PR TITLE
fix(docker): make docker compose up actually work for self-host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 **/dist
 **/build
 **/coverage
+**/*.tsbuildinfo
 **/.git
 .env
 .env.*

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7-labs
 # Multistage build for the Munin NestJS backend.
 # Build context expected to be the monorepo root.
 
@@ -8,30 +9,25 @@ WORKDIR /repo
 # ─── deps ──────────────────────────────────────────────────────────────
 FROM base AS deps
 COPY pnpm-workspace.yaml pnpm-lock.yaml* package.json ./
-COPY apps/backend/package.json apps/backend/
-COPY packages/core/package.json packages/core/
-COPY packages/db/package.json packages/db/
-COPY packages/mcp-toolkit/package.json packages/mcp-toolkit/
-COPY packages/types/package.json packages/types/
-COPY packages/tsconfig/package.json packages/tsconfig/
-COPY packages/eslint-config/package.json packages/eslint-config/
+COPY --parents apps/*/package.json packages/*/package.json ./
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --filter @getmunin/backend...
 
 # ─── build ─────────────────────────────────────────────────────────────
 FROM deps AS build
 COPY tsconfig.base.json turbo.json ./
-COPY packages/ packages/
-COPY apps/backend apps/backend
+COPY packages packages
+COPY apps apps
 RUN pnpm --filter @getmunin/backend... build
+RUN pnpm --filter @getmunin/backend --prod --legacy deploy /deploy
 
 # ─── runtime ───────────────────────────────────────────────────────────
 FROM base AS runtime
 ENV NODE_ENV=production
 WORKDIR /app
+COPY --from=build /deploy/package.json ./
+COPY --from=build /deploy/node_modules ./node_modules
 COPY --from=build /repo/apps/backend/dist ./dist
-COPY --from=build /repo/apps/backend/package.json ./
 COPY --from=build /repo/apps/backend/public ./public
-COPY --from=build /repo/node_modules ./node_modules
 EXPOSE 3001
 CMD ["node", "dist/main.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7-labs
 # Multistage build for the Munin Next.js web app (output: standalone).
 # Build context expected to be the monorepo root.
 
@@ -8,21 +9,16 @@ WORKDIR /repo
 # ─── deps ──────────────────────────────────────────────────────────────
 FROM base AS deps
 COPY pnpm-workspace.yaml pnpm-lock.yaml* package.json ./
-COPY apps/web/package.json apps/web/
-COPY packages/sdk/package.json packages/sdk/
-COPY packages/types/package.json packages/types/
-COPY packages/tsconfig/package.json packages/tsconfig/
-COPY packages/eslint-config/package.json packages/eslint-config/
+COPY --parents apps/*/package.json packages/*/package.json ./
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --filter @getmunin/web...
 
 # ─── build ─────────────────────────────────────────────────────────────
 FROM deps AS build
 COPY tsconfig.base.json turbo.json ./
-COPY packages/ packages/
-COPY apps/web apps/web
-RUN pnpm --filter @getmunin/sdk build && pnpm --filter @getmunin/types build
-RUN pnpm --filter @getmunin/web build
+COPY packages packages
+COPY apps apps
+RUN pnpm --filter @getmunin/web... build
 
 # ─── runtime ───────────────────────────────────────────────────────────
 FROM base AS runtime

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -33,17 +33,13 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    env_file: ../.env
     environment:
       NODE_ENV: production
       PORT: 3001
-      DATABASE_URL: postgres://${POSTGRES_USER:-munin}:${POSTGRES_PASSWORD:-munin}@postgres:5432/${POSTGRES_DB:-munin}
-      NEXT_PUBLIC_MCP_URL: ${NEXT_PUBLIC_MCP_URL:-http://localhost:3001/mcp}
-      NEXT_PUBLIC_AUTH_URL: ${NEXT_PUBLIC_AUTH_URL:-http://localhost:3001}
-      MUNIN_AUTH_SECRET: ${MUNIN_AUTH_SECRET:?set MUNIN_AUTH_SECRET in .env}
-      MUNIN_CURATOR_KB_SWEEP_CRON: ${MUNIN_CURATOR_KB_SWEEP_CRON:-}
-      MUNIN_CURATOR_CRM_HYGIENE_CRON: ${MUNIN_CURATOR_CRM_HYGIENE_CRON:-}
-      MUNIN_CURATOR_CMS_STALE_CRON: ${MUNIN_CURATOR_CMS_STALE_CRON:-}
-      MUNIN_CURATOR_SCHEDULER_DISABLED: ${MUNIN_CURATOR_SCHEDULER_DISABLED:-0}
+      MUNIN_MIGRATE_URL: postgres://${POSTGRES_USER:-munin}:${POSTGRES_PASSWORD:-munin}@postgres:5432/${POSTGRES_DB:-munin}
+      DATABASE_URL: postgres://munin_app:munin_app@postgres:5432/${POSTGRES_DB:-munin}
+    command: ["sh", "-c", "node dist/migrate.js && node dist/main.js"]
     ports:
       - "${BACKEND_PORT:-3001}:3001"
 
@@ -54,13 +50,10 @@ services:
     restart: unless-stopped
     depends_on:
       - backend
+    env_file: ../.env
     environment:
       NODE_ENV: production
       PORT: 3000
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001}
-      NEXT_PUBLIC_MCP_URL: ${NEXT_PUBLIC_MCP_URL:-http://localhost:3001/mcp}
-      NEXT_PUBLIC_AUTH_URL: ${NEXT_PUBLIC_AUTH_URL:-http://localhost:3001}
-      NEXT_PUBLIC_DOCS_URL: ${NEXT_PUBLIC_DOCS_URL:-http://localhost:3000/docs}
     ports:
       - "${WEB_PORT:-3000}:3000"
 


### PR DESCRIPTION
## Summary

The documented `docker compose up` quickstart in `docker/compose.yml`'s own header was broken end-to-end on a clean clone. Fixing it required changes in four files; details below.

## Test plan

- [x] `docker compose --env-file ../.env build` succeeds for both backend and web
- [x] `docker compose --env-file ../.env up -d` brings backend, web, and postgres up healthy
- [x] Backend boots Nest, runs migrations, maps all `/v1/*` and OAuth controllers, schedules curator sweeps, starts the realtime gateway and agent-host runner
- [x] `GET /.well-known/oauth-authorization-server` → `200`
- [x] `GET /mcp` → `401` (auth-gated, expected)
- [x] `GET /` (web) → `307` → `/en` → `200`
- [ ] CI passes

## What was broken

### 1. Stale selective `COPY` of `package.json` (backend + web Dockerfiles)
Both Dockerfiles' deps stages hand-listed 5–7 workspace `package.json` files to copy before `pnpm install --filter X...`. The lists drifted as new workspace packages were added (`emails`, `backend-core`, `agent-host`, `agent-runtime`, `dashboard-pages`, …), so `pnpm install` silently skipped them. The first build error was the cryptic `WARN Local package.json exists, but node_modules missing` deep inside `packages/emails`.

**Fix:** opt into BuildKit labs syntax (`# syntax=docker/dockerfile:1.7-labs`) and use `COPY --parents apps/*/package.json packages/*/package.json ./`. Adding a new workspace package no longer requires a Dockerfile edit. Also widened the build stage to `COPY apps apps` so transitive workspace apps like `chat-widget` (consumed by backend's `prebuild` step) come along.

### 2. `.dockerignore` leaked `tsc` incremental cache
`.dockerignore` excluded `**/dist` so prebuilt artifacts couldn't sneak in — but not `**/*.tsbuildinfo`. tsc's incremental marker came in from the host, telling tsc "you already built this" while the corresponding `dist/` was gone. Result: `@getmunin/db` reported `build: Done` without emitting anything, then `@getmunin/core` failed with `Cannot find module '@getmunin/db'`. **Fix:** ignore `**/*.tsbuildinfo`.

### 3. Backend runtime missing `node_modules` for app deps
The runtime stage copied `/repo/node_modules` only. pnpm's symlinked layout means actual deps live under `apps/backend/node_modules/<dep> → ../../node_modules/.pnpm/<dep>@version/...`; copying just the root broke `@sentry/nestjs` (and everything else) at runtime. **Fix:** `pnpm --filter @getmunin/backend --prod --legacy deploy /deploy` produces a self-contained directory; runtime image copies that. (`--legacy` is required on pnpm 10 for non-injected workspaces.)

### 4. `compose.yml` env wiring + missing migrations
- Only 6 env vars were forwarded; `MUNIN_KEY_PEPPER`, `MUNIN_ENCRYPTION_KEY`, `MUNIN_STORAGE_LOCAL_SECRET`, `OPENAI_*`, etc. never reached the container. First-boot crash: `MUNIN_STORAGE_LOCAL_SECRET must be set when NODE_ENV=production with provider=local`.
- `DATABASE_URL` in `.env` points to `localhost:5432` (correct for host dev, wrong inside the container).
- The old override used the postgres superuser, which bypasses RLS — the `.env.example` documents that `munin_app` is the right role.
- Nothing ran migrations, so even with the right URL the `munin_app` role didn't exist yet.

**Fix:** `env_file: ../.env` per service so every documented var flows through. Override `DATABASE_URL=munin_app:munin_app@postgres` and `MUNIN_MIGRATE_URL=munin:munin@postgres` (the only two URLs that need the in-network hostname). Backend command runs `node dist/migrate.js && node dist/main.js`.

## Design notes

- **No new build args.** Every customization that matters at runtime is already an env var; pinning Node + pnpm versions in the base image is a feature.
- **`env_file` + `environment` override** rather than enumerating every Munin env var in `compose.yml`: the latter has to be touched every time a new env var is added.