### PR TITLE
fix(security): block OAuth bearers from acting as control-plane credentials

### DIFF
--- a/.changeset/fix-oauth-control-plane-escalation.md
+++ b/.changeset/fix-oauth-control-plane-escalation.md
@@ -1,0 +1,25 @@
+---
+'@getmunin/core': patch
+'@getmunin/backend-core': patch
+---
+
+**Security (critical)**: prevent OAuth bearer tokens from acting as control-plane credentials.
+
+Before this patch, an OAuth access token with any non-empty scope set — even one
+containing only `openid` — resolved to a `user` actor whose `ControlPlaneGuard`
+branch (`actor.type === 'user' → return true`) admitted it without checking the
+token's audience or scopes. Combined with `deriveAudiencesFromScopes` defaulting
+to the `admin` audience for any scope-bearing token, every issued OAuth token
+was effectively a full org-admin key for the dashboard's `/v1/*` REST surface
+(conversations, inbox, activity, curator jobs, CRM, CMS, …).
+
+Three changes:
+
+- `deriveAudiencesFromScopes` no longer falls back to `admin` when no `mcp:*`
+  scope is present. `admin` requires `mcp:admin`, `self_service` requires
+  `mcp:self_service`.
+- `ControlPlaneGuard` rejects `user` actors whose credential carries an MCP
+  resource `audience` (i.e. was issued via OAuth). Session-cookie users — whose
+  credentials never set `audience` — still pass.
+- `AuthGuard` enforces audience binding on every route, not just `/mcp`. A
+  bearer minted for the MCP resource cannot be presented to `/v1/*`.

--- a/packages/backend-core/src/common/auth/auth.guard.test.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.test.ts
@@ -1,6 +1,6 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResolvedCredential } from '@getmunin/core';
 import { AuthGuard, type AuthenticatedRequest } from './auth.guard.ts';
 
@@ -67,5 +67,64 @@ describe('AuthGuard cookie fallback', () => {
     });
     await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
     expect(resolveSessionToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuthGuard audience binding', () => {
+  let originalMcp: string | undefined;
+
+  beforeEach(() => {
+    originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://api.example.com/mcp';
+  });
+  afterEach(() => {
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+  });
+
+  function mcpCred(audience = 'https://api.example.com/mcp'): ResolvedCredential {
+    return {
+      actor: {
+        type: 'user',
+        scopes: ['mcp:admin'],
+        audiences: ['admin'],
+      } as never,
+      audience,
+    };
+  }
+
+  it('rejects an MCP-audience bearer when presented to /v1/*', async () => {
+    const resolveBearerToken = vi.fn().mockResolvedValue(mcpCred());
+    const guard = makeGuard({ resolveBearerToken });
+    const ctx = makeContext({
+      headers: { authorization: 'Bearer some-oauth-token' },
+      url: '/v1/conversations',
+      path: '/v1/conversations',
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('accepts an MCP-audience bearer on /mcp when audience matches exactly', async () => {
+    const resolveBearerToken = vi.fn().mockResolvedValue(mcpCred());
+    const guard = makeGuard({ resolveBearerToken });
+    const ctx = makeContext({
+      headers: { authorization: 'Bearer some-oauth-token' },
+      url: '/mcp',
+      path: '/mcp',
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('rejects an MCP-audience bearer on /mcp when audience does not match', async () => {
+    const resolveBearerToken = vi
+      .fn()
+      .mockResolvedValue(mcpCred('https://wrong.example.com/mcp'));
+    const guard = makeGuard({ resolveBearerToken });
+    const ctx = makeContext({
+      headers: { authorization: 'Bearer some-oauth-token' },
+      url: '/mcp',
+      path: '/mcp',
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
   });
 });

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -134,7 +134,16 @@ export class AuthGuard implements CanActivate {
       throw new UnauthorizedException('invalid or expired credential');
     }
 
-    if (isMcpRequest(request) && credential.audience) {
+    // Audience binding: OAuth-issued credentials carry an `audience` that
+    // names the MCP resource URL they were minted for. Reject if presented
+    // to a different surface — MCP tokens must not satisfy /v1/* (control
+    // plane), and the audience value must match exactly on /mcp.
+    if (credential.audience) {
+      if (!isMcpRequest(request)) {
+        throw new UnauthorizedException(
+          'token was issued for the MCP resource and cannot be used on this endpoint',
+        );
+      }
       if (credential.audience !== mcpResourceUrl()) {
         maybeSetMcpResourceMetadataHeader(context, request);
         throw new UnauthorizedException('token audience does not match the requested resource');

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -134,10 +134,6 @@ export class AuthGuard implements CanActivate {
       throw new UnauthorizedException('invalid or expired credential');
     }
 
-    // Audience binding: OAuth-issued credentials carry an `audience` that
-    // names the MCP resource URL they were minted for. Reject if presented
-    // to a different surface — MCP tokens must not satisfy /v1/* (control
-    // plane), and the audience value must match exactly on /mcp.
     if (credential.audience) {
       if (!isMcpRequest(request)) {
         throw new UnauthorizedException(

--- a/packages/backend-core/src/common/auth/control-plane.guard.test.ts
+++ b/packages/backend-core/src/common/auth/control-plane.guard.test.ts
@@ -1,0 +1,78 @@
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { describe, expect, it } from 'vitest';
+import type { ResolvedCredential } from '@getmunin/core';
+import { ControlPlaneGuard } from './control-plane.guard.ts';
+
+function makeCtx(credential?: ResolvedCredential) {
+  return {
+    switchToHttp: () => ({ getRequest: () => ({ credential }) }),
+  } as never;
+}
+
+function actor(overrides: Partial<{ type: string; scopes: string[]; audiences: string[] }>) {
+  const a = {
+    type: 'user',
+    scopes: ['*'],
+    audiences: ['admin'],
+    ...overrides,
+  };
+  return {
+    ...a,
+    hasScope: (s: string) => a.scopes.includes(s) || a.scopes.includes('*'),
+    hasAudience: (aud: string) => a.audiences.includes(aud),
+  } as never;
+}
+
+describe('ControlPlaneGuard', () => {
+  it('rejects unauthenticated requests', () => {
+    const guard = new ControlPlaneGuard();
+    expect(() => guard.canActivate(makeCtx())).toThrow(UnauthorizedException);
+  });
+
+  it('admits a session-cookie user (no audience on credential)', () => {
+    const guard = new ControlPlaneGuard();
+    const cred = { actor: actor({ type: 'user' }) } as ResolvedCredential;
+    expect(guard.canActivate(makeCtx(cred))).toBe(true);
+  });
+
+  it('rejects an OAuth-derived user actor (credential has MCP audience)', () => {
+    const guard = new ControlPlaneGuard();
+    const cred = {
+      actor: actor({ type: 'user' }),
+      audience: 'https://api.example.com/mcp',
+    } as ResolvedCredential;
+    expect(() => guard.canActivate(makeCtx(cred))).toThrow(ForbiddenException);
+  });
+
+  it('admits an admin_agent with admin audience and wildcard scope', () => {
+    const guard = new ControlPlaneGuard();
+    const cred = {
+      actor: actor({ type: 'admin_agent', scopes: ['*'], audiences: ['admin'] }),
+    } as ResolvedCredential;
+    expect(guard.canActivate(makeCtx(cred))).toBe(true);
+  });
+
+  it('rejects an admin_agent without admin audience', () => {
+    const guard = new ControlPlaneGuard();
+    const cred = {
+      actor: actor({ type: 'admin_agent', scopes: ['*'], audiences: ['self_service'] }),
+    } as ResolvedCredential;
+    expect(() => guard.canActivate(makeCtx(cred))).toThrow(ForbiddenException);
+  });
+
+  it('rejects an admin_agent without wildcard scope', () => {
+    const guard = new ControlPlaneGuard();
+    const cred = {
+      actor: actor({ type: 'admin_agent', scopes: ['kb:read'], audiences: ['admin'] }),
+    } as ResolvedCredential;
+    expect(() => guard.canActivate(makeCtx(cred))).toThrow(ForbiddenException);
+  });
+
+  it('rejects widget_agent, end_user_agent, and other actor types', () => {
+    const guard = new ControlPlaneGuard();
+    for (const type of ['widget_agent', 'end_user_agent', 'partner']) {
+      const cred = { actor: actor({ type }) } as ResolvedCredential;
+      expect(() => guard.canActivate(makeCtx(cred))).toThrow(ForbiddenException);
+    }
+  });
+});

--- a/packages/backend-core/src/common/auth/control-plane.guard.ts
+++ b/packages/backend-core/src/common/auth/control-plane.guard.ts
@@ -18,7 +18,19 @@ export class ControlPlaneGuard implements CanActivate {
       throw new UnauthorizedException('unauthenticated');
     }
     const actor = credential.actor;
-    if (actor.type === 'system' || actor.type === 'user') {
+    if (actor.type === 'system') {
+      return true;
+    }
+    if (actor.type === 'user') {
+      // OAuth-derived credentials carry an `audience` field naming the MCP
+      // resource they were issued for. The control plane is the dashboard's
+      // session-cookie surface — MCP bearer tokens (even with broad scopes)
+      // must not pass. Session-cookie credentials never set `audience`.
+      if (credential.audience) {
+        throw new ForbiddenException(
+          'OAuth bearer tokens cannot access control-plane routes; use a session cookie or an admin API key',
+        );
+      }
       return true;
     }
     if (actor.type === 'admin_agent') {

--- a/packages/backend-core/src/common/auth/control-plane.guard.ts
+++ b/packages/backend-core/src/common/auth/control-plane.guard.ts
@@ -22,10 +22,6 @@ export class ControlPlaneGuard implements CanActivate {
       return true;
     }
     if (actor.type === 'user') {
-      // OAuth-derived credentials carry an `audience` field naming the MCP
-      // resource they were issued for. The control plane is the dashboard's
-      // session-cookie surface — MCP bearer tokens (even with broad scopes)
-      // must not pass. Session-cookie credentials never set `audience`.
       if (credential.audience) {
         throw new ForbiddenException(
           'OAuth bearer tokens cannot access control-plane routes; use a session cookie or an admin API key',

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -213,8 +213,5 @@ export function deriveAudiencesFromScopes(scopes: string[]): Audience[] {
     if (scope === 'mcp:admin') set.add('admin');
     if (scope === 'mcp:self_service') set.add('self_service');
   }
-  if (set.size === 0) {
-    if (scopes.length > 0) set.add('admin');
-  }
   return Array.from(set);
 }

--- a/packages/core/src/request/derive-audiences.test.ts
+++ b/packages/core/src/request/derive-audiences.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { deriveAudiencesFromScopes } from './credentials.ts';
+
+describe('deriveAudiencesFromScopes', () => {
+  it('grants admin only when mcp:admin is present', () => {
+    expect(deriveAudiencesFromScopes(['mcp:admin'])).toEqual(['admin']);
+    expect(deriveAudiencesFromScopes(['mcp:admin', 'kb:read'])).toEqual(['admin']);
+  });
+
+  it('grants self_service only when mcp:self_service is present', () => {
+    expect(deriveAudiencesFromScopes(['mcp:self_service'])).toEqual(['self_service']);
+  });
+
+  it('grants both when both mcp:* scopes are present', () => {
+    expect(deriveAudiencesFromScopes(['mcp:admin', 'mcp:self_service']).sort()).toEqual(
+      ['admin', 'self_service'].sort(),
+    );
+  });
+
+  it('returns an empty list for OIDC-only or resource-scope-only tokens', () => {
+    expect(deriveAudiencesFromScopes(['openid'])).toEqual([]);
+    expect(deriveAudiencesFromScopes(['openid', 'profile', 'email'])).toEqual([]);
+    expect(deriveAudiencesFromScopes(['kb:read', 'crm:write'])).toEqual([]);
+  });
+
+  it('returns an empty list for an empty scope set', () => {
+    expect(deriveAudiencesFromScopes([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

OAuth access tokens — even ones carrying only `openid` — resolved to a `user`
actor that `ControlPlaneGuard` admitted unconditionally. Combined with
`deriveAudiencesFromScopes` defaulting any scope-bearing token to the `admin`
audience, every issued OAuth token was effectively a full org-admin credential
for the dashboard's `/v1/*` REST surface (conversations, inbox, activity,
curator jobs, CRM, CMS, …).

Three changes, all small:

- **`deriveAudiencesFromScopes`** (`packages/core/src/request/credentials.ts`):
  drop the "any non-empty scope -> admin" fallback. `admin` now requires
  `mcp:admin`, `self_service` requires `mcp:self_service`.
- **`ControlPlaneGuard`**: a `user` actor only passes when its credential has
  no `audience` (i.e. came from a session cookie). OAuth-derived credentials,
  which always set the MCP resource audience, are rejected.
- **`AuthGuard`**: enforce audience binding on every route, not just `/mcp`.
  An MCP-audience bearer presented to `/v1/*` is rejected up-front.

Closes findings #1 (OAuth bearers → control plane) and #3 (audience derivation
defaults to admin) from the internal review.

## Test plan

- [x] `pnpm typecheck` clean (27/27)
- [x] `pnpm -F @getmunin/backend-core test` — 212 pass, 0 new failures; new
      tests cover the OAuth-bearer-rejected path on `/v1/*`, MCP-audience
      mismatch on `/mcp`, session-cookie pass-through, and every
      `ControlPlaneGuard` branch.
- [x] `pnpm -F @getmunin/core test` — 119 pass; new `derive-audiences.test.ts`
      covers OIDC-only and scope-only inputs.
- [ ] Manual: `curl -H "Authorization: Bearer <oauth-token>"
      $MCP_URL/v1/conversations` should return 401 after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)