### PR TITLE
fix(security): harden widget rate limiting and origin enforcement

### DIFF
--- a/.changeset/fix-widget-throttling-and-allowlist.md
+++ b/.changeset/fix-widget-throttling-and-allowlist.md
@@ -1,0 +1,22 @@
+---
+'@getmunin/backend-core': patch
+---
+
+**Security**: harden chat-widget rate limiting and origin enforcement.
+
+- **Throttler key**: drop caller-controlled `sessionId` from the tracker key.
+  The widget previously bucketed by `ip|channelId|sessionId`, so an embed
+  that rotated session IDs through the same IP could open unbounded
+  conversations. The key is now `apiKeyId|channelId|ip` — independent of
+  session and indexed by the resolved widget credential.
+- **Trusted IP**: the guard now reads `req.ip` (which honours Express's
+  `trust proxy` setting) instead of parsing `x-forwarded-for` directly. New
+  `MUNIN_TRUST_PROXY` env (forwarded to `app.set('trust proxy', …)`) lets
+  deployments behind a load balancer / CDN trust their proxy hop and have
+  `req.ip` reflect the real client. Left unset, Express trusts no proxy
+  and `req.ip` is the socket address — so an unproxied app no longer
+  honours a spoofed XFF.
+- **Origin allowlist (opt-in strict mode)**: `enforceOriginAllowlist` keeps
+  the dev-friendly default (empty allowlist allows any origin) but now
+  rejects when `MUNIN_WIDGET_REQUIRE_ALLOWLIST=1` is set. Production
+  deployments should set it.

--- a/packages/backend-core/src/bootstrap-app.trust-proxy.test.ts
+++ b/packages/backend-core/src/bootstrap-app.trust-proxy.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readTrustProxySetting } from './bootstrap-app.ts';
+
+describe('readTrustProxySetting', () => {
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env.MUNIN_TRUST_PROXY;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.MUNIN_TRUST_PROXY;
+    else process.env.MUNIN_TRUST_PROXY = original;
+  });
+
+  it('returns null when unset (Express default: trust nothing)', () => {
+    delete process.env.MUNIN_TRUST_PROXY;
+    expect(readTrustProxySetting()).toBeNull();
+  });
+
+  it('returns null for explicit false/0', () => {
+    process.env.MUNIN_TRUST_PROXY = 'false';
+    expect(readTrustProxySetting()).toBeNull();
+    process.env.MUNIN_TRUST_PROXY = '0';
+    expect(readTrustProxySetting()).toBeNull();
+  });
+
+  it('returns true for true/1 (trust the first hop)', () => {
+    process.env.MUNIN_TRUST_PROXY = 'true';
+    expect(readTrustProxySetting()).toBe(true);
+    process.env.MUNIN_TRUST_PROXY = '1';
+    expect(readTrustProxySetting()).toBe(true);
+  });
+
+  it('returns the integer for numeric hop counts', () => {
+    process.env.MUNIN_TRUST_PROXY = '2';
+    expect(readTrustProxySetting()).toBe(2);
+  });
+
+  it('forwards IPs / CIDRs / csv verbatim', () => {
+    process.env.MUNIN_TRUST_PROXY = '10.0.0.0/8';
+    expect(readTrustProxySetting()).toBe('10.0.0.0/8');
+    process.env.MUNIN_TRUST_PROXY = '127.0.0.1, 10.0.0.0/8';
+    expect(readTrustProxySetting()).toBe('127.0.0.1, 10.0.0.0/8');
+  });
+});

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -31,20 +31,9 @@ function readAllowedHosts(): string[] | null {
   return env.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
 }
 
-/**
- * Parse `MUNIN_TRUST_PROXY` for Express's `trust proxy` setting.
- *
- *   unset / empty                → null (no trust proxy; `req.ip` is the
- *                                  socket address — safe default for local
- *                                  dev where nothing fronts the app)
- *   "true" / "1"                 → boolean true (trust the first hop)
- *   numeric ("2")                → number of hops to trust
- *   anything else                → forwarded verbatim (IPs / CIDRs / csv)
- *
- * Behind a proxy (LB, Cloudflare, ALB), set this so `x-forwarded-for` is
- * parsed by Express and `req.ip` returns the real client IP — which the
- * widget throttler keys on.
- */
+// Parse MUNIN_TRUST_PROXY for Express's `trust proxy` setting. Returns
+// null when unset (req.ip = socket addr), true/number/string verbatim
+// otherwise. Set this behind any LB/CDN so XFF is honoured.
 export function readTrustProxySetting(): boolean | number | string | null {
   const raw = process.env.MUNIN_TRUST_PROXY?.trim();
   if (!raw) return null;
@@ -97,9 +86,6 @@ export async function createApp(
   const app = await NestFactory.create(appModule, { rawBody: true, ...nestOpts });
   const trustProxy = readTrustProxySetting();
   if (trustProxy !== null) {
-    // Hand the value to Express verbatim — it accepts boolean, number of
-    // hops, IP, CIDR, or comma-separated list. Anything else than null
-    // means "we are behind a known proxy and req.ip should reflect XFF".
     (app.getHttpAdapter().getInstance() as { set: (k: string, v: unknown) => void }).set(
       'trust proxy',
       trustProxy,

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -31,6 +31,30 @@ function readAllowedHosts(): string[] | null {
   return env.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
 }
 
+/**
+ * Parse `MUNIN_TRUST_PROXY` for Express's `trust proxy` setting.
+ *
+ *   unset / empty                → null (no trust proxy; `req.ip` is the
+ *                                  socket address — safe default for local
+ *                                  dev where nothing fronts the app)
+ *   "true" / "1"                 → boolean true (trust the first hop)
+ *   numeric ("2")                → number of hops to trust
+ *   anything else                → forwarded verbatim (IPs / CIDRs / csv)
+ *
+ * Behind a proxy (LB, Cloudflare, ALB), set this so `x-forwarded-for` is
+ * parsed by Express and `req.ip` returns the real client IP — which the
+ * widget throttler keys on.
+ */
+export function readTrustProxySetting(): boolean | number | string | null {
+  const raw = process.env.MUNIN_TRUST_PROXY?.trim();
+  if (!raw) return null;
+  if (raw === 'true' || raw === '1') return true;
+  if (raw === 'false' || raw === '0') return null;
+  const n = Number(raw);
+  if (Number.isFinite(n) && Number.isInteger(n) && n >= 0) return n;
+  return raw;
+}
+
 export interface CreateAppOptions extends NestApplicationOptions {
   /**
    * Absolute path to the directory holding the chat-widget's hashed
@@ -71,6 +95,16 @@ export async function createApp(
 ): Promise<INestApplication> {
   const { widgetAssetDir, iconAssetDir, ...nestOpts } = opts;
   const app = await NestFactory.create(appModule, { rawBody: true, ...nestOpts });
+  const trustProxy = readTrustProxySetting();
+  if (trustProxy !== null) {
+    // Hand the value to Express verbatim — it accepts boolean, number of
+    // hops, IP, CIDR, or comma-separated list. Anything else than null
+    // means "we are behind a known proxy and req.ip should reflect XFF".
+    (app.getHttpAdapter().getInstance() as { set: (k: string, v: unknown) => void }).set(
+      'trust proxy',
+      trustProxy,
+    );
+  }
   const allowedHosts = readAllowedHosts();
   if (allowedHosts) app.use(hostAllowlistMiddleware(allowedHosts));
   app.use(publicUrlRewriteMiddleware());

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -31,9 +31,6 @@ function readAllowedHosts(): string[] | null {
   return env.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
 }
 
-// Parse MUNIN_TRUST_PROXY for Express's `trust proxy` setting. Returns
-// null when unset (req.ip = socket addr), true/number/string verbatim
-// otherwise. Set this behind any LB/CDN so XFF is honoured.
 export function readTrustProxySetting(): boolean | number | string | null {
   const raw = process.env.MUNIN_TRUST_PROXY?.trim();
   if (!raw) return null;

--- a/packages/backend-core/src/modules/conv/widget/widget-allowlist.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-allowlist.test.ts
@@ -1,0 +1,52 @@
+import { ForbiddenException } from '@nestjs/common';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { enforceOriginAllowlist } from './widget-ingest.service.ts';
+
+describe('enforceOriginAllowlist', () => {
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST;
+    else process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST = original;
+  });
+
+  it('allows any origin when the allowlist is empty (dev default)', () => {
+    delete process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST;
+    expect(() =>
+      enforceOriginAllowlist({ originAllowlist: [] }, 'https://attacker.example'),
+    ).not.toThrow();
+  });
+
+  it('rejects all origins when allowlist is empty and require-allowlist is set', () => {
+    process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST = '1';
+    expect(() =>
+      enforceOriginAllowlist({ originAllowlist: [] }, 'https://customer.example'),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('matches an origin against the allowlist', () => {
+    expect(() =>
+      enforceOriginAllowlist(
+        { originAllowlist: ['https://customer.example'] },
+        'https://customer.example',
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects an origin not on the allowlist regardless of the env var', () => {
+    expect(() =>
+      enforceOriginAllowlist(
+        { originAllowlist: ['https://customer.example'] },
+        'https://attacker.example',
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('requires an Origin header when allowlist is non-empty', () => {
+    expect(() =>
+      enforceOriginAllowlist({ originAllowlist: ['https://customer.example'] }, undefined),
+    ).toThrow(ForbiddenException);
+  });
+});

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -923,7 +923,6 @@ export function enforceOriginAllowlist(
 ): void {
   const list = channelConfig.originAllowlist ?? [];
   if (list.length === 0) {
-    // Empty = allow-all in dev; deny-all under MUNIN_WIDGET_REQUIRE_ALLOWLIST.
     if (requireWidgetAllowlist()) {
       throw new ForbiddenException('origin_allowlist_required');
     }

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -923,10 +923,7 @@ export function enforceOriginAllowlist(
 ): void {
   const list = channelConfig.originAllowlist ?? [];
   if (list.length === 0) {
-    // Empty allowlist defaults to allow-all so that fresh channels work in
-    // dev before an operator has configured origins. In production this
-    // becomes deny-all when MUNIN_WIDGET_REQUIRE_ALLOWLIST is set — an
-    // unconfigured channel should not be a free conversation faucet.
+    // Empty = allow-all in dev; deny-all under MUNIN_WIDGET_REQUIRE_ALLOWLIST.
     if (requireWidgetAllowlist()) {
       throw new ForbiddenException('origin_allowlist_required');
     }

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -922,10 +922,24 @@ export function enforceOriginAllowlist(
   origin: string | undefined,
 ): void {
   const list = channelConfig.originAllowlist ?? [];
-  if (list.length === 0) return;
+  if (list.length === 0) {
+    // Empty allowlist defaults to allow-all so that fresh channels work in
+    // dev before an operator has configured origins. In production this
+    // becomes deny-all when MUNIN_WIDGET_REQUIRE_ALLOWLIST is set — an
+    // unconfigured channel should not be a free conversation faucet.
+    if (requireWidgetAllowlist()) {
+      throw new ForbiddenException('origin_allowlist_required');
+    }
+    return;
+  }
   if (!origin) throw new ForbiddenException('origin_required');
   const allowed = list.some((entry) => originMatches(entry, origin));
   if (!allowed) throw new ForbiddenException('origin_not_allowed');
+}
+
+function requireWidgetAllowlist(): boolean {
+  const raw = process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST?.trim().toLowerCase();
+  return raw === '1' || raw === 'true';
 }
 
 export async function loadWidgetChannel(

--- a/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.test.ts
@@ -89,10 +89,6 @@ describe('WidgetThrottlerGuard.getTracker', () => {
   });
 
   it('uses req.ip and does not parse x-forwarded-for itself', async () => {
-    // req.ip is what Express produces — when trust proxy is unset it's the
-    // socket address; when set it reflects XFF. Either way, the guard does
-    // not parse XFF directly, so spoofing the header from an unproxied
-    // client has no effect on the bucket key.
     const t = await guard.publicGetTracker(
       makeReq({ ip: '10.0.0.1', apiKeyId: 'ak_1', body: { channelId: 'chan_a' } }),
     );

--- a/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Request } from 'express';
+import type { ResolvedCredential } from '@getmunin/core';
 import { WidgetThrottlerGuard } from './widget-throttler.guard.ts';
 
 class TestGuard extends WidgetThrottlerGuard {
@@ -13,69 +14,88 @@ class TestGuard extends WidgetThrottlerGuard {
 
 function makeReq(input: {
   ip?: string;
-  xff?: string;
   body?: Record<string, unknown>;
   query?: Record<string, unknown>;
+  apiKeyId?: string;
 }): Request {
+  const credential: ResolvedCredential | undefined = input.apiKeyId
+    ? ({ actor: { id: input.apiKeyId } } as ResolvedCredential)
+    : undefined;
   return {
     ip: input.ip ?? '127.0.0.1',
-    headers: input.xff ? { 'x-forwarded-for': input.xff } : {},
+    headers: {},
     body: input.body,
     query: input.query ?? {},
     socket: { remoteAddress: input.ip ?? '127.0.0.1' },
+    credential,
   } as unknown as Request;
 }
 
 describe('WidgetThrottlerGuard.getTracker', () => {
   const guard = new TestGuard();
 
-  it('keys by ip|channelId|sessionId from the request body', async () => {
-    const t = await guard.publicGetTracker(
-      makeReq({ ip: '203.0.113.5', body: { channelId: 'chan_a', sessionId: 'sess_1' } }),
-    );
-    expect(t).toBe('widget:203.0.113.5|chan_a|sess_1');
-  });
-
-  it('falls back to query string for GET endpoints', async () => {
-    const t = await guard.publicGetTracker(
-      makeReq({ ip: '203.0.113.5', query: { channelId: 'chan_a', sessionId: 'sess_1' } }),
-    );
-    expect(t).toBe('widget:203.0.113.5|chan_a|sess_1');
-  });
-
-  it('uses the first id from listConversations sessionIds csv', async () => {
-    const t = await guard.publicGetTracker(
-      makeReq({ ip: '203.0.113.5', query: { channelId: 'chan_a', sessionIds: 'sess_1,sess_2' } }),
-    );
-    expect(t).toBe('widget:203.0.113.5|chan_a|sess_1');
-  });
-
-  it('isolates trackers across (channelId, sessionId) pairs from the same ip', async () => {
-    const a = await guard.publicGetTracker(
-      makeReq({ ip: '203.0.113.5', body: { channelId: 'chan_a', sessionId: 'sess_1' } }),
-    );
-    const b = await guard.publicGetTracker(
-      makeReq({ ip: '203.0.113.5', body: { channelId: 'chan_a', sessionId: 'sess_2' } }),
-    );
-    const c = await guard.publicGetTracker(
-      makeReq({ ip: '203.0.113.5', body: { channelId: 'chan_b', sessionId: 'sess_1' } }),
-    );
-    expect(new Set([a, b, c]).size).toBe(3);
-  });
-
-  it('prefers X-Forwarded-For first hop over req.ip when behind a proxy', async () => {
+  it('keys by apiKeyId|channelId|ip — independent of caller-supplied sessionId', async () => {
     const t = await guard.publicGetTracker(
       makeReq({
-        ip: '10.0.0.1',
-        xff: '198.51.100.7, 10.0.0.1',
+        ip: '203.0.113.5',
+        apiKeyId: 'ak_1',
         body: { channelId: 'chan_a', sessionId: 'sess_1' },
       }),
     );
-    expect(t).toBe('widget:198.51.100.7|chan_a|sess_1');
+    expect(t).toBe('widget:ak_1|chan_a|203.0.113.5');
   });
 
-  it('falls back to "-" when channelId or sessionId is missing', async () => {
+  it('produces the same key when only sessionId changes', async () => {
+    const a = await guard.publicGetTracker(
+      makeReq({
+        ip: '203.0.113.5',
+        apiKeyId: 'ak_1',
+        body: { channelId: 'chan_a', sessionId: 'sess_1' },
+      }),
+    );
+    const b = await guard.publicGetTracker(
+      makeReq({
+        ip: '203.0.113.5',
+        apiKeyId: 'ak_1',
+        body: { channelId: 'chan_a', sessionId: 'sess_2' },
+      }),
+    );
+    expect(a).toBe(b);
+  });
+
+  it('isolates trackers across api keys with the same channel + ip', async () => {
+    const a = await guard.publicGetTracker(
+      makeReq({ ip: '203.0.113.5', apiKeyId: 'ak_1', body: { channelId: 'chan_a' } }),
+    );
+    const b = await guard.publicGetTracker(
+      makeReq({ ip: '203.0.113.5', apiKeyId: 'ak_2', body: { channelId: 'chan_a' } }),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('isolates trackers across channels', async () => {
+    const a = await guard.publicGetTracker(
+      makeReq({ ip: '203.0.113.5', apiKeyId: 'ak_1', body: { channelId: 'chan_a' } }),
+    );
+    const b = await guard.publicGetTracker(
+      makeReq({ ip: '203.0.113.5', apiKeyId: 'ak_1', body: { channelId: 'chan_b' } }),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to "-" when apiKeyId or channelId is missing', async () => {
     const t = await guard.publicGetTracker(makeReq({ ip: '203.0.113.5' }));
-    expect(t).toBe('widget:203.0.113.5|-|-');
+    expect(t).toBe('widget:-|-|203.0.113.5');
+  });
+
+  it('uses req.ip and does not parse x-forwarded-for itself', async () => {
+    // req.ip is what Express produces — when trust proxy is unset it's the
+    // socket address; when set it reflects XFF. Either way, the guard does
+    // not parse XFF directly, so spoofing the header from an unproxied
+    // client has no effect on the bucket key.
+    const t = await guard.publicGetTracker(
+      makeReq({ ip: '10.0.0.1', apiKeyId: 'ak_1', body: { channelId: 'chan_a' } }),
+    );
+    expect(t).toBe('widget:ak_1|chan_a|10.0.0.1');
   });
 });

--- a/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.ts
@@ -3,21 +3,8 @@ import { ThrottlerGuard } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { ResolvedCredential } from '@getmunin/core';
 
-/**
- * Tracker key for widget POSTs / GETs.
- *
- * Key shape: `widget:<apiKeyId>|<channelId>|<ip>`.
- *
- * sessionId is *not* part of the key. It's caller-controlled — a hostile
- * embed can rotate session IDs ad infinitum, so including it lets a flood
- * trivially defeat the per-session bucket. Limiting per (apiKey, channel,
- * ip) means even a session-rotating flood from one source hits the cap.
- *
- * IP comes from `req.ip`, which uses Express's `trust proxy` setting
- * (configured at bootstrap from `MUNIN_TRUST_PROXY`). Trusting raw
- * `x-forwarded-for` was wrong: without a proxy in front, any client can
- * spoof it.
- */
+// Key by (apiKeyId, channelId, ip) — never sessionId, which is
+// caller-controlled and would let a rotating-session flood defeat the bucket.
 @Injectable()
 export class WidgetThrottlerGuard extends ThrottlerGuard {
   protected override getTracker(req: Request): Promise<string> {

--- a/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.ts
@@ -3,8 +3,6 @@ import { ThrottlerGuard } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { ResolvedCredential } from '@getmunin/core';
 
-// Key by (apiKeyId, channelId, ip) — never sessionId, which is
-// caller-controlled and would let a rotating-session flood defeat the bucket.
 @Injectable()
 export class WidgetThrottlerGuard extends ThrottlerGuard {
   protected override getTracker(req: Request): Promise<string> {

--- a/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-throttler.guard.ts
@@ -1,24 +1,31 @@
 import { Injectable } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
 import type { Request } from 'express';
+import type { ResolvedCredential } from '@getmunin/core';
 
+/**
+ * Tracker key for widget POSTs / GETs.
+ *
+ * Key shape: `widget:<apiKeyId>|<channelId>|<ip>`.
+ *
+ * sessionId is *not* part of the key. It's caller-controlled — a hostile
+ * embed can rotate session IDs ad infinitum, so including it lets a flood
+ * trivially defeat the per-session bucket. Limiting per (apiKey, channel,
+ * ip) means even a session-rotating flood from one source hits the cap.
+ *
+ * IP comes from `req.ip`, which uses Express's `trust proxy` setting
+ * (configured at bootstrap from `MUNIN_TRUST_PROXY`). Trusting raw
+ * `x-forwarded-for` was wrong: without a proxy in front, any client can
+ * spoof it.
+ */
 @Injectable()
 export class WidgetThrottlerGuard extends ThrottlerGuard {
   protected override getTracker(req: Request): Promise<string> {
-    const ip = readIp(req);
+    const ip = req.ip ?? req.socket?.remoteAddress ?? 'unknown';
     const channelId = readField(req, 'channelId') ?? '-';
-    const sessionId = readField(req, 'sessionId') ?? readFirstSessionId(req) ?? '-';
-    return Promise.resolve(`widget:${ip}|${channelId}|${sessionId}`);
+    const apiKeyId = readApiKeyId(req) ?? '-';
+    return Promise.resolve(`widget:${apiKeyId}|${channelId}|${ip}`);
   }
-}
-
-function readIp(req: Request): string {
-  const xff = req.headers['x-forwarded-for'];
-  if (typeof xff === 'string' && xff.length > 0) {
-    const first = xff.split(',')[0]!.trim();
-    if (first.length > 0) return first;
-  }
-  return req.ip ?? req.socket?.remoteAddress ?? 'unknown';
 }
 
 function readField(req: Request, name: string): string | null {
@@ -29,10 +36,7 @@ function readField(req: Request, name: string): string | null {
   return null;
 }
 
-function readFirstSessionId(req: Request): string | null {
-  const query = req.query as Record<string, unknown> | undefined;
-  const raw = query?.['sessionIds'];
-  if (typeof raw !== 'string' || raw.length === 0) return null;
-  const first = raw.split(',')[0]?.trim();
-  return first && first.length > 0 ? first : null;
+function readApiKeyId(req: Request): string | null {
+  const credential = (req as Request & { credential?: ResolvedCredential }).credential;
+  return credential?.actor.id ?? null;
 }


### PR DESCRIPTION
## Summary

Three widget-channel hardening changes from finding #2 of the internal review:

- **Throttler key**: drop caller-controlled `sessionId`. Previously the tracker
  was `widget:<ip>|<channelId>|<sessionId>` — a hostile embed could rotate
  session IDs through the same IP and key to keep generating new buckets,
  bypassing the limit. Key is now `widget:<apiKeyId>|<channelId>|<ip>`, read
  from the resolved widget credential the AuthGuard attaches.
- **Trusted IP**: the guard now uses `req.ip` (which honours Express's
  `trust proxy` setting) instead of parsing `x-forwarded-for` directly. New
  `MUNIN_TRUST_PROXY` env wires this — set to `1`/`true` behind a single
  proxy hop, a hop count, or specific IPs/CIDRs. Unset means trust nothing
  and `req.ip` is the socket address, so an unproxied app no longer honours
  a spoofed XFF.
- **Origin allowlist (opt-in strict mode)**: empty `originAllowlist` still
  allows any origin (dev ergonomics), but `MUNIN_WIDGET_REQUIRE_ALLOWLIST=1`
  flips it to deny-all so production won't accept a fresh channel that
  hasn't been configured.

## Test plan

- [x] `pnpm typecheck` clean (27/27)
- [x] New unit tests cover: session-id rotation no longer changes the key,
      different api keys / channels still isolate, env-driven trust-proxy
      parsing, allowlist semantics in both modes.
- [x] Existing widget integration tests untouched (skipped without
      `TEST_DATABASE_URL`).
- [ ] Manual: behind nginx with `MUNIN_TRUST_PROXY=1`, `req.ip` reflects
      the real client. With it unset and a spoofed XFF, the bucket keys by
      the socket address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)