### PR TITLE
fix(security): rate-limit /auth/* endpoints

### DIFF
--- a/.changeset/fix-auth-rate-limiting.md
+++ b/.changeset/fix-auth-rate-limiting.md
@@ -1,0 +1,21 @@
+---
+'@getmunin/backend': patch
+---
+
+**Security**: rate-limit `/auth/*` endpoints.
+
+Previously `/auth/*` was anonymous-by-design but not throttled. Login, signup,
+forgot-password, OAuth dynamic-client-registration, and OAuth token endpoints
+were all subject only to BetterAuth's defaults (in-memory, off by default in
+dev). Two layers now:
+
+- Nest's `ThrottlerGuard` is attached to the controller (`PublicController('auth',
+  { throttle: true })`) — a generic per-IP ceiling (60/min, 1000/hr from
+  `MUNIN_PUBLIC_THROTTLE_*`) that runs before BetterAuth touches the request.
+- BetterAuth's own per-path rate limiter is enabled with DB storage (the
+  `auth_rate_limit` table already existed), default 30/min, plus `customRules`
+  ratcheting `/sign-in/email`, `/sign-up/email`, `/forget-password`,
+  `/reset-password`, `/oauth2/register`, and `/oauth2/token` down further.
+
+Defaults tunable via `MUNIN_AUTH_RATELIMIT_WINDOW` (seconds) and
+`MUNIN_AUTH_RATELIMIT_MAX`.

--- a/apps/backend/src/auth/auth.config.rate-limit.test.ts
+++ b/apps/backend/src/auth/auth.config.rate-limit.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildAuthRateLimit } from './auth.config.ts';
+
+describe('buildAuthRateLimit', () => {
+  let originalWindow: string | undefined;
+  let originalMax: string | undefined;
+
+  beforeEach(() => {
+    originalWindow = process.env.MUNIN_AUTH_RATELIMIT_WINDOW;
+    originalMax = process.env.MUNIN_AUTH_RATELIMIT_MAX;
+  });
+  afterEach(() => {
+    if (originalWindow === undefined) delete process.env.MUNIN_AUTH_RATELIMIT_WINDOW;
+    else process.env.MUNIN_AUTH_RATELIMIT_WINDOW = originalWindow;
+    if (originalMax === undefined) delete process.env.MUNIN_AUTH_RATELIMIT_MAX;
+    else process.env.MUNIN_AUTH_RATELIMIT_MAX = originalMax;
+  });
+
+  it('is enabled with database storage by default', () => {
+    delete process.env.MUNIN_AUTH_RATELIMIT_WINDOW;
+    delete process.env.MUNIN_AUTH_RATELIMIT_MAX;
+    const cfg = buildAuthRateLimit()!;
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.storage).toBe('database');
+    expect(cfg.window).toBe(60);
+    expect(cfg.max).toBe(30);
+  });
+
+  it('reads window and max from env', () => {
+    process.env.MUNIN_AUTH_RATELIMIT_WINDOW = '120';
+    process.env.MUNIN_AUTH_RATELIMIT_MAX = '10';
+    const cfg = buildAuthRateLimit()!;
+    expect(cfg.window).toBe(120);
+    expect(cfg.max).toBe(10);
+  });
+
+  it('ratchets sensitive endpoints below the default', () => {
+    const cfg = buildAuthRateLimit()!;
+    const rules = cfg.customRules as Record<string, { window: number; max: number }>;
+    expect(rules['/sign-in/email']).toEqual({ window: 60, max: 5 });
+    expect(rules['/forget-password']).toEqual({ window: 60, max: 3 });
+    expect(rules['/oauth2/register']).toEqual({ window: 60, max: 10 });
+  });
+});

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -157,9 +157,6 @@ export function readAllowedEmailDomainsFromEnv(): string[] {
     .filter(Boolean);
 }
 
-// BetterAuth's per-path rate limiter, DB-backed (cross-replica) with tighter
-// custom rules on the credential-bruteforce endpoints. Runs alongside the
-// generic Nest ThrottlerGuard on /auth/*.
 export function buildAuthRateLimit(): BetterAuthOptions['rateLimit'] {
   return {
     enabled: true,

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -157,21 +157,9 @@ export function readAllowedEmailDomainsFromEnv(): string[] {
     .filter(Boolean);
 }
 
-/**
- * Per-endpoint rate limits for `/auth/*`. Two complementary defences:
- *
- *   1. `PublicController('auth', { throttle: true })` wraps everything in
- *      Nest's `ThrottlerGuard` — a generic per-IP ceiling (60/min, 1000/hr)
- *      that runs before BetterAuth touches the request.
- *   2. BetterAuth's own rate limiter runs inside the auth handler, keyed
- *      by IP + path and storing counters in the `auth_rate_limit` table so
- *      they survive across replicas. `customRules` ratchets the sensitive
- *      endpoints down further than the default (10 / 60s).
- *
- * All tunable via env without code changes; defaults are intentionally
- * conservative since legitimate users hit each of these once or twice per
- * incident.
- */
+// BetterAuth's per-path rate limiter, DB-backed (cross-replica) with tighter
+// custom rules on the credential-bruteforce endpoints. Runs alongside the
+// generic Nest ThrottlerGuard on /auth/*.
 export function buildAuthRateLimit(): BetterAuthOptions['rateLimit'] {
   return {
     enabled: true,

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -45,6 +45,7 @@ export function createMuninAuth({
     trustedOrigins,
     webBaseUrl,
     logger,
+    rateLimit: buildAuthRateLimit(),
     socialProviders: google || github ? { google, github } : undefined,
     sendResetPassword: mailer
       ? async ({ user, url }) => {
@@ -154,6 +155,39 @@ export function readAllowedEmailDomainsFromEnv(): string[] {
     .split(',')
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean);
+}
+
+/**
+ * Per-endpoint rate limits for `/auth/*`. Two complementary defences:
+ *
+ *   1. `PublicController('auth', { throttle: true })` wraps everything in
+ *      Nest's `ThrottlerGuard` — a generic per-IP ceiling (60/min, 1000/hr)
+ *      that runs before BetterAuth touches the request.
+ *   2. BetterAuth's own rate limiter runs inside the auth handler, keyed
+ *      by IP + path and storing counters in the `auth_rate_limit` table so
+ *      they survive across replicas. `customRules` ratchets the sensitive
+ *      endpoints down further than the default (10 / 60s).
+ *
+ * All tunable via env without code changes; defaults are intentionally
+ * conservative since legitimate users hit each of these once or twice per
+ * incident.
+ */
+export function buildAuthRateLimit(): BetterAuthOptions['rateLimit'] {
+  return {
+    enabled: true,
+    storage: 'database',
+    window: Number(process.env.MUNIN_AUTH_RATELIMIT_WINDOW ?? 60),
+    max: Number(process.env.MUNIN_AUTH_RATELIMIT_MAX ?? 30),
+    customRules: {
+      '/sign-in/email': { window: 60, max: 5 },
+      '/sign-up/email': { window: 60, max: 5 },
+      '/forget-password': { window: 60, max: 3 },
+      '/reset-password': { window: 60, max: 5 },
+      '/verify-email': { window: 60, max: 5 },
+      '/oauth2/register': { window: 60, max: 10 },
+      '/oauth2/token': { window: 60, max: 30 },
+    },
+  };
 }
 
 type CaptureExceptionFn = (

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -21,7 +21,7 @@ import {
 
 const AUTH_URL_FALLBACK = 'http://localhost:3001';
 
-@PublicController('auth')
+@PublicController('auth', { throttle: true })
 export class AuthController {
   private readonly auth: MuninAuth;
 


### PR DESCRIPTION
## Summary

`/auth/*` was anonymous-by-design but not throttled. Login, signup,
forgot-password, OAuth dynamic-client-registration, and the OAuth token
endpoint were subject only to BetterAuth's defaults (in-memory, off by default
in dev). Two complementary layers now:

- **Nest `ThrottlerGuard`** is attached at the controller level via
  `@PublicController('auth', { throttle: true })`. Same per-IP ceiling we
  already use for other public routes (60/min, 1000/hr from
  `MUNIN_PUBLIC_THROTTLE_*`). Runs before BetterAuth touches the request.
- **BetterAuth's per-path limiter** with `storage: 'database'` (the
  `auth_rate_limit` table already exists). Default 30/min, plus `customRules`
  ratcheting sensitive endpoints down: sign-in/sign-up at 5/min, forget-password
  at 3/min, oauth2/register at 10/min, oauth2/token at 30/min.

New env tunables: `MUNIN_AUTH_RATELIMIT_WINDOW` (seconds), `MUNIN_AUTH_RATELIMIT_MAX`.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] New unit test asserts the rate-limit config shape and env handling.
- [ ] Manual: `for i in $(seq 1 20); do curl -X POST $URL/auth/sign-in/email
      -d '{"email":"x@y","password":"wrong"}' -H 'content-type: application/json';
      done` — expect 429 after the 5th request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)