### PR TITLE
fix(security): enable RLS on org_members

### DIFF
--- a/.changeset/fix-org-members-rls.md
+++ b/.changeset/fix-org-members-rls.md
@@ -1,0 +1,30 @@
+---
+'@getmunin/db': patch
+'@getmunin/core': patch
+'@getmunin/backend': patch
+---
+
+**Security**: enable RLS on `org_members`.
+
+`org_members` was the last org-scoped table without a tenant-isolation policy.
+The composite `(org_id, user_id)` primary key meant correct controllers couldn't
+return cross-org rows by accident, but the database stopped catching mistakes —
+any future controller that forgot the WHERE clause would leak membership info
+across tenants. The meta-test in `rls.test.ts` was suppressed with an
+exemption.
+
+This patch:
+
+- Adds a `tenant_isolation` policy on `org_members` mirroring the other
+  org-scoped tables (`org_id = app_org_id() OR app_bypass_rls()`).
+- Wraps the three structurally cross-org reads (OAuth credential resolver,
+  JWT credential resolver, session credential resolver, signup) in a
+  `bypass_rls` transaction — they filter by `user_id` and run before
+  `TenancyInterceptor` sets `app.org_id`, so they could not satisfy a strict
+  policy. Introduces a shared `readMembershipsForUser` helper in
+  `@getmunin/core` so the three sites stay consistent.
+- Drops the `org_members` exemption from the "every org_id table has RLS"
+  meta-test.
+
+Migrations are idempotent and re-apply `rls.sql` on each run, so existing
+deployments pick up the policy on next migrate.

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -110,9 +110,6 @@ async function ensureSingletonOrgMembershipFor(
   user: { id: string; email: string; name?: string | null },
 ): Promise<void> {
   await db.transaction(async (tx) => {
-    // org_members is RLS-managed and we have no tenancy context yet — must
-    // bypass before reading or inserting. Inlined inside the tx so both the
-    // existence check and the singleton-org creation use the same bypass.
     await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
 
     const existing = await tx

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -109,15 +109,18 @@ async function ensureSingletonOrgMembershipFor(
   db: Db,
   user: { id: string; email: string; name?: string | null },
 ): Promise<void> {
-  const existing = await db
-    .select({ orgId: schema.orgMembers.orgId })
-    .from(schema.orgMembers)
-    .where(eq(schema.orgMembers.userId, user.id))
-    .limit(1);
-  if (existing[0]) return;
-
   await db.transaction(async (tx) => {
+    // org_members is RLS-managed and we have no tenancy context yet — must
+    // bypass before reading or inserting. Inlined inside the tx so both the
+    // existence check and the singleton-org creation use the same bypass.
     await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+
+    const existing = await tx
+      .select({ orgId: schema.orgMembers.orgId })
+      .from(schema.orgMembers)
+      .where(eq(schema.orgMembers.userId, user.id))
+      .limit(1);
+    if (existing[0]) return;
 
     let orgRow = (
       await tx

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -6,14 +6,6 @@ import { ActorIdentity, type ActorType, type Audience } from './context.ts';
 import { hashSecret } from '../crypto/primitives.ts';
 import { looksLikeJwt, resolveOauthJwtAccessToken } from './oauth-jwt.ts';
 
-/**
- * Read the user's membership rows by user_id with RLS bypassed. Credential
- * resolution runs *before* the TenancyInterceptor sets `app.org_id`, so a
- * direct query under RLS would always return zero rows. The query filters
- * by user_id, which is sufficient narrowing — RLS is the policy backstop
- * for org-scoped controllers that might forget the WHERE clause, not for
- * this code path which is structurally cross-org.
- */
 async function readMembershipsForUser(
   db: Db,
   userId: string,

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -1,10 +1,33 @@
 import { createHash } from 'node:crypto';
 import type { Db } from '@getmunin/db';
 import { schema } from '@getmunin/db';
-import { and, eq, gt, isNull } from 'drizzle-orm';
+import { and, eq, gt, isNull, sql } from 'drizzle-orm';
 import { ActorIdentity, type ActorType, type Audience } from './context.ts';
 import { hashSecret } from '../crypto/primitives.ts';
 import { looksLikeJwt, resolveOauthJwtAccessToken } from './oauth-jwt.ts';
+
+/**
+ * Read the user's membership rows by user_id with RLS bypassed. Credential
+ * resolution runs *before* the TenancyInterceptor sets `app.org_id`, so a
+ * direct query under RLS would always return zero rows. The query filters
+ * by user_id, which is sufficient narrowing — RLS is the policy backstop
+ * for org-scoped controllers that might forget the WHERE clause, not for
+ * this code path which is structurally cross-org.
+ */
+async function readMembershipsForUser(
+  db: Db,
+  userId: string,
+): Promise<Array<typeof schema.orgMembers.$inferSelect>> {
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+    return tx
+      .select()
+      .from(schema.orgMembers)
+      .where(eq(schema.orgMembers.userId, userId));
+  });
+}
+
+export { readMembershipsForUser };
 
 function hashOauthOpaqueToken(rawToken: string): string {
   return createHash('sha256').update(rawToken).digest('base64url');
@@ -77,10 +100,7 @@ export class CredentialResolver {
     if (tokenRow.expiresAt < new Date()) return null;
     if (!tokenRow.userId) return null;
 
-    const memberships = await this.db
-      .select()
-      .from(schema.orgMembers)
-      .where(eq(schema.orgMembers.userId, tokenRow.userId));
+    const memberships = await readMembershipsForUser(this.db, tokenRow.userId);
     const active = memberships.find((m) => m.isDefault) ?? memberships[0];
     if (!active) return null;
 
@@ -170,10 +190,7 @@ export class CredentialResolver {
     const session = sessionRows[0];
     if (!session) return null;
 
-    const memberships = await this.db
-      .select()
-      .from(schema.orgMembers)
-      .where(eq(schema.orgMembers.userId, session.userId));
+    const memberships = await readMembershipsForUser(this.db, session.userId);
     const membership =
       memberships.find((m) => m.isDefault) ??
       [...memberships].sort((a, b) => +a.createdAt - +b.createdAt)[0];

--- a/packages/core/src/request/oauth-jwt.ts
+++ b/packages/core/src/request/oauth-jwt.ts
@@ -6,6 +6,7 @@ import { ActorIdentity } from './context.ts';
 import {
   deriveAudiencesFromScopes,
   oauthMcpResourceAudience,
+  readMembershipsForUser,
   type ResolvedCredential,
 } from './credentials.ts';
 
@@ -63,10 +64,7 @@ export async function resolveOauthJwtAccessToken(
   const scopes =
     typeof payload['scope'] === 'string' ? payload['scope'].split(/\s+/).filter(Boolean) : [];
 
-  const memberships = await db
-    .select()
-    .from(schema.orgMembers)
-    .where(eq(schema.orgMembers.userId, userId));
+  const memberships = await readMembershipsForUser(db, userId);
   const active = memberships.find((m) => m.isDefault) ?? memberships[0];
   if (!active) return null;
 

--- a/packages/db/src/rls.test.ts
+++ b/packages/db/src/rls.test.ts
@@ -123,11 +123,7 @@ const skipReason = TEST_URL
   // explicitly below — usually because tenancy is delegated to a parent
   // table's policy via FK or the table is a system-level catalog.
   it('every table with an org_id column has RLS enabled', async () => {
-    const exempt = new Set<string>([
-      // org_members: composite (org_id, user_id) primary key + service-role
-      // reads via assertOwnerOrAdmin. Documented in rls.sql.
-      'org_members',
-    ]);
+    const exempt = new Set<string>([]);
     const rows = await client.begin(async (sql) => {
       await sql`SELECT set_config('app.bypass_rls', 'on', true)`;
       return sql<{ table_name: string; relrowsecurity: boolean; relforcerowsecurity: boolean; policy_count: number }[]>`

--- a/packages/db/src/sql/rls.sql
+++ b/packages/db/src/sql/rls.sql
@@ -214,9 +214,27 @@ CREATE POLICY tenant_isolation ON feedback_outbox
   USING (app_bypass_rls() OR org_id = app_org_id())
   WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
 
+-- ───────────────────────── org_members ─────────────────────────────────────
+-- Membership rows. Tenant-scoped by `org_id`. Some legitimate code paths read
+-- across orgs:
+--   - credential resolvers pick the user's default org *before* TenancyInterceptor
+--     sets app.org_id, so they have to query by user_id with bypass_rls.
+--   - /v1/me/memberships lists every org the signed-in user belongs to so the
+--     dashboard can render the org switcher; this also runs under bypass_rls.
+--   - signup creates the very first membership row before a tenancy context
+--     exists.
+-- All three paths explicitly opt into bypass_rls and the app-layer queries
+-- filter by user_id. A future "missed filter" inside an org-scoped controller
+-- is what RLS catches.
+ALTER TABLE org_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE org_members FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON org_members;
+CREATE POLICY tenant_isolation ON org_members
+  USING (app_bypass_rls() OR org_id = app_org_id())
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
 -- ───────────────────────── tables intentionally WITHOUT RLS ────────────────
 -- These are accessed only by the service role / migrations:
 --   users          (BetterAuth-managed; tenant scoping via org_members)
---   org_members    (composite key already enforces tenancy)
 --   system_config  (deployment-wide singleton; no org_id; read through
 --                   InstanceIdService which sets app.bypass_rls explicitly)


### PR DESCRIPTION
## Summary

`org_members` was the last org-scoped table without a tenant-isolation policy.
The composite `(org_id, user_id)` primary key prevented accidental cross-org
SELECT in well-written controllers, but the database had stopped catching
mistakes — a future controller that forgot the WHERE clause could leak
membership info across tenants. The meta-test in `rls.test.ts` was suppressed
with an exemption for this table.

This PR:

- Adds the `tenant_isolation` policy on `org_members` mirroring the shape used
  by every other org-scoped table (`org_id = app_org_id() OR app_bypass_rls()`).
- Wraps the three structurally cross-org callers in a `bypass_rls` transaction:
  - `CredentialResolver.resolveOauthAccessToken` (opaque OAuth)
  - `resolveOauthJwtAccessToken`
  - `CredentialResolver.resolveSessionToken`
  - `auth.config.ts:ensureSingletonOrgMembershipFor` (signup path)
  These run *before* `TenancyInterceptor` sets `app.org_id`, so a strict policy
  is unsatisfiable. Filter remains app-layer `user_id = actor.userId`. A new
  shared `readMembershipsForUser` helper in `@getmunin/core` keeps the three
  credential-resolver sites consistent.
- Drops the `org_members` exemption from the "every org_id table has RLS"
  meta-test.

`rls.sql` is idempotent and re-applied on every migration, so existing
deployments pick up the policy on next migrate.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm -F @getmunin/core test` — 114 pass, JWT/session/OAuth resolver
      paths exercised.
- [ ] `pnpm -F @getmunin/db test` with `TEST_DATABASE_URL` set — the meta-test
      should pass with the new policy and the exemption removed.
- [ ] Manual: log in as user X (member of orgs A + B with A default), call
      `GET /v1/me/memberships`, expect both orgs returned. Then `PATCH active`
      to org B and confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)