### PR TITLE
fix(security): encrypt social-provider tokens at rest

### DIFF
--- a/.changeset/fix-encrypt-oauth-account-tokens.md
+++ b/.changeset/fix-encrypt-oauth-account-tokens.md
@@ -1,0 +1,31 @@
+---
+'@getmunin/backend-core': patch
+---
+
+**Security**: encrypt social-provider tokens at rest (`accounts.accessToken`,
+`refreshToken`, `idToken`).
+
+Audit of finding #5 (sensitive auth material plaintext at rest):
+
+| Column                       | Status                                        |
+|------------------------------|-----------------------------------------------|
+| `accounts.password`          | ✅ Already hashed (scrypt) by BetterAuth.     |
+| `accounts.accessToken/refreshToken/idToken` | ❌ **Plaintext by default.** Fixed. |
+| `jwks.privateKey`            | ✅ Encrypted (BetterAuth's jwt plugin wraps with `symmetricEncrypt` unless `disablePrivateKeyEncryption` is set). |
+| `oauthClient.clientSecret`   | ✅ Hashed (SHA-256) by `@better-auth/oauth-provider`'s `storeClientSecret` (default `'hashed'`). |
+| `oauthRefreshToken.token`    | ✅ Hashed (SHA-256) by `storeToken`.          |
+| `oauthAccessToken.token`     | ✅ Hashed (SHA-256). Matches our `credentials.ts` lookup hash. |
+
+Only `accounts.*Token` columns were actually plaintext. Set
+`account.encryptOAuthTokens: true` in the BetterAuth factory — provider tokens
+are now `symmetricEncrypt`-wrapped with the existing `secret`. Decryption
+happens transparently on read.
+
+The remaining columns the auditor flagged were already protected at the
+application layer despite their `text` shape in the Drizzle schema.
+
+**Existing rows**: any social-provider tokens already in `accounts` from
+previous logins remain plaintext until that row is rewritten. BetterAuth's
+`decryptOAuthToken` helper detects "looks-encrypted" tokens and only attempts
+decryption when the format matches, so existing plaintext tokens keep working
+on read. New tokens (refresh on next sign-in) land encrypted.

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -124,6 +124,14 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
         }
       : undefined,
     socialProviders,
+    account: {
+      // Encrypt provider-issued tokens (access/refresh/id) at rest. BetterAuth
+      // wraps these with `symmetricEncrypt` using the same `secret` we already
+      // pass below. Without this they sit in the `accounts` table as
+      // plaintext — and a leaked DB dump would yield usable Google/GitHub
+      // refresh tokens for every linked account.
+      encryptOAuthTokens: true,
+    },
     user: opts.deleteUser
       ? {
           deleteUser: {

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -124,14 +124,7 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
         }
       : undefined,
     socialProviders,
-    account: {
-      // Encrypt provider-issued tokens (access/refresh/id) at rest. BetterAuth
-      // wraps these with `symmetricEncrypt` using the same `secret` we already
-      // pass below. Without this they sit in the `accounts` table as
-      // plaintext — and a leaked DB dump would yield usable Google/GitHub
-      // refresh tokens for every linked account.
-      encryptOAuthTokens: true,
-    },
+    account: { encryptOAuthTokens: true },
     user: opts.deleteUser
       ? {
           deleteUser: {


### PR DESCRIPTION
## Summary

Reviewer's finding #5 listed six columns suspected to be plaintext at rest.
After auditing the BetterAuth / @better-auth/oauth-provider source, five of
them were already protected at the application layer despite their `text`
shape in the Drizzle schema:

| Column                       | Status                                        |
|------------------------------|-----------------------------------------------|
| `accounts.password`          | ✅ Hashed (scrypt).                            |
| `accounts.accessToken/refreshToken/idToken` | ❌ **Plaintext by default.** Fixed here. |
| `jwks.privateKey`            | ✅ `symmetricEncrypt`'d by BetterAuth's jwt plugin (unless `disablePrivateKeyEncryption: true`). |
| `oauthClient.clientSecret`   | ✅ SHA-256 hashed by `@better-auth/oauth-provider`'s `storeClientSecret` (default `'hashed'`). |
| `oauthRefreshToken.token`    | ✅ SHA-256 hashed by `storeToken`.             |
| `oauthAccessToken.token`     | ✅ SHA-256 hashed. Matches our `credentials.ts` lookup hash. |

The fix is small: set `account.encryptOAuthTokens: true` in the auth factory.
BetterAuth wraps Google/GitHub access/refresh/id tokens with `symmetricEncrypt`
using the existing `secret`, and decrypts transparently on read.

**Migration impact**: BetterAuth's `decryptOAuthToken` checks whether a stored
value "looks encrypted" before attempting decryption. Pre-existing plaintext
tokens continue working on read; new tokens (refresh on next sign-in) land
encrypted. No data migration required.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm -F @getmunin/backend-core test` — 202 pass.
- [ ] Manual: sign in via Google in a dev env, query `SELECT
      access_token FROM accounts WHERE provider_id = 'google';` — value should
      now start with `$ba$` (encrypted marker) instead of the raw OAuth
      access-token string.

## Why this PR is smaller than the original plan

The plan ("encrypt JWKS private key, audit oauth_access_token storage, etc.")
assumed BetterAuth stored these verbatim. The audit showed it already encrypts
or hashes them at write time. Only the social-provider token columns were
genuinely exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)