### PR TITLE
fix(core): drop misleading openai label from embedding errors

### DIFF
--- a/.changeset/embedding-error-message.md
+++ b/.changeset/embedding-error-message.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/core': patch
+---
+
+Drop the misleading `openai` label from embedding-provider output.
+
+The HTTP embedding provider is OpenAI-protocol compatible but routinely
+points at Scaleway, Ollama, vLLM, etc. — calling its errors and telemetry
+name `openai:…` made production failures look like OpenAI outages when
+they were really upstream IAM/permission errors at the configured base URL.
+
+- Error on non-2xx response is now `embedding provider request failed: <status> <body> (<name> via <baseUrl>)` instead of `openai embeddings failed: …`. The model name and endpoint are included so the failure is self-diagnosing.
+- `EmbeddingProvider.name` no longer prefixes `openai:`; it's just `<model>` or `<model>@<dimensions>`. Anything consuming this for telemetry/audit will see the bare model identifier.

--- a/packages/core/src/providers/embedding.test.ts
+++ b/packages/core/src/providers/embedding.test.ts
@@ -80,7 +80,7 @@ describe('OpenAIEmbeddingProvider', () => {
     const spy = installFetchSpy(new Array<number>(1536).fill(0.1));
     const p = new OpenAIEmbeddingProvider({ apiKey: 'sk-test' });
     expect(p.dimensions).toBe(1536);
-    expect(p.name).toBe('openai:text-embedding-3-small');
+    expect(p.name).toBe('text-embedding-3-small');
     await p.embed(['hi']);
     expect(spy.lastCall().body.dimensions).toBeUndefined();
   });
@@ -94,7 +94,7 @@ describe('OpenAIEmbeddingProvider', () => {
       dimensions: 4000,
     });
     expect(p.dimensions).toBe(4000);
-    expect(p.name).toBe('openai:qwen3-embedding-8b@4000');
+    expect(p.name).toBe('qwen3-embedding-8b@4000');
     await p.embed(['hi']);
     expect(spy.lastCall().body).toMatchObject({
       model: 'qwen3-embedding-8b',
@@ -177,7 +177,7 @@ describe('readEmbeddingProviderFromEnv', () => {
     const p = readEmbeddingProviderFromEnv();
     expect(p).toBeInstanceOf(OpenAIEmbeddingProvider);
     expect(p.dimensions).toBe(4000);
-    expect(p.name).toBe('openai:qwen3-embedding-8b@4000');
+    expect(p.name).toBe('qwen3-embedding-8b@4000');
   });
 
   it('keeps the OSS default (no env vars) producing a 1536-dim OpenAI provider', () => {
@@ -185,6 +185,6 @@ describe('readEmbeddingProviderFromEnv', () => {
     const p = readEmbeddingProviderFromEnv();
     expect(p).toBeInstanceOf(OpenAIEmbeddingProvider);
     expect(p.dimensions).toBe(1536);
-    expect(p.name).toBe('openai:text-embedding-3-small');
+    expect(p.name).toBe('text-embedding-3-small');
   });
 });

--- a/packages/core/src/providers/embedding.ts
+++ b/packages/core/src/providers/embedding.ts
@@ -54,8 +54,8 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
     this.dimensions = opts.dimensions ?? DEFAULT_DIMENSIONS;
     this.sendDimensions = opts.dimensions !== undefined;
     this.name = this.sendDimensions
-      ? `openai:${this.model}@${this.dimensions}`
-      : `openai:${this.model}`;
+      ? `${this.model}@${this.dimensions}`
+      : this.model;
   }
 
   async embed(texts: readonly string[]): Promise<number[][]> {
@@ -72,7 +72,10 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
     });
     if (!res.ok) {
       const errBody = await res.text();
-      throw new Error(`openai embeddings failed: ${res.status} ${errBody}`);
+      throw new Error(
+        `embedding provider request failed: ${res.status} ${errBody} ` +
+          `(${this.name} via ${this.baseUrl})`,
+      );
     }
     const json = (await res.json()) as { data: { embedding: number[]; index: number }[] };
     const ordered = [...json.data].sort((a, b) => a.index - b.index).map((d) => d.embedding);


### PR DESCRIPTION
## Summary
- The HTTP embedding provider in `@getmunin/core` is OpenAI-protocol compatible but in production usually points at Scaleway, Ollama, vLLM, etc. Labelling its failures and `.name` telemetry as `openai:…` made upstream IAM errors look like OpenAI outages (we hit this with a Scaleway 403 surfacing as `openai embeddings failed: 403 …`).
- Error on non-2xx HTTP response is now `embedding provider request failed: <status> <body> (<model[@dim]> via <baseUrl>)` — self-diagnosing.
- `EmbeddingProvider.name` is now just `<model>` or `<model>@<dimensions>`, no `openai:` prefix.
- Env vars (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_EMBEDDING_MODEL`, `MUNIN_EMBEDDING_PROVIDER=openai`) are unchanged — they correctly identify the *protocol*, not the upstream vendor, and renaming would churn every deployment.

## Test plan
- [x] `pnpm -F @getmunin/core test` — embedding suite green (16/16)
- [x] `pnpm typecheck` — clean
- [ ] Confirm in prod logs that the next embedding failure shows the model + baseUrl in the error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)