### PR TITLE
fix(changeset): drop ignored @getmunin/backend from org-members-rls

### DIFF
--- a/.changeset/fix-org-members-rls.md
+++ b/.changeset/fix-org-members-rls.md
@@ -1,7 +1,6 @@
 ---
 '@getmunin/db': patch
 '@getmunin/core': patch
-'@getmunin/backend': patch
 ---
 
 **Security**: enable RLS on `org_members`.


### PR DESCRIPTION
## Summary

The release workflow's \`changeset version\` step on main is failing:

\`\`\`
🦋 error Error: Found mixed changeset fix-org-members-rls
🦋 error Found ignored packages: @getmunin/backend
🦋 error Found not ignored packages: @getmunin/db @getmunin/core
🦋 error Mixed changesets that contain both ignored and not ignored packages are not allowed
\`\`\`

\`apps/backend\` is in the changesets \`ignore\` list (\`.changeset/config.json\`)
because it doesn't publish to a registry — it ships from the release tag.
Mixing it with publishable workspace packages in the same changeset is
disallowed.

Fix: remove \`'@getmunin/backend': patch\` from the org-members-rls changeset.
The only change in \`apps/backend\` was the signup membership lookup, which is
already covered by the wider patch description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)