### PR TITLE
feat(cms+crm): partial-update semantics on jsonb payloads

### DIFF
--- a/.changeset/cms-crm-partial-update.md
+++ b/.changeset/cms-crm-partial-update.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': minor
+---
+
+`cms_update_entry` and `crm_update_contact` now do partial updates on their jsonb payloads. Previously you had to send every field on `cms_update_entry.data` (or every key on `crm_update_contact.patch.customFields`) even if you only wanted to change one — and for CMS the validator then re-ran against the full payload, so omitted required fields blew up the call.
+
+Both tools now shallow-merge the incoming patch into the existing payload: keys you send replace the corresponding keys, keys you omit are preserved, and `key: null` clears a single key. CMS still re-validates the merged result against the collection schema, regenerates search_text + embedding, and rewires references.
+
+No behavior change for callers that were already sending the full payload. The "wipe everything" case (set the whole bag to a new object) is rare in practice — if you need it, send the new payload plus explicit `null`s for the keys you want gone.

--- a/packages/backend-core/src/modules/cms/cms.service.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.test.ts
@@ -323,6 +323,52 @@ class StubStorage implements AssetStorage {
       ).rejects.toThrow(CmsConflictError);
     });
 
+    it('updateEntry shallow-merges data into the existing entry', async () => {
+      const col = await seedCollection();
+      const entry = await run(() =>
+        svc.createEntry({
+          collection: col.slug,
+          slug: 'merge',
+          data: { title: 'Original', body: 'Body stays' },
+        }),
+      );
+      const updated = await run(() =>
+        svc.updateEntry({ id: entry.id, ifVersion: 1, data: { title: 'Patched' } }),
+      );
+      expect(updated.data.title).toBe('Patched');
+      expect(updated.data.body).toBe('Body stays');
+    });
+
+    it('updateEntry passes validation on partial patch that omits required fields', async () => {
+      const col = await seedCollection();
+      const entry = await run(() =>
+        svc.createEntry({
+          collection: col.slug,
+          slug: 'partial',
+          data: { title: 'Required is set', body: 'b' },
+        }),
+      );
+      await expect(
+        run(() => svc.updateEntry({ id: entry.id, ifVersion: 1, data: { body: 'b2' } })),
+      ).resolves.toBeTruthy();
+    });
+
+    it('updateEntry clears a single field when patch sends null', async () => {
+      const col = await seedCollection();
+      const entry = await run(() =>
+        svc.createEntry({
+          collection: col.slug,
+          slug: 'clear',
+          data: { title: 'Keep', body: 'remove me' },
+        }),
+      );
+      const updated = await run(() =>
+        svc.updateEntry({ id: entry.id, ifVersion: 1, data: { body: null } }),
+      );
+      expect(updated.data.title).toBe('Keep');
+      expect(updated.data.body).toBeNull();
+    });
+
     it('updateEntry with no field change does not invoke embedding rebuild', async () => {
       const col = await seedCollection();
       const entry = await run(() =>

--- a/packages/backend-core/src/modules/cms/cms.service.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.ts
@@ -399,7 +399,10 @@ export class CmsService {
     }
     const collection = await this.getCollectionById(existing.collectionId);
 
-    const newData = input.data ?? existing.data;
+    const existingData = (existing.data ?? {});
+    const newData = input.data
+      ? { ...existingData, ...input.data }
+      : existingData;
     if (input.data) {
       const errors = validateEntryData(collection.fields, newData);
       if (errors.length > 0) {

--- a/packages/backend-core/src/modules/cms/cms.tools.ts
+++ b/packages/backend-core/src/modules/cms/cms.tools.ts
@@ -260,7 +260,7 @@ export class CmsAdminTools {
     name: 'cms_update_entry',
     title: 'CMS: Update entry',
     description:
-      'Update an entry. Pass `ifVersion` (the current version you read) for optimistic concurrency. Updating `data` re-validates against the collection schema, regenerates search_text + embedding, and rewrites references.',
+      'Update an entry. Pass `ifVersion` (the current version you read) for optimistic concurrency. `data` is a partial patch — keys you send replace the corresponding keys on the existing entry; keys you omit are preserved. Pass an explicit `null` to clear a single key. The merged payload is then re-validated against the collection schema, and search_text + embedding + references are regenerated.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: UpdateEntryInput,

--- a/packages/backend-core/src/modules/cms/skills/publish-entry.md
+++ b/packages/backend-core/src/modules/cms/skills/publish-entry.md
@@ -32,14 +32,14 @@ If you're picking from the queue: `cms_list_entries` with `{ "status": "draft", 
   "arguments": {
     "id": "<entryId>",
     "ifVersion": 7,
-    "data": { /* the full updated payload */ },
+    "data": { /* just the keys you want to change; omitted keys are preserved. Send `key: null` to clear. */ },
     "slug": "optional-new-slug",
     "locale": "optional-new-locale"
   }
 }
 ```
 
-Update increments `version` to 8 and re-validates against the collection schema, regenerates the search-text + embedding, and rewires inbound references. **You now have version 8** — use it for the next write.
+Update merges the patch into the existing payload, then increments `version` to 8 and re-validates the merged result against the collection schema, regenerates the search-text + embedding, and rewires inbound references. **You now have version 8** — use it for the next write.
 
 If you get a `cms_version_conflict` error, re-read with `cms_get_entry` and retry. Don't blindly bump the number.
 

--- a/packages/backend-core/src/modules/crm/crm.service.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.test.ts
@@ -170,6 +170,20 @@ const skipReason = TEST_URL
       ).rejects.toThrow(NotFoundException);
     });
 
+    it('updateContact shallow-merges customFields with existing', async () => {
+      const c = await run(() =>
+        svc.createContact({ name: 'A', email: 'a@x', customFields: { region: 'EU', plan: 'pro' } }),
+      );
+      const updated = await run(() =>
+        svc.updateContact({ id: c.id, patch: { customFields: { plan: 'enterprise' } } }),
+      );
+      expect(updated.customFields).toEqual({ region: 'EU', plan: 'enterprise' });
+      const cleared = await run(() =>
+        svc.updateContact({ id: c.id, patch: { customFields: { region: null } } }),
+      );
+      expect(cleared.customFields).toEqual({ region: null, plan: 'enterprise' });
+    });
+
     it('updateContact toggling doNotContact stamps unsubscribedAt', async () => {
       const c = await run(() => svc.createContact({ name: 'A', email: 'a@x' }));
       const subscribed = await run(() =>

--- a/packages/backend-core/src/modules/crm/crm.service.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.ts
@@ -335,6 +335,20 @@ export class CrmService {
     for (const [k, v] of Object.entries(effectivePatch)) {
       if (v !== undefined) updates[k] = v;
     }
+    if (effectivePatch.customFields !== undefined) {
+      const incoming = effectivePatch.customFields as Record<string, unknown>;
+      let existingCustom: Record<string, unknown> = {};
+      if (mode !== 'fill-null') {
+        const [row] = await ctx.db
+          .select({ customFields: schema.crmContacts.customFields })
+          .from(schema.crmContacts)
+          .where(eq(schema.crmContacts.id, input.id))
+          .limit(1);
+        if (!row) throw new NotFoundException(`crm_not_found: contact ${input.id}`);
+        existingCustom = (row.customFields ?? {});
+      }
+      updates.customFields = { ...existingCustom, ...incoming };
+    }
     if (effectivePatch.doNotContact === false) {
       updates.unsubscribedAt = null;
     } else if (effectivePatch.doNotContact === true) {

--- a/packages/backend-core/src/modules/crm/crm.tools.ts
+++ b/packages/backend-core/src/modules/crm/crm.tools.ts
@@ -284,7 +284,7 @@ export class CrmAdminTools {
     name: 'crm_update_contact',
     title: 'CRM: Update contact',
     description:
-      "Update fields on a contact. Setting `doNotContact: true` also stamps `unsubscribedAt`; setting it false clears it. Pass `mode: 'fill-null'` from automated/curator contexts to refuse overwriting existing non-null values (only null/empty fields are filled). Default `mode: 'overwrite'` applies the patch as-is and is appropriate for human-driven edits.",
+      "Update fields on a contact. Only keys present in `patch` are touched; omitted keys are preserved. `customFields` is a partial patch — keys you send replace the corresponding keys; keys you omit are preserved (send `key: null` to clear a single custom field). Setting `doNotContact: true` also stamps `unsubscribedAt`; setting it false clears it. Pass `mode: 'fill-null'` from automated/curator contexts to refuse overwriting existing non-null values (only null/empty fields are filled). Default `mode: 'overwrite'` applies the patch as-is and is appropriate for human-driven edits.",
     audiences: ['admin'],
     scopes: ['crm:write'],
     input: UpdateContactInput,


### PR DESCRIPTION
## Summary
- \`cms_update_entry.data\` is now a partial patch — keys you send replace the corresponding keys on the existing entry; omitted keys are preserved.
- \`crm_update_contact.patch.customFields\` does the same shallow merge with the existing custom-fields blob.
- Both: pass \`key: null\` to clear a single key. CMS still re-validates the merged result against the collection schema and regenerates search_text + embedding + references.

## Why
Both update tools previously required the full payload on the jsonb field. To change one CMS data field you had to read, copy, modify, and write back every other field — and the validator would then re-run against the full payload, so omitting a required field broke the call. Same trap on CRM \`customFields\`: setting one key wiped the others.

## What did NOT change
Audited every \`*_update_*\` MCP tool:

| Tool | Status |
|---|---|
| \`kb_update_document\` | ✓ already correct (per-field partial) |
| \`crm_update_contact\` | **fixed** (customFields shallow-merge) |
| \`crm_update_my_contact\` | inherits fix |
| \`crm_update_segment\` | ✓ correct (filter is a structured object — replace by design) |
| \`conv_widget_update_channel\` | ✓ correct |
| \`cms_update_collection\` | ✓ correct (fields/settings are structured — replace by design) |
| \`cms_update_entry\` | **fixed** |
| \`outreach_update_campaign\` | ✓ correct |

## Test plan
- [x] \`pnpm -F @getmunin/backend-core test\` — 683 tests pass, including 4 new ones (CMS merge / merge-validates-merged / null-clears-key, CRM customFields shallow-merge + null-clears).
- [x] \`pnpm -F @getmunin/backend-core typecheck\` clean.
- [ ] After merge + release: trigger a real \`cms_update_entry\` against a multi-field collection with just one key in \`data\` — confirm the other fields are preserved on the returned DTO and on the next \`cms_get_entry\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)