### PR TITLE
fix(dashboard-pages): absolute OAuth callbackURL + use docs host for recipe links

### DIFF
--- a/.changeset/fix-callback-url-and-docs-link.md
+++ b/.changeset/fix-callback-url-and-docs-link.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Fix two URL regressions in the dashboard.
+
+- **OAuth sign-in landed on the API host.** `LoginForm` and `SignupForm` were passing a path-only `callbackURL: '/dashboard'` to `authClient.signIn.social({ provider: ... })`. BetterAuth's backend resolves a relative callback against its own baseURL, so post-OAuth users were redirected to `<auth-host>/dashboard` (404) instead of the dashboard host they signed in from. Both forms now wrap `redirectTo` with `absoluteCallbackUrl(...)` so the value sent to the backend is fully qualified against `window.location.origin`.
+
+- **"View prompt" on the dashboard home pointed at the dashboard host.** The recipe links in `GetStarted` used a relative `href` of `/docs/guides/recipe-<id>`, which the browser resolved against the dashboard host instead of the docs host. They now prepend `process.env.NEXT_PUBLIC_DOCS_URL` (already read for the MCP-setup `docsHref`), matching how the MCP `docsHref` is constructed.
+
+Both regressions were latent until 4.25/4.26 (when the recipes moved to docs and the auth pages consolidated into this package); the first deploy of either path against a backend-on-a-different-host surfaced them.

--- a/packages/dashboard-pages/src/auth/post-signin-redirect.ts
+++ b/packages/dashboard-pages/src/auth/post-signin-redirect.ts
@@ -3,6 +3,12 @@ export function safeRedirect(raw: string | null, fallback = '/dashboard'): strin
   return fallback;
 }
 
+export function absoluteCallbackUrl(path: string): string {
+  if (typeof window === 'undefined') return path;
+  if (/^https?:\/\//i.test(path)) return path;
+  return new URL(path, window.location.origin).toString();
+}
+
 export function resumeOauthAuthorizeUrl(params: URLSearchParams): string | null {
   if (params.get('response_type') !== 'code') return null;
   if (!params.get('client_id')) return null;

--- a/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from 'next-intl';
 import { authClient } from '../../auth-client';
 import { Link, useRouter } from '../../i18n-navigation';
 import { useTranslateError } from '../../i18n/translate-error';
-import { safeRedirect, resumeOauthAuthorizeUrl } from '../../auth/post-signin-redirect';
+import { absoluteCallbackUrl, safeRedirect, resumeOauthAuthorizeUrl } from '../../auth/post-signin-redirect';
 import {
   AuthShell,
   AuthHeading,
@@ -100,7 +100,7 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
               onClick={() => {
                 void authClient.signIn.social({
                   provider: 'google',
-                  callbackURL: redirectTo,
+                  callbackURL: absoluteCallbackUrl(redirectTo),
                 });
               }}
             >
@@ -114,7 +114,7 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
               onClick={() => {
                 void authClient.signIn.social({
                   provider: 'github',
-                  callbackURL: redirectTo,
+                  callbackURL: absoluteCallbackUrl(redirectTo),
                 });
               }}
             >

--- a/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
@@ -7,7 +7,7 @@ import { api, ApiError } from '../../api';
 import { authClient } from '../../auth-client';
 import { Link, useRouter } from '../../i18n-navigation';
 import { useTranslateError } from '../../i18n/translate-error';
-import { safeRedirect, resumeOauthAuthorizeUrl } from '../../auth/post-signin-redirect';
+import { absoluteCallbackUrl, safeRedirect, resumeOauthAuthorizeUrl } from '../../auth/post-signin-redirect';
 import {
   AuthShell,
   AuthHeading,
@@ -122,7 +122,7 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
               onClick={() => {
                 void authClient.signIn.social({
                   provider: 'google',
-                  callbackURL: redirectTo,
+                  callbackURL: absoluteCallbackUrl(redirectTo),
                 });
               }}
             >
@@ -136,7 +136,7 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
               onClick={() => {
                 void authClient.signIn.social({
                   provider: 'github',
-                  callbackURL: redirectTo,
+                  callbackURL: absoluteCallbackUrl(redirectTo),
                 });
               }}
             >

--- a/packages/dashboard-pages/src/components/dashboard/get-started.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/get-started.tsx
@@ -161,7 +161,7 @@ export function GetStarted() {
             {RECIPES.map((r) => (
               <li key={r.id} className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
                 <a
-                  href={`/docs/guides/recipe-${r.id}`}
+                  href={`${docsHost ?? ''}/guides/recipe-${r.id}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="no-underline text-inherit grid grid-cols-[1fr_auto] gap-5 items-center px-1.5 py-3.5 transition-[padding,background] duration-fast ease-munin hover:bg-paper-deep hover:pl-3 focus:outline-none focus:bg-paper-deep dark:hover:bg-secondary dark:focus:bg-secondary"


### PR DESCRIPTION
## Summary

Two URL regressions surfaced when prod deployed @getmunin/* 4.27 against a dashboard host (`app.getmunin.com`) and backend host (`api.getmunin.com`) that differ.

### Bug 1 — Google sign-in lands on the API host (404)

`LoginForm` and `SignupForm` passed `callbackURL: '/dashboard'` (a relative path) to `authClient.signIn.social({ provider, callbackURL })`. BetterAuth's backend resolves a relative callbackURL against **its own baseURL**, so post-OAuth users were redirected to `https://api.getmunin.com/dashboard` (404).

**Fix:** New helper `absoluteCallbackUrl(path)` in `post-signin-redirect.ts` that resolves the path against `window.location.origin`. Both forms wrap `redirectTo` with it before passing to `signIn.social`. SSR returns the path unchanged (the OAuth buttons only run client-side anyway).

Introduced by #278 (auth-page consolidation, 2026-05-30).

### Bug 2 — Dashboard "view prompt" links land on the dashboard host (404)

`GetStarted`'s recipe links used a relative `href={`/docs/guides/recipe-${r.id}`}`, which the browser resolved against the dashboard host instead of the docs host. The same component **already** computes `docsHost = process.env.NEXT_PUBLIC_DOCS_URL` for the MCP setup's `docsHref` — recipe links just never used it.

**Fix:** Prepend `${docsHost ?? ''}` to the recipe href.

Introduced by #233 (recipes-as-docs, 2026-05-26).

## Files

- `packages/dashboard-pages/src/auth/post-signin-redirect.ts` — new `absoluteCallbackUrl` helper.
- `packages/dashboard-pages/src/components/auth-shell/login-form.tsx` — wrap both Google + GitHub callbacks.
- `packages/dashboard-pages/src/components/auth-shell/signup-form.tsx` — same.
- `packages/dashboard-pages/src/components/dashboard/get-started.tsx` — prepend `docsHost` to recipe links.
- `.changeset/fix-callback-url-and-docs-link.md` — patch on `@getmunin/dashboard-pages`.

## Test plan

- [x] `pnpm -F @getmunin/dashboard-pages typecheck` — clean
- [ ] In OSS dev: sign in via Google, confirm landing path is dashboard host
- [ ] In OSS dev: click a recipe card on the home dashboard, confirm it opens on the docs host
- [ ] Cloud bump after release → redeploy prod → same checks against the deployed surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)