### PR TITLE
chore: lint cleanup, per-package CI test groups, Node 24 opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ permissions:
   packages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: lint · typecheck · test · build · release
@@ -75,7 +78,28 @@ jobs:
         run: pnpm typecheck
 
       - name: Test
-        run: pnpm test
+        run: |
+          set -e
+          pkgs=$(node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const out = [];
+            for (const dir of ['packages', 'apps']) {
+              if (!fs.existsSync(dir)) continue;
+              for (const sub of fs.readdirSync(dir)) {
+                const pj = path.join(dir, sub, 'package.json');
+                if (!fs.existsSync(pj)) continue;
+                const m = JSON.parse(fs.readFileSync(pj, 'utf8'));
+                if (m.scripts && m.scripts.test) out.push(m.name);
+              }
+            }
+            console.log(out.join(' '));
+          ")
+          for pkg in $pkgs; do
+            echo "::group::Test $pkg"
+            pnpm --filter "$pkg" test
+            echo "::endgroup::"
+          done
 
       - name: Build
         run: pnpm build

--- a/packages/backend-core/src/common/quotas/quotas.service.test.ts
+++ b/packages/backend-core/src/common/quotas/quotas.service.test.ts
@@ -25,7 +25,6 @@ const skipReason = TEST_URL
     const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
     appDb = createDb(appUrl);
 
-    const ts = Date.now();
     const [org] = await db
       .insert(schema.orgs)
       .values({
@@ -101,7 +100,6 @@ const skipReason = TEST_URL
   });
 
   it('falls back to free-tier defaults when settings.quotas is absent', async () => {
-    const ts = Date.now();
     const [defaultOrg] = await db
       .insert(schema.orgs)
       .values({ name: 'Default Org' })

--- a/packages/backend-core/src/common/rate-limit/rate-limit.service.test.ts
+++ b/packages/backend-core/src/common/rate-limit/rate-limit.service.test.ts
@@ -23,7 +23,6 @@ const skipReason = TEST_URL
     const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
     appDb = createDb(appUrl);
 
-    const ts = Date.now();
     const [org] = await db
       .insert(schema.orgs)
       .values({
@@ -79,7 +78,6 @@ const skipReason = TEST_URL
   });
 
   it('uses free-tier defaults when org settings have no rateLimits', async () => {
-    const ts = Date.now();
     const [defaultOrg] = await db
       .insert(schema.orgs)
       .values({ name: 'Default Org' })
@@ -111,7 +109,6 @@ const skipReason = TEST_URL
   });
 
   it('different orgs have isolated counters', async () => {
-    const ts = Date.now();
     const [otherOrg] = await db
       .insert(schema.orgs)
       .values({

--- a/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
@@ -36,7 +36,6 @@ const skipReason = TEST_URL
     db = createDb(TEST_URL!, { serviceRole: true });
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
 
-    const ts = Date.now();
     const [org] = await db
       .insert(schema.orgs)
       .values({ name: 'EndUser Conv Org' })

--- a/packages/backend-core/src/control/inbox.controller.ts
+++ b/packages/backend-core/src/control/inbox.controller.ts
@@ -7,7 +7,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { schema } from '@getmunin/db';
-import { and, desc, eq, gt, inArray, isNotNull, or, sql } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, isNotNull, sql } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';

--- a/packages/backend-core/src/control/invitations.service.ts
+++ b/packages/backend-core/src/control/invitations.service.ts
@@ -112,7 +112,6 @@ export class InvitationsService {
 
   async listPending(): Promise<InvitationDto[]> {
     const ctx = getCurrentContext();
-    const actor = ctx.actor!;
     const rows = await ctx.db
       .select()
       .from(schema.orgInvitations)

--- a/packages/backend-core/src/control/outreach-unsubscribe.controller.integration.test.ts
+++ b/packages/backend-core/src/control/outreach-unsubscribe.controller.integration.test.ts
@@ -35,7 +35,6 @@ const skipReason = TEST_URL
     db = createDb(TEST_URL!, { serviceRole: true });
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
 
-    const ts = Date.now();
     const [org] = await db
       .insert(schema.orgs)
       .values({ name: 'Unsub Org' })

--- a/packages/dashboard-pages/src/components/dashboard/dashboard-hero.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/dashboard-hero.tsx
@@ -4,13 +4,12 @@ import { useTranslations, useLocale } from 'next-intl';
 import { Hero } from '@getmunin/ui';
 
 interface DashboardHeroProps {
-  orgName: string | null;
   date: Date;
   liveCount: number;
   queueCount: number;
 }
 
-export function DashboardHero({ orgName, date, liveCount, queueCount }: DashboardHeroProps) {
+export function DashboardHero({ date, liveCount, queueCount }: DashboardHeroProps) {
   const t = useTranslations('dashboard.overview');
   const locale = useLocale();
   const dateLabel = new Intl.DateTimeFormat(locale, {

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '../api';
-import { useActiveMembership } from '../auth/use-active-role';
 import { useRealtime } from '../realtime';
 import { DashboardHero } from '../components/dashboard/dashboard-hero';
 import { GetStarted } from '../components/dashboard/get-started';
@@ -20,9 +19,7 @@ import {
 export function DashboardPage() {
   const inbox = useInboxData();
   const [summary, setSummary] = useState<UsageSummary | null>(null);
-  const { membership } = useActiveMembership();
   const buildLoadFailedProps = useInboxLoadFailedProps();
-  const orgName = membership?.name ?? null;
 
   const loadSummary = useCallback(() => {
     void api<UsageSummary>('/v1/usage/summary')
@@ -59,7 +56,6 @@ export function DashboardPage() {
     <>
       <div className="px-4 md:px-10 pt-11 pb-6 max-w-7xl mx-auto space-y-9">
         <DashboardHero
-        orgName={orgName}
         date={new Date()}
         liveCount={inbox.items.length}
         queueCount={inbox.queue.length}


### PR DESCRIPTION
## Summary
- Remove unused vars/imports flagged by eslint (`ts` in 5 test files, `actor` in `invitations.service`, stale `or` import in `inbox.controller`, `orgName` prop in `DashboardHero` + its now-unused derivation in `overview.tsx`).
- Wrap each package's test run in a GitHub Actions `::group::Test @getmunin/<pkg>` so the failing package is obvious in the CI log instead of scrolling through a single merged stream.
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at workflow scope to silence the Node 20 deprecation warning across `build`, `licenses`, and `e2e` without bumping every action version.

## Test plan
- [ ] CI green on this branch
- [ ] No Node 20 deprecation warnings on the three jobs
- [ ] Test step shows one collapsible group per package with the package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)