### PR TITLE
fix(emails): default logo URL to www.getmunin.com

### DIFF
--- a/.changeset/email-logo-www-url.md
+++ b/.changeset/email-logo-www-url.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/emails': patch
+---
+
+Point the default email logo URL at `https://www.getmunin.com/email-assets/raven-flying.png` (was the apex `getmunin.com`). The apex's HTTP→HTTPS redirect on the LB ACL already forwarded to `www.`, but going directly avoids the extra hop and the brief render gap some mail clients show when an image URL redirects. `MUNIN_EMAIL_LOGO_URL` still overrides the default — set it for self-hosters who don't own getmunin.com.

--- a/packages/emails/src/components/tokens.ts
+++ b/packages/emails/src/components/tokens.ts
@@ -23,4 +23,4 @@ export const sizes = {
 };
 
 export const RAVEN_PNG_URL =
-  process.env.MUNIN_EMAIL_LOGO_URL ?? 'https://getmunin.com/email-assets/raven-flying.png';
+  process.env.MUNIN_EMAIL_LOGO_URL ?? 'https://www.getmunin.com/email-assets/raven-flying.png';


### PR DESCRIPTION
## Summary

The default email logo URL was the apex `https://getmunin.com/email-assets/raven-flying.png`. The apex redirects to `www.` via the LB ACL, so it worked — but some mail clients (notably Apple Mail) render the broken-image placeholder during the redirect resolve. Pointing straight at `www.` makes the first request the final one.

```diff
- 'https://getmunin.com/email-assets/raven-flying.png'
+ 'https://www.getmunin.com/email-assets/raven-flying.png'
```

`MUNIN_EMAIL_LOGO_URL` env override is unchanged — self-hosters who don't own getmunin.com still set it to point at their own host.

## Test plan
- [x] Changeset added (`@getmunin/emails` patch)
- [ ] Next OSS release publishes 4.27.2; cloud picks it up on next `@getmunin/*` bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)