### PR TITLE
fix(conv): surface SMTP/IMAP host validation errors as 400 + reason

### DIFF
--- a/.changeset/email-setup-friendly-host-errors.md
+++ b/.changeset/email-setup-friendly-host-errors.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/backend-core': patch
+---
+
+`POST /v1/conversations/channels/email` now returns a `400` with the underlying reason when an SMTP or IMAP host fails the SSRF guard, instead of an opaque `500`. The dashboard's generic error renderer surfaces the message verbatim, so a typo like `imag.gmail.com` now reads as `SMTP: dns lookup failed for imag.gmail.com: getaddrinfo ENOTFOUND imag.gmail.com` rather than "Munin couldn't reach the server".
+
+Only `SsrfBlockedError`s thrown during the inbound/outbound host validation are remapped; all other failures stay as-is.

--- a/packages/backend-core/src/modules/conv/email/email.service.ts
+++ b/packages/backend-core/src/modules/conv/email/email.service.ts
@@ -12,6 +12,7 @@ import {
   encryptSecretSql,
   getCurrentContext,
   setEncryptionKeySql,
+  SsrfBlockedError,
 } from '@getmunin/core';
 import { z } from 'zod';
 import {
@@ -100,10 +101,10 @@ export type StoredEmailChannelConfig = z.infer<typeof StoredEmailChannelConfigSc
 export class EmailService {
   async toStored(input: EmailChannelConfigInputT): Promise<StoredEmailChannelConfig> {
     if (input.outbound.provider === 'smtp') {
-      await assertPublicHost(input.outbound.host);
+      await assertReachableMailHost('SMTP', input.outbound.host);
     }
     if (input.inbound) {
-      await assertPublicHost(input.inbound.host);
+      await assertReachableMailHost('IMAP', input.inbound.host);
     }
     const out: StoredEmailChannelConfig = {
       addressing: { ...input.addressing },
@@ -443,4 +444,13 @@ async function decryptString(tx: Db | Tx, ciphertext: string): Promise<string> {
   const pt = rows[0]?.pt;
   if (pt === undefined || pt === null) throw new ConflictException('decryption_failed');
   return pt;
+}
+
+async function assertReachableMailHost(role: 'SMTP' | 'IMAP', host: string): Promise<void> {
+  try {
+    await assertPublicHost(host);
+  } catch (err) {
+    if (!(err instanceof SsrfBlockedError)) throw err;
+    throw new BadRequestException(`${role}: ${err.message}`);
+  }
 }


### PR DESCRIPTION
## Summary

`POST /v1/conversations/channels/email` now returns `400` with the actual SSRF-guard reason when an SMTP or IMAP host fails validation, instead of an opaque `500`.

### Before

User types `imag.gmail.com` (one letter off). Backend's `assertPublicHost` throws `SsrfBlockedError: dns lookup failed for imag.gmail.com: getaddrinfo ENOTFOUND imag.gmail.com`. Nest's default 500 handler converts it to a generic error response. Dashboard renders "Munin couldn't reach the server" — no hint that the host is wrong.

### After

```
HTTP 400
{ "message": "IMAP: dns lookup failed for imag.gmail.com: getaddrinfo ENOTFOUND imag.gmail.com", ... }
```

The dashboard's generic error renderer surfaces the message verbatim, so the typo is self-evident. The `SMTP:` / `IMAP:` prefix tells the user which field is wrong; the rest of the message is the `SsrfBlockedError` text unchanged (already descriptive enough — covers NXDOMAIN, private IP, blocked TLD, empty host without any per-case branching).

## Files

- `packages/backend-core/src/modules/conv/email/email.service.ts` — new `assertReachableMailHost` helper wraps the two `assertPublicHost` calls in `toStored()`. Non-SSRF errors (encryption_failed, etc.) still bubble untouched.
- `.changeset/email-setup-friendly-host-errors.md` — patch on `@getmunin/backend-core`.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck` — clean
- [ ] After OSS release + cloud bump, retry the email channel setup with a deliberate typo → dashboard renders the reason, not "couldn't reach the server".

🤖 Generated with [Claude Code](https://claude.com/claude-code)