### PR TITLE
fix(core): safeFetch lookup callback must match undici's all:true shape

### DIFF
--- a/.changeset/safe-fetch-lookup-all-shape.md
+++ b/.changeset/safe-fetch-lookup-all-shape.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/core': patch
+---
+
+**Critical fix:** `safeFetch` now returns the array-shaped callback undici expects when it asks for `all: true` resolution.
+
+Every `safeFetch` call against a non-IP-literal host (i.e. virtually every real-world call) was failing with `TypeError: fetch failed` → `cause: Invalid IP address: undefined` after undici started passing `lookup({ ..., all: true }, cb)`. The custom SSRF agent's `lookup` was forcing `all: false` internally and calling `cb(null, address, family)`. Undici read the wrong shape from that callback, ended up with `undefined` where it expected an IP, and threw inside `node:net`'s `emitLookup`.
+
+The fix: always resolve with `all: true` (which also lets us SSRF-check every resolved address, not just the first one), then format the callback response to match what undici asked for — array if `all: true`, single string if `all: false`. Adds a regression test that fetches through the DNS path against an `*.nip.io` hostname with `MUNIN_SSRF_ALLOW_PRIVATE` set (existing tests used literal `127.0.0.1`, which short-circuits the lookup callback and didn't exercise this code).
+
+Impact of the bug while live: AI provider credential validation, model listing, agent-runtime LLM calls, outbound webhook delivery (incl. CMS-content webhooks), and website-import crawls all failed against any real host.

--- a/packages/core/src/net/safe-fetch.test.ts
+++ b/packages/core/src/net/safe-fetch.test.ts
@@ -146,6 +146,19 @@ describe('safeFetch', () => {
     }
   });
 
+  it('returns the array shape undici expects when lookup is called with all:true', async () => {
+    await start();
+    process.env.MUNIN_SSRF_ALLOW_PRIVATE = 'true';
+    try {
+      const res = await safeFetch(`http://127.0.0.1.nip.io:${port}/`);
+      expect(res.status).toBe(200);
+      await res.body?.cancel().catch(() => {});
+    } finally {
+      delete process.env.MUNIN_SSRF_ALLOW_PRIVATE;
+      await stop();
+    }
+  });
+
   it('blocks rebinding: upfront resolver lies "public" but real DNS returns private', async () => {
     await start();
     const lyingResolver = () => Promise.resolve([{ address: '93.184.216.34', family: 4 }]);

--- a/packages/core/src/net/safe-fetch.ts
+++ b/packages/core/src/net/safe-fetch.ts
@@ -210,25 +210,35 @@ function makeBlockingAgent(): Agent {
         lookupOpts: LookupOptions,
         cb: (err: NodeJS.ErrnoException | null, address: string | LookupAddress[], family: number) => void,
       ) => {
+        const wantAll = lookupOpts.all === true;
         const rejectSsrf = (msg: string): void => {
           const e = new Error(msg) as NodeJS.ErrnoException;
           e.code = 'ESSRF_BLOCKED';
-          cb(e, '', 0);
+          cb(e, wantAll ? [] : '', 0);
         };
         const hostOk = isIp(hostname) ? !isPrivateIp(hostname) : !isBannedHostname(hostname);
         if (!hostOk && !envBool('MUNIN_SSRF_ALLOW_PRIVATE')) {
           rejectSsrf(`host ${hostname} is not allowed`);
           return;
         }
-        dnsLookupCallback(hostname, { ...lookupOpts, all: false }, (err, address, family) => {
-          if (err) return cb(err, '', 0);
-          if (typeof address !== 'string' || !address) {
-            return cb(new Error('no address resolved'), '', 0);
+        dnsLookupCallback(hostname, { ...lookupOpts, all: true }, (err, records) => {
+          if (err) return cb(err, wantAll ? [] : '', 0);
+          if (!Array.isArray(records) || records.length === 0) {
+            return cb(new Error('no address resolved'), wantAll ? [] : '', 0);
           }
-          if (!envBool('MUNIN_SSRF_ALLOW_PRIVATE') && isPrivateIp(address)) {
-            return rejectSsrf(`host ${hostname} resolved to private ip ${address}`);
+          if (!envBool('MUNIN_SSRF_ALLOW_PRIVATE')) {
+            for (const r of records) {
+              if (isPrivateIp(r.address)) {
+                return rejectSsrf(`host ${hostname} resolved to private ip ${r.address}`);
+              }
+            }
           }
-          cb(null, address, family ?? (isIp(address) === 6 ? 6 : 4));
+          if (wantAll) {
+            cb(null, records, 0);
+          } else {
+            const first = records[0]!;
+            cb(null, first.address, first.family);
+          }
         });
       },
     },


### PR DESCRIPTION
## Summary

**P0 — every `safeFetch` call against a real (DNS-resolved) host has been failing.**

undici 7.26 calls `Agent.connect.lookup(hostname, { ..., all: true }, cb)`. Our SSRF agent was forcing `all: false` internally and invoking `cb(null, address, family)`. Undici read the wrong callback shape, ended up with `undefined` where it expected an IP, and threw inside `node:net`'s `emitLookup`:

```
TypeError: fetch failed
  [cause]: TypeError [ERR_INVALID_IP_ADDRESS]: Invalid IP address: undefined
    at emitLookup (node:net:1554:17)
```

Reproduced locally against `https://api.anthropic.com/v1/models` via `safeFetch`. Plain `undici.fetch` (without our agent) works fine — confirming the bug is in our `lookup` adapter.

## Blast radius

Every call site that uses `safeFetch` against a real hostname:

- AI provider credential validation (`packages/agent-host/src/provider-auth.ts`) — what the user just hit
- AI model listing (`packages/agent-host/src/models.service.ts`)
- Agent runtime LLM calls (`packages/agent-runtime/src/providers/openai-compatible.ts`)
- Outbound webhook delivery (`packages/backend-core/src/common/webhooks/webhook.worker.ts`) — including the CMS-content webhooks that drive the new marketing-rebuild trigger
- Website-import crawls (`packages/agent-runtime/src/web-crawl.ts`)

## Fix

`packages/core/src/net/safe-fetch.ts`:

- Always resolve with `all: true` (which also lets us SSRF-check every resolved address, not just the first one — closes a latent multi-A-record bug).
- Format the callback response to match what undici actually asked for: array of `{address, family}` when `all: true`, single `address + family` when `all: false`.

## Test

Existing safe-fetch tests all used literal `127.0.0.1`, which short-circuits the `lookup` callback (the IP-literal branch returns immediately without going through DNS). They passed against the broken code.

Added one positive regression test that goes through the DNS path: `safeFetch('http://127.0.0.1.nip.io:PORT/')` with `MUNIN_SSRF_ALLOW_PRIVATE=true`. Confirmed it fails against the old code and passes against the fix.

- [x] `pnpm -F @getmunin/core test` — 120 passed (was 119), 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)