### PR TITLE
fix(agent-host): clear degraded status when admin saves a new model

### DIFF
--- a/.changeset/recordsuccess-on-model-change.md
+++ b/.changeset/recordsuccess-on-model-change.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/agent-host': patch
+---
+
+Saving a new fast or smart model in the agent config now calls `agent_health.recordSuccess`, the same recovery path that already runs after a successful API-key validation. If the agent was degraded with `model_not_found` (or any other model-level error), the admin can recover it by picking a different model — previously only an API-key edit cleared the degraded status. Same-value patches don't trigger the call, so a noop save still won't fake-recover a truly broken agent.

--- a/packages/agent-host/src/config.service.test.ts
+++ b/packages/agent-host/src/config.service.test.ts
@@ -41,7 +41,10 @@ function makeWebhooks(): WebhookDispatcher & { emit: ReturnType<typeof vi.fn> } 
   return stub;
 }
 
-function makeHealthStub(): AgentHealthRecorder {
+function makeHealthStub(): AgentHealthRecorder & {
+  recordSuccess: ReturnType<typeof vi.fn>;
+  recordFailure: ReturnType<typeof vi.fn>;
+} {
   return {
     recordSuccess: vi.fn().mockResolvedValue({ flipped: false }),
     recordFailure: vi.fn().mockResolvedValue(undefined),
@@ -91,5 +94,35 @@ describe('AgentConfigService', () => {
       type: 'agent.config.updated',
       payload: { configId: 'singleton' },
     });
+  });
+
+  it('records success when fastModel changes so a degraded agent can recover', async () => {
+    const repo = makeRepo({ before: baseRow, after: baseRow });
+    const health = makeHealthStub();
+    const svc = new AgentConfigService(repo, makeWebhooks(), health);
+
+    await svc.upsertForCurrentActor({ fastModel: 'anthropic/claude-sonnet-4.6' });
+
+    expect(health.recordSuccess).toHaveBeenCalledWith('singleton');
+  });
+
+  it('records success when smartModel changes', async () => {
+    const repo = makeRepo({ before: baseRow, after: baseRow });
+    const health = makeHealthStub();
+    const svc = new AgentConfigService(repo, makeWebhooks(), health);
+
+    await svc.upsertForCurrentActor({ smartModel: 'anthropic/claude-opus-4.7' });
+
+    expect(health.recordSuccess).toHaveBeenCalledWith('singleton');
+  });
+
+  it('does not record success when model patch matches the existing value', async () => {
+    const repo = makeRepo({ before: baseRow, after: baseRow });
+    const health = makeHealthStub();
+    const svc = new AgentConfigService(repo, makeWebhooks(), health);
+
+    await svc.upsertForCurrentActor({ fastModel: baseRow.fastModel });
+
+    expect(health.recordSuccess).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent-host/src/config.service.ts
+++ b/packages/agent-host/src/config.service.ts
@@ -55,6 +55,10 @@ export class AgentConfigService {
       }
     }
 
+    const modelChanged =
+      (input.fastModel !== undefined && input.fastModel !== before.fastModel) ||
+      (input.smartModel !== undefined && input.smartModel !== before.smartModel);
+
     const after = await this.repo.update(id, input);
 
     await this.webhooks.emit({
@@ -62,7 +66,7 @@ export class AgentConfigService {
       payload: { configId: id },
     });
 
-    if (credentialsValidated) {
+    if (credentialsValidated || modelChanged) {
       await this.health.recordSuccess(id).catch((err) => {
         this.log.warn(`recordSuccess after save failed for ${id}: ${describe(err)}`);
       });


### PR DESCRIPTION
## Summary
- `AgentConfigService.upsertForCurrentActor` now calls `AgentHealthService.recordSuccess` when `fastModel` or `smartModel` actually changes, mirroring the existing recovery path after a successful API-key revalidation.
- Fixes a gap where an agent degraded with `model_not_found` could only recover by re-saving the API key — picking a different model did not clear the degraded status or re-enqueue retryable curator jobs.
- Same-value patches don't trigger the call, so a noop save doesn't fake-recover a truly broken agent.

## Test plan
- [x] 3 new unit tests cover: fastModel change triggers, smartModel change triggers, same-value patch does not.
- [x] `pnpm -F @getmunin/agent-host test` — 20 pass.
- [x] `pnpm -F @getmunin/agent-host typecheck` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)