### PR TITLE
polish(dashboard-pages): tighten auth success states + responsive logo

### DIFF
--- a/packages/dashboard-pages/src/components/auth-shell/auth-shell.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/auth-shell.tsx
@@ -18,7 +18,7 @@ export function AuthShell({ leftZone, rightZone, variant = 'form' }: AuthShellPr
 
       <Link
         href="/"
-        className="absolute left-14 top-9 z-10 inline-flex items-center gap-3 text-ink"
+        className="absolute left-8 top-9 z-10 inline-flex items-center gap-3 text-ink md:left-14"
         aria-label="Munin home"
       >
         <Image

--- a/packages/dashboard-pages/src/components/auth-shell/forgot-password-page.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/forgot-password-page.tsx
@@ -56,20 +56,21 @@ export function ForgotPasswordPage({ footer }: ForgotPasswordPageProps) {
             </AuthHeading>
             <AuthSubheading>{t('sentBody', { email })}</AuthSubheading>
 
-            <div className="mb-6 rounded-[12px] border-[0.5px] border-rule-soft bg-paper-deep px-5 py-4 text-[13px] leading-[1.55] text-ink-soft">
+            <div className="mb-[22px] bg-paper-deep px-4 py-3.5 text-[13px] leading-[1.5] text-ink-soft">
               {t('sentInfo')}
             </div>
 
-            <AuthSubmit
-              type="button"
-              variant="ghost"
-              onClick={() => {
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
                 setSent(false);
                 setError(null);
               }}
             >
-              {t('resend')}
-            </AuthSubmit>
+              <AuthSubmit type="submit" variant="ghost" autoFocus>
+                {t('resend')}
+              </AuthSubmit>
+            </form>
 
             <AuthFootnote>
               <Link

--- a/packages/dashboard-pages/src/components/auth-shell/reset-password-page.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/reset-password-page.tsx
@@ -72,7 +72,8 @@ function ResetPasswordInner({ footer }: ResetPasswordPageProps) {
             <AuthSubheading>{t('doneSubtitle')}</AuthSubheading>
             <Link
               href="/login"
-              className="mt-2 inline-flex w-full items-center justify-center gap-2 rounded-[12px] border-[0.5px] border-auth-navy bg-auth-navy px-[18px] py-4 text-[15px] font-medium text-white transition-colors duration-fast ease-munin hover:border-auth-navy-hover hover:bg-auth-navy-hover"
+              autoFocus
+              className="mt-2 inline-flex w-full items-center justify-center gap-2 border-[0.5px] border-ink bg-ink px-[18px] py-4 text-[15px] font-medium text-paper transition-colors duration-fast ease-munin hover:border-cobalt-deep hover:bg-cobalt-deep active:translate-y-px"
             >
               {t('doneCta')}
             </Link>

--- a/packages/dashboard-pages/src/components/auth-shell/verify-email-page.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/verify-email-page.tsx
@@ -43,7 +43,8 @@ function VerifyEmailInner({ footer }: VerifyEmailPageProps) {
           <AuthSubheading>{subtitle}</AuthSubheading>
           <Link
             href="/login"
-            className="mt-2 inline-flex w-full items-center justify-center gap-2 rounded-[12px] border-[0.5px] border-auth-navy bg-auth-navy px-[18px] py-4 text-[15px] font-medium text-white transition-colors duration-fast ease-munin hover:border-auth-navy-hover hover:bg-auth-navy-hover"
+            autoFocus
+            className="mt-2 inline-flex w-full items-center justify-center gap-2 border-[0.5px] border-ink bg-ink px-[18px] py-4 text-[15px] font-medium text-paper transition-colors duration-fast ease-munin hover:border-cobalt-deep hover:bg-cobalt-deep active:translate-y-px"
           >
             {cta}
           </Link>


### PR DESCRIPTION
## Summary
- Move logo to `left-8` on mobile, `left-14` from `md` up so it doesn't crowd the safe area on small screens.
- AutoFocus the primary action on the success states (forgot-password sent, reset-password done, verify-email done) so keyboard users land on the next step.
- Restyle the reset/verify success links to the ink/paper button treatment used elsewhere and drop the legacy `auth-navy` token.
- Drop the bordered info pill on the "email sent" state — flat block reads cleaner against the auth panel.

## Test plan
- [ ] /forgot-password → submit → confirm "resend" button is focused and Enter re-sends
- [ ] /reset-password (valid token) → complete reset → confirm "Back to login" CTA is focused and styled like other primary actions
- [ ] /verify-email success → confirm CTA is focused and styled consistently
- [ ] Resize to mobile width → logo no longer clips into the left edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)