### PR TITLE
fix(backend-core): stabilize multi-tenant pool — idempotent interceptors + halfvec index use

### DIFF
--- a/.changeset/embedding-column-type.md
+++ b/.changeset/embedding-column-type.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/core': patch
+'@getmunin/backend-core': patch
+---
+
+KB and CMS vector search now cast the query embedding to match the deployed column type. The hard-coded `::vector` cast in `kb.search.ts` and `cms.search.ts` bypassed the HNSW index when the column was switched to `halfvec` (required for embeddings above 2000 dimensions, since pgvector's `vector` type caps HNSW indexing at 2000). Queries fell back to sequential scans of every chunk in the org. A new `embeddingColumnType()` helper in `@getmunin/core` reads `MUNIN_EMBEDDING_COLUMN_TYPE` (defaulting to `vector`), and the search SQL uses it via `sql.raw` to keep the index in play. Set `MUNIN_EMBEDDING_COLUMN_TYPE=halfvec` on deployments where the column was migrated to `halfvec`.

--- a/.changeset/tenancy-audit-idempotent.md
+++ b/.changeset/tenancy-audit-idempotent.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+`TenancyInterceptor` and `AuditInterceptor` are now idempotent across nested invocations. Previously, if either was registered both globally (via `APP_INTERCEPTOR`) and per-controller (via `@UseInterceptors`) — as can happen when a downstream backend composes the OSS module — every authenticated request would open a second `db.transaction` and write a duplicate audit row. The second transaction acquired a separate pool connection that sat in `BEGIN` for the lifetime of the request, capping useful concurrency well below the configured pool size. The guards short-circuit on a second pass: `TenancyInterceptor` skips when `RequestContextStore.getStore()` is already populated; `AuditInterceptor` skips when the request was already audited.

--- a/packages/backend-core/src/common/audit/audit.interceptor.test.ts
+++ b/packages/backend-core/src/common/audit/audit.interceptor.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { firstValueFrom, of } from 'rxjs';
+import { ActorIdentity, RequestContextStore, type RequestContext } from '@getmunin/core';
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+import { AuditInterceptor } from './audit.interceptor.ts';
+
+function makeContext(request: Record<string, unknown>): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+}
+
+function makeNext(value: unknown): CallHandler {
+  return { handle: () => of(value) };
+}
+
+function makeActiveContext(): RequestContext {
+  return {
+    db: { execute: vi.fn().mockResolvedValue(undefined) } as never,
+    actor: new ActorIdentity('user', 'usr_1', 'org_1', ['*'], ['admin']),
+    correlationId: 'corr-1',
+  };
+}
+
+describe('AuditInterceptor double-wrap guard', () => {
+  it('records exactly one audit row even if the interceptor runs twice on the same request', async () => {
+    const interceptor = new AuditInterceptor();
+    const record = vi.fn().mockResolvedValue(undefined);
+    (interceptor as unknown as { audit: { record: typeof record } }).audit = { record };
+
+    const request = {
+      method: 'GET',
+      url: '/v1/whoami',
+      headers: { 'user-agent': 'test' },
+    };
+
+    await RequestContextStore.run(makeActiveContext(), async () => {
+      await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+      await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+    });
+
+    expect(record).toHaveBeenCalledTimes(1);
+  });
+
+  it('short-circuits anonymous requests (no active context)', async () => {
+    const interceptor = new AuditInterceptor();
+    const record = vi.fn().mockResolvedValue(undefined);
+    (interceptor as unknown as { audit: { record: typeof record } }).audit = { record };
+
+    const request = {
+      method: 'GET',
+      url: '/health',
+      headers: {},
+    };
+
+    await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+    expect(record).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend-core/src/common/audit/audit.interceptor.ts
+++ b/packages/backend-core/src/common/audit/audit.interceptor.ts
@@ -30,7 +30,14 @@ export class AuditInterceptor implements NestInterceptor {
 
     const request = context
       .switchToHttp()
-      .getRequest<{ method: string; url: string; headers: Record<string, string | string[] | undefined> }>();
+      .getRequest<{
+        method: string;
+        url: string;
+        headers: Record<string, string | string[] | undefined>;
+        _auditRecorded?: boolean;
+      }>();
+    if (request._auditRecorded) return next.handle();
+    request._auditRecorded = true;
     const verb = request.method.toUpperCase();
     const path = request.url.split('?')[0] ?? request.url;
     const method = `${verb} ${path}`;

--- a/packages/backend-core/src/common/tenancy/tenancy.interceptor.test.ts
+++ b/packages/backend-core/src/common/tenancy/tenancy.interceptor.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { firstValueFrom, of } from 'rxjs';
+import { ActorIdentity, RequestContextStore, type RequestContext } from '@getmunin/core';
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+import { TenancyInterceptor } from './tenancy.interceptor.ts';
+
+function makeContext(request: Record<string, unknown>): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+}
+
+function makeNext(value: unknown): CallHandler {
+  return { handle: () => of(value) };
+}
+
+function makeActor(): ActorIdentity {
+  return new ActorIdentity('user', 'usr_1', 'org_1', ['*'], ['admin']);
+}
+
+describe('TenancyInterceptor double-wrap guard', () => {
+  it('opens a transaction on the first invocation', async () => {
+    const transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+      return fn({ execute: vi.fn().mockResolvedValue(undefined) });
+    });
+    const db = { transaction } as never;
+    const interceptor = new TenancyInterceptor(db);
+    const request = { credential: { actor: makeActor() } };
+
+    const result = await firstValueFrom(
+      interceptor.intercept(makeContext(request), makeNext('handler-output')),
+    );
+
+    expect(result).toBe('handler-output');
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT open a second transaction when a RequestContext is already active', async () => {
+    const transaction = vi.fn();
+    const db = { transaction } as never;
+    const interceptor = new TenancyInterceptor(db);
+    const request = { credential: { actor: makeActor() } };
+    const outerCtx: RequestContext = {
+      db: { transaction: vi.fn() } as never,
+      actor: makeActor(),
+      correlationId: 'outer-corr',
+    };
+
+    const result = await RequestContextStore.run(outerCtx, async () =>
+      firstValueFrom(interceptor.intercept(makeContext(request), makeNext('handler-output'))),
+    );
+
+    expect(result).toBe('handler-output');
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend-core/src/common/tenancy/tenancy.interceptor.ts
+++ b/packages/backend-core/src/common/tenancy/tenancy.interceptor.ts
@@ -55,6 +55,9 @@ export class TenancyInterceptor implements NestInterceptor {
   constructor(@Inject(DB) private readonly db: Db) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (RequestContextStore.getStore()) {
+      return next.handle();
+    }
     const request = context.switchToHttp().getRequest<RequestWithAuth>();
     const correlationId = request.correlationId ?? randomUUID();
     request.correlationId = correlationId;

--- a/packages/backend-core/src/modules/cms/cms.search.ts
+++ b/packages/backend-core/src/modules/cms/cms.search.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { sql, type SQL, and, eq } from 'drizzle-orm';
-import { getCurrentContext } from '@getmunin/core';
+import { embeddingColumnType, getCurrentContext } from '@getmunin/core';
 import type { Db, Tx } from '@getmunin/db';
 import { schema } from '@getmunin/db';
 import { DB } from '../../common/db/db.module.ts';
@@ -144,6 +144,7 @@ export class CmsSearchService {
     `);
 
     const [queryVec] = await this.embeddings.get().embed([trimmed]);
+    const colType = sql.raw(embeddingColumnType());
     const vectorRows = queryVec
       ? await db.execute<VectorRow>(sql`
           SELECT
@@ -156,8 +157,8 @@ export class CmsSearchService {
             e.data            AS data,
             c.fields          AS fields,
             left(e.search_text, 400) AS excerpt,
-            1 - (e.embedding <=> ${formatVector(queryVec)}::vector) AS similarity,
-            ROW_NUMBER() OVER (ORDER BY e.embedding <=> ${formatVector(queryVec)}::vector ASC) AS rn
+            1 - (e.embedding <=> ${formatVector(queryVec)}::${colType}) AS similarity,
+            ROW_NUMBER() OVER (ORDER BY e.embedding <=> ${formatVector(queryVec)}::${colType} ASC) AS rn
           FROM cms_entries e
           JOIN cms_collections c ON c.id = e.collection_id
           WHERE e.embedding IS NOT NULL AND ${whereExpr}

--- a/packages/backend-core/src/modules/kb/kb.search.ts
+++ b/packages/backend-core/src/modules/kb/kb.search.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { sql } from 'drizzle-orm';
-import { getCurrentContext, type Audience } from '@getmunin/core';
+import { embeddingColumnType, getCurrentContext, type Audience } from '@getmunin/core';
 import { EmbeddingProviderHolder } from './embedding.provider.ts';
 
 export interface SearchHit {
@@ -89,6 +89,7 @@ export class KbSearchService {
     `);
 
     const [queryVec] = await this.embeddings.get().embed([trimmed]);
+    const colType = sql.raw(embeddingColumnType());
     const vectorRows = queryVec
       ? await ctx.db.execute<VectorRow>(sql`
           WITH ranked AS (
@@ -98,10 +99,10 @@ export class KbSearchService {
               d.title         AS title,
               d.audiences     AS audiences,
               left(c.content, 400) AS excerpt,
-              1 - (c.embedding <=> ${formatVector(queryVec)}::vector) AS similarity,
+              1 - (c.embedding <=> ${formatVector(queryVec)}::${colType}) AS similarity,
               ROW_NUMBER() OVER (
                 PARTITION BY c.document_id
-                ORDER BY c.embedding <=> ${formatVector(queryVec)}::vector ASC
+                ORDER BY c.embedding <=> ${formatVector(queryVec)}::${colType} ASC
               ) AS chunk_rn
             FROM kb_document_chunks c
             JOIN kb_documents d ON d.id = c.document_id

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,8 @@ export {
 
 export {
   type EmbeddingProvider,
+  type EmbeddingColumnType,
+  embeddingColumnType,
   OpenAIEmbeddingProvider,
   StubEmbeddingProvider,
   readEmbeddingProviderFromEnv,

--- a/packages/core/src/providers/embedding.ts
+++ b/packages/core/src/providers/embedding.ts
@@ -17,6 +17,12 @@ export interface EmbeddingProvider {
   embed(texts: readonly string[]): Promise<number[][]>;
 }
 
+export type EmbeddingColumnType = 'vector' | 'halfvec';
+
+export function embeddingColumnType(): EmbeddingColumnType {
+  return process.env.MUNIN_EMBEDDING_COLUMN_TYPE === 'halfvec' ? 'halfvec' : 'vector';
+}
+
 // ─── OpenAI ──────────────────────────────────────────────────────────────────
 
 export interface OpenAIEmbeddingOptions {


### PR DESCRIPTION
## Summary

Two independent fixes from a connection-pool-starvation review, both safe no-ops for the OSS single-tenant deployment but high-impact for multi-tenant composers (e.g. a cloud backend that registers interceptors globally and runs on `halfvec` embeddings).

### 1. `TenancyInterceptor` + `AuditInterceptor` idempotency

If a downstream backend registers either interceptor both globally (`APP_INTERCEPTOR`) and per-controller (`@UseInterceptors`), Nest invokes the same interceptor twice in the chain. Today that means:

- `TenancyInterceptor` opens a second `db.transaction` on the injected top-level `Db`. With postgres-js that acquires a separate pool connection. The outer connection sits in `BEGIN` for the full request lifetime doing nothing — capping useful concurrency well below the configured pool size.
- The outer transaction's tx-local GUCs (`app.org_id`, `app.bypass_rls`) are not visible to the inner transaction either, so the inner tx (the one services actually use via `getCurrentContext()`) runs with RLS unset against the actor's org. That's a quiet correctness smell hiding inside the perf bug.
- `AuditInterceptor` writes a duplicate audit row.

Fix: short-circuit on the second pass.
- `TenancyInterceptor`: skip when `RequestContextStore.getStore()` is already populated (AsyncLocalStorage propagates through `next.handle()`).
- `AuditInterceptor`: skip when a `_auditRecorded` flag is set on the request.

OSS itself doesn't double-register, so behavior here is unchanged — this is defense-in-depth for downstream composers.

### 2. `::vector` cast bypasses HNSW index on halfvec columns

`kb.search.ts` and `cms.search.ts` hard-coded the query-vector cast as `::vector`. When the column is `halfvec` (required for embeddings >2000 dim, since `vector_cosine_ops` HNSW caps at 2000), the operator-type mismatch makes the planner skip `halfvec_cosine_ops`, falling back to a seq scan of every chunk in the org.

Fix: new `embeddingColumnType()` helper in `@getmunin/core` reads `MUNIN_EMBEDDING_COLUMN_TYPE` (default `vector`). The search SQL interpolates it via `sql.raw` so the operator type matches the index opclass. OSS default unchanged; halfvec deployments set `MUNIN_EMBEDDING_COLUMN_TYPE=halfvec`.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck` passes
- [x] `pnpm -F @getmunin/core build` passes
- [x] New unit tests cover both interceptors: first-pass passthrough + second-pass short-circuit (4 tests, ~5ms)
- [ ] Smoke-test in a deployment with the cloud-style double registration: confirm `audit_log` shows one row per request and `pg_stat_activity` does not show paired `idle in transaction` connections per request
- [ ] On a `halfvec` deployment, run `EXPLAIN ANALYZE` on a `kb_search` query and confirm `Index Scan using kb_chunks_embedding_hnsw_idx` (instead of the previous seq scan)

## Changesets

- `tenancy-audit-idempotent.md` — patch bump on `@getmunin/backend-core`
- `embedding-column-type.md` — patch bump on `@getmunin/core` + `@getmunin/backend-core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)