### PR TITLE
chore(changeset): add @getmunin/emails to the fixed-version group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core", "@getmunin/agent-runtime", "@getmunin/agent-host", "@getmunin/docs-pages", "@getmunin/chat-widget"]],
+  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core", "@getmunin/agent-runtime", "@getmunin/agent-host", "@getmunin/docs-pages", "@getmunin/chat-widget", "@getmunin/emails"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary

Adds `@getmunin/emails` to the Changesets fixed-version group so it moves in lockstep with the rest of the publishable `@getmunin/*` packages (`core`, `backend-core`, `db`, `types`, `sdk`, `mcp-toolkit`, `ui`, `dashboard-pages`, `agent-runtime`, `agent-host`, `docs-pages`, `chat-widget`).

## Why

`emails` was the last `@getmunin/*` publishable package on a separate version track (currently `4.23.6` while the lockstep group is at `4.29.2`). That produced version skew in downstream composers and forced manual reasoning about which deps move together. With it in the group, every release of the group also stamps a matching `emails` version, even when nothing in `packages/emails/` changed — annoying for an unchanged package, but the cost of consistency, and it makes the "match all `@getmunin/*` to one version" rule actually true.

## Effect

- This PR alone does **not** publish a new `emails` version (no changeset attached, nothing in `packages/emails/` changed).
- The **next** release that bumps anything in the fixed group will also bump `emails` from `4.23.6` → the joint version (e.g. `4.29.3`).
- After that, downstream `package.json` ranges like `"@getmunin/emails": "^4.23.6"` should be moved up to the new joint version to keep one canonical `@getmunin/*` version across a deployment.

## Test plan
- [x] `jq .` on `.changeset/config.json` parses
- [ ] On the next release PR, confirm `emails` shows up in the `chore: release` diff alongside the rest of the fixed group

🤖 Generated with [Claude Code](https://claude.com/claude-code)