### PR TITLE
feat(dashboard-pages): server-side redirect away from /login and /signup when signed in

### DIFF
--- a/.changeset/auth-server-redirect-when-logged-in.md
+++ b/.changeset/auth-server-redirect-when-logged-in.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/dashboard-pages': minor
+'@getmunin/web': patch
+---
+
+Auth pages now redirect already-signed-in users away from `/login` and `/signup` on the server, before any UI renders. Adds a new `@getmunin/dashboard-pages/server` subpath export with `getServerSession()` and `redirectIfAuthenticated({ locale, redirectParam })`, which forward the request cookies to the BetterAuth `/auth/get-session` endpoint and call the i18n-aware `redirect()` to `safeRedirect(redirectParam)` (defaults to `/dashboard`). The OSS `apps/web` login and signup pages adopt the helper. The server-only entry is kept off the main barrel export so client bundles aren't pulled into the `next/headers` graph.

--- a/apps/web/app/[locale]/(auth)/login/page.tsx
+++ b/apps/web/app/[locale]/(auth)/login/page.tsx
@@ -4,8 +4,17 @@ import {
   LoginForm,
   OSS_AUTH_FOOTER,
 } from '@getmunin/dashboard-pages';
+import { redirectIfAuthenticated } from '@getmunin/dashboard-pages/server';
 
-export default async function LoginPage() {
+export default async function LoginPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{ redirect?: string | string[] }>;
+}) {
+  const [{ locale }, sp] = await Promise.all([params, searchParams]);
+  await redirectIfAuthenticated({ locale, redirectParam: sp.redirect });
   const providers = await fetchAuthProviders();
   return (
     <Suspense fallback={null}>

--- a/apps/web/app/[locale]/(auth)/signup/page.tsx
+++ b/apps/web/app/[locale]/(auth)/signup/page.tsx
@@ -4,8 +4,17 @@ import {
   SignupForm,
   OSS_AUTH_FOOTER,
 } from '@getmunin/dashboard-pages';
+import { redirectIfAuthenticated } from '@getmunin/dashboard-pages/server';
 
-export default async function SignupPage() {
+export default async function SignupPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{ redirect?: string | string[] }>;
+}) {
+  const [{ locale }, sp] = await Promise.all([params, searchParams]);
+  await redirectIfAuthenticated({ locale, redirectParam: sp.redirect });
   const providers = await fetchAuthProviders();
   return (
     <Suspense fallback={null}>

--- a/packages/dashboard-pages/package.json
+++ b/packages/dashboard-pages/package.json
@@ -16,7 +16,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./server": "./src/server.ts"
   },
   "files": [
     "src"

--- a/packages/dashboard-pages/src/auth/server-session.ts
+++ b/packages/dashboard-pages/src/auth/server-session.ts
@@ -1,0 +1,40 @@
+import 'server-only';
+import { cookies } from 'next/headers';
+import { redirect } from '../i18n-navigation';
+import { safeRedirect } from './post-signin-redirect';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+export interface ServerSession {
+  user: { id: string; email?: string | null } & Record<string, unknown>;
+  session: { id: string } & Record<string, unknown>;
+}
+
+export async function getServerSession(): Promise<ServerSession | null> {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+  if (!cookieHeader) return null;
+  try {
+    const res = await fetch(`${API_URL}/auth/get-session`, {
+      headers: { cookie: cookieHeader },
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as ServerSession | null;
+    if (!data || !data.user || !data.session) return null;
+    return data;
+  } catch (err) {
+    console.warn('[server-session] fetch failed', err);
+    return null;
+  }
+}
+
+export async function redirectIfAuthenticated(opts: {
+  locale: string;
+  redirectParam?: string | string[] | null;
+}): Promise<void> {
+  const session = await getServerSession();
+  if (!session) return;
+  const raw = Array.isArray(opts.redirectParam) ? opts.redirectParam[0] : opts.redirectParam;
+  redirect({ href: safeRedirect(raw ?? null), locale: opts.locale });
+}

--- a/packages/dashboard-pages/src/server.ts
+++ b/packages/dashboard-pages/src/server.ts
@@ -1,0 +1,5 @@
+export {
+  getServerSession,
+  redirectIfAuthenticated,
+  type ServerSession,
+} from './auth/server-session';


### PR DESCRIPTION
## Summary

- New `@getmunin/dashboard-pages/server` subpath export with `getServerSession()` and `redirectIfAuthenticated({ locale, redirectParam })`. They read request cookies via `next/headers`, forward them to BetterAuth's `/auth/get-session`, and (if a session is present) call the i18n-aware `redirect()` to `safeRedirect(redirectParam)` (defaults to `/dashboard`).
- OSS `apps/web` `login/page.tsx` and `signup/page.tsx` call the helper before rendering, so authenticated visitors land on their post-signin destination (honoring the `?redirect=` query param) without the auth UI flashing.
- The server-only entry is intentionally kept off the main barrel (`./index.ts`) — only reachable via `@getmunin/dashboard-pages/server` — so client component bundles aren't pulled into the `next/headers` import graph (Turbopack would otherwise fail to build, since `useActiveMembership` is imported from the same barrel by the dashboard layout).

## Notes

- Server-side detection depends on the BetterAuth session cookie reaching the Next.js server. In OSS dev that works because both apps run on `localhost` (cookies are not scoped by port). In a production split-subdomain deployment (e.g. `app.munin.com` + `api.munin.com`), the OSS `AuthController` would need to opt into `crossSubDomainCookies` — `auth-factory.ts` already supports it, but `apps/backend/src/auth/auth.controller.ts` doesn't pass that option today. Out of scope for this PR; flagged as a follow-up.
- Cloud (`munin-cloud/apps/web-cloud`) consumes `@getmunin/dashboard-pages` from npm, so its login/signup pages are unchanged here. After this release ships, the cloud repo can bump the dep and apply the same one-liner.

## Test plan

- [x] `pnpm -F @getmunin/dashboard-pages -F @getmunin/web typecheck`
- [ ] Visit `/login` while signed in → redirected to `/dashboard`
- [ ] Visit `/login?redirect=/dashboard/settings` while signed in → redirected to `/dashboard/settings`
- [ ] Visit `/login` while signed out → form renders as before
- [ ] Same checks on `/signup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)