### PR TITLE
chore(changeset): drop ignored @getmunin/web from auth-redirect changeset

### DIFF
--- a/.changeset/auth-server-redirect-when-logged-in.md
+++ b/.changeset/auth-server-redirect-when-logged-in.md
@@ -1,6 +1,5 @@
 ---
 '@getmunin/dashboard-pages': minor
-'@getmunin/web': patch
 ---
 
 Auth pages now redirect already-signed-in users away from `/login` and `/signup` on the server, before any UI renders. Adds a new `@getmunin/dashboard-pages/server` subpath export with `getServerSession()` and `redirectIfAuthenticated({ locale, redirectParam })`, which forward the request cookies to the BetterAuth `/auth/get-session` endpoint and call the i18n-aware `redirect()` to `safeRedirect(redirectParam)` (defaults to `/dashboard`). The OSS `apps/web` login and signup pages adopt the helper. The server-only entry is kept off the main barrel export so client bundles aren't pulled into the `next/headers` graph.


### PR DESCRIPTION
## Summary

- Drops `@getmunin/web` from `.changeset/auth-server-redirect-when-logged-in.md` (added in #339).
- Changesets refuses to version a changeset that mixes ignored and non-ignored packages, so the post-merge Release workflow failed with `Mixed changesets that contain both ignored and not ignored packages are not allowed` ([run](https://github.com/getmunin/munin/actions/runs/26879879894)). `@getmunin/web` is in `.changeset/config.json`'s `ignore` list, so the entry was a no-op anyway.

## Test plan

- [ ] Release (Changesets) workflow on merge produces the release PR with the `@getmunin/dashboard-pages` minor bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)