### PR TITLE
perf(backend-core): trim audit-log write volume and add retention

### DIFF
--- a/.changeset/audit-log-volume-and-retention.md
+++ b/.changeset/audit-log-volume-and-retention.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Trim audit-log write volume and add retention. The `AuditInterceptor` now skips chatty polling GETs (`/agent-health`, `/agent-config`, `/widget/messages`, `/widget/conversations`, `/inbox`, `/usage/summary`, `/system/alerts` — under both `/v1` and `/api/v1`); non-GET requests on the same paths are still audited. The in-process agent runner no longer records `runner:claimCuratorJobs` ticks. A new `AuditRetentionService` prunes `audit_log` rows daily; window is configurable via `MUNIN_AUDIT_RETENTION_DAYS` (default `30`, set to `off` or `0` to disable) and `MUNIN_AUDIT_RETENTION_CRON` (default `0 3 * * *`).

--- a/.env.example
+++ b/.env.example
@@ -178,6 +178,13 @@ MUNIN_QUOTAS_ENABLED=false
 # MUNIN_CURATOR_CMS_STALE_CRON=0 0 1 * *
 # MUNIN_CURATOR_SCHEDULER_DISABLED=0
 
+# --- Audit log retention -----------------------------------------------
+# The audit_log table is append-only by default; this cron prunes rows
+# older than N days. Default 30. Set to "off" or "0" to disable. Cron
+# defaults to daily at 03:00.
+# MUNIN_AUDIT_RETENTION_DAYS=30
+# MUNIN_AUDIT_RETENTION_CRON=0 3 * * *
+
 # --- Public-API rate limiting (in-memory, per IP) ---------------------
 # Caps for the anonymous endpoints (CMS delivery, public skills, public
 # MCP tools catalog, email open pixel, outreach unsubscribe). Authenticated

--- a/packages/backend-core/src/agent/in-process-rest-client.ts
+++ b/packages/backend-core/src/agent/in-process-rest-client.ts
@@ -228,7 +228,7 @@ function buildClient(opts: BuildOptions): MuninRestClient {
     },
 
     async claimCuratorJobs(input: ClaimCuratorJobsInput): Promise<CuratorJob[]> {
-      return audited('runner:claimCuratorJobs', () =>
+      return withTenancy(() =>
         opts.curator.claim({
           holder: input.holder,
           limit: input.limit,

--- a/packages/backend-core/src/app.module.ts
+++ b/packages/backend-core/src/app.module.ts
@@ -6,6 +6,7 @@ import { WhoamiController } from './common/whoami.controller.ts';
 import { AuthGuard } from './common/auth/auth.guard.ts';
 import { TenancyInterceptor } from './common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from './common/audit/audit.interceptor.ts';
+import { AuditModule } from './common/audit/audit.module.ts';
 import { CallQuotaInterceptor } from './common/quotas/call-quota.interceptor.ts';
 import { McpModule } from './mcp/mcp.module.ts';
 import { ControlModule } from './control/control.module.ts';
@@ -40,6 +41,7 @@ export const BACKEND_FEATURE_MODULES = [
   RealtimeModule,
   OAuthModule,
   SystemAlertsModule,
+  AuditModule,
 ];
 
 export const BACKEND_BASE_CONTROLLERS = [HealthController, WhoamiController];

--- a/packages/backend-core/src/common/audit/audit-retention.service.ts
+++ b/packages/backend-core/src/common/audit/audit-retention.service.ts
@@ -1,0 +1,73 @@
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { CronExpression, SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { sql } from 'drizzle-orm';
+import { type Db } from '@getmunin/db';
+import { DB } from '../db/db.module.ts';
+import { withSchedulerLock } from '../scheduler-lock/index.ts';
+
+const DEFAULT_RETENTION_DAYS = 30;
+
+@Injectable()
+export class AuditRetentionService implements OnModuleInit {
+  private readonly logger = new Logger(AuditRetentionService.name);
+
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    private readonly registry: SchedulerRegistry,
+  ) {}
+
+  onModuleInit(): void {
+    if (process.env.NODE_ENV === 'test') return;
+    const days = parseRetentionDays(process.env.MUNIN_AUDIT_RETENTION_DAYS);
+    if (days === null) {
+      this.logger.log('audit retention disabled');
+      return;
+    }
+    const cron =
+      process.env.MUNIN_AUDIT_RETENTION_CRON?.trim() ||
+      CronExpression.EVERY_DAY_AT_3AM;
+    const job = new CronJob(cron, () => {
+      void withSchedulerLock(this.db, 'audit-retention', () =>
+        this.prune(days),
+      );
+    });
+    this.registry.addCronJob('audit-retention', job);
+    job.start();
+    this.logger.log(
+      `audit retention scheduled with "${cron}" (${days} day window)`,
+    );
+  }
+
+  private async prune(days: number): Promise<void> {
+    try {
+      await this.db.transaction(async (tx) => {
+        await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+        const result = await tx.execute(
+          sql`DELETE FROM audit_log WHERE created_at < now() - make_interval(days => ${days})`,
+        );
+        const deleted =
+          (result as { rowCount?: number | null }).rowCount ?? null;
+        this.logger.log(
+          deleted === null
+            ? `audit retention pruned rows older than ${days} days`
+            : `audit retention pruned ${deleted} rows older than ${days} days`,
+        );
+      });
+    } catch (err) {
+      this.logger.error(
+        `audit retention failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+function parseRetentionDays(raw: string | undefined): number | null {
+  if (raw === undefined) return DEFAULT_RETENTION_DAYS;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === '') return DEFAULT_RETENTION_DAYS;
+  if (trimmed === 'off' || trimmed === '0') return null;
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_RETENTION_DAYS;
+  return n;
+}

--- a/packages/backend-core/src/common/audit/audit.interceptor.test.ts
+++ b/packages/backend-core/src/common/audit/audit.interceptor.test.ts
@@ -42,6 +42,50 @@ describe('AuditInterceptor double-wrap guard', () => {
     expect(record).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    '/v1/agent-health',
+    '/api/v1/agent-health',
+    '/v1/widget/messages',
+    '/v1/widget/conversations',
+    '/v1/widget/conversations/ccv_abc123',
+    '/v1/inbox',
+    '/v1/usage/summary',
+    '/v1/system/alerts',
+    '/v1/agent-config',
+  ])('skips audit for chatty GET %s', async (url) => {
+    const interceptor = new AuditInterceptor();
+    const record = vi.fn().mockResolvedValue(undefined);
+    (interceptor as unknown as { audit: { record: typeof record } }).audit = { record };
+
+    const request = { method: 'GET', url, headers: { 'user-agent': 'test' } };
+
+    await RequestContextStore.run(makeActiveContext(), async () => {
+      await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+    });
+
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it('still audits non-polling GETs and all non-GETs on the same prefixes', async () => {
+    const interceptor = new AuditInterceptor();
+    const record = vi.fn().mockResolvedValue(undefined);
+    (interceptor as unknown as { audit: { record: typeof record } }).audit = { record };
+
+    const requests = [
+      { method: 'GET', url: '/v1/whoami', headers: {} },
+      { method: 'POST', url: '/v1/inbox', headers: {} },
+      { method: 'DELETE', url: '/v1/agent-config/foo', headers: {} },
+    ];
+
+    await RequestContextStore.run(makeActiveContext(), async () => {
+      for (const req of requests) {
+        await firstValueFrom(interceptor.intercept(makeContext(req), makeNext(null)));
+      }
+    });
+
+    expect(record).toHaveBeenCalledTimes(requests.length);
+  });
+
   it('short-circuits anonymous requests (no active context)', async () => {
     const interceptor = new AuditInterceptor();
     const record = vi.fn().mockResolvedValue(undefined);

--- a/packages/backend-core/src/common/audit/audit.interceptor.ts
+++ b/packages/backend-core/src/common/audit/audit.interceptor.ts
@@ -7,14 +7,29 @@ import {
 import { Observable, catchError, from, mergeMap, throwError } from 'rxjs';
 import { AuditLogger, getCurrentContext } from '@getmunin/core';
 
-/**
- * Records every controller invocation as an audit row. Runs INSIDE the
- * tenancy transaction (via getCurrentContext()) so the audit row is
- * committed atomically with the request's other writes.
- *
- * Skips routes where there's no active request context (anonymous routes
- * that didn't open a transaction).
- */
+const POLLING_GET_PREFIXES = [
+  '/agent-health',
+  '/agent-config',
+  '/widget/messages',
+  '/widget/conversations',
+  '/inbox',
+  '/usage/summary',
+  '/system/alerts',
+];
+
+function stripVersionPrefix(path: string): string {
+  if (path.startsWith('/api/v1/') || path === '/api/v1') return path.slice(7);
+  if (path.startsWith('/v1/') || path === '/v1') return path.slice(3);
+  return path;
+}
+
+function isPollingGet(path: string): boolean {
+  const stripped = stripVersionPrefix(path);
+  return POLLING_GET_PREFIXES.some(
+    (p) => stripped === p || stripped.startsWith(`${p}/`),
+  );
+}
+
 @Injectable()
 export class AuditInterceptor implements NestInterceptor {
   private readonly audit = new AuditLogger();
@@ -47,6 +62,9 @@ export class AuditInterceptor implements NestInterceptor {
       return next.handle();
     }
     if (verb === 'GET' && path === '/mcp') {
+      return next.handle();
+    }
+    if (verb === 'GET' && isPollingGet(path)) {
       return next.handle();
     }
 

--- a/packages/backend-core/src/common/audit/audit.module.ts
+++ b/packages/backend-core/src/common/audit/audit.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { AuditRetentionService } from './audit-retention.service.ts';
+
+@Module({
+  imports: [ScheduleModule.forRoot()],
+  providers: [AuditRetentionService],
+})
+export class AuditModule {}


### PR DESCRIPTION
## Summary

- `AuditInterceptor` now skips chatty polling GETs (`/agent-health`, `/agent-config`, `/widget/messages`, `/widget/conversations`, `/inbox`, `/usage/summary`, `/system/alerts` — under both `/v1` and `/api/v1`). Non-GET writes on the same paths and every other endpoint keep auditing.
- `runner:claimCuratorJobs` no longer audits (it ran every tick on every replica and added zero forensic value).
- New `AuditRetentionService`: daily cron prunes `audit_log` older than the retention window. Configurable via `MUNIN_AUDIT_RETENTION_DAYS` (default `30`, `off`/`0` disables) and `MUNIN_AUDIT_RETENTION_CRON` (default `0 3 * * *`). Uses `withSchedulerLock` so only one replica deletes; sets `app.bypass_rls=on` for the cross-org delete.

## Why

Prod is at 1.23 GB and climbing linearly with 1 test org. Local snapshot showed `audit_log` is by far the biggest table (11 MB / 17.4k rows) and ~90% of rows are idempotent polling: agent-health, widget polls, inbox polls, curator-job claims. The table was append-only with no retention.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck`
- [x] `pnpm -F @getmunin/backend-core test` (713 pass, includes new interceptor cases)
- [ ] Smoke: bring up dev stack, open dashboard, confirm `audit_log` no longer grows on polling
- [ ] Smoke: set `MUNIN_AUDIT_RETENTION_DAYS=1` + a near-future `MUNIN_AUDIT_RETENTION_CRON`, confirm prune log line + row drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)