### PR TITLE
feat(core): shared env-parsing helpers

### DIFF
--- a/.changeset/shared-env-parsing-helpers.md
+++ b/.changeset/shared-env-parsing-helpers.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/core': minor
+---
+
+feat(core): add shared env-parsing helpers (`parseEnvInt`, `parseEnvBool`, `parseEnvDisableFlag`, `parseEnvCron`) and migrate existing call sites in core, backend-core, agent-host, and apps/backend.
+
+`Number(process.env.X ?? D)` patterns previously passed NaN through silently when an env var was set to garbage; `parseEnvInt` falls back to the default in that case. `parseEnvDisableFlag` and `parseEnvBool` accept both `'1'` and `'true'` (case-insensitive). `parseEnvCron` returns `null` when the value is `'off'` or `'0'`, so callers can opt out of a cron without an inline guard.

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -7,7 +7,7 @@ import {
   type SignupHookUser,
 } from '@getmunin/backend-core';
 import { schema, type Db } from '@getmunin/db';
-import type { Mailer } from '@getmunin/core';
+import { parseEnvInt, type Mailer } from '@getmunin/core';
 import { renderResetPasswordEmail, renderVerifyEmail } from '@getmunin/emails';
 import { and, asc, eq, isNull, sql } from 'drizzle-orm';
 
@@ -161,8 +161,8 @@ export function buildAuthRateLimit(): BetterAuthOptions['rateLimit'] {
   return {
     enabled: true,
     storage: 'database',
-    window: Number(process.env.MUNIN_AUTH_RATELIMIT_WINDOW ?? 60),
-    max: Number(process.env.MUNIN_AUTH_RATELIMIT_MAX ?? 30),
+    window: parseEnvInt({ name: 'MUNIN_AUTH_RATELIMIT_WINDOW', default: 60 }),
+    max: parseEnvInt({ name: 'MUNIN_AUTH_RATELIMIT_MAX', default: 30 }),
     customRules: {
       '/sign-in/email': { window: 60, max: 5 },
       '/sign-up/email': { window: 60, max: 5 },

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -3,6 +3,7 @@ import './instrument.js';
 import 'reflect-metadata';
 import { setDefaultResultOrder } from 'node:dns';
 import { createApp } from '@getmunin/backend-core';
+import { parseEnvInt } from '@getmunin/core';
 import { AppModule } from './app.module.ts';
 
 setDefaultResultOrder('ipv4first');
@@ -11,7 +12,7 @@ async function bootstrap() {
   const widgetAssetDir = process.env.MUNIN_WIDGET_ASSET_DIR?.trim() || undefined;
   const app = await createApp(AppModule, widgetAssetDir ? { widgetAssetDir } : undefined);
   app.enableShutdownHooks();
-  const port = Number(process.env.PORT ?? 3001);
+  const port = parseEnvInt({ name: 'PORT', default: 3001 });
   await app.listen(port);
   console.log(`munin-backend listening on :${port}`);
 }

--- a/packages/agent-host/src/config.controller.ts
+++ b/packages/agent-host/src/config.controller.ts
@@ -17,12 +17,12 @@ import {
   RequireRole,
   RequireActorType,
 } from '@getmunin/backend-core';
+import { parseEnvBool } from '@getmunin/core';
 import { AgentConfigService, type AgentConfigDto } from './config.service.ts';
 import { AgentModelsService, type ListModelsResult } from './models.service.ts';
 
 function allowPrivateProviderHosts(): boolean {
-  const v = process.env.MUNIN_SSRF_ALLOW_PRIVATE;
-  return v === '1' || v === 'true';
+  return parseEnvBool({ name: 'MUNIN_SSRF_ALLOW_PRIVATE', default: false });
 }
 
 export const ProviderBaseUrl = z

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -24,6 +24,7 @@ import {
   type MessageReceivedBusEvent,
   type RealtimeBusSubscription,
 } from '@getmunin/backend-core';
+import { parseEnvBool } from '@getmunin/core';
 import {
   createConversationHandler,
   createPromptResolver,
@@ -128,7 +129,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
   }
 
   onApplicationBootstrap(): void {
-    if (process.env.MUNIN_BUILTIN_AGENT === '0') {
+    if (!parseEnvBool({ name: 'MUNIN_BUILTIN_AGENT', default: true })) {
       this.logger.log('bundled agent runner disabled via MUNIN_BUILTIN_AGENT=0');
       return;
     }

--- a/packages/backend-core/src/common/quotas/quotas.service.ts
+++ b/packages/backend-core/src/common/quotas/quotas.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
-import { getCurrentContext } from '@getmunin/core';
+import { getCurrentContext, parseEnvBool } from '@getmunin/core';
 
 export const QUOTAS_SERVICE = Symbol('QUOTAS_SERVICE');
 
@@ -45,9 +45,7 @@ const TABLE_FOR: Record<QuotaResource, string> = {
 };
 
 function isEnabled(): boolean {
-  const raw = process.env.MUNIN_QUOTAS_ENABLED;
-  if (raw === undefined) return false;
-  return raw.toLowerCase() === 'true' || raw === '1';
+  return parseEnvBool({ name: 'MUNIN_QUOTAS_ENABLED', default: false });
 }
 
 export abstract class QuotasService {

--- a/packages/backend-core/src/common/rate-limit/public-throttle.module.ts
+++ b/packages/backend-core/src/common/rate-limit/public-throttle.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ThrottlerModule } from '@nestjs/throttler';
+import { parseEnvInt } from '@getmunin/core';
 
 /**
  * Per-IP rate limiting for anonymous public endpoints (CMS delivery,
@@ -25,12 +26,12 @@ import { ThrottlerModule } from '@nestjs/throttler';
       {
         name: 'public-minute',
         ttl: 60_000,
-        limit: Number(process.env.MUNIN_PUBLIC_THROTTLE_MIN ?? 60),
+        limit: parseEnvInt({ name: 'MUNIN_PUBLIC_THROTTLE_MIN', default: 60 }),
       },
       {
         name: 'public-hour',
         ttl: 60 * 60_000,
-        limit: Number(process.env.MUNIN_PUBLIC_THROTTLE_HOUR ?? 1_000),
+        limit: parseEnvInt({ name: 'MUNIN_PUBLIC_THROTTLE_HOUR', default: 1_000 }),
       },
     ]),
   ],

--- a/packages/backend-core/src/common/webhooks/webhook.worker.ts
+++ b/packages/backend-core/src/common/webhooks/webhook.worker.ts
@@ -1,11 +1,11 @@
 import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, isNull, lt, lte } from 'drizzle-orm';
-import { safeFetch, WebhookDispatcher } from '@getmunin/core';
+import { parseEnvDisableFlag, parseEnvInt, safeFetch, WebhookDispatcher } from '@getmunin/core';
 import { DB } from '../db/db.module.ts';
 import { withSchedulerLock } from '../scheduler-lock/index.ts';
 
-const POLL_INTERVAL_MS = Number(process.env.MUNIN_WEBHOOK_POLL_MS ?? 5000);
+const POLL_INTERVAL_MS = parseEnvInt({ name: 'MUNIN_WEBHOOK_POLL_MS', default: 5000 });
 const MAX_ATTEMPTS = 5;
 const BATCH_SIZE = 25;
 const BACKOFF_BASE_MS = 30_000; // 30s, then 1m, 2m, 4m, 8m for ~16m total span.
@@ -30,7 +30,7 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private disabled =
-    process.env.MUNIN_WEBHOOK_WORKER_DISABLED === '1' ||
+    parseEnvDisableFlag('MUNIN_WEBHOOK_WORKER_DISABLED') ||
     process.env.NODE_ENV === 'test';
 
   constructor(@Inject(DB) private readonly db: Db) {}

--- a/packages/backend-core/src/modules/cms/cms.schedule.worker.ts
+++ b/packages/backend-core/src/modules/cms/cms.schedule.worker.ts
@@ -1,12 +1,19 @@
 import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, lte, sql } from 'drizzle-orm';
-import { WebhookDispatcher, ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
+import {
+  ActorIdentity,
+  WebhookDispatcher,
+  parseEnvDisableFlag,
+  parseEnvInt,
+  withContext,
+  type RequestContext,
+} from '@getmunin/core';
 import { randomUUID } from 'node:crypto';
 import { DB } from '../../common/db/db.module.ts';
 import { withSchedulerLock } from '../../common/scheduler-lock/index.ts';
 
-const POLL_INTERVAL_MS = Number(process.env.MUNIN_CMS_SCHEDULE_POLL_MS ?? 60_000);
+const POLL_INTERVAL_MS = parseEnvInt({ name: 'MUNIN_CMS_SCHEDULE_POLL_MS', default: 60_000 });
 const BATCH_SIZE = 50;
 
 /**
@@ -27,7 +34,7 @@ export class CmsScheduleWorker implements OnModuleInit, OnModuleDestroy {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private disabled =
-    process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED === '1' ||
+    parseEnvDisableFlag('MUNIN_CMS_SCHEDULE_WORKER_DISABLED') ||
     process.env.NODE_ENV === 'test';
 
   constructor(

--- a/packages/backend-core/src/modules/conv/channels/inbound-poll.worker.ts
+++ b/packages/backend-core/src/modules/conv/channels/inbound-poll.worker.ts
@@ -2,17 +2,23 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
-import { ActorIdentity, getCurrentContext, withContext, type RequestContext } from '@getmunin/core';
+import {
+  ActorIdentity,
+  getCurrentContext,
+  parseEnvDisableFlag,
+  parseEnvInt,
+  withContext,
+  type RequestContext,
+} from '@getmunin/core';
 import { DB } from '../../../common/db/db.module.ts';
 import { withSchedulerLock } from '../../../common/scheduler-lock/index.ts';
 import { AlertsService } from '../../system-alerts/system-alerts.service.ts';
 import { CHANNEL_ADAPTERS, ChannelAdapterRegistry, type ChannelAdapter } from './adapter.ts';
 
-const POLL_INTERVAL_MS = Number(
-  process.env.MUNIN_INBOUND_POLL_WORKER_INTERVAL_MS ??
-    process.env.MUNIN_EMAIL_INBOUND_POLL_MS ??
-    60_000,
-);
+const POLL_INTERVAL_MS = parseEnvInt({
+  name: 'MUNIN_INBOUND_POLL_WORKER_INTERVAL_MS',
+  default: parseEnvInt({ name: 'MUNIN_EMAIL_INBOUND_POLL_MS', default: 60_000 }),
+});
 
 const AUTO_DEACTIVATE_THRESHOLD = 5;
 
@@ -32,8 +38,8 @@ export class InboundPollWorker implements OnModuleInit, OnModuleDestroy {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private disabled =
-    process.env.MUNIN_INBOUND_POLL_WORKER_DISABLED === '1' ||
-    process.env.MUNIN_EMAIL_INBOUND_WORKER_DISABLED === '1' ||
+    parseEnvDisableFlag('MUNIN_INBOUND_POLL_WORKER_DISABLED') ||
+    parseEnvDisableFlag('MUNIN_EMAIL_INBOUND_WORKER_DISABLED') ||
     process.env.NODE_ENV === 'test';
 
   private readonly registry: ChannelAdapterRegistry;

--- a/packages/backend-core/src/modules/conv/channels/outbound-delivery.worker.ts
+++ b/packages/backend-core/src/modules/conv/channels/outbound-delivery.worker.ts
@@ -4,6 +4,8 @@ import { and, eq, isNotNull, lt, lte, sql } from 'drizzle-orm';
 import {
   ActorIdentity,
   WebhookDispatcher,
+  parseEnvDisableFlag,
+  parseEnvInt,
   withContext,
   type RequestContext,
 } from '@getmunin/core';
@@ -23,11 +25,10 @@ import {
   type SendCounts,
 } from './send-rate-limit.ts';
 
-const POLL_INTERVAL_MS = Number(
-  process.env.MUNIN_OUTBOUND_DELIVERY_WORKER_INTERVAL_MS ??
-    process.env.MUNIN_EMAIL_OUTBOUND_POLL_MS ??
-    10_000,
-);
+const POLL_INTERVAL_MS = parseEnvInt({
+  name: 'MUNIN_OUTBOUND_DELIVERY_WORKER_INTERVAL_MS',
+  default: parseEnvInt({ name: 'MUNIN_EMAIL_OUTBOUND_POLL_MS', default: 10_000 }),
+});
 const MAX_ATTEMPTS = 5;
 const BATCH_SIZE = 25;
 const BACKOFF_BASE_MS = 30_000;
@@ -49,8 +50,8 @@ export class OutboundDeliveryWorker implements OnModuleInit, OnModuleDestroy {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private disabled =
-    process.env.MUNIN_OUTBOUND_DELIVERY_WORKER_DISABLED === '1' ||
-    process.env.MUNIN_EMAIL_OUTBOUND_WORKER_DISABLED === '1' ||
+    parseEnvDisableFlag('MUNIN_OUTBOUND_DELIVERY_WORKER_DISABLED') ||
+    parseEnvDisableFlag('MUNIN_EMAIL_OUTBOUND_WORKER_DISABLED') ||
     process.env.NODE_ENV === 'test';
 
   private readonly registry: ChannelAdapterRegistry;

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -4,6 +4,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import {
   ActorIdentity,
   WebhookDispatcher,
+  parseEnvInt,
   resolvePublicHost,
   signEmailOpenToken,
   withContext,
@@ -47,7 +48,7 @@ import type {
   SendResult,
 } from '../channels/adapter.ts';
 
-const POLL_INTERVAL_MS = Number(process.env.MUNIN_EMAIL_INBOUND_POLL_MS ?? 60_000);
+const POLL_INTERVAL_MS = parseEnvInt({ name: 'MUNIN_EMAIL_INBOUND_POLL_MS', default: 60_000 });
 const MAX_MESSAGES_PER_TICK = 100;
 
 interface ImapMessageMin {

--- a/packages/backend-core/src/modules/conv/widget/widget-email-fallback.worker.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-email-fallback.worker.ts
@@ -2,7 +2,12 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, sql } from 'drizzle-orm';
 import { createTransport, type Transporter } from 'nodemailer';
-import { resolvePublicHost, type Mailer } from '@getmunin/core';
+import {
+  parseEnvDisableFlag,
+  parseEnvInt,
+  resolvePublicHost,
+  type Mailer,
+} from '@getmunin/core';
 import { DB } from '../../../common/db/db.module.ts';
 import { MAILER } from '../../../common/mail/mail.module.ts';
 import { EmailService, jsonbToStored, type StoredEmailChannelConfig } from '../email/email.service.ts';
@@ -44,14 +49,16 @@ export class WidgetEmailFallbackWorker implements OnModuleInit, OnModuleDestroy 
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private readonly disabled =
-    process.env.MUNIN_WIDGET_EMAIL_FALLBACK_DISABLED === '1' ||
+    parseEnvDisableFlag('MUNIN_WIDGET_EMAIL_FALLBACK_DISABLED') ||
     process.env.NODE_ENV === 'test';
-  private readonly intervalMs = Number(
-    process.env.MUNIN_WIDGET_EMAIL_FALLBACK_INTERVAL_MS ?? DEFAULT_INTERVAL_MS,
-  );
-  private readonly thresholdMs = Number(
-    process.env.MUNIN_WIDGET_EMAIL_FALLBACK_THRESHOLD_MS ?? DEFAULT_THRESHOLD_MS,
-  );
+  private readonly intervalMs = parseEnvInt({
+    name: 'MUNIN_WIDGET_EMAIL_FALLBACK_INTERVAL_MS',
+    default: DEFAULT_INTERVAL_MS,
+  });
+  private readonly thresholdMs = parseEnvInt({
+    name: 'MUNIN_WIDGET_EMAIL_FALLBACK_THRESHOLD_MS',
+    default: DEFAULT_THRESHOLD_MS,
+  });
 
   constructor(
     @Inject(DB) private readonly db: Db,

--- a/packages/backend-core/src/modules/curator/curator-scheduler.service.ts
+++ b/packages/backend-core/src/modules/curator/curator-scheduler.service.ts
@@ -3,7 +3,13 @@ import { CronExpression, SchedulerRegistry } from '@nestjs/schedule';
 import { CronJob } from 'cron';
 import { schema, type Db } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
-import { ActorIdentity, RequestContextStore, type RequestContext } from '@getmunin/core';
+import {
+  ActorIdentity,
+  RequestContextStore,
+  parseEnvCron,
+  parseEnvDisableFlag,
+  type RequestContext,
+} from '@getmunin/core';
 import { randomUUID } from 'node:crypto';
 import { DB } from '../../common/db/db.module.ts';
 import { withSchedulerLock } from '../../common/scheduler-lock/index.ts';
@@ -20,8 +26,7 @@ const OUTREACH_DRAFT_INITIAL_PROMPT =
 
 interface SweepDef {
   name: string;
-  envCron: string | undefined;
-  defaultCron: string;
+  cron: string | null;
   jobUri: string;
   userPrompt: string;
   dedupeKey: string;
@@ -31,7 +36,7 @@ interface SweepDef {
 export class CuratorSchedulerService implements OnModuleInit {
   private readonly logger = new Logger(CuratorSchedulerService.name);
   private readonly disabled =
-    process.env.MUNIN_CURATOR_SCHEDULER_DISABLED === '1' ||
+    parseEnvDisableFlag('MUNIN_CURATOR_SCHEDULER_DISABLED') ||
     process.env.NODE_ENV === 'test';
 
   constructor(
@@ -49,32 +54,34 @@ export class CuratorSchedulerService implements OnModuleInit {
     const sweeps: SweepDef[] = [
       {
         name: 'curator-kb-sweep',
-        envCron: process.env.MUNIN_CURATOR_KB_SWEEP_CRON,
-        defaultCron: CronExpression.EVERY_WEEK,
+        cron: parseEnvCron({ name: 'MUNIN_CURATOR_KB_SWEEP_CRON', default: CronExpression.EVERY_WEEK }),
         jobUri: 'skill://kb/review-content',
         userPrompt: KB_SWEEP_PROMPT,
         dedupeKey: 'kb-sweep:scheduled',
       },
       {
         name: 'curator-crm-hygiene',
-        envCron: process.env.MUNIN_CURATOR_CRM_HYGIENE_CRON,
-        defaultCron: CronExpression.EVERY_WEEK,
+        cron: parseEnvCron({ name: 'MUNIN_CURATOR_CRM_HYGIENE_CRON', default: CronExpression.EVERY_WEEK }),
         jobUri: 'skill://crm/clean-contact-data',
         userPrompt: CRM_HYGIENE_PROMPT,
         dedupeKey: 'crm-hygiene:scheduled',
       },
       {
         name: 'curator-cms-stale',
-        envCron: process.env.MUNIN_CURATOR_CMS_STALE_CRON,
-        defaultCron: CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT,
+        cron: parseEnvCron({
+          name: 'MUNIN_CURATOR_CMS_STALE_CRON',
+          default: CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT,
+        }),
         jobUri: 'skill://cms/review-stale-entries',
         userPrompt: CMS_STALE_PROMPT,
         dedupeKey: 'cms-stale:scheduled',
       },
       {
         name: 'curator-outreach-draft-initial',
-        envCron: process.env.MUNIN_CURATOR_OUTREACH_INITIAL_CRON,
-        defaultCron: CronExpression.EVERY_WEEK,
+        cron: parseEnvCron({
+          name: 'MUNIN_CURATOR_OUTREACH_INITIAL_CRON',
+          default: CronExpression.EVERY_WEEK,
+        }),
         jobUri: 'skill://outreach/draft-initial-email',
         userPrompt: OUTREACH_DRAFT_INITIAL_PROMPT,
         dedupeKey: 'outreach-draft-initial:scheduled',
@@ -82,19 +89,18 @@ export class CuratorSchedulerService implements OnModuleInit {
     ];
 
     for (const sweep of sweeps) {
-      const cron = (sweep.envCron && sweep.envCron.trim()) || sweep.defaultCron;
-      if (cron === 'off' || cron === '0') {
+      if (sweep.cron === null) {
         this.logger.log(`${sweep.name} disabled by env`);
         continue;
       }
-      const job = new CronJob(cron, () => {
+      const job = new CronJob(sweep.cron, () => {
         void withSchedulerLock(this.db, `curator-scheduler:${sweep.name}`, () =>
           this.runSweep(sweep),
         );
       });
       this.registry.addCronJob(sweep.name, job);
       job.start();
-      this.logger.log(`${sweep.name} scheduled with "${cron}"`);
+      this.logger.log(`${sweep.name} scheduled with "${sweep.cron}"`);
     }
   }
 

--- a/packages/backend-core/src/modules/feedback/feedback.module.ts
+++ b/packages/backend-core/src/modules/feedback/feedback.module.ts
@@ -1,4 +1,5 @@
 import { Global, Module } from '@nestjs/common';
+import { parseEnvBool } from '@getmunin/core';
 import { FeedbackService } from './feedback.service.ts';
 import { FeedbackController } from './feedback.controller.ts';
 import { FeedbackTools } from './feedback.tools.ts';
@@ -14,7 +15,5 @@ import { InstanceIdService } from './instance-id.service.ts';
 export class FeedbackModule {}
 
 export function isFeedbackEnabled(): boolean {
-  const raw = process.env.MUNIN_FEEDBACK_ENABLED;
-  if (raw === undefined) return false;
-  return raw.toLowerCase() === 'true' || raw === '1';
+  return parseEnvBool({ name: 'MUNIN_FEEDBACK_ENABLED', default: false });
 }

--- a/packages/backend-core/src/realtime/db-listener.service.ts
+++ b/packages/backend-core/src/realtime/db-listener.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
 import postgres from 'postgres';
+import { parseEnvDisableFlag } from '@getmunin/core';
 
 export interface EventRow {
   id: string;
@@ -21,7 +22,7 @@ export class DbListenerService implements OnModuleInit, OnModuleDestroy {
   private readonly handlers = new Set<EventHandler>();
 
   async onModuleInit(): Promise<void> {
-    if (process.env.MUNIN_REALTIME_DISABLED === '1') {
+    if (parseEnvDisableFlag('MUNIN_REALTIME_DISABLED')) {
       this.logger.log('realtime listener disabled via MUNIN_REALTIME_DISABLED');
       return;
     }

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -16,6 +16,7 @@ import {
   ActorIdentity,
   CredentialResolver,
   WebhookDispatcher,
+  parseEnvDisableFlag,
   withContext,
   type RequestContext,
   type ResolvedCredential,
@@ -99,7 +100,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   }
 
   onApplicationBootstrap(): void {
-    if (process.env.MUNIN_REALTIME_DISABLED === '1') {
+    if (parseEnvDisableFlag('MUNIN_REALTIME_DISABLED')) {
       this.logger.log('realtime gateway disabled via MUNIN_REALTIME_DISABLED');
       return;
     }

--- a/packages/core/src/env/index.ts
+++ b/packages/core/src/env/index.ts
@@ -1,0 +1,9 @@
+export {
+  parseEnvBool,
+  parseEnvCron,
+  parseEnvDisableFlag,
+  parseEnvInt,
+  type ParseEnvBoolOptions,
+  type ParseEnvCronOptions,
+  type ParseEnvIntOptions,
+} from './parse.ts';

--- a/packages/core/src/env/parse.test.ts
+++ b/packages/core/src/env/parse.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  parseEnvBool,
+  parseEnvCron,
+  parseEnvDisableFlag,
+  parseEnvInt,
+} from './parse.ts';
+
+const ENV_KEY = '__MUNIN_ENV_PARSE_TEST__';
+
+describe('parseEnvInt', () => {
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    delete process.env[ENV_KEY];
+  });
+
+  it('returns parsed integer when value is valid', () => {
+    process.env[ENV_KEY] = '42';
+    expect(parseEnvInt({ name: ENV_KEY, default: 10 })).toBe(42);
+  });
+
+  it('falls back to default when value is missing', () => {
+    expect(parseEnvInt({ name: ENV_KEY, default: 10 })).toBe(10);
+  });
+
+  it('falls back to default when value is empty string', () => {
+    process.env[ENV_KEY] = '';
+    expect(parseEnvInt({ name: ENV_KEY, default: 10 })).toBe(10);
+  });
+
+  it('falls back to default on unparseable input (no silent NaN)', () => {
+    process.env[ENV_KEY] = 'garbage';
+    expect(parseEnvInt({ name: ENV_KEY, default: 10 })).toBe(10);
+  });
+
+  it('throws when value is missing and no default provided', () => {
+    expect(() => parseEnvInt({ name: ENV_KEY })).toThrow(/required/);
+  });
+
+  it('throws when out of range with onInvalid=throw', () => {
+    process.env[ENV_KEY] = '5000';
+    expect(() =>
+      parseEnvInt({ name: ENV_KEY, default: 1536, min: 32, max: 4000, onInvalid: 'throw' }),
+    ).toThrow(/32\.\.4000/);
+  });
+
+  it('falls back when out of range with default and no onInvalid override', () => {
+    process.env[ENV_KEY] = '5000';
+    expect(parseEnvInt({ name: ENV_KEY, default: 1536, min: 32, max: 4000 })).toBe(1536);
+  });
+
+  it('throws on non-integer when no default', () => {
+    process.env[ENV_KEY] = 'abc';
+    expect(() => parseEnvInt({ name: ENV_KEY })).toThrow(/must be an integer/);
+  });
+});
+
+describe('parseEnvBool', () => {
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    delete process.env[ENV_KEY];
+  });
+
+  it.each([
+    ['1', true],
+    ['0', false],
+    ['true', true],
+    ['false', false],
+    ['TRUE', true],
+    ['False', false],
+  ])('parses %j as %s', (raw, expected) => {
+    process.env[ENV_KEY] = raw;
+    expect(parseEnvBool({ name: ENV_KEY, default: !expected })).toBe(expected);
+  });
+
+  it('returns default when unset', () => {
+    expect(parseEnvBool({ name: ENV_KEY, default: true })).toBe(true);
+    expect(parseEnvBool({ name: ENV_KEY, default: false })).toBe(false);
+  });
+
+  it('returns default on unrecognized value', () => {
+    process.env[ENV_KEY] = 'yes';
+    expect(parseEnvBool({ name: ENV_KEY, default: false })).toBe(false);
+  });
+});
+
+describe('parseEnvDisableFlag', () => {
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    delete process.env[ENV_KEY];
+  });
+
+  it('returns false when unset', () => {
+    expect(parseEnvDisableFlag(ENV_KEY)).toBe(false);
+  });
+
+  it('returns true for "1"', () => {
+    process.env[ENV_KEY] = '1';
+    expect(parseEnvDisableFlag(ENV_KEY)).toBe(true);
+  });
+
+  it('returns true for "true" (widened from strict =="1")', () => {
+    process.env[ENV_KEY] = 'true';
+    expect(parseEnvDisableFlag(ENV_KEY)).toBe(true);
+  });
+
+  it('returns false for "0"', () => {
+    process.env[ENV_KEY] = '0';
+    expect(parseEnvDisableFlag(ENV_KEY)).toBe(false);
+  });
+});
+
+describe('parseEnvCron', () => {
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    delete process.env[ENV_KEY];
+  });
+
+  it('returns env value when set', () => {
+    process.env[ENV_KEY] = '0 0 * * *';
+    expect(parseEnvCron({ name: ENV_KEY, default: '0 12 * * *' })).toBe('0 0 * * *');
+  });
+
+  it('returns default when unset or blank', () => {
+    expect(parseEnvCron({ name: ENV_KEY, default: '0 12 * * *' })).toBe('0 12 * * *');
+    process.env[ENV_KEY] = '   ';
+    expect(parseEnvCron({ name: ENV_KEY, default: '0 12 * * *' })).toBe('0 12 * * *');
+  });
+
+  it('returns null when value is "off"', () => {
+    process.env[ENV_KEY] = 'off';
+    expect(parseEnvCron({ name: ENV_KEY, default: '0 12 * * *' })).toBeNull();
+  });
+
+  it('returns null when value is "0"', () => {
+    process.env[ENV_KEY] = '0';
+    expect(parseEnvCron({ name: ENV_KEY, default: '0 12 * * *' })).toBeNull();
+  });
+
+  it('returns null when default itself is "off"', () => {
+    expect(parseEnvCron({ name: ENV_KEY, default: 'off' })).toBeNull();
+  });
+
+  it('trims surrounding whitespace', () => {
+    process.env[ENV_KEY] = '  0 * * * *  ';
+    expect(parseEnvCron({ name: ENV_KEY, default: 'off' })).toBe('0 * * * *');
+  });
+});

--- a/packages/core/src/env/parse.ts
+++ b/packages/core/src/env/parse.ts
@@ -1,0 +1,63 @@
+export type ParseEnvIntOptions = {
+  name: string;
+  default?: number;
+  min?: number;
+  max?: number;
+  onInvalid?: 'throw' | 'fallback';
+};
+
+export function parseEnvInt(opts: ParseEnvIntOptions): number {
+  const onInvalid = opts.onInvalid ?? (opts.default !== undefined ? 'fallback' : 'throw');
+  const raw = process.env[opts.name];
+
+  if (raw === undefined || raw === '') {
+    if (opts.default !== undefined) return opts.default;
+    throw new Error(`${opts.name} is required`);
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  const inRange =
+    Number.isInteger(parsed) &&
+    (opts.min === undefined || parsed >= opts.min) &&
+    (opts.max === undefined || parsed <= opts.max);
+
+  if (inRange) return parsed;
+
+  if (onInvalid === 'fallback' && opts.default !== undefined) return opts.default;
+
+  const rangeHint =
+    opts.min !== undefined || opts.max !== undefined
+      ? ` in ${opts.min ?? '-∞'}..${opts.max ?? '∞'}`
+      : '';
+  throw new Error(`${opts.name} must be an integer${rangeHint}, got ${raw}`);
+}
+
+export type ParseEnvBoolOptions = {
+  name: string;
+  default: boolean;
+};
+
+export function parseEnvBool(opts: ParseEnvBoolOptions): boolean {
+  const raw = process.env[opts.name];
+  if (raw === undefined) return opts.default;
+  const lower = raw.trim().toLowerCase();
+  if (lower === '1' || lower === 'true') return true;
+  if (lower === '0' || lower === 'false') return false;
+  return opts.default;
+}
+
+export function parseEnvDisableFlag(name: string): boolean {
+  return parseEnvBool({ name, default: false });
+}
+
+export type ParseEnvCronOptions = {
+  name: string;
+  default: string;
+};
+
+export function parseEnvCron(opts: ParseEnvCronOptions): string | null {
+  const raw = process.env[opts.name]?.trim();
+  const value = raw && raw.length > 0 ? raw : opts.default;
+  if (value === 'off' || value === '0') return null;
+  return value;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,16 @@ export {
   type SafeFetchOptions,
 } from './net/safe-fetch.ts';
 
+export {
+  parseEnvBool,
+  parseEnvCron,
+  parseEnvDisableFlag,
+  parseEnvInt,
+  type ParseEnvBoolOptions,
+  type ParseEnvCronOptions,
+  type ParseEnvIntOptions,
+} from './env/index.ts';
+
 export { WebhookDispatcher, type WebhookEventInput } from './webhooks.ts';
 export {
   chunkDocument,

--- a/packages/core/src/net/safe-fetch.ts
+++ b/packages/core/src/net/safe-fetch.ts
@@ -7,6 +7,7 @@ import { promisify } from 'node:util';
 import { isIP as isIp } from 'node:net';
 import { Agent, fetch as undiciFetch } from 'undici';
 import type { RequestInit as UndiciRequestInit, Response as UndiciResponse } from 'undici';
+import { parseEnvBool } from '../env/index.ts';
 
 const dnsLookup = promisify((hostname: string, cb: (err: NodeJS.ErrnoException | null, addrs: LookupAddress[]) => void) =>
   dnsLookupCallback(hostname, { all: true, verbatim: true }, cb),
@@ -21,11 +22,6 @@ const BLOCKED_HOSTNAMES = new Set([
   'ip6-loopback',
   'broadcasthost',
 ]);
-
-function envBool(name: string): boolean {
-  const v = process.env[name];
-  return v === '1' || v === 'true';
-}
 
 function ipv4ToInt(ip: string): number | null {
   const parts = ip.split('.');
@@ -167,7 +163,7 @@ export async function resolvePublicHost(
   hostname: string,
   opts: AssertPublicHostOptions = {},
 ): Promise<{ address: string; family: number } | null> {
-  if (envBool('MUNIN_SSRF_ALLOW_PRIVATE')) return null;
+  if (parseEnvBool({ name: 'MUNIN_SSRF_ALLOW_PRIVATE', default: false })) return null;
   const host = hostname.toLowerCase();
   if (!host) throw new SsrfBlockedError('empty host');
   if (BLOCKED_HOSTNAMES.has(host)) {
@@ -217,7 +213,7 @@ function makeBlockingAgent(): Agent {
           cb(e, wantAll ? [] : '', 0);
         };
         const hostOk = isIp(hostname) ? !isPrivateIp(hostname) : !isBannedHostname(hostname);
-        if (!hostOk && !envBool('MUNIN_SSRF_ALLOW_PRIVATE')) {
+        if (!hostOk && !parseEnvBool({ name: 'MUNIN_SSRF_ALLOW_PRIVATE', default: false })) {
           rejectSsrf(`host ${hostname} is not allowed`);
           return;
         }
@@ -226,7 +222,7 @@ function makeBlockingAgent(): Agent {
           if (!Array.isArray(records) || records.length === 0) {
             return cb(new Error('no address resolved'), wantAll ? [] : '', 0);
           }
-          if (!envBool('MUNIN_SSRF_ALLOW_PRIVATE')) {
+          if (!parseEnvBool({ name: 'MUNIN_SSRF_ALLOW_PRIVATE', default: false })) {
             for (const r of records) {
               if (isPrivateIp(r.address)) {
                 return rejectSsrf(`host ${hostname} resolved to private ip ${r.address}`);

--- a/packages/core/src/providers/embedding.ts
+++ b/packages/core/src/providers/embedding.ts
@@ -8,6 +8,8 @@
  * controlled by `MUNIN_EMBEDDING_DIMENSIONS` (default 1536).
  */
 
+import { parseEnvInt } from '../env/index.ts';
+
 export interface EmbeddingProvider {
   /** Vector dimension this provider produces. Must match the kb schema. */
   readonly dimensions: number;
@@ -194,21 +196,16 @@ export function readEmbeddingProviderFromEnv(): EmbeddingProvider {
 }
 
 function parseOptionalDimensions(envName: string): number | undefined {
-  const raw = process.env[envName];
-  if (!raw) return undefined;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isInteger(n) || n < 32 || n > 4000) {
-    throw new Error(`${envName} must be an integer in 32..4000, got ${raw}`);
-  }
-  return n;
+  if (process.env[envName] === undefined || process.env[envName] === '') return undefined;
+  return parseEnvInt({ name: envName, min: 32, max: 4000, onInvalid: 'throw' });
 }
 
 function readSchemaDimensionsFromEnv(): number {
-  const raw = process.env.MUNIN_EMBEDDING_DIMENSIONS;
-  if (!raw) return DEFAULT_DIMENSIONS;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isInteger(n) || n < 32 || n > 4000) {
-    throw new Error(`MUNIN_EMBEDDING_DIMENSIONS must be an integer in 32..4000, got ${raw}`);
-  }
-  return n;
+  return parseEnvInt({
+    name: 'MUNIN_EMBEDDING_DIMENSIONS',
+    default: DEFAULT_DIMENSIONS,
+    min: 32,
+    max: 4000,
+    onInvalid: 'throw',
+  });
 }

--- a/packages/core/src/providers/mailer.ts
+++ b/packages/core/src/providers/mailer.ts
@@ -89,6 +89,7 @@ export class ResendMailer implements Mailer {
 // ─── Generic SMTP (covers Scaleway TEM, Postmark, Mailgun, etc.) ────────────
 
 import { createTransport, type Transporter, type SendMailOptions } from 'nodemailer';
+import { parseEnvBool } from '../env/index.ts';
 
 export interface SmtpMailerOptions {
   host: string;
@@ -202,7 +203,7 @@ export function readMailerFromEnv(): Mailer {
       user,
       password,
       from,
-      secure: process.env.MUNIN_SMTP_SECURE === '1',
+      secure: parseEnvBool({ name: 'MUNIN_SMTP_SECURE', default: false }),
     });
   }
   const apiKey = process.env.RESEND_API_KEY;


### PR DESCRIPTION
## Summary

Follow-up to #342. Extracts a tiny env-parsing utility into `@getmunin/core/env` and migrates the ~30 call sites that were each rolling their own. Five patterns collapse to four helpers:

- `parseEnvInt({ name, default?, min?, max?, onInvalid? })` — replaces `Number(process.env.X ?? D)` (was silently passing NaN through) and `parseInt + bounds + throw` (used for `MUNIN_EMBEDDING_DIMENSIONS`).
- `parseEnvBool({ name, default })` — replaces `=== 'true' || === '1'` (`MUNIN_QUOTAS_ENABLED`, `MUNIN_FEEDBACK_ENABLED`, `MUNIN_SSRF_ALLOW_PRIVATE`, `MUNIN_SMTP_SECURE`, `MUNIN_BUILTIN_AGENT`).
- `parseEnvDisableFlag(name)` — replaces the strict `=== '1'` disable convention on worker / realtime / scheduler / widget-fallback flags.
- `parseEnvCron({ name, default })` — replaces the cron + `'off' | '0'` disable logic in `curator-scheduler.service.ts`. Returns `null` when disabled.

`packages/db/src/schema.ts` keeps its inline `MUNIN_EMBEDDING_DIMENSIONS` parse because `db` is below `core` in the dep graph.

## Behavior changes (all widening, none narrowing)

- `Number(process.env.X ?? D)` patterns previously produced `NaN` when set to garbage; `parseEnvInt` falls back to the default instead. This is the bug fix from the #342 discussion.
- Disable flags previously matched only `=== '1'`; they now also accept `'true'` (case-insensitive). No call site relied on rejecting `'true'`.

## Test plan

- [x] `pnpm -r typecheck` (clean across all 18 packages)
- [x] `pnpm -F @getmunin/core exec vitest run` — 296 pass / 24 skipped, includes 26 new tests for the helpers
- [x] `pnpm -F @getmunin/backend-core exec vitest run --exclude '**/*.integration.test.ts'` — 226 pass / 182 skipped (curator scheduler tests visibly exercise the new `parseEnvCron` disable path in logs)
- [x] `pnpm -F @getmunin/agent-host exec vitest run` — 40 pass
- [x] `pnpm -F @getmunin/agent-runtime exec vitest run` — 236 pass
- [ ] Integration tests (gated on `TEST_DATABASE_URL`) — please run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)