### PR TITLE
feat(backend-core): MCP tools for webhooks + upload-from-URL asset path

### DIFF
--- a/.changeset/webhooks-mcp-and-upload-from-url.md
+++ b/.changeset/webhooks-mcp-and-upload-from-url.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/types': minor
+---
+
+Webhook management is now available to AI agents via MCP. Adds seven `webhooks_*` tools (`list`, `create`, `update`, `delete`, `rotate_secret`, `list_deliveries`, `list_event_types`) backed by a new `WebhooksService` that the existing REST controller at `/v1/webhooks` also delegates to. The controller gains `POST :id/rotate-secret`, `GET :id/deliveries`, and `GET event-types` endpoints. Tools follow the system-alerts convention (`audiences: ['admin']`, `scopes: []`) — no new OAuth scopes were introduced.
+
+Adds `cms_upload_asset_from_url`: server-side fetches an HTTPS asset and stores it as a CMS asset in one call. Bypasses the presigned-PUT + base64 round-trips that some agent sandboxes (e.g. ChatGPT/Claude workspaces) cannot complete. Guarded by `safeFetch` (SSRF, redirect cap, 15s timeout), a 50 MB streamed size cap (Content-Length is not trusted), and a MIME allowlist (`image/*`, `video/*`, `audio/*`, `application/pdf`; SVG remains rejected). The original URL is recorded in `metadata.sourceUrl`.
+
+Consolidates webhook event-type strings in `@getmunin/types`: new exports `CMS_EVENT_TYPES`, `CRM_EVENT_TYPES`, `KB_EVENT_TYPES`, `CONVERSATION_EVENT_TYPES`, `OUTREACH_EVENT_TYPES`, `SYSTEM_EVENT_TYPES`, `EVENT_TYPES_BY_MODULE`, `KNOWN_EVENT_TYPES`, and `isKnownEventType`. The dispatcher's `emit({ type })` still accepts arbitrary strings; the catalog is the source of truth for `webhooks_list_event_types` and is available for typed consumers going forward.
+
+Realtime gateway now sends `{ type: 'read_ack', conversationId, messageIds }` to the originating socket after a `read` frame's `conv_message_reads` INSERT commits. All existing WebSocket consumers (chat-widget, dashboard, agent-runtime) silently ignore unknown frame types, so this is additive. The widget integration test for `conv_message_reads` waits for the ack instead of `setTimeout(200)`, eliminating a CI flake.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -829,6 +829,54 @@
     }
   },
   {
+    "name": "cms_upload_asset_from_url",
+    "title": "CMS: Upload asset from URL",
+    "description": "Fetch a publicly reachable HTTPS asset and store it as a CMS asset in one call. Use this when your runtime cannot PUT to a presigned URL or pass large base64 payloads — typical for ChatGPT/Claude workspace agents whose sandbox blocks outbound PUTs and truncates long base64 strings. The server fetches the URL with SSRF protection, validates content-type (image/*, video/*, audio/*, application/pdf — SVG rejected) and size (≤50 MB), and creates the asset row in `uploaded:true` state. Filename and MIME are inferred from the response unless overridden. The original URL is recorded in `metadata.sourceUrl`.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "cms:write"
+    ],
+    "danger": "writes",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "sourceUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "mime": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "altText": {
+          "type": "string",
+          "maxLength": 500
+        },
+        "metadata": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "sourceUrl"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "cms_complete_asset_upload",
     "title": "CMS: Complete asset upload",
     "description": "Mark a previously-requested asset upload as complete.",
@@ -4575,6 +4623,325 @@
       "required": [
         "conversationId",
         "draftBody"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "webhooks_list",
+    "title": "Webhooks: List",
+    "description": "List all webhook subscriptions for your org. Secrets are not returned — they are only shown once at creation. Use webhooks_rotate_secret if you lost it.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "webhooks_create",
+    "title": "Webhooks: Create",
+    "description": "Create a webhook subscription. `url` must be https://. `events` is an array of event type strings (e.g. [\"cms.entry.published\"]); omit or pass an empty array to subscribe to all events. The response includes a one-time `secret` of the form `whsec_…` — store it now; it cannot be retrieved later. Deliveries are signed with `x-munin-signature: sha256=<HMAC-SHA256(body, secret)>` and include `x-munin-event`, `x-munin-delivery-id` headers. Retries: up to 5 attempts with exponential backoff (30s → 8m). Use webhooks_list_event_types to discover known event names.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": "writes",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "events": {
+          "maxItems": 64,
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          }
+        },
+        "active": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "webhooks_update",
+    "title": "Webhooks: Update",
+    "description": "Patch a webhook subscription. Pass only the fields you want to change. Replacing `events` overwrites the full array — read first if you mean to append.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": "writes",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "patch": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "events": {
+              "maxItems": 64,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 64
+              }
+            },
+            "active": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "patch"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "webhooks_delete",
+    "title": "Webhooks: Delete",
+    "description": "Delete a webhook. Pending deliveries are cascade-deleted; in-flight HTTP attempts finish their current run.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "webhooks_rotate_secret",
+    "title": "Webhooks: Rotate signing secret",
+    "description": "Generate a new `whsec_…` secret for a webhook. The previous secret stops signing deliveries immediately — update your receiver before rotating. The new secret is returned once in the response.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "webhooks_list_deliveries",
+    "title": "Webhooks: List deliveries",
+    "description": "List delivery attempts for one webhook, newest first. Each row has attempt count, statusCode, durationMs, error, deliveredAt, nextAttemptAt, and a rolled-up `status` (pending / delivered / failed). Filter with `status` and cap with `limit` (default 50, max 200).",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "webhookId": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 200
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "delivered",
+            "failed"
+          ]
+        }
+      },
+      "required": [
+        "webhookId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "webhooks_list_event_types",
+    "title": "Webhooks: List event types",
+    "description": "List the known event type strings emitted across modules (cms, crm, kb, conv, outreach, system). Use the returned strings as input to webhooks_create. The subscription accepts arbitrary strings, so future event types work without a tool update — but this is the canonical catalog today.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "system_alerts_list",
+    "title": "System alerts: list",
+    "description": "List operational alerts for the org. Defaults to open alerts only; pass includeResolved to see history.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "includeResolved": {
+          "type": "boolean"
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "system_alerts_get",
+    "title": "System alerts: get",
+    "description": "Read a single alert by id.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "system_alerts_acknowledge",
+    "title": "System alerts: acknowledge",
+    "description": "Mark an alert as acknowledged. Does not resolve it; only signals that someone is on it.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": "writes",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "system_alerts_resolve",
+    "title": "System alerts: resolve",
+    "description": "Manually resolve the open alert for the given source+subject. Writers normally self-resolve; use this when the underlying state can no longer be observed.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": "writes",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": [
+            "llm_provider",
+            "channel_inbound",
+            "channel_outbound",
+            "curator",
+            "delivery",
+            "quota"
+          ]
+        },
+        "subjectId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "source"
       ],
       "additionalProperties": false
     }

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -823,6 +823,28 @@
         ]
       }
     },
+    "/v1/webhooks/event-types": {
+      "get": {
+        "operationId": "WebhooksController_listEventTypes",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/webhooks/{id}": {
       "patch": {
         "operationId": "WebhooksController_patch",
@@ -867,6 +889,68 @@
         ],
         "responses": {
           "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/webhooks/{id}/rotate-secret": {
+      "post": {
+        "operationId": "WebhooksController_rotateSecret",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/webhooks/{id}/deliveries": {
+      "get": {
+        "operationId": "WebhooksController_listDeliveries",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
             "description": ""
           }
         },

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -28,6 +28,7 @@ import { OutreachUnsubscribeController } from './outreach-unsubscribe.controller
 import { EmailOpensController } from './email-opens.controller.ts';
 import { OutreachProposalsController } from './outreach-proposals.controller.ts';
 import { OutreachModule } from '../modules/outreach/outreach.module.ts';
+import { WebhooksModule } from '../modules/webhooks/webhooks.module.ts';
 import { PublicSkillsController } from './public-skills.controller.ts';
 import { PublicMcpToolsController } from './public-mcp-tools.controller.ts';
 import { InvitationsController } from './invitations.controller.ts';
@@ -60,6 +61,7 @@ import { AuthProvidersController } from './auth-providers.controller.ts';
     McpModule,
     OutreachModule,
     RealtimeModule,
+    WebhooksModule,
   ],
   controllers: [
     ApiKeysController,

--- a/packages/backend-core/src/control/webhooks.controller.ts
+++ b/packages/backend-core/src/control/webhooks.controller.ts
@@ -5,23 +5,25 @@ import {
   Delete,
   Get,
   HttpCode,
-  NotFoundException,
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { z } from 'zod';
-import { schema } from '@getmunin/db';
-import { and, asc, eq } from 'drizzle-orm';
-import { getCurrentContext, randomToken } from '@getmunin/core';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 import { RoleGuard } from './role.guard.ts';
 import { RequireRole } from './role.decorator.ts';
+import {
+  WebhooksService,
+  type WebhookDto,
+  type WebhookDeliveryDto,
+} from '../modules/webhooks/webhooks.service.ts';
 
 export const WebhookUrl = z
   .string()
@@ -46,94 +48,61 @@ const PatchDto = z.object({
   active: z.boolean().optional(),
 });
 
-interface WebhookDto {
-  id: string;
-  url: string;
-  events: string[];
-  active: boolean;
-  /** Plaintext shared secret — returned ONCE at creation time. */
-  secret?: string;
-  createdAt: string;
-  updatedAt: string;
-}
+const DeliveriesQuery = z.object({
+  limit: z.coerce.number().int().positive().max(200).optional(),
+  status: z.enum(['pending', 'delivered', 'failed']).optional(),
+});
 
 @Controller('v1/webhooks')
 @UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 @RequireRole('owner', 'admin')
 export class WebhooksController {
+  constructor(private readonly webhooks: WebhooksService) {}
+
   @Get()
-  async list(): Promise<WebhookDto[]> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const rows = await ctx.db
-      .select()
-      .from(schema.webhooks)
-      .where(eq(schema.webhooks.orgId, actor.orgId))
-      .orderBy(asc(schema.webhooks.createdAt));
-    return rows.map(toDto);
+  list(): Promise<WebhookDto[]> {
+    return this.webhooks.list();
+  }
+
+  @Get('event-types')
+  listEventTypes() {
+    return this.webhooks.listEventTypes();
   }
 
   @Post()
   @HttpCode(201)
-  async create(@Body() body: unknown): Promise<WebhookDto> {
+  create(@Body() body: unknown): Promise<WebhookDto> {
     const parsed = CreateDto.safeParse(body);
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const secret = `whsec_${randomToken(24)}`;
-    const [row] = await ctx.db
-      .insert(schema.webhooks)
-      .values({
-        orgId: actor.orgId,
-        url: parsed.data.url,
-        secret,
-        events: parsed.data.events,
-        active: parsed.data.active ?? true,
-      })
-      .returning();
-    return { ...toDto(row!), secret };
+    return this.webhooks.create(parsed.data);
   }
 
   @Patch(':id')
-  async patch(@Param('id') id: string, @Body() body: unknown): Promise<WebhookDto> {
+  patch(@Param('id') id: string, @Body() body: unknown): Promise<WebhookDto> {
     const parsed = PatchDto.safeParse(body);
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (parsed.data.url !== undefined) updates.url = parsed.data.url;
-    if (parsed.data.events !== undefined) updates.events = parsed.data.events;
-    if (parsed.data.active !== undefined) updates.active = parsed.data.active;
-    const result = await ctx.db
-      .update(schema.webhooks)
-      .set(updates)
-      .where(and(eq(schema.webhooks.id, id), eq(schema.webhooks.orgId, actor.orgId)))
-      .returning();
-    if (!result[0]) throw new NotFoundException(`webhook ${id} not found`);
-    return toDto(result[0]);
+    return this.webhooks.update(id, parsed.data);
   }
 
   @Delete(':id')
   @HttpCode(204)
   async remove(@Param('id') id: string): Promise<void> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const result = await ctx.db
-      .delete(schema.webhooks)
-      .where(and(eq(schema.webhooks.id, id), eq(schema.webhooks.orgId, actor.orgId)))
-      .returning({ id: schema.webhooks.id });
-    if (result.length === 0) throw new NotFoundException(`webhook ${id} not found`);
+    await this.webhooks.delete(id);
   }
-}
 
-function toDto(row: typeof schema.webhooks.$inferSelect): WebhookDto {
-  return {
-    id: row.id,
-    url: row.url,
-    events: row.events,
-    active: row.active,
-    createdAt: row.createdAt.toISOString(),
-    updatedAt: row.updatedAt.toISOString(),
-  };
+  @Post(':id/rotate-secret')
+  rotateSecret(@Param('id') id: string): Promise<WebhookDto> {
+    return this.webhooks.rotateSecret(id);
+  }
+
+  @Get(':id/deliveries')
+  listDeliveries(
+    @Param('id') id: string,
+    @Query() query: unknown,
+  ): Promise<WebhookDeliveryDto[]> {
+    const parsed = DeliveriesQuery.safeParse(query);
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return this.webhooks.listDeliveries({ webhookId: id, ...parsed.data });
+  }
 }

--- a/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
+++ b/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
@@ -23,6 +23,7 @@ const EXPECTED_BY_MODULE: Record<string, RegExp> = {
   cms: /^cms_/,
   outreach: /^outreach_/,
   system: /^system_/,
+  webhooks: /^webhooks_/,
 };
 
 const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
@@ -32,6 +33,7 @@ const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
   cms: 20,
   outreach: 7,
   system: 4,
+  webhooks: 7,
 };
 
 (skipReason ? describe.skip : describe)('MCP tools smoke: registry shape across all modules', () => {
@@ -110,6 +112,7 @@ const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
         cms: 'CMS:',
         outreach: 'Outreach:',
         system: 'System ',
+        webhooks: 'Webhooks:',
       };
       const tools = await admin.listTools();
       for (const t of tools) {

--- a/packages/backend-core/src/modules/cms/cms.service.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.test.ts
@@ -721,6 +721,12 @@ class StubStorage implements AssetStorage {
         ),
       ).rejects.toThrow(/svg uploads are not allowed/);
     });
+
+    it('uploadAssetFromUrl rejects loopback host via SSRF guard', async () => {
+      await expect(
+        run(() => svc.uploadAssetFromUrl({ sourceUrl: 'https://127.0.0.1/x.png' })),
+      ).rejects.toThrow(/sourceUrl blocked/);
+    });
   });
 
   // ─── Locales ─────────────────────────────────────────────────────────

--- a/packages/backend-core/src/modules/cms/cms.service.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.ts
@@ -10,6 +10,8 @@ import { and, asc, desc, eq, sql, type SQL } from 'drizzle-orm';
 import {
   contentHash,
   getCurrentContext,
+  safeFetch,
+  SsrfBlockedError,
   WebhookDispatcher,
   type AssetStorage,
 } from '@getmunin/core';
@@ -607,6 +609,61 @@ export class CmsService {
     metadata?: Record<string, unknown>;
   }): Promise<AssetDto> {
     const body = decodeAssetBody(input.base64Body);
+    return this.persistAssetBytes({
+      name: input.name,
+      mime: input.mime,
+      body,
+      altText: input.altText,
+      metadata: input.metadata,
+    });
+  }
+
+  async uploadAssetFromUrl(input: {
+    sourceUrl: string;
+    name?: string;
+    mime?: string;
+    altText?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<AssetDto> {
+    const res = await safeFetch(input.sourceUrl, {
+      method: 'GET',
+      headers: { 'user-agent': 'Munin-CMS/1.0 (+https://getmunin.com)' },
+      signal: AbortSignal.timeout(15_000),
+    }).catch((err) => {
+      throw new CmsInvalidError(
+        err instanceof SsrfBlockedError
+          ? `sourceUrl blocked: ${err.message}`
+          : `fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+    if (!res.ok) throw new CmsInvalidError(`fetch failed with status ${res.status}`);
+
+    const mime = (
+      input.mime ?? res.headers.get('content-type')?.split(';')[0]?.trim() ?? 'application/octet-stream'
+    ).toLowerCase();
+    if (!isAllowedFetchedMime(mime)) {
+      throw new CmsInvalidError(`fetched content-type "${mime}" is not allowed`);
+    }
+
+    const body = await readBodyWithCap(res, FETCH_BYTES_MAX);
+    if (body.length === 0) throw new CmsInvalidError('fetched body is empty');
+
+    return this.persistAssetBytes({
+      name: input.name ?? deriveNameFromUrl(new URL(input.sourceUrl), mime),
+      mime,
+      body,
+      altText: input.altText,
+      metadata: { ...(input.metadata ?? {}), sourceUrl: input.sourceUrl },
+    });
+  }
+
+  private async persistAssetBytes(input: {
+    name: string;
+    mime: string;
+    body: Buffer;
+    altText?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<AssetDto> {
     const ext = assetExtensionFromName(input.name);
     rejectSvgAsset(ext, input.mime);
     await this.quotas.assertCanAdd('cms_assets');
@@ -617,7 +674,7 @@ export class CmsService {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     const key = `cms/${actor.orgId}/${randomKeySegment()}.${ext}`;
-    await this.storage.writeDirect(key, body, { mime: input.mime });
+    await this.storage.writeDirect(key, input.body, { mime: input.mime });
 
     const [row] = await ctx.db
       .insert(schema.cmsAssets)
@@ -625,7 +682,7 @@ export class CmsService {
         orgId: actor.orgId,
         name: input.name,
         mime: input.mime,
-        sizeBytes: body.length,
+        sizeBytes: input.body.length,
         storageProvider: this.storage.provider,
         storageKey: key,
         publicUrl: this.storage.publicUrlFor(key),
@@ -1097,4 +1154,62 @@ function rejectSvgAsset(ext: string, mime: string): void {
       'svg uploads are not allowed: SVG can carry inline scripts that execute in the browser',
     );
   }
+}
+
+const FETCH_BYTES_MAX = 50 * 1024 * 1024;
+
+const FETCHED_MIME_ALLOWLIST = [/^image\//, /^video\//, /^audio\//, /^application\/pdf$/];
+
+function isAllowedFetchedMime(mime: string): boolean {
+  if (isSvgMime(mime)) return false;
+  return FETCHED_MIME_ALLOWLIST.some((re) => re.test(mime));
+}
+
+async function readBodyWithCap(
+  res: { body: ReadableStream<Uint8Array> | null; arrayBuffer: () => Promise<ArrayBuffer> },
+  cap: number,
+): Promise<Buffer> {
+  if (!res.body) {
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.length > cap) {
+      throw new CmsInvalidError(`fetched body exceeds ${cap} bytes`);
+    }
+    return buf;
+  }
+  const reader = res.body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > cap) {
+      await reader.cancel().catch(() => {});
+      throw new CmsInvalidError(`fetched body exceeds ${cap} bytes`);
+    }
+    chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks, total);
+}
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/avif': 'avif',
+  'application/pdf': 'pdf',
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+  'audio/mpeg': 'mp3',
+  'audio/ogg': 'ogg',
+};
+
+function deriveNameFromUrl(url: URL, mime: string): string {
+  const last = url.pathname.split('/').filter(Boolean).pop();
+  if (last && last.includes('.')) return decodeURIComponent(last).slice(0, 200);
+  const ext = MIME_TO_EXT[mime] ?? mime.split('/')[1] ?? 'bin';
+  return `asset.${ext.replace(/[^a-z0-9]/gi, '').slice(0, 16) || 'bin'}`;
 }

--- a/packages/backend-core/src/modules/cms/cms.tools.ts
+++ b/packages/backend-core/src/modules/cms/cms.tools.ts
@@ -117,6 +117,23 @@ const UploadAssetBytesInput = z.object({
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
+const UploadAssetFromUrlInput = z.object({
+  sourceUrl: z
+    .string()
+    .url()
+    .refine((u) => {
+      try {
+        return new URL(u).protocol === 'https:';
+      } catch {
+        return false;
+      }
+    }, 'sourceUrl must use https://'),
+  name: z.string().min(1).max(255).optional(),
+  mime: z.string().min(1).max(120).optional(),
+  altText: z.string().max(500).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
 const CreateLocaleInput = z.object({
   code: z.string().min(2).max(16),
   name: z.string().min(1).max(120),
@@ -409,6 +426,21 @@ export class CmsAdminTools {
   })
   uploadAssetBytes(args: z.infer<typeof UploadAssetBytesInput>) {
     return this.cms.uploadAssetBytes(args);
+  }
+
+  @McpTool({
+    name: 'cms_upload_asset_from_url',
+    title: 'CMS: Upload asset from URL',
+    description:
+      'Fetch a publicly reachable HTTPS asset and store it as a CMS asset in one call. Use this when your runtime cannot PUT to a presigned URL or pass large base64 payloads — typical for ChatGPT/Claude workspace agents whose sandbox blocks outbound PUTs and truncates long base64 strings. The server fetches the URL with SSRF protection, validates content-type (image/*, video/*, audio/*, application/pdf — SVG rejected) and size (≤50 MB), and creates the asset row in `uploaded:true` state. Filename and MIME are inferred from the response unless overridden. The original URL is recorded in `metadata.sourceUrl`.',
+    audiences: ['admin'],
+    scopes: ['cms:write'],
+    input: UploadAssetFromUrlInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  uploadAssetFromUrl(args: z.infer<typeof UploadAssetFromUrlInput>) {
+    return this.cms.uploadAssetFromUrl(args);
   }
 
   @McpTool({

--- a/packages/backend-core/src/modules/webhooks/webhooks.module.ts
+++ b/packages/backend-core/src/modules/webhooks/webhooks.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { WebhooksService } from './webhooks.service.ts';
+import { WebhookAdminTools } from './webhooks.tools.ts';
+
+@Module({
+  providers: [WebhooksService, WebhookAdminTools],
+  exports: [WebhooksService],
+})
+export class WebhooksModule {}

--- a/packages/backend-core/src/modules/webhooks/webhooks.service.test.ts
+++ b/packages/backend-core/src/modules/webhooks/webhooks.service.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { WebhooksService } from './webhooks.service.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run webhook service tests.';
+
+(skipReason ? describe.skip : describe)('WebhooksService', () => {
+  let db: ReturnType<typeof createDb>;
+  let appDb: ReturnType<typeof createDb>;
+  let svc: WebhooksService;
+  let orgId: string;
+  let actor: ActorIdentity;
+
+  beforeAll(async () => {
+    await runMigrations(TEST_URL!);
+    db = createDb(TEST_URL!, { serviceRole: true });
+    const appUrl = TEST_URL!.replace(
+      /(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/,
+      '$1munin_app:munin_app@',
+    );
+    appDb = createDb(appUrl);
+
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Webhooks Service Test Org' })
+      .returning();
+    orgId = org!.id;
+    actor = new ActorIdentity('admin_agent', 'agt_wh_test', orgId, ['*'], ['admin']);
+    svc = new WebhooksService();
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  beforeEach(async () => {
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    await db.execute(
+      sql`DELETE FROM webhook_deliveries WHERE webhook_id IN (SELECT id FROM webhooks WHERE org_id = ${orgId})`,
+    );
+    await db.execute(sql`DELETE FROM webhooks WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM events WHERE org_id = ${orgId}`);
+  });
+
+  function run<T>(fn: () => Promise<T>, runAs: ActorIdentity = actor): Promise<T> {
+    return appDb.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
+      await tx.execute(sql`SELECT set_config('app.org_id', ${runAs.orgId}, true)`);
+      const ctx: RequestContext = { db: tx, actor: runAs, correlationId: randomUUID() };
+      return withContext(ctx, fn);
+    });
+  }
+
+  it('create returns secret once; list never exposes it', async () => {
+    const created = await run(() =>
+      svc.create({ url: 'https://hooks.example.com/h', events: ['cms.entry.published'] }),
+    );
+    expect(created.secret).toMatch(/^whsec_/);
+    expect(created.events).toEqual(['cms.entry.published']);
+
+    const list = await run(() => svc.list());
+    expect(list).toHaveLength(1);
+    expect(list[0]!.id).toBe(created.id);
+    expect(list[0]!.secret).toBeUndefined();
+  });
+
+  it('create rejects non-https URL', async () => {
+    await expect(
+      run(() => svc.create({ url: 'http://hooks.example.com/h' })),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('update patches fields; missing id is 404', async () => {
+    const created = await run(() => svc.create({ url: 'https://hooks.example.com/h' }));
+    const updated = await run(() =>
+      svc.update(created.id, { events: ['crm.contact.created'], active: false }),
+    );
+    expect(updated.events).toEqual(['crm.contact.created']);
+    expect(updated.active).toBe(false);
+
+    await expect(run(() => svc.update('whk_missing', { active: true }))).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('delete removes the row; second delete is 404', async () => {
+    const created = await run(() => svc.create({ url: 'https://hooks.example.com/h' }));
+    await run(() => svc.delete(created.id));
+    expect(await run(() => svc.list())).toHaveLength(0);
+    await expect(run(() => svc.delete(created.id))).rejects.toThrow(NotFoundException);
+  });
+
+  it('rotateSecret returns a fresh whsec_ and persists', async () => {
+    const created = await run(() => svc.create({ url: 'https://hooks.example.com/h' }));
+    const rotated = await run(() => svc.rotateSecret(created.id));
+    expect(rotated.secret).toMatch(/^whsec_/);
+    expect(rotated.secret).not.toBe(created.secret);
+
+    const rows = await db
+      .select()
+      .from(schema.webhooks)
+      .where(sql`id = ${created.id}`);
+    expect(rows[0]!.secret).toBe(rotated.secret);
+  });
+
+  it('rotateSecret 404 on unknown id', async () => {
+    await expect(run(() => svc.rotateSecret('whk_missing'))).rejects.toThrow(NotFoundException);
+  });
+
+  it('listDeliveries returns rows newest first, filterable by status', async () => {
+    const created = await run(() => svc.create({ url: 'https://hooks.example.com/h' }));
+
+    const [evt] = await db
+      .insert(schema.events)
+      .values({
+        orgId,
+        type: 'cms.entry.published',
+        actorId: actor.id,
+        correlationId: 'test',
+        payload: {},
+      })
+      .returning({ id: schema.events.id });
+    const eventId = evt!.id;
+
+    await db.insert(schema.webhookDeliveries).values([
+      { webhookId: created.id, eventId, attempt: 0, nextAttemptAt: new Date() },
+      {
+        webhookId: created.id,
+        eventId,
+        attempt: 1,
+        statusCode: 200,
+        deliveredAt: new Date(),
+        durationMs: 42,
+      },
+      {
+        webhookId: created.id,
+        eventId,
+        attempt: 5,
+        statusCode: 500,
+        deliveredAt: new Date(),
+        error: 'boom',
+      },
+    ]);
+
+    const all = await run(() => svc.listDeliveries({ webhookId: created.id }));
+    expect(all).toHaveLength(3);
+
+    const pending = await run(() => svc.listDeliveries({ webhookId: created.id, status: 'pending' }));
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.status).toBe('pending');
+
+    const delivered = await run(() =>
+      svc.listDeliveries({ webhookId: created.id, status: 'delivered' }),
+    );
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]!.statusCode).toBe(200);
+
+    const failed = await run(() => svc.listDeliveries({ webhookId: created.id, status: 'failed' }));
+    expect(failed).toHaveLength(1);
+    expect(failed[0]!.statusCode).toBe(500);
+  });
+
+  it('listDeliveries on unknown webhook is 404', async () => {
+    await expect(run(() => svc.listDeliveries({ webhookId: 'whk_missing' }))).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('listEventTypes returns module catalogs from packages/types', () => {
+    const catalog = svc.listEventTypes();
+    expect(catalog.modules.cms).toContain('cms.entry.published');
+    expect(catalog.modules.crm).toContain('crm.contact.created');
+    expect(catalog.all).toContain('kb.document.created');
+    expect(catalog.all.length).toBeGreaterThan(20);
+  });
+});

--- a/packages/backend-core/src/modules/webhooks/webhooks.service.ts
+++ b/packages/backend-core/src/modules/webhooks/webhooks.service.ts
@@ -1,0 +1,210 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { and, desc, eq, isNotNull, isNull, asc } from 'drizzle-orm';
+import { schema } from '@getmunin/db';
+import { getCurrentContext, randomToken } from '@getmunin/core';
+import { EVENT_TYPES_BY_MODULE, KNOWN_EVENT_TYPES } from '@getmunin/types';
+
+export interface WebhookDto {
+  id: string;
+  url: string;
+  events: string[];
+  active: boolean;
+  /** Plaintext shared secret — returned ONCE at creation time. */
+  secret?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WebhookDeliveryDto {
+  id: string;
+  webhookId: string;
+  eventId: string;
+  attempt: number;
+  statusCode: number | null;
+  durationMs: number | null;
+  error: string | null;
+  deliveredAt: string | null;
+  nextAttemptAt: string | null;
+  createdAt: string;
+  status: 'pending' | 'delivered' | 'failed';
+}
+
+export interface CreateWebhookInput {
+  url: string;
+  events?: string[];
+  active?: boolean;
+}
+
+export interface UpdateWebhookInput {
+  url?: string;
+  events?: string[];
+  active?: boolean;
+}
+
+export interface ListDeliveriesInput {
+  webhookId: string;
+  limit?: number;
+  status?: 'pending' | 'delivered' | 'failed';
+}
+
+export interface EventTypeCatalog {
+  modules: Record<string, readonly string[]>;
+  all: readonly string[];
+}
+
+function assertHttpsUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new BadRequestException('webhook URL is not a valid URL');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new BadRequestException('webhook URL must use https://');
+  }
+}
+
+function toDto(row: typeof schema.webhooks.$inferSelect): WebhookDto {
+  return {
+    id: row.id,
+    url: row.url,
+    events: row.events,
+    active: row.active,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function toDeliveryDto(row: typeof schema.webhookDeliveries.$inferSelect): WebhookDeliveryDto {
+  const delivered = row.deliveredAt !== null;
+  const status: WebhookDeliveryDto['status'] = delivered
+    ? row.statusCode !== null && row.statusCode >= 200 && row.statusCode < 300
+      ? 'delivered'
+      : 'failed'
+    : 'pending';
+  return {
+    id: row.id,
+    webhookId: row.webhookId,
+    eventId: row.eventId,
+    attempt: row.attempt,
+    statusCode: row.statusCode,
+    durationMs: row.durationMs,
+    error: row.error,
+    deliveredAt: row.deliveredAt ? row.deliveredAt.toISOString() : null,
+    nextAttemptAt: row.nextAttemptAt ? row.nextAttemptAt.toISOString() : null,
+    createdAt: row.createdAt.toISOString(),
+    status,
+  };
+}
+
+@Injectable()
+export class WebhooksService {
+  async list(): Promise<WebhookDto[]> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db
+      .select()
+      .from(schema.webhooks)
+      .where(eq(schema.webhooks.orgId, actor.orgId))
+      .orderBy(asc(schema.webhooks.createdAt));
+    return rows.map(toDto);
+  }
+
+  async create(input: CreateWebhookInput): Promise<WebhookDto> {
+    assertHttpsUrl(input.url);
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const secret = `whsec_${randomToken(24)}`;
+    const [row] = await ctx.db
+      .insert(schema.webhooks)
+      .values({
+        orgId: actor.orgId,
+        url: input.url,
+        secret,
+        events: input.events ?? [],
+        active: input.active ?? true,
+      })
+      .returning();
+    return { ...toDto(row!), secret };
+  }
+
+  async update(id: string, patch: UpdateWebhookInput): Promise<WebhookDto> {
+    if (patch.url !== undefined) assertHttpsUrl(patch.url);
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (patch.url !== undefined) updates.url = patch.url;
+    if (patch.events !== undefined) updates.events = patch.events;
+    if (patch.active !== undefined) updates.active = patch.active;
+    const result = await ctx.db
+      .update(schema.webhooks)
+      .set(updates)
+      .where(and(eq(schema.webhooks.id, id), eq(schema.webhooks.orgId, actor.orgId)))
+      .returning();
+    if (!result[0]) throw new NotFoundException(`webhook ${id} not found`);
+    return toDto(result[0]);
+  }
+
+  async delete(id: string): Promise<void> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const result = await ctx.db
+      .delete(schema.webhooks)
+      .where(and(eq(schema.webhooks.id, id), eq(schema.webhooks.orgId, actor.orgId)))
+      .returning({ id: schema.webhooks.id });
+    if (result.length === 0) throw new NotFoundException(`webhook ${id} not found`);
+  }
+
+  async rotateSecret(id: string): Promise<WebhookDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const secret = `whsec_${randomToken(24)}`;
+    const result = await ctx.db
+      .update(schema.webhooks)
+      .set({ secret, updatedAt: new Date() })
+      .where(and(eq(schema.webhooks.id, id), eq(schema.webhooks.orgId, actor.orgId)))
+      .returning();
+    if (!result[0]) throw new NotFoundException(`webhook ${id} not found`);
+    return { ...toDto(result[0]), secret };
+  }
+
+  async listDeliveries(input: ListDeliveriesInput): Promise<WebhookDeliveryDto[]> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+
+    const [webhook] = await ctx.db
+      .select({ id: schema.webhooks.id })
+      .from(schema.webhooks)
+      .where(and(eq(schema.webhooks.id, input.webhookId), eq(schema.webhooks.orgId, actor.orgId)));
+    if (!webhook) throw new NotFoundException(`webhook ${input.webhookId} not found`);
+
+    const limit = Math.min(Math.max(input.limit ?? 50, 1), 200);
+    const conditions = [eq(schema.webhookDeliveries.webhookId, input.webhookId)];
+    if (input.status === 'pending') {
+      conditions.push(isNull(schema.webhookDeliveries.deliveredAt));
+    } else if (input.status === 'delivered' || input.status === 'failed') {
+      conditions.push(isNotNull(schema.webhookDeliveries.deliveredAt));
+    }
+
+    const rows = await ctx.db
+      .select()
+      .from(schema.webhookDeliveries)
+      .where(and(...conditions))
+      .orderBy(desc(schema.webhookDeliveries.createdAt))
+      .limit(limit);
+
+    const mapped = rows.map(toDeliveryDto);
+    if (input.status === 'delivered') return mapped.filter((d) => d.status === 'delivered');
+    if (input.status === 'failed') return mapped.filter((d) => d.status === 'failed');
+    return mapped;
+  }
+
+  listEventTypes(): EventTypeCatalog {
+    return {
+      modules: Object.fromEntries(
+        Object.entries(EVENT_TYPES_BY_MODULE).map(([k, v]) => [k, [...v]]),
+      ),
+      all: [...KNOWN_EVENT_TYPES],
+    };
+  }
+}

--- a/packages/backend-core/src/modules/webhooks/webhooks.tools.ts
+++ b/packages/backend-core/src/modules/webhooks/webhooks.tools.ts
@@ -1,0 +1,150 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpTool } from '@getmunin/mcp-toolkit';
+import { WebhooksService } from './webhooks.service.ts';
+
+const WebhookUrlSchema = z
+  .string()
+  .url()
+  .refine((u) => {
+    try {
+      return new URL(u).protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }, 'webhook URL must use https://');
+
+const EmptyInput = z.object({});
+
+const CreateInput = z.object({
+  url: WebhookUrlSchema,
+  events: z.array(z.string().min(1).max(64)).max(64).optional(),
+  active: z.boolean().optional(),
+});
+
+const UpdateInput = z.object({
+  id: z.string(),
+  patch: z.object({
+    url: WebhookUrlSchema.optional(),
+    events: z.array(z.string().min(1).max(64)).max(64).optional(),
+    active: z.boolean().optional(),
+  }),
+});
+
+const IdInput = z.object({ id: z.string() });
+
+const ListDeliveriesInput = z.object({
+  webhookId: z.string(),
+  limit: z.number().int().positive().max(200).optional(),
+  status: z.enum(['pending', 'delivered', 'failed']).optional(),
+});
+
+@Injectable()
+export class WebhookAdminTools {
+  constructor(@Inject(WebhooksService) private readonly webhooks: WebhooksService) {}
+
+  @McpTool({
+    name: 'webhooks_list',
+    title: 'Webhooks: List',
+    description:
+      'List all webhook subscriptions for your org. Secrets are not returned — they are only shown once at creation. Use webhooks_rotate_secret if you lost it.',
+    audiences: ['admin'],
+    scopes: [],
+    input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  list() {
+    return this.webhooks.list();
+  }
+
+  @McpTool({
+    name: 'webhooks_create',
+    title: 'Webhooks: Create',
+    description:
+      'Create a webhook subscription. `url` must be https://. `events` is an array of event type strings (e.g. ["cms.entry.published"]); omit or pass an empty array to subscribe to all events. The response includes a one-time `secret` of the form `whsec_…` — store it now; it cannot be retrieved later. Deliveries are signed with `x-munin-signature: sha256=<HMAC-SHA256(body, secret)>` and include `x-munin-event`, `x-munin-delivery-id` headers. Retries: up to 5 attempts with exponential backoff (30s → 8m). Use webhooks_list_event_types to discover known event names.',
+    audiences: ['admin'],
+    scopes: [],
+    input: CreateInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  create(args: z.infer<typeof CreateInput>) {
+    return this.webhooks.create(args);
+  }
+
+  @McpTool({
+    name: 'webhooks_update',
+    title: 'Webhooks: Update',
+    description:
+      'Patch a webhook subscription. Pass only the fields you want to change. Replacing `events` overwrites the full array — read first if you mean to append.',
+    audiences: ['admin'],
+    scopes: [],
+    input: UpdateInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  update(args: z.infer<typeof UpdateInput>) {
+    return this.webhooks.update(args.id, args.patch);
+  }
+
+  @McpTool({
+    name: 'webhooks_delete',
+    title: 'Webhooks: Delete',
+    description:
+      'Delete a webhook. Pending deliveries are cascade-deleted; in-flight HTTP attempts finish their current run.',
+    audiences: ['admin'],
+    scopes: [],
+    input: IdInput,
+    readOnlyHint: false,
+    destructiveHint: true,
+  })
+  delete(args: z.infer<typeof IdInput>) {
+    return this.webhooks.delete(args.id);
+  }
+
+  @McpTool({
+    name: 'webhooks_rotate_secret',
+    title: 'Webhooks: Rotate signing secret',
+    description:
+      'Generate a new `whsec_…` secret for a webhook. The previous secret stops signing deliveries immediately — update your receiver before rotating. The new secret is returned once in the response.',
+    audiences: ['admin'],
+    scopes: [],
+    input: IdInput,
+    readOnlyHint: false,
+    destructiveHint: true,
+  })
+  rotateSecret(args: z.infer<typeof IdInput>) {
+    return this.webhooks.rotateSecret(args.id);
+  }
+
+  @McpTool({
+    name: 'webhooks_list_deliveries',
+    title: 'Webhooks: List deliveries',
+    description:
+      'List delivery attempts for one webhook, newest first. Each row has attempt count, statusCode, durationMs, error, deliveredAt, nextAttemptAt, and a rolled-up `status` (pending / delivered / failed). Filter with `status` and cap with `limit` (default 50, max 200).',
+    audiences: ['admin'],
+    scopes: [],
+    input: ListDeliveriesInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  listDeliveries(args: z.infer<typeof ListDeliveriesInput>) {
+    return this.webhooks.listDeliveries(args);
+  }
+
+  @McpTool({
+    name: 'webhooks_list_event_types',
+    title: 'Webhooks: List event types',
+    description:
+      'List the known event type strings emitted across modules (cms, crm, kb, conv, outreach, system). Use the returned strings as input to webhooks_create. The subscription accepts arbitrary strings, so future event types work without a tool update — but this is the canonical catalog today.',
+    audiences: ['admin'],
+    scopes: [],
+    input: EmptyInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  listEventTypes() {
+    return this.webhooks.listEventTypes();
+  }
+}

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -514,6 +514,17 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     const rows: { message_id: string; read_at: Date | string }[] = Array.isArray(inserted)
       ? (inserted as { message_id: string; read_at: Date | string }[])
       : ((inserted as { rows?: { message_id: string; read_at: Date | string }[] }).rows ?? []);
+
+    if (entry.ws.readyState === entry.ws.OPEN) {
+      entry.ws.send(
+        JSON.stringify({
+          type: 'read_ack',
+          conversationId,
+          messageIds: rows.map((r) => r.message_id),
+        }),
+      );
+    }
+
     if (rows.length === 0) return;
 
     const actor = new ActorIdentity(

--- a/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
+++ b/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
@@ -921,7 +921,6 @@ const skipReason = TEST_URL
     const wsVisitor = connectWs(widgetKey, { origin: ALLOWED_ORIGIN });
     await waitForOpen(wsVisitor);
     try {
-      // Single-id read — exercises the IN (...) path with one element.
       wsVisitor.send(
         JSON.stringify({
           type: 'read',
@@ -931,9 +930,8 @@ const skipReason = TEST_URL
           messageIds: [firstId],
         }),
       );
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForReadAck(wsVisitor, [firstId!]);
 
-      // Multi-id read — exercises sql.join with multiple elements.
       wsVisitor.send(
         JSON.stringify({
           type: 'read',
@@ -943,7 +941,7 @@ const skipReason = TEST_URL
           messageIds: [secondId, thirdId],
         }),
       );
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForReadAck(wsVisitor, [secondId!, thirdId!]);
 
       const readRows = await db
         .select({ messageId: schema.convMessageReads.messageId })
@@ -957,6 +955,30 @@ const skipReason = TEST_URL
     }
   });
 });
+
+function waitForReadAck(ws: WebSocket, expected: string[], timeoutMs = 5000): Promise<void> {
+  const want = new Set(expected);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`no read_ack for [${expected.join(', ')}] within ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    const onMessage = (data: WebSocket.RawData) => {
+      try {
+        const msg = JSON.parse(decodeWsData(data)) as { type?: string; messageIds?: string[] };
+        if (msg.type !== 'read_ack' || !Array.isArray(msg.messageIds)) return;
+        if (msg.messageIds.length !== want.size) return;
+        if (!msg.messageIds.every((id) => want.has(id))) return;
+        clearTimeout(timer);
+        ws.off('message', onMessage);
+        resolve();
+      } catch (err) {
+        console.warn(`waitForReadAck: failed to parse frame: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    };
+    ws.on('message', onMessage);
+  });
+}
 
 function decodeWsData(data: WebSocket.RawData): string {
   if (typeof data === 'string') return data;

--- a/packages/types/src/event-catalog.ts
+++ b/packages/types/src/event-catalog.ts
@@ -1,0 +1,82 @@
+export const CMS_EVENT_TYPES = [
+  'cms.collection.created',
+  'cms.collection.fields_changed',
+  'cms.entry.created',
+  'cms.entry.updated',
+  'cms.entry.published',
+  'cms.entry.unpublished',
+  'cms.entry.scheduled',
+  'cms.entry.deleted',
+] as const;
+
+export const CRM_EVENT_TYPES = [
+  'crm.contact.created',
+  'crm.contact.updated',
+  'crm.company.created',
+  'crm.deal.created',
+  'crm.deal.stage_changed',
+  'crm.activity.logged',
+  'crm.merge_proposal.proposed',
+] as const;
+
+export const KB_EVENT_TYPES = [
+  'kb.document.created',
+  'kb.document.updated',
+  'kb.document.deleted',
+] as const;
+
+export const CONVERSATION_EVENT_TYPES = [
+  'conversation.created',
+  'conversation.status_changed',
+  'conversation.assigned',
+  'conversation.released',
+  'conversation.taken_over',
+  'conversation.agent_mode_changed',
+  'conversation.handover_requested',
+  'conversation.handover_resolved',
+  'conversation.greet_requested',
+  'conversation.message.received',
+  'conversation.message.sent',
+  'conversation.voice.call_ended',
+] as const;
+
+export const OUTREACH_EVENT_TYPES = [
+  'outreach.proposal.created',
+  'outreach.proposal.updated',
+  'outreach.proposal.sent',
+  'outreach.proposal.dismissed',
+] as const;
+
+export const SYSTEM_EVENT_TYPES = [
+  'org_alert.opened',
+  'org_alert.acknowledged',
+  'org_alert.resolved',
+  'curator_job.pending',
+] as const;
+
+export const EVENT_TYPES_BY_MODULE = {
+  cms: CMS_EVENT_TYPES,
+  crm: CRM_EVENT_TYPES,
+  kb: KB_EVENT_TYPES,
+  conv: CONVERSATION_EVENT_TYPES,
+  outreach: OUTREACH_EVENT_TYPES,
+  system: SYSTEM_EVENT_TYPES,
+} as const;
+
+export const KNOWN_EVENT_TYPES = [
+  ...CMS_EVENT_TYPES,
+  ...CRM_EVENT_TYPES,
+  ...KB_EVENT_TYPES,
+  ...CONVERSATION_EVENT_TYPES,
+  ...OUTREACH_EVENT_TYPES,
+  ...SYSTEM_EVENT_TYPES,
+] as const;
+
+export type KnownEventType = (typeof KNOWN_EVENT_TYPES)[number];
+export type EventModule = keyof typeof EVENT_TYPES_BY_MODULE;
+
+const KNOWN_SET: ReadonlySet<string> = new Set(KNOWN_EVENT_TYPES);
+
+export function isKnownEventType(value: string): value is KnownEventType {
+  return KNOWN_SET.has(value);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -41,3 +41,16 @@ export {
   type JobKind,
   type ModelTier,
 } from './job-catalog.ts';
+export {
+  CMS_EVENT_TYPES,
+  CRM_EVENT_TYPES,
+  KB_EVENT_TYPES,
+  CONVERSATION_EVENT_TYPES,
+  OUTREACH_EVENT_TYPES,
+  SYSTEM_EVENT_TYPES,
+  EVENT_TYPES_BY_MODULE,
+  KNOWN_EVENT_TYPES,
+  isKnownEventType,
+  type KnownEventType,
+  type EventModule,
+} from './event-catalog.ts';


### PR DESCRIPTION
## Summary

- **Seven new `webhooks_*` MCP tools** (`list`, `create`, `update`, `delete`, `rotate_secret`, `list_deliveries`, `list_event_types`) backed by a new `WebhooksService`. The existing `/v1/webhooks` REST controller delegates to the same service and gains `POST :id/rotate-secret`, `GET :id/deliveries`, and `GET event-types` endpoints. Audiences: `admin`; scopes: `[]` — follows the system-alerts convention, no new OAuth scopes.
- **`cms_upload_asset_from_url`** server-side fetches an HTTPS asset and stores it as a CMS asset in one call. Bypasses the presigned-PUT + base64 round-trips that some agent sandboxes (ChatGPT/Claude workspaces) can't complete. SSRF-guarded via `safeFetch`, 50 MB streamed cap, MIME allowlist (`image/*`, `video/*`, `audio/*`, `application/pdf`; SVG stays rejected). Source URL recorded in `metadata.sourceUrl`.
- **Webhook event types consolidated in `@getmunin/types`**: new exports `CMS_EVENT_TYPES`, `CRM_EVENT_TYPES`, `KB_EVENT_TYPES`, `CONVERSATION_EVENT_TYPES`, `OUTREACH_EVENT_TYPES`, `SYSTEM_EVENT_TYPES`, `EVENT_TYPES_BY_MODULE`, `KNOWN_EVENT_TYPES`, `isKnownEventType`. Dispatcher `emit({ type })` still accepts arbitrary strings — catalog powers `webhooks_list_event_types` and is available for typed consumers.
- **Realtime `read_ack` frame**: gateway sends `{ type: 'read_ack', conversationId, messageIds }` to the originating socket after a `read` frame's `conv_message_reads` INSERT commits. Additive — every existing client (chat-widget, dashboard, agent-runtime) already silently ignores unknown frame types. Widget integration test waits on the ack instead of `setTimeout(200)`, killing a CI flake.

## Test plan

- [x] `pnpm typecheck` — 27/27 packages
- [x] `pnpm -F @getmunin/backend-core test` with `TEST_DATABASE_URL` set — 724/724
- [x] `realtime.widget.integration.test.ts` repeated 3× — no flakes after switching to ack-based wait
- [x] `pnpm -F @getmunin/backend-core docs:generate` — openapi + mcp-tools fixtures regenerated (128 tools, 142 operations)
- [ ] Manual smoke: call `webhooks_list_event_types` via MCP, then `webhooks_create` subscribing to one of the returned types
- [ ] Manual smoke: `cms_upload_asset_from_url` from a real LLM workspace (the failure mode this targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)