### PR TITLE
fix(dashboard-pages): Live Now bg spans full page width

### DIFF
--- a/.changeset/chat-widget-dev-resolve-conditions.md
+++ b/.changeset/chat-widget-dev-resolve-conditions.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/chat-widget': patch
+---
+
+Vite config now adds `development` to `resolve.conditions` when running in dev mode (`vite build --watch --mode development`). Without it, the chat-widget watcher resolved workspace deps like `@getmunin/widget-voice` through the `default` (production) export and required their `dist/` to exist before `pnpm dev` could start. With the condition wired up, dev resolves directly to each workspace package's `src/index.ts`. Production builds are unchanged.

--- a/.changeset/dashboard-live-now-full-width.md
+++ b/.changeset/dashboard-live-now-full-width.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Dashboard overview: the Live Now section's tinted background now spans the full page width instead of stopping at the page's `max-w-7xl` content cap. The section uses a full-bleed `w-screen` breakout and keeps inner content aligned via an inner `max-w-7xl` container. The dashboard shell `<main>` gets `overflow-x-clip` so the breakout can't introduce a horizontal scrollbar on browsers that reserve space for the vertical scrollbar.

--- a/.changeset/inputs-no-ios-zoom.md
+++ b/.changeset/inputs-no-ios-zoom.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/ui': patch
+'@getmunin/dashboard-pages': patch
+---
+
+Inputs and dashboard reply/edit textareas now render at `text-base` (16px) on mobile and `md:text-sm` (14px) from the `md` breakpoint up. iOS Safari auto-zooms on focus whenever the focused field's effective font-size is below 16px; bumping mobile sizes avoids that without disabling viewport zoom (which is a WCAG 1.4.4 regression). Desktop density is unchanged.

--- a/.changeset/safe-fetch-rebinding-test-stable.md
+++ b/.changeset/safe-fetch-rebinding-test-stable.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/core': patch
+---
+
+`safeFetch`: factor the agent's connect-time DNS lookup behind a `ConnectLookup` seam and expose it as the optional `__connectLookup` option on `SafeFetchOptions`. Behavior is unchanged when the option is not passed — the default uses `dns.lookup` with `{ all: true, verbatim: true }`. The SSRF DNS-rebinding regression test stops depending on real-world DNS for `127.0.0.1.nip.io` (a flaky source of test timeouts on CI) and uses the seam to deterministically simulate a connect-time DNS that returns a private address.

--- a/apps/chat-widget/vite.config.ts
+++ b/apps/chat-widget/vite.config.ts
@@ -18,7 +18,10 @@ import { resolve, join } from 'node:path';
  * The bundle is fully self-contained — no runtime CSS imports, no async
  * chunks. Operators paste one `<script>` line; that's it.
  */
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  resolve: {
+    conditions: mode === 'development' ? ['development'] : [],
+  },
   build: {
     target: 'es2020',
     cssCodeSplit: false,
@@ -92,4 +95,4 @@ export default defineConfig({
       },
     },
   ],
-});
+}));

--- a/packages/core/src/net/safe-fetch.test.ts
+++ b/packages/core/src/net/safe-fetch.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createServer, type Server, type RequestListener } from 'node:http';
+import type { LookupAddress } from 'node:dns';
 import type { AddressInfo } from 'node:net';
 import {
   assertPublicHost,
@@ -149,8 +150,14 @@ describe('safeFetch', () => {
   it('returns the array shape undici expects when lookup is called with all:true', async () => {
     await start();
     process.env.MUNIN_SSRF_ALLOW_PRIVATE = 'true';
+    const loopbackLookup = (
+      _host: string,
+      cb: (err: NodeJS.ErrnoException | null, records: LookupAddress[]) => void,
+    ) => cb(null, [{ address: '127.0.0.1', family: 4 }]);
     try {
-      const res = await safeFetch(`http://127.0.0.1.nip.io:${port}/`);
+      const res = await safeFetch(`http://public.example:${port}/`, {
+        __connectLookup: loopbackLookup,
+      });
       expect(res.status).toBe(200);
       await res.body?.cancel().catch(() => {});
     } finally {
@@ -159,13 +166,20 @@ describe('safeFetch', () => {
     }
   });
 
-  it('blocks rebinding: upfront resolver lies "public" but real DNS returns private', async () => {
+  it('blocks rebinding: upfront resolver lies "public" but connect-time DNS returns private', async () => {
     await start();
     const lyingResolver = () => Promise.resolve([{ address: '93.184.216.34', family: 4 }]);
+    const rebindingLookup = (
+      _host: string,
+      cb: (err: NodeJS.ErrnoException | null, records: LookupAddress[]) => void,
+    ) => cb(null, [{ address: '127.0.0.1', family: 4 }]);
     try {
       let caught: unknown;
       try {
-        await safeFetch(`http://127.0.0.1.nip.io:${port}/`, { resolver: lyingResolver });
+        await safeFetch(`http://public.example:${port}/`, {
+          resolver: lyingResolver,
+          __connectLookup: rebindingLookup,
+        });
       } catch (err) {
         caught = err;
       }

--- a/packages/core/src/net/safe-fetch.ts
+++ b/packages/core/src/net/safe-fetch.ts
@@ -202,7 +202,18 @@ export async function resolvePublicHost(
   return records[0]!;
 }
 
-function makeBlockingAgent(): Agent {
+type ConnectLookup = (
+  hostname: string,
+  cb: (err: NodeJS.ErrnoException | null, records: LookupAddress[]) => void,
+) => void;
+
+const defaultConnectLookup: ConnectLookup = (hostname, cb) => {
+  dnsLookupCallback(hostname, { all: true, verbatim: true }, (err, records) => {
+    cb(err, Array.isArray(records) ? records : []);
+  });
+};
+
+function makeBlockingAgent(connectLookup: ConnectLookup): Agent {
   return new Agent({
     connect: {
       lookup: (
@@ -221,7 +232,7 @@ function makeBlockingAgent(): Agent {
           rejectSsrf(`host ${hostname} is not allowed`);
           return;
         }
-        dnsLookupCallback(hostname, { ...lookupOpts, all: true }, (err, records) => {
+        connectLookup(hostname, (err, records) => {
           if (err) return cb(err, wantAll ? [] : '', 0);
           if (!Array.isArray(records) || records.length === 0) {
             return cb(new Error('no address resolved'), wantAll ? [] : '', 0);
@@ -255,11 +266,12 @@ function isBannedHostname(host: string): boolean {
 export interface SafeFetchOptions extends Omit<UndiciRequestInit, 'redirect' | 'dispatcher'> {
   resolver?: (hostname: string) => Promise<{ address: string; family: number }[]>;
   maxRedirects?: number;
+  __connectLookup?: ConnectLookup;
 }
 
 export async function safeFetch(input: string, init: SafeFetchOptions = {}): Promise<UndiciResponse> {
-  const { resolver, maxRedirects = MAX_REDIRECTS, ...rest } = init;
-  const agent = makeBlockingAgent();
+  const { resolver, maxRedirects = MAX_REDIRECTS, __connectLookup, ...rest } = init;
+  const agent = makeBlockingAgent(__connectLookup ?? defaultConnectLookup);
   try {
     let currentUrl = input;
     let hops = 0;

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -1157,7 +1157,7 @@ function SimplifiedConvDrawer({
               value={draftBody}
               onChange={(e) => setDraftEdit(e.target.value)}
               rows={8}
-              className="w-full rounded-input border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark dark:text-foreground"
+              className="w-full rounded-input border-[0.5px] border-ink bg-paper px-4 py-3 text-base md:text-sm leading-relaxed outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark dark:text-foreground"
               autoFocus
             />
           ) : (
@@ -1328,7 +1328,7 @@ function FullConvDrawer({
             }}
             rows={3}
             placeholder={t('replyPlaceholder')}
-            className="w-full rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-2 text-sm outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark"
+            className="w-full rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-2 text-base md:text-sm outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark"
           />
           <div className="mt-3 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
@@ -1508,7 +1508,7 @@ function QueueDrawer({
               value={editedBody}
               onChange={(e) => setEditedBody(e.target.value)}
               rows={14}
-              className="w-full resize-y rounded-input border-[0.5px] border-cobalt bg-paper px-4 py-3 text-sm leading-relaxed outline-none focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:text-foreground"
+              className="w-full resize-y rounded-input border-[0.5px] border-cobalt bg-paper px-4 py-3 text-base md:text-sm leading-relaxed outline-none focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:text-foreground"
               autoFocus
             />
           ) : (

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -638,38 +638,40 @@ export function LiveNowSection({ controller }: { controller: InboxController }) 
   if (items.length === 0) return null;
 
   return (
-    <section className="bg-paper-deep -mx-4 px-4 py-6 md:-mx-10 md:px-10 dark:bg-secondary">
-      <div className="flex items-center justify-between gap-3 mb-4">
-        <div className="flex items-center gap-3">
-          <span
-            className="size-2 rounded-full bg-cobalt animate-pulse dark:bg-cobalt-soft"
-            aria-hidden
-          />
-          <h2 className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
-            {t('eyebrow')} · {items.length}
-          </h2>
+    <section className="bg-paper-deep dark:bg-secondary relative left-1/2 right-1/2 -translate-x-1/2 w-screen py-6">
+      <div className="max-w-7xl mx-auto px-4 md:px-10">
+        <div className="flex items-center justify-between gap-3 mb-4">
+          <div className="flex items-center gap-3">
+            <span
+              className="size-2 rounded-full bg-cobalt animate-pulse dark:bg-cobalt-soft"
+              aria-hidden
+            />
+            <h2 className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+              {t('eyebrow')} · {items.length}
+            </h2>
+          </div>
+          <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            {t('subtitle')}
+          </span>
         </div>
-        <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
-          {t('subtitle')}
-        </span>
+        <ul className="space-y-3">
+          {items.map((c) => (
+            <LiveCard
+              key={c.id}
+              conv={c}
+              detail={details[c.id]}
+              pending={pending}
+              actionError={actionError?.conversationId === c.id ? actionError : null}
+              onOpen={(mode) => {
+                setReply('');
+                setDraftEdit(null);
+                setConvDrawer({ id: c.id, mode });
+              }}
+              onTakeOver={() => void takeOver(c.id, true)}
+            />
+          ))}
+        </ul>
       </div>
-      <ul className="space-y-3">
-        {items.map((c) => (
-          <LiveCard
-            key={c.id}
-            conv={c}
-            detail={details[c.id]}
-            pending={pending}
-            actionError={actionError?.conversationId === c.id ? actionError : null}
-            onOpen={(mode) => {
-              setReply('');
-              setDraftEdit(null);
-              setConvDrawer({ id: c.id, mode });
-            }}
-            onTakeOver={() => void takeOver(c.id, true)}
-          />
-        ))}
-      </ul>
     </section>
   );
 }

--- a/packages/dashboard-pages/src/shells/dashboard-shell.tsx
+++ b/packages/dashboard-pages/src/shells/dashboard-shell.tsx
@@ -47,7 +47,7 @@ export function DashboardShell({
           settingsLabel={tNav('settings')}
         />
       )}
-      <main className="flex-1 bg-paper dark:bg-background">{children}</main>
+      <main className="flex-1 overflow-x-clip bg-paper dark:bg-background">{children}</main>
     </div>
   );
 

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-1.5 text-sm text-ink transition-colors duration-fast ease-munin outline-none placeholder:text-ink-mute focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive dark:bg-card dark:text-foreground dark:border-rule-on-dark dark:focus-visible:border-cobalt-soft dark:focus-visible:ring-cobalt-soft",
+        "h-9 w-full min-w-0 rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-1.5 text-base md:text-sm text-ink transition-colors duration-fast ease-munin outline-none placeholder:text-ink-mute focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive dark:bg-card dark:text-foreground dark:border-rule-on-dark dark:focus-visible:border-cobalt-soft dark:focus-visible:ring-cobalt-soft",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- The dashboard overview wraps its content in `max-w-7xl mx-auto`, so the Live Now section's tinted background stopped at the content cap on wide screens. Replaces the `-mx-4 md:-mx-10` parent-padding escape with a full-bleed `w-screen` breakout, with an inner `max-w-7xl mx-auto px-4 md:px-10` so cards stay aligned with the rest of the page.
- Adds `overflow-x-clip` on the dashboard shell `<main>` so the `w-screen` breakout can't introduce a horizontal scrollbar on browsers that reserve space for the vertical scrollbar.

## Test plan
- [ ] Open the dashboard with at least one live conversation — the Live Now tinted background should reach the left/right edges of the viewport.
- [ ] Verify the Live Now cards and header stay aligned with the rest of the page content (DashboardHero, Queue, Usage KPIs).
- [ ] Confirm no horizontal scrollbar appears on Chrome/Firefox with a vertical scrollbar visible.
- [ ] Sanity check mobile widths: section still bleeds edge-to-edge and content keeps its 16px gutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)