### PR TITLE
fix(dashboard-pages): red dot, invalid border, centered load-failed, debounced disconnect banner

### DIFF
--- a/.changeset/dashboard-polish.md
+++ b/.changeset/dashboard-polish.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Dashboard polish: four small bug fixes.
+
+- **`LoadFailed` red dot was invisible.** The eyebrow dot's class string was a concatenation typo (`bg-alert-bad-border-[0.5px]` — `bg-alert-bad-border` ran into a stray `border-[0.5px]`), so the dot rendered without a background colour. Fixed to `bg-alert-bad-border animate-pulse` to match the live-state dot pattern used elsewhere.
+- **`AuthForm` invalid border was invisible.** Same concatenation typo (`border-alert-bad-border-[0.5px]`) meant invalid inputs in the auth flow didn't actually get a red border. Now uses `border-alert-bad-border` (with the border-width already declared on the base class).
+- **Inbox `LoadFailed` no longer hugs the top-left.** When the overview can't load, the error card now sits in a `flex min-h-[70vh] items-center justify-center` wrapper so it's centred both horizontally and vertically.
+- **`SystemAlertsBanner` no longer flickers on transient reconnects.** A short WS blip used to flash the yellow "Connection lost. Reconnecting…" banner. The component now debounces the disconnected state by 1.5 s — if the socket reconnects within that window, the banner never shows; it still hides immediately on reconnect.

--- a/packages/dashboard-pages/src/components/auth-shell/auth-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/auth-form.tsx
@@ -38,7 +38,7 @@ export const AuthInput = forwardRef<HTMLInputElement, AuthInputProps>(
           'transition-colors duration-fast ease-munin',
           'focus:outline-none focus:ring-[3px] focus:ring-ink/[0.08]',
           invalid
-            ? 'border-alert-bad-border-[0.5px] focus:border-alert-bad-border-[0.5px]'
+            ? 'border-alert-bad-border focus:border-alert-bad-border'
             : 'border-rule-soft focus:border-ink',
           className,
         )}

--- a/packages/dashboard-pages/src/components/load-failed.tsx
+++ b/packages/dashboard-pages/src/components/load-failed.tsx
@@ -60,7 +60,7 @@ export function LoadFailed({
         <div className="flex items-center gap-2 font-mono uppercase tracking-eyebrow text-[11px] text-alert-bad-ink">
           <span
             aria-hidden
-            className="size-1.5 rounded-full bg-alert-bad-border-[0.5px]"
+            className="size-1.5 animate-pulse rounded-full bg-alert-bad-border"
           />
           <span>{eyebrow}</span>
         </div>

--- a/packages/dashboard-pages/src/components/system-alerts-banner.tsx
+++ b/packages/dashboard-pages/src/components/system-alerts-banner.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useTranslations } from 'next-intl';
 import { Link } from '../i18n-navigation';
 import { api, ApiError } from '../api';
-import { useRealtime, type RealtimeStatus } from '../realtime';
+import { useRealtime } from '../realtime';
 
 type AlertSource =
   | 'llm_provider'
@@ -35,11 +35,13 @@ interface AlertDto {
 }
 
 const POLL_INTERVAL_MS = 5 * 60_000;
+const DISCONNECT_GRACE_MS = 1500;
 
 export function SystemAlertsBanner() {
   const t = useTranslations('dashboard.runnerStatusBanner');
   const [alerts, setAlerts] = useState<AlertDto[]>([]);
   const [hasBeenConnected, setHasBeenConnected] = useState(false);
+  const [showDisconnected, setShowDisconnected] = useState(false);
   const cancelledRef = useRef(false);
 
   const fetchAlerts = useCallback(async () => {
@@ -66,6 +68,16 @@ export function SystemAlertsBanner() {
   }, [realtime]);
 
   useEffect(() => {
+    if (realtime === 'connected') {
+      setShowDisconnected(false);
+      return;
+    }
+    if (!hasBeenConnected) return;
+    const handle = window.setTimeout(() => setShowDisconnected(true), DISCONNECT_GRACE_MS);
+    return () => window.clearTimeout(handle);
+  }, [realtime, hasBeenConnected]);
+
+  useEffect(() => {
     cancelledRef.current = false;
     void fetchAlerts();
     const handle = window.setInterval(() => void fetchAlerts(), POLL_INTERVAL_MS);
@@ -75,7 +87,7 @@ export function SystemAlertsBanner() {
     };
   }, [fetchAlerts]);
 
-  const state = pickState({ realtime, hasBeenConnected, alerts, t });
+  const state = pickState({ showDisconnected, alerts, t });
   if (!state) return null;
 
   return (
@@ -110,13 +122,12 @@ interface BannerState {
 }
 
 function pickState(args: {
-  realtime: RealtimeStatus;
-  hasBeenConnected: boolean;
+  showDisconnected: boolean;
   alerts: AlertDto[];
   t: ReturnType<typeof useTranslations<'dashboard.runnerStatusBanner'>>;
 }): BannerState | null {
-  const { realtime, hasBeenConnected, alerts, t } = args;
-  if (hasBeenConnected && realtime !== 'connected') {
+  const { showDisconnected, alerts, t } = args;
+  if (showDisconnected) {
     return {
       tag: t('disconnectedTag'),
       message: t('disconnectedMessage'),

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -44,7 +44,7 @@ export function DashboardPage() {
 
   if (inbox.loadError && !inbox.hasLoadedOnce) {
     return (
-      <div className="px-4 md:px-10 pt-11 pb-6 max-w-7xl mx-auto">
+      <div className="flex min-h-[70vh] items-center justify-center px-4 md:px-10 py-12">
         <LoadFailed
           {...buildLoadFailedProps(inbox.loadError, () => void inbox.retryLoad(), inbox.retrying)}
         />


### PR DESCRIPTION
## Summary

Four small dashboard polish fixes that came up while testing the CMS drawer PR — keeping them in a separate PR so they can land independently.

- **`LoadFailed` red dot was invisible.** The eyebrow dot's class string was a concatenation typo (`bg-alert-bad-border-[0.5px]` — `bg-alert-bad-border` ran into a stray `border-[0.5px]`), so the dot rendered without a background colour. Now uses `bg-alert-bad-border animate-pulse` to match the live-state dot pattern used elsewhere in the dashboard.
- **`AuthForm` invalid border was invisible.** Same concatenation typo (`border-alert-bad-border-[0.5px]`) meant invalid inputs in the auth flow didn't actually get a red border. The width is already declared on the base class, so now just `border-alert-bad-border`.
- **Inbox `LoadFailed` no longer hugs the top-left.** When the overview can't load, the error card now sits in a `flex min-h-[70vh] items-center justify-center` wrapper so it's centred both horizontally and vertically. Previously the surrounding `max-w-7xl mx-auto` only centred the outer column, not the error card itself.
- **`SystemAlertsBanner` no longer flickers on transient reconnects.** A short WS blip used to flash the yellow "Connection lost. Reconnecting…" banner. The component now debounces the disconnected state by 1.5s (`DISCONNECT_GRACE_MS`) — if the socket reconnects within that window, the banner never shows; it still hides immediately on reconnect.

## Test plan

- [x] `pnpm -F @getmunin/dashboard-pages typecheck`
- [ ] Browser smoke
  - [ ] Trigger a load failure (stop the backend, reload the dashboard overview): error card sits in the middle of the page; red dot pulses next to "CONNECTION · FAILED".
  - [ ] Try to sign in with an invalid email: input border turns red.
  - [ ] Quickly cycle the backend (kill + start within ~1s): yellow "Reconnecting…" banner does not flash. Kill it for longer: banner appears after ~1.5s and clears on reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)