### PR TITLE
feat(analytics): page-view + search event ingestion (CMS as first consumer)

### DIFF
--- a/.changeset/analytics-module-page-views.md
+++ b/.changeset/analytics-module-page-views.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/core': minor
+'@getmunin/db': minor
+---
+
+Add an `analytics` module that records page-view and search events for any consumer surface. Two ingress paths: a 1×1 GIF pixel at `GET /v1/a/v/:token.gif` and a JSON beacon at `POST /v1/a/v`. Both anonymous, throttled, bot-UA filtered, and gated by an HMAC-signed view token bound to `(orgId, subjectType, subjectId)` so callers can't spoof arbitrary subjects. Events land in two new polymorphic tables (`analytics_view_events`, `analytics_search_events`) keyed by `subject_type` (`'cms_entry'` today, `'landing'`/`'dashboard_route'`/… later) — no per-consumer schema churn.
+
+CMS delivery wires in as the first consumer: every entry and list item from `/v1/cms/{orgId}/...` now ships with a `_tracking: { pixelUrl, beaconUrl }` block (suppressible via `?tracking=0`), and the public `/search` endpoint logs every query plus its `result_count` for "what to write next" analysis (zero-result queries are indexed for fast lookup).
+
+Also: the email open pixel and the new CMS tracking URLs both now build off `MUNIN_API_URL` via a new `readApiBaseUrl()` helper, fixing a latent bug where pixels were minted against the MCP host on split-host deployments (`api.*` vs `mcp.*` subdomains). The unused `readPublicBaseUrl()` shim is removed, and `MUNIN_API_URL` is documented in `.env.example` under the Backend section.

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,13 @@ TEST_DATABASE_URL=postgres://munin:munin@localhost:5432/munin_test
 
 # --- Backend ------------------------------------------------------------
 BACKEND_PORT=3001
+# Server-side analog of NEXT_PUBLIC_API_URL. The backend embeds it into
+# self-referencing URLs it serves to external consumers — the email open
+# pixel (/v1/c/o/*.gif) and the CMS delivery API's _tracking block
+# (/v1/a/v/*). Single-host deployments mirror NEXT_PUBLIC_API_URL;
+# split-host setups (separate api.* and mcp.* subdomains) point this at
+# the API host specifically.
+MUNIN_API_URL=http://localhost:3001
 # Generate with: openssl rand -base64 48
 MUNIN_AUTH_SECRET=replace-me-with-strong-random-secret
 # Used to pepper API-key hashes; rotate it and you invalidate every key.

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -1034,6 +1034,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "visitor_id",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1090,6 +1098,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "tracking",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1133,6 +1149,14 @@
           },
           {
             "name": "locale",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tracking",
             "required": true,
             "in": "query",
             "schema": {
@@ -1333,6 +1357,45 @@
             "session": []
           }
         ]
+      }
+    },
+    "/v1/a/v/{token}.gif": {
+      "get": {
+        "operationId": "AnalyticsViewsController_pixel",
+        "parameters": [
+          {
+            "name": "token",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AnalyticsViews"
+        ],
+        "security": []
+      }
+    },
+    "/v1/a/v": {
+      "post": {
+        "operationId": "AnalyticsViewsController_beacon",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AnalyticsViews"
+        ],
+        "security": []
       }
     },
     "/v1/orgs/me/invitations": {

--- a/packages/backend-core/src/control/analytics-views.controller.ts
+++ b/packages/backend-core/src/control/analytics-views.controller.ts
@@ -1,0 +1,114 @@
+import {
+  Body,
+  Get,
+  HttpCode,
+  Headers,
+  Inject,
+  Param,
+  Post,
+  Res,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { ViewTokenError, looksLikeBot, verifyViewToken } from '@getmunin/core';
+import { PublicController } from '../common/auth/auth.guard.ts';
+import { AnalyticsService } from '../modules/analytics/analytics.service.ts';
+
+const TRANSPARENT_GIF = Buffer.from(
+  'R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+  'base64',
+);
+
+interface BeaconBody {
+  token?: string;
+  path?: string;
+  referrer?: string;
+  visitorId?: string;
+  locale?: string;
+  dwellMs?: number;
+  readDepth?: number;
+  utm?: {
+    source?: string;
+    medium?: string;
+    campaign?: string;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+@PublicController('v1/a/v', { throttle: true })
+export class AnalyticsViewsController {
+  constructor(@Inject(AnalyticsService) private readonly analytics: AnalyticsService) {}
+
+  @Get(':token.gif')
+  async pixel(
+    @Param('token') token: string,
+    @Headers('user-agent') userAgent: string | undefined,
+    @Headers('referer') referer: string | undefined,
+    @Res() res: Response,
+  ): Promise<void> {
+    sendPixel(res);
+    if (looksLikeBot(userAgent)) return;
+    if (!token) return;
+
+    let payload;
+    try {
+      payload = verifyViewToken(token);
+    } catch (err) {
+      if (err instanceof ViewTokenError) return;
+      throw err;
+    }
+
+    await this.analytics.recordView({
+      orgId: payload.orgId,
+      subjectType: payload.subjectType,
+      subjectId: payload.subjectId,
+      source: 'pixel',
+      referrer: referer ?? null,
+      userAgentClass: 'browser',
+    });
+  }
+
+  @Post()
+  @HttpCode(204)
+  async beacon(
+    @Body() body: BeaconBody,
+    @Headers('user-agent') userAgent: string | undefined,
+    @Headers('referer') referer: string | undefined,
+  ): Promise<void> {
+    if (looksLikeBot(userAgent)) return;
+    if (!body || typeof body.token !== 'string') return;
+
+    let payload;
+    try {
+      payload = verifyViewToken(body.token);
+    } catch (err) {
+      if (err instanceof ViewTokenError) return;
+      throw err;
+    }
+
+    await this.analytics.recordView({
+      orgId: payload.orgId,
+      subjectType: payload.subjectType,
+      subjectId: payload.subjectId,
+      source: 'beacon',
+      path: body.path ?? null,
+      locale: body.locale ?? null,
+      referrer: body.referrer ?? referer ?? null,
+      visitorId: body.visitorId ?? null,
+      dwellMs: typeof body.dwellMs === 'number' ? body.dwellMs : null,
+      readDepth: typeof body.readDepth === 'number' ? body.readDepth : null,
+      utmSource: body.utm?.source ?? null,
+      utmMedium: body.utm?.medium ?? null,
+      utmCampaign: body.utm?.campaign ?? null,
+      userAgentClass: 'sdk',
+      metadata: body.metadata ?? null,
+    });
+  }
+}
+
+function sendPixel(res: Response): void {
+  res.setHeader('Content-Type', 'image/gif');
+  res.setHeader('Content-Length', String(TRANSPARENT_GIF.length));
+  res.setHeader('Cache-Control', 'no-store, private, max-age=0');
+  res.setHeader('Pragma', 'no-cache');
+  res.status(200).end(TRANSPARENT_GIF);
+}

--- a/packages/backend-core/src/control/cms-delivery.controller.ts
+++ b/packages/backend-core/src/control/cms-delivery.controller.ts
@@ -11,9 +11,11 @@ import {
 import type { Request, Response } from 'express';
 import { schema, type Db } from '@getmunin/db';
 import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
+import { readApiBaseUrl, signViewToken } from '@getmunin/core';
 import { PublicController } from '../common/auth/auth.guard.ts';
 import { DB } from '../common/db/db.module.ts';
 import { CmsSearchService } from '../modules/cms/cms.search.ts';
+import { AnalyticsService } from '../modules/analytics/analytics.service.ts';
 import {
   applyAssetExpansion,
   collectAssetIds,
@@ -39,6 +41,7 @@ export class CmsDeliveryController {
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(CmsSearchService) private readonly search: CmsSearchService,
+    @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
   ) {}
 
   @Get(':orgId/collections')
@@ -67,10 +70,11 @@ export class CmsDeliveryController {
     @Query('collection') collection?: string,
     @Query('locale') locale?: string,
     @Query('limit') limit?: string,
+    @Query('visitor_id') visitorId?: string,
   ) {
     if (!q || !q.trim()) return [];
     const org = await this.resolveOrg(orgId);
-    return this.search.search(
+    const hits = await this.search.search(
       {
         query: q,
         collection,
@@ -80,6 +84,15 @@ export class CmsDeliveryController {
       },
       { orgId: org.id },
     );
+    void this.analytics.recordSearch({
+      orgId: org.id,
+      subjectType: 'cms',
+      query: q,
+      resultCount: hits.length,
+      locale,
+      visitorId,
+    });
+    return hits;
   }
 
   @Get(':orgId/:collectionSlug')
@@ -91,6 +104,7 @@ export class CmsDeliveryController {
     @Query('locale') locale?: string,
     @Query('limit') limit?: string,
     @Query('before') before?: string,
+    @Query('tracking') tracking?: string,
   ) {
     const { org, collection } = await this.resolveOrgCollection(orgId, collectionSlug);
     const filters: SQL[] = [
@@ -112,7 +126,9 @@ export class CmsDeliveryController {
       .limit(take);
 
     const fields = collection.fields as FieldDef[];
+    const trackingOn = trackingEnabled(tracking);
     const projected = rows.map((r) => ({
+      id: r.id,
       slug: r.slug,
       locale: r.locale,
       data: projectData(fields, r.data),
@@ -121,9 +137,10 @@ export class CmsDeliveryController {
       updatedAt: r.updatedAt.toISOString(),
     }));
     const assets = await this.fetchAssets(org.id, fields, projected.map((p) => p.data));
-    const items = projected.map((p) => ({
+    const items = projected.map(({ id, ...p }) => ({
       ...p,
       data: applyAssetExpansion(fields, p.data, assets),
+      ...(trackingOn ? { _tracking: buildTracking(org.id, id) } : {}),
     }));
 
     const etag = computeEtag(rows.map((r) => r.updatedAt.getTime()));
@@ -140,6 +157,7 @@ export class CmsDeliveryController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
     @Query('locale') locale?: string,
+    @Query('tracking') tracking?: string,
   ) {
     const { org, collection } = await this.resolveOrgCollection(orgId, collectionSlug);
     const filters: SQL[] = [
@@ -172,6 +190,7 @@ export class CmsDeliveryController {
       version: row.version,
       publishedAt: row.publishedAt?.toISOString() ?? null,
       updatedAt: row.updatedAt.toISOString(),
+      ...(trackingEnabled(tracking) ? { _tracking: buildTracking(org.id, row.id) } : {}),
     };
   }
 
@@ -242,5 +261,27 @@ function handleEtag(req: Request, res: Response, etag: string): boolean {
 
 function setCdnHeaders(res: Response): void {
   res.setHeader('cache-control', 'public, max-age=60, stale-while-revalidate=600');
+}
+
+function trackingEnabled(flag: string | undefined): boolean {
+  if (!process.env.MUNIN_KEY_PEPPER) return false;
+  if (flag === '0' || flag === 'false' || flag === 'off') return false;
+  return true;
+}
+
+function buildTracking(
+  orgId: string,
+  entryId: string,
+): { pixelUrl: string; beaconUrl: string } | undefined {
+  try {
+    const token = signViewToken({ orgId, subjectType: 'cms_entry', subjectId: entryId });
+    const base = readApiBaseUrl();
+    return {
+      pixelUrl: `${base}/v1/a/v/${token}.gif`,
+      beaconUrl: `${base}/v1/a/v`,
+    };
+  } catch {
+    return undefined;
+  }
 }
 

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -13,6 +13,8 @@ import { ExportController } from './export.controller.ts';
 import { WebhooksController } from './webhooks.controller.ts';
 import { CmsDeliveryController } from './cms-delivery.controller.ts';
 import { CmsDraftsController } from './cms-drafts.controller.ts';
+import { AnalyticsViewsController } from './analytics-views.controller.ts';
+import { AnalyticsModule } from '../modules/analytics/analytics.module.ts';
 import { CmsModule } from '../modules/cms/cms.module.ts';
 import { ConvModule } from '../modules/conv/conv.module.ts';
 import { CrmModule } from '../modules/crm/crm.module.ts';
@@ -54,6 +56,7 @@ import { AuthProvidersController } from './auth-providers.controller.ts';
  */
 @Module({
   imports: [
+    AnalyticsModule,
     CmsModule,
     ConvModule,
     CrmModule,
@@ -79,6 +82,7 @@ import { AuthProvidersController } from './auth-providers.controller.ts';
     WebhooksController,
     CmsDeliveryController,
     CmsDraftsController,
+    AnalyticsViewsController,
     InvitationsController,
     AcceptInvitationController,
     MembersController,

--- a/packages/backend-core/src/control/email-opens.controller.ts
+++ b/packages/backend-core/src/control/email-opens.controller.ts
@@ -6,6 +6,7 @@ import {
   ActorIdentity,
   EmailOpenTokenError,
   WebhookDispatcher,
+  looksLikeBot,
   verifyEmailOpenToken,
   withContext,
   type RequestContext,
@@ -18,8 +19,6 @@ const TRANSPARENT_GIF = Buffer.from(
   'R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
   'base64',
 );
-
-const BOT_UA = /\b(bot|crawler|spider|preview|linkcheck|monitor)\b/i;
 
 @Controller('v1/c/o')
 export class EmailOpensController {
@@ -37,7 +36,7 @@ export class EmailOpensController {
   ): Promise<void> {
     sendPixel(res);
     if (!token) return;
-    if (userAgent && BOT_UA.test(userAgent)) return;
+    if (looksLikeBot(userAgent)) return;
 
     let payload;
     try {

--- a/packages/backend-core/src/modules/analytics/analytics.module.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AnalyticsService } from './analytics.service.ts';
+
+@Module({
+  providers: [AnalyticsService],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/packages/backend-core/src/modules/analytics/analytics.service.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.service.ts
@@ -1,0 +1,95 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { schema, type Db } from '@getmunin/db';
+import { DB } from '../../common/db/db.module.ts';
+
+export interface RecordViewInput {
+  orgId: string;
+  subjectType: string;
+  subjectId: string;
+  source: 'pixel' | 'beacon';
+  path?: string | null;
+  locale?: string | null;
+  referrer?: string | null;
+  utmSource?: string | null;
+  utmMedium?: string | null;
+  utmCampaign?: string | null;
+  visitorId?: string | null;
+  userAgentClass?: string | null;
+  dwellMs?: number | null;
+  readDepth?: number | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface RecordSearchInput {
+  orgId: string;
+  subjectType: string;
+  query: string;
+  resultCount: number;
+  locale?: string | null;
+  visitorId?: string | null;
+}
+
+@Injectable()
+export class AnalyticsService {
+  private readonly logger = new Logger(AnalyticsService.name);
+
+  constructor(@Inject(DB) private readonly db: Db) {}
+
+  async recordView(input: RecordViewInput): Promise<void> {
+    try {
+      await this.db.insert(schema.analyticsViewEvents).values({
+        orgId: input.orgId,
+        subjectType: input.subjectType.slice(0, 32),
+        subjectId: input.subjectId,
+        source: input.source,
+        path: truncate(input.path, 512),
+        locale: truncate(input.locale, 16),
+        referrer: truncate(input.referrer, 512),
+        utmSource: truncate(input.utmSource, 128),
+        utmMedium: truncate(input.utmMedium, 128),
+        utmCampaign: truncate(input.utmCampaign, 128),
+        visitorId: truncate(input.visitorId, 64),
+        userAgentClass: truncate(input.userAgentClass, 16),
+        dwellMs: clampInt(input.dwellMs, 0, 24 * 60 * 60 * 1000),
+        readDepth: clampInt(input.readDepth, 0, 100),
+        metadata: input.metadata ?? null,
+      });
+    } catch (err) {
+      this.logger.warn(`analytics.view.record_failed: ${(err as Error).message}`);
+    }
+  }
+
+  async recordSearch(input: RecordSearchInput): Promise<void> {
+    try {
+      const q = input.query.trim();
+      if (!q) return;
+      await this.db.insert(schema.analyticsSearchEvents).values({
+        orgId: input.orgId,
+        subjectType: input.subjectType.slice(0, 32),
+        query: q.slice(0, 256),
+        locale: truncate(input.locale, 16),
+        resultCount: Math.max(0, Math.floor(input.resultCount)),
+        visitorId: truncate(input.visitorId, 64),
+      });
+    } catch (err) {
+      this.logger.warn(`analytics.search.record_failed: ${(err as Error).message}`);
+    }
+  }
+}
+
+function truncate(value: string | null | undefined, max: number): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, max);
+}
+
+function clampInt(
+  value: number | null | undefined,
+  min: number,
+  max: number,
+): number | null {
+  if (value === null || value === undefined) return null;
+  if (!Number.isFinite(value)) return null;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}

--- a/packages/backend-core/src/modules/cms/cms.integration.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.integration.test.ts
@@ -424,7 +424,142 @@ const skipReason = TEST_URL
       expect(names.find((n) => n.startsWith('cms_'))).toBeFalsy();
     });
   }, 30_000);
+
+  it('analytics: delivery returns _tracking, pixel records a view, beacon records rich attrs', async () => {
+    await withClient(adminKey, async (c) => {
+      await c.callTool({
+        name: 'cms_create_entry',
+        arguments: {
+          collection: 'pages',
+          slug: 'tracked-page',
+          data: { title: 'Tracked', slug: 'tracked-page', body: 'Body.' },
+          status: 'published',
+        },
+      });
+    });
+
+    const res = await fetchUntil(
+      `${baseUrl}/v1/cms/${orgId}/pages/tracked-page`,
+      (r) => r.status === 200,
+    );
+    const entry = (await res.json()) as {
+      _tracking?: { pixelUrl: string; beaconUrl: string };
+    };
+    expect(entry._tracking?.pixelUrl).toMatch(/\/v1\/a\/v\/.+\.gif$/);
+    expect(entry._tracking?.beaconUrl).toMatch(/\/v1\/a\/v$/);
+
+    const pixelUrl = retarget(entry._tracking!.pixelUrl, baseUrl);
+    const beaconUrl = retarget(entry._tracking!.beaconUrl, baseUrl);
+
+    const beforePixel = await countViewEvents(db, orgId, 'pixel');
+    const pixel = await fetch(pixelUrl);
+    expect(pixel.status).toBe(200);
+    expect(pixel.headers.get('content-type')).toBe('image/gif');
+    await waitFor(async () => (await countViewEvents(db, orgId, 'pixel')) > beforePixel);
+
+    const pixelBot = await fetch(pixelUrl, {
+      headers: { 'user-agent': 'Googlebot/2.1' },
+    });
+    expect(pixelBot.status).toBe(200);
+    const afterBot = await countViewEvents(db, orgId, 'pixel');
+    expect(afterBot).toBe(beforePixel + 1);
+
+    const beforeBeacon = await countViewEvents(db, orgId, 'beacon');
+    const tokenMatch = pixelUrl.match(/\/v1\/a\/v\/(.+)\.gif$/);
+    const token = tokenMatch![1]!;
+    const beacon = await fetch(beaconUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        token,
+        referrer: 'https://example.com/blog',
+        visitorId: 'visitor-xyz',
+        dwellMs: 42_000,
+        readDepth: 75,
+        utm: { source: 'twitter', medium: 'social', campaign: 'launch' },
+      }),
+    });
+    expect(beacon.status).toBe(204);
+    await waitFor(async () => (await countViewEvents(db, orgId, 'beacon')) > beforeBeacon);
+
+    const beaconRow = await db
+      .select()
+      .from(schema.analyticsViewEvents)
+      .where(sql`org_id = ${orgId} AND source = 'beacon' AND visitor_id = 'visitor-xyz'`)
+      .limit(1);
+    expect(beaconRow[0]?.dwellMs).toBe(42_000);
+    expect(beaconRow[0]?.readDepth).toBe(75);
+    expect(beaconRow[0]?.utmSource).toBe('twitter');
+    expect(beaconRow[0]?.subjectType).toBe('cms_entry');
+
+    const tampered = token.replace(/.$/, (c) => (c === 'a' ? 'b' : 'a'));
+    const bad = await fetch(beaconUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: tampered, visitorId: 'should-not-write' }),
+    });
+    expect(bad.status).toBe(204);
+    const tamperedCount = await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(schema.analyticsViewEvents)
+      .where(sql`org_id = ${orgId} AND visitor_id = 'should-not-write'`);
+    expect(tamperedCount[0]?.n ?? 0).toBe(0);
+  }, 30_000);
+
+  it('analytics: ?tracking=0 suppresses the _tracking block', async () => {
+    const res = await fetch(`${baseUrl}/v1/cms/${orgId}/pages/tracked-page?tracking=0`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { _tracking?: unknown };
+    expect(json._tracking).toBeUndefined();
+  }, 30_000);
+
+  it('analytics: public search logs every query with its result_count', async () => {
+    const q = `analytics_probe_${Date.now()}`;
+    const res = await fetch(
+      `${baseUrl}/v1/cms/${orgId}/search?q=${encodeURIComponent(q)}&collection=pages&visitor_id=probe-v`,
+    );
+    expect(res.status).toBe(200);
+    const hits = (await res.json()) as unknown[];
+    await waitFor(async () => {
+      const rows = await db
+        .select()
+        .from(schema.analyticsSearchEvents)
+        .where(sql`org_id = ${orgId} AND query = ${q}`)
+        .limit(1);
+      return (
+        rows.length > 0 &&
+        rows[0]!.resultCount === hits.length &&
+        rows[0]!.subjectType === 'cms' &&
+        rows[0]!.visitorId === 'probe-v'
+      );
+    });
+  }, 30_000);
 });
+
+function retarget(url: string, baseUrl: string): string {
+  return url.replace(/^https?:\/\/[^/]+/, baseUrl);
+}
+
+async function countViewEvents(
+  db: ReturnType<typeof createDb>,
+  orgId: string,
+  source: 'pixel' | 'beacon',
+): Promise<number> {
+  const r = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(schema.analyticsViewEvents)
+    .where(sql`org_id = ${orgId} AND source = ${source}`);
+  return r[0]?.n ?? 0;
+}
+
+async function waitFor(check: () => Promise<boolean>, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error('waitFor: condition not met before timeout');
+}
 
 function parseToolResult<T>(result: unknown): T {
   const r = result as { content?: Array<{ type: string; text?: string }> };

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -5,13 +5,13 @@ import {
   ActorIdentity,
   WebhookDispatcher,
   parseEnvInt,
+  readApiBaseUrl,
   resolvePublicHost,
   signEmailOpenToken,
   withContext,
   type Mailer,
   type RequestContext,
 } from '@getmunin/core';
-import { readPublicBaseUrl } from '../../../oauth/oauth.constants.ts';
 import { ImapFlow } from 'imapflow';
 import { simpleParser, type ParsedMail, type AddressObject } from 'mailparser';
 import { randomUUID } from 'node:crypto';
@@ -568,7 +568,7 @@ function trackerUrlFor(
       orgId: ctx.channel.orgId,
       deliveryId: ctx.delivery.id,
     });
-    return `${readPublicBaseUrl()}/v1/c/o/${token}.gif`;
+    return `${readApiBaseUrl()}/v1/c/o/${token}.gif`;
   } catch {
     return undefined;
   }

--- a/packages/backend-core/src/oauth/oauth.constants.ts
+++ b/packages/backend-core/src/oauth/oauth.constants.ts
@@ -31,10 +31,6 @@ export function authorizationServerUrl(): string {
   return parsePublicUrl().origin;
 }
 
-export function readPublicBaseUrl(): string {
-  return authorizationServerUrl();
-}
-
 export function resourceMetadataUrl(): string {
   return `${authorizationServerUrl()}/.well-known/oauth-protected-resource`;
 }

--- a/packages/core/src/crypto/view-token.test.ts
+++ b/packages/core/src/crypto/view-token.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { signViewToken, verifyViewToken, ViewTokenError } from './view-token.ts';
+
+const PEPPER = 'test-pepper-do-not-use-in-prod';
+
+describe('view tokens', () => {
+  it('round-trips a signed token', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b' },
+      PEPPER,
+    );
+    const payload = verifyViewToken(token, PEPPER);
+    expect(payload.orgId).toBe('org_a');
+    expect(payload.subjectType).toBe('cms_entry');
+    expect(payload.subjectId).toBe('cme_b');
+    expect(payload.issuedAt).toBeGreaterThan(0);
+  });
+
+  it('rejects a token signed with a different pepper', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b' },
+      PEPPER,
+    );
+    expect(() => verifyViewToken(token, 'other-pepper')).toThrow(ViewTokenError);
+  });
+
+  it('rejects a tampered subject', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b' },
+      PEPPER,
+    );
+    const tampered = token.replace('cme_b', 'cme_evil');
+    expect(() => verifyViewToken(tampered, PEPPER)).toThrow(ViewTokenError);
+  });
+
+  it('rejects a tampered subjectType', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b' },
+      PEPPER,
+    );
+    const tampered = token.replace('cms_entry', 'landing');
+    expect(() => verifyViewToken(tampered, PEPPER)).toThrow(ViewTokenError);
+  });
+
+  it('rejects malformed tokens', () => {
+    expect(() => verifyViewToken('garbage', PEPPER)).toThrow(ViewTokenError);
+    expect(() => verifyViewToken('a.b.c.d', PEPPER)).toThrow(ViewTokenError);
+  });
+
+  it('rejects field values containing dots or whitespace', () => {
+    expect(() =>
+      signViewToken({ orgId: 'org.a', subjectType: 'x', subjectId: 'y' }, PEPPER),
+    ).toThrow();
+    expect(() =>
+      signViewToken({ orgId: 'org_a', subjectType: 'x y', subjectId: 'y' }, PEPPER),
+    ).toThrow();
+  });
+
+  it('preserves a caller-supplied issuedAt', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b', issuedAt: 1700000000 },
+      PEPPER,
+    );
+    const payload = verifyViewToken(token, PEPPER);
+    expect(payload.issuedAt).toBe(1700000000);
+  });
+});

--- a/packages/core/src/crypto/view-token.ts
+++ b/packages/core/src/crypto/view-token.ts
@@ -1,0 +1,49 @@
+import { signHmac, timingSafeEqual } from './primitives.ts';
+
+const VERSION = 'v1';
+
+export interface ViewTokenPayload {
+  orgId: string;
+  subjectType: string;
+  subjectId: string;
+  issuedAt: number;
+}
+
+export class ViewTokenError extends Error {
+  readonly code = 'view_token_invalid';
+  constructor(message: string) {
+    super(`view_token_invalid: ${message}`);
+  }
+}
+
+export function signViewToken(
+  payload: Omit<ViewTokenPayload, 'issuedAt'> & { issuedAt?: number },
+  pepper?: string,
+): string {
+  const secret = pepper ?? process.env.MUNIN_KEY_PEPPER ?? '';
+  if (!secret) throw new Error('MUNIN_KEY_PEPPER is required to sign view tokens');
+  const issuedAt = payload.issuedAt ?? Math.floor(Date.now() / 1000);
+  for (const v of [payload.orgId, payload.subjectType, payload.subjectId]) {
+    if (!v || /[.\s]/.test(v)) {
+      throw new Error('view token fields must be non-empty and contain no dots or whitespace');
+    }
+  }
+  const body = `${VERSION}.${payload.orgId}.${payload.subjectType}.${payload.subjectId}.${issuedAt}`;
+  const sig = signHmac(body, secret);
+  return `${body}.${sig}`;
+}
+
+export function verifyViewToken(token: string, pepper?: string): ViewTokenPayload {
+  const secret = pepper ?? process.env.MUNIN_KEY_PEPPER ?? '';
+  if (!secret) throw new ViewTokenError('server pepper not configured');
+  const parts = token.split('.');
+  if (parts.length !== 6) throw new ViewTokenError('malformed token');
+  const [version, orgId, subjectType, subjectId, issuedAtStr, sig] = parts;
+  if (version !== VERSION) throw new ViewTokenError(`unknown version ${version}`);
+  const body = `${version}.${orgId}.${subjectType}.${subjectId}.${issuedAtStr}`;
+  const expected = signHmac(body, secret);
+  if (!timingSafeEqual(expected, sig!)) throw new ViewTokenError('signature mismatch');
+  const issuedAt = Number(issuedAtStr);
+  if (!Number.isFinite(issuedAt)) throw new ViewTokenError('issuedAt not numeric');
+  return { orgId: orgId!, subjectType: subjectType!, subjectId: subjectId!, issuedAt };
+}

--- a/packages/core/src/env/api-url.ts
+++ b/packages/core/src/env/api-url.ts
@@ -1,0 +1,6 @@
+const LOCAL_FALLBACK = 'http://localhost:3001';
+
+export function readApiBaseUrl(): string {
+  const raw = process.env.MUNIN_API_URL ?? LOCAL_FALLBACK;
+  return raw.replace(/\/+$/, '');
+}

--- a/packages/core/src/env/index.ts
+++ b/packages/core/src/env/index.ts
@@ -7,3 +7,4 @@ export {
   type ParseEnvCronOptions,
   type ParseEnvIntOptions,
 } from './parse.ts';
+export { readApiBaseUrl } from './api-url.ts';

--- a/packages/core/src/http/bot-ua.ts
+++ b/packages/core/src/http/bot-ua.ts
@@ -1,0 +1,6 @@
+export const BOT_UA = /\b(bot|crawler|spider|preview|linkcheck|monitor)\b/i;
+
+export function looksLikeBot(userAgent: string | undefined | null): boolean {
+  if (!userAgent) return false;
+  return BOT_UA.test(userAgent);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,13 @@ export {
   signEmailOpenToken,
   verifyEmailOpenToken,
 } from './crypto/email-open-token.ts';
+export {
+  type ViewTokenPayload,
+  ViewTokenError,
+  signViewToken,
+  verifyViewToken,
+} from './crypto/view-token.ts';
+export { BOT_UA, looksLikeBot } from './http/bot-ua.ts';
 
 export {
   type EmbeddingProvider,
@@ -80,6 +87,7 @@ export {
   parseEnvCron,
   parseEnvDisableFlag,
   parseEnvInt,
+  readApiBaseUrl,
   type ParseEnvBoolOptions,
   type ParseEnvCronOptions,
   type ParseEnvIntOptions,

--- a/packages/db/drizzle/0035_analytics_events.sql
+++ b/packages/db/drizzle/0035_analytics_events.sql
@@ -1,0 +1,56 @@
+-- Analytics: append-only event tables for delivered page views and search
+-- invocations. Polymorphic via (subject_type, subject_id) so CMS entries,
+-- landing pages, dashboard routes, etc. all share the same ingest path.
+-- Bot traffic is filtered upstream; IPs are intentionally not stored.
+
+CREATE TABLE IF NOT EXISTS "analytics_view_events" (
+    "id" text PRIMARY KEY NOT NULL,
+    "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+    "subject_type" varchar(32) NOT NULL,
+    "subject_id" text NOT NULL,
+    "path" varchar(512),
+    "locale" varchar(16),
+    "referrer" varchar(512),
+    "utm_source" varchar(128),
+    "utm_medium" varchar(128),
+    "utm_campaign" varchar(128),
+    "visitor_id" varchar(64),
+    "user_agent_class" varchar(16),
+    "dwell_ms" integer,
+    "read_depth" integer,
+    "source" varchar(8) NOT NULL,
+    "metadata" jsonb,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT "analytics_view_events_source_chk" CHECK ("source" IN ('pixel', 'beacon')),
+    CONSTRAINT "analytics_view_events_read_depth_chk"
+        CHECK ("read_depth" IS NULL OR ("read_depth" >= 0 AND "read_depth" <= 100))
+);
+
+CREATE INDEX IF NOT EXISTS "analytics_view_events_org_idx"
+    ON "analytics_view_events" ("org_id", "created_at");
+
+CREATE INDEX IF NOT EXISTS "analytics_view_events_subject_idx"
+    ON "analytics_view_events" ("org_id", "subject_type", "subject_id", "created_at");
+
+CREATE INDEX IF NOT EXISTS "analytics_view_events_type_idx"
+    ON "analytics_view_events" ("org_id", "subject_type", "created_at");
+
+CREATE TABLE IF NOT EXISTS "analytics_search_events" (
+    "id" text PRIMARY KEY NOT NULL,
+    "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+    "subject_type" varchar(32) NOT NULL,
+    "query" varchar(256) NOT NULL,
+    "locale" varchar(16),
+    "result_count" integer NOT NULL,
+    "visitor_id" varchar(64),
+    "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "analytics_search_events_zero_idx"
+    ON "analytics_search_events" ("org_id", "subject_type", "result_count", "created_at");
+
+CREATE INDEX IF NOT EXISTS "analytics_search_events_org_idx"
+    ON "analytics_search_events" ("org_id", "created_at");
+
+-- RLS policies live in src/sql/analytics.sql so they run AFTER the
+-- app_bypass_rls() / app_org_id() helpers are defined.

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1780500000000,
       "tag": "0034_org_alerts",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1780600000000,
+      "tag": "0035_analytics_events",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -35,6 +35,7 @@ export async function runMigrations(connectionString: string, migrationsFolder?:
   const cmsPath = resolve(sqlDir, 'cms.sql');
   const convChannelsPath = resolve(sqlDir, 'conv-channels.sql');
   const outreachPath = resolve(sqlDir, 'outreach.sql');
+  const analyticsPath = resolve(sqlDir, 'analytics.sql');
 
   const client = postgres(connectionString, { max: 1 });
   const db = drizzle(client);
@@ -57,6 +58,7 @@ export async function runMigrations(connectionString: string, migrationsFolder?:
   await client.unsafe(readFileSync(cmsPath, 'utf8'));
   await client.unsafe(readFileSync(convChannelsPath, 'utf8'));
   await client.unsafe(readFileSync(outreachPath, 'utf8'));
+  await client.unsafe(readFileSync(analyticsPath, 'utf8'));
 
   // 4. App role (idempotent). Password defaults to the role name; override
   //    via MUNIN_APP_PASSWORD for non-dev deployments.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1497,6 +1497,76 @@ export const cmsReferences = pgTable(
   }),
 );
 
+// ───────────────────────────── Analytics ─────────────────────────────
+// Polymorphic page-view and search events. The first consumer is the
+// CMS delivery API (subject_type='cms_entry'); landing pages, dashboard
+// routes, and other surfaces use their own subject types without
+// schema changes. Append-only; aggregation/rollups are deferred.
+
+export const analyticsViewEvents = pgTable(
+  'analytics_view_events',
+  {
+    id: id('avw'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    subjectType: varchar('subject_type', { length: 32 }).notNull(),
+    subjectId: text('subject_id').notNull(),
+    path: varchar('path', { length: 512 }),
+    locale: varchar('locale', { length: 16 }),
+    referrer: varchar('referrer', { length: 512 }),
+    utmSource: varchar('utm_source', { length: 128 }),
+    utmMedium: varchar('utm_medium', { length: 128 }),
+    utmCampaign: varchar('utm_campaign', { length: 128 }),
+    visitorId: varchar('visitor_id', { length: 64 }),
+    userAgentClass: varchar('user_agent_class', { length: 16 }),
+    dwellMs: integer('dwell_ms'),
+    readDepth: integer('read_depth'),
+    source: varchar('source', { length: 8 }).notNull(),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    createdAt,
+  },
+  (t) => ({
+    orgIdx: index('analytics_view_events_org_idx').on(t.orgId, t.createdAt),
+    subjectIdx: index('analytics_view_events_subject_idx').on(
+      t.orgId,
+      t.subjectType,
+      t.subjectId,
+      t.createdAt,
+    ),
+    typeIdx: index('analytics_view_events_type_idx').on(
+      t.orgId,
+      t.subjectType,
+      t.createdAt,
+    ),
+  }),
+);
+
+export const analyticsSearchEvents = pgTable(
+  'analytics_search_events',
+  {
+    id: id('asr'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    subjectType: varchar('subject_type', { length: 32 }).notNull(),
+    query: varchar('query', { length: 256 }).notNull(),
+    locale: varchar('locale', { length: 16 }),
+    resultCount: integer('result_count').notNull(),
+    visitorId: varchar('visitor_id', { length: 64 }),
+    createdAt,
+  },
+  (t) => ({
+    zeroResultIdx: index('analytics_search_events_zero_idx').on(
+      t.orgId,
+      t.subjectType,
+      t.resultCount,
+      t.createdAt,
+    ),
+    orgIdx: index('analytics_search_events_org_idx').on(t.orgId, t.createdAt),
+  }),
+);
+
 // ───────────────────────────── Curator jobs ──────────────────────────
 // Persistent queue for curator background jobs. The bundled in-process
 // runner (or any admin-authenticated runner) claims pending rows via
@@ -1773,6 +1843,8 @@ export const allTables = {
   cmsAssets,
   cmsLocales,
   cmsReferences,
+  analyticsViewEvents,
+  analyticsSearchEvents,
   curatorJobs,
   systemConfig,
   feedbackOutbox,

--- a/packages/db/src/sql/analytics.sql
+++ b/packages/db/src/sql/analytics.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- Analytics module RLS policies.
+-- Org-scoped, admin-only. Write path is the public ingest endpoint, which
+-- uses the service-role DB and bypasses RLS; reads are admin-side only.
+-- ============================================================================
+
+ALTER TABLE analytics_view_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE analytics_view_events FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON analytics_view_events;
+CREATE POLICY tenant_isolation ON analytics_view_events
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
+ALTER TABLE analytics_search_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE analytics_search_events FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON analytics_search_events;
+CREATE POLICY tenant_isolation ON analytics_search_events
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());


### PR DESCRIPTION
## Summary

- **New `analytics` module** (`packages/backend-core/src/modules/analytics/`) with two anonymous, throttled, bot-UA-filtered ingress paths: a 1×1 GIF pixel at `GET /v1/a/v/:token.gif` and a JSON beacon at `POST /v1/a/v`. Both gated by an HMAC-signed view token bound to `(orgId, subjectType, subjectId)` so callers can't spoof arbitrary subjects.
- **Polymorphic storage**: two new tables (`analytics_view_events`, `analytics_search_events`) keyed by `subject_type` — `'cms_entry'` today, `'landing'` / `'dashboard_route'` / etc. later without schema changes.
- **CMS as first consumer**: `/v1/cms/{orgId}/...` entry + list responses now ship `_tracking: { pixelUrl, beaconUrl }` (suppressible via `?tracking=0`), and the public `/search` route logs every query with its `result_count` (zero-result queries are indexed for fast "what to write next" lookups).
- **Latent fix**: pixel URLs (this PR + the existing email open pixel) now resolve through a new `readApiBaseUrl()` helper that reads `MUNIN_API_URL`. The old `readPublicBaseUrl()` returned the OAuth/MCP origin, which is wrong on split-host deployments (`api.*` vs `mcp.*` subdomains). `MUNIN_API_URL` is now documented in `.env.example` under the Backend section.

## Test plan

- [x] Unit: `view-token.test.ts` — 7 round-trip / tamper / version tests pass.
- [x] Integration (`cms.integration.test.ts`, gated on `TEST_DATABASE_URL`):
  - delivery response includes `_tracking`; pixel GET writes a row; Googlebot UA is silently dropped; beacon POST writes rich attrs (dwell, depth, UTM); tampered token is silently dropped; `?tracking=0` suppresses the block; public search logs every query with the correct `result_count`.
- [x] Full `pnpm -F @getmunin/backend-core test` — 729/729 pass.
- [x] `pnpm typecheck` — clean across the workspace.
- [x] `pnpm docs:generate` regenerated `openapi.json` (included in commit) for the two new endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)