### PR TITLE
feat(analytics): tracker entity, drop-in script, origin allowlist (forward PR #357 to main)

### DIFF
--- a/.changeset/analytics-module-page-views.md
+++ b/.changeset/analytics-module-page-views.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/core': minor
+'@getmunin/db': minor
+---
+
+Add an `analytics` module that records page-view and search events for any consumer surface. Two ingress paths: a 1×1 GIF pixel at `GET /v1/a/v/:token.gif` and a JSON beacon at `POST /v1/a/v`. Both anonymous, throttled, bot-UA filtered, and gated by an HMAC-signed view token bound to `(orgId, subjectType, subjectId)` so callers can't spoof arbitrary subjects. Events land in two new polymorphic tables (`analytics_view_events`, `analytics_search_events`) keyed by `subject_type` (`'cms_entry'` today, `'landing'`/`'dashboard_route'`/… later) — no per-consumer schema churn.
+
+CMS delivery wires in as the first consumer: every entry and list item from `/v1/cms/{orgId}/...` now ships with a `_tracking: { pixelUrl, beaconUrl }` block (suppressible via `?tracking=0`), and the public `/search` endpoint logs every query plus its `result_count` for "what to write next" analysis (zero-result queries are indexed for fast lookup).
+
+Also: the email open pixel and the new CMS tracking URLs both now build off `MUNIN_API_URL` via a new `readApiBaseUrl()` helper, fixing a latent bug where pixels were minted against the MCP host on split-host deployments (`api.*` vs `mcp.*` subdomains). The unused `readPublicBaseUrl()` shim is removed, and `MUNIN_API_URL` is documented in `.env.example` under the Backend section.

--- a/.changeset/analytics-tracker-drop-in-script.md
+++ b/.changeset/analytics-tracker-drop-in-script.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/core': minor
+'@getmunin/db': minor
+---
+
+Add a drop-in tracker script for arbitrary web pages — same ergonomics as the chat widget. `analytics_create_tracker` mints a public `mn_track_*` API key, then a single `<script async src=".../v1/a/tracker.js" data-key="mn_track_…">` tag auto-fires page views, tracks dwell on `pagehide`, and exposes `window.mn.track(subjectId, attrs)` for SPA route changes. Events land in `analytics_view_events` with `source='tracker'`. Tracker keys are write-only and org-scoped — safe to embed in browsers.
+
+Also adds three admin read tools: `analytics_top_subjects` (most-viewed pages/entries), `analytics_subject_engagement` (views/dwell/depth for one subject), `analytics_zero_result_searches` (queries readers asked that returned nothing — the best "what to write next" signal). The `cms/review-stale-entries` skill now consults `analytics_subject_engagement` to judge refresh-vs-archive instead of relying on inbound references alone; a new `skill://analytics/track-website-traffic` walks operators through the full setup.

--- a/.env.example
+++ b/.env.example
@@ -200,6 +200,17 @@ MUNIN_QUOTAS_ENABLED=false
 # MUNIN_PUBLIC_THROTTLE_MIN=60
 # MUNIN_PUBLIC_THROTTLE_HOUR=1000
 
+# --- Origin allowlist enforcement --------------------------------------
+# Chat-widget channels (conv_channels.config.originAllowlist) and
+# analytics trackers (analytics_trackers.allowed_origins) each carry an
+# optional allowed-origins list. Empty list = accept any origin (dev
+# default). Set the matching env var to "1" in production to make empty
+# lists fail-closed — any widget channel or tracker without explicit
+# origins refuses all ingest requests until the operator sets the list
+# via conv_widget_update_channel / analytics_update_tracker.
+# MUNIN_WIDGET_REQUIRE_ALLOWLIST=0
+# MUNIN_TRACKER_REQUIRE_ALLOWLIST=0
+
 # --- Web ----------------------------------------------------------------
 WEB_PORT=3000
 

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,13 @@ TEST_DATABASE_URL=postgres://munin:munin@localhost:5432/munin_test
 
 # --- Backend ------------------------------------------------------------
 BACKEND_PORT=3001
+# Server-side analog of NEXT_PUBLIC_API_URL. The backend embeds it into
+# self-referencing URLs it serves to external consumers — the email open
+# pixel (/v1/c/o/*.gif) and the CMS delivery API's _tracking block
+# (/v1/a/v/*). Single-host deployments mirror NEXT_PUBLIC_API_URL;
+# split-host setups (separate api.* and mcp.* subdomains) point this at
+# the API host specifically.
+MUNIN_API_URL=http://localhost:3001
 # Generate with: openssl rand -base64 48
 MUNIN_AUTH_SECRET=replace-me-with-strong-random-secret
 # Used to pepper API-key hashes; rotate it and you invalidate every key.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 > MCP-first customer platform made for the agentic era. The agent is the UI.
 
-Munin is an open-source customer platform built for the agentic era (Knowledge Base, Conversations, CRM, CMS, Outreach) where the only interface is via AI agents. There is no traditional admin UI for the apps themselves — every action runs through MCP tools, callable from any MCP-compatible client.
+Munin is an open-source customer platform built for the agentic era (Knowledge Base, Conversations, CRM, CMS, Outreach, Analytics) where the only interface is via AI agents. There is no traditional admin UI for the apps themselves — every action runs through MCP tools, callable from any MCP-compatible client.
 
 ## What's in the box
 
 - **Knowledge Base** — markdown documents, hybrid search (BM25 + pgvector embeddings), per-document audience scoping.
 - **Conversations** — multi-channel threads (email, voice via Vapi, SMS via Twilio/MessageBird, chat widget) routed to end-users, assignable, agent-resolvable, with handover state and webhook fan-out.
 - **CRM** — contacts, companies, deals, activities, pipelines, segments, plus a merge-proposal queue the `clean-contact-data` curator runs against.
-- **CMS** — agent-authored content collections with field schemas, localized entries, scheduled publishing, an asset library backed by S3-compatible storage, and a public delivery API.
+- **CMS** — agent-authored content collections with field schemas, localized entries, scheduled publishing, an asset library backed by S3-compatible storage, and a public delivery API that ships a `_tracking` block on every entry for built-in engagement signal.
 - **Outreach** — propose-only outbound emails: campaigns + segments + drafts queued for human approval; never auto-sends.
+- **Analytics** — polymorphic page-view + search-query ingestion. CMS delivery wires in for free; arbitrary pages drop in a `<script src="…/tracker.js" data-key="mn_track_…">` tag. Read tools (`analytics_top_subjects`, `analytics_subject_engagement`, `analytics_zero_result_searches`) feed the "what should we write next" loop into curator skills like `cms/review-stale-entries`.
 - **Curator** — durable background job queue running skills (KB curation, CRM hygiene, contact extraction, stale-content review, outreach drafts) on a schedule with retry + dead-letter.
 - **Playbooks + skills** — packaged markdown procedures (`skill://module/<verb-object>`) the agent reads via MCP resources to follow multi-step flows.
 - **Cross-cutting** — audit log, webhooks, team invites, OAuth 2.1 dynamic-client registration, BetterAuth-backed sign-in.
@@ -82,13 +83,13 @@ Once you've signed up (hosted) or run `docker compose up` (self-host), point you
 }
 ```
 
-(For the hosted version, swap in `https://mcp.getmunin.com`.) The first call triggers an OAuth consent screen in your browser, then your agent has the full tool surface — Knowledge Base, Conversations, CRM, CMS, Outreach.
+(For the hosted version, swap in `https://mcp.getmunin.com`.) The first call triggers an OAuth consent screen in your browser, then your agent has the full tool surface — Knowledge Base, Conversations, CRM, CMS, Outreach, Analytics.
 
 ## Two trust contexts, one MCP endpoint
 
 The same `/mcp` endpoint serves two distinct callers, audience-aware:
 
-- **Admin agents** (Claude Desktop, Cursor, internal automation) — OAuth-authorized by you. Full tool surface, scope-gated per `kb:*`, `conv:*`, `crm:*`, `cms:*`, `outreach:*`.
+- **Admin agents** (Claude Desktop, Cursor, internal automation) — OAuth-authorized by you. Full tool surface, scope-gated per `kb:*`, `conv:*`, `crm:*`, `cms:*`, `outreach:*`, `analytics:*`.
 - **End-user agents** (your voice AI, web chatbot, mobile app helper) — short-lived delegated tokens minted server-side from your backend, scoped to one of your end-users. Only self-service tools (read your own contact, send a message in your own conversation).
 
 See `packages/backend-core/src/control/delegated-token.controller.ts` for the token-mint API. The `@getmunin/sdk` Node client wraps it.
@@ -98,7 +99,8 @@ See `packages/backend-core/src/control/delegated-token.controller.ts` for the to
 - `apps/backend` — thin NestJS entry composing `@getmunin/backend-core` modules with single-tenant `AuthModule`. Exposes the MCP server (Streamable HTTP), OAuth 2.1 + OIDC discovery, and the control-plane REST API on port 3001.
 - `apps/web` — Next.js dashboard + landing on port 3000.
 - `apps/chat-widget` — embeddable browser widget that consumes a `mn_widget_*` key and the widget ingest API.
-- `packages/backend-core` — every shared NestJS module (KB, Conversations, CRM, CMS, Outreach, Curator, Web, Playbooks, MCP, control plane, audit, tenancy, RLS, mailer, storage, webhooks, rate limit, quotas, OAuth) plus `createApp` and the `createAuthController` helper. Cloud composes the same modules with multi-tenant auth.
+- `apps/analytics-tracker` — embeddable browser tracker, served at `/tracker.js`, that consumes a public `mn_track_*` key and writes page-view events.
+- `packages/backend-core` — every shared NestJS module (KB, Conversations, CRM, CMS, Outreach, Analytics, Curator, Web, Playbooks, MCP, control plane, audit, tenancy, RLS, mailer, storage, webhooks, rate limit, quotas, OAuth) plus `createApp` and the `createAuthController` helper. Cloud composes the same modules with multi-tenant auth.
 - `packages/dashboard-pages` — dashboard page components shared between OSS and cloud webs.
 - `packages/ui` — design-system primitives (shadcn-style).
 - `packages/{core, db, types, sdk, mcp-toolkit}` — non-Nest building blocks: actor identity + tenancy GUCs, Drizzle schema + migrations, shared types, Node client SDK, MCP `@McpTool` / `@SkillRegistry` decorators.

--- a/apps/analytics-tracker/eslint.config.mjs
+++ b/apps/analytics-tracker/eslint.config.mjs
@@ -3,6 +3,6 @@ import base from '@getmunin/eslint-config';
 export default [
   ...base,
   {
-    ignores: ['scripts/**/*.mjs', 'eslint.config.mjs'],
+    ignores: ['eslint.config.mjs'],
   },
 ];

--- a/apps/analytics-tracker/package.json
+++ b/apps/analytics-tracker/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@getmunin/analytics-tracker",
+  "version": "4.33.0",
+  "license": "MIT",
+  "description": "Drop-in browser analytics tracker for self-hosted Munin. Built as a single content-hashed IIFE bundle and served by the Munin backend.",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getmunin/munin.git",
+    "directory": "apps/analytics-tracker"
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch --mode development",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "devDependencies": {
+    "@getmunin/eslint-config": "workspace:*",
+    "@getmunin/tsconfig": "workspace:*",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.10.0",
+    "happy-dom": "^20.9.0",
+    "typescript": "^5.6.0",
+    "typescript-eslint": "^8.5.0",
+    "vite": "^6.4.2",
+    "vitest": "^4.1.0"
+  }
+}

--- a/apps/analytics-tracker/src/tracker.ts
+++ b/apps/analytics-tracker/src/tracker.ts
@@ -1,0 +1,185 @@
+/**
+ * Munin analytics tracker — drop-in browser script.
+ *
+ * Embedded as `<script async src="…/tracker.js" data-key="mn_track_…">`.
+ * Auto-fires a page view on DOMContentLoaded, captures referrer + UTM +
+ * locale, persists a random visitor id in localStorage, and reports
+ * best-effort dwell time on `pagehide`. Optional SPA mode hooks
+ * `history.pushState` / `replaceState` so route changes fire fresh
+ * views.
+ *
+ * Exposes `window.mn.track(subjectId, attrs)` for custom events.
+ */
+
+interface TrackAttrs {
+  subjectType?: string;
+  path?: string;
+  referrer?: string | null;
+  dwellMs?: number;
+  readDepth?: number;
+  utm?: { source?: string; medium?: string; campaign?: string };
+  metadata?: Record<string, unknown>;
+}
+
+interface BeaconPayload {
+  key: string;
+  subjectType: string;
+  subjectId: string;
+  path: string;
+  referrer: string | null;
+  visitorId: string | null;
+  locale: string | undefined;
+  dwellMs?: number;
+  readDepth?: number;
+  utm: { source?: string; medium?: string; campaign?: string };
+  metadata?: Record<string, unknown>;
+}
+
+interface MuninGlobal {
+  track: (subjectId: string, attrs?: TrackAttrs) => void;
+  trackPageView: () => void;
+}
+
+const VISITOR_KEY = 'mn.vid';
+
+(function init(): void {
+  const doc = document;
+  const script = doc.currentScript as HTMLScriptElement | null;
+  if (!script) {
+    console.warn('[munin-tracker] document.currentScript unavailable; tracker disabled');
+    return;
+  }
+  const key = script.getAttribute('data-key');
+  if (!key) {
+    console.warn('[munin-tracker] data-key attribute missing on script tag; tracker disabled');
+    return;
+  }
+
+  let apiBase = script.getAttribute('data-api');
+  if (!apiBase) {
+    try {
+      apiBase = new URL(script.src).origin;
+    } catch (err) {
+      console.warn('[munin-tracker] could not resolve data-api or script.src origin:', err);
+      return;
+    }
+  }
+  apiBase = apiBase.replace(/\/+$/, '');
+
+  const subjectType = script.getAttribute('data-subject-type') || 'page';
+  const spa = script.getAttribute('data-spa') === 'true';
+  const beaconUrl = apiBase + '/v1/a/t';
+
+  let visitorId: string | null = null;
+  try {
+    visitorId = localStorage.getItem(VISITOR_KEY);
+    if (!visitorId) {
+      visitorId =
+        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? crypto.randomUUID()
+          : 'v-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+      localStorage.setItem(VISITOR_KEY, visitorId);
+    }
+  } catch {
+    visitorId = null;
+  }
+
+  const initialReferrer = doc.referrer || null;
+  let pageEnter = Date.now();
+  let lastPath = location.pathname;
+
+  function send(payload: BeaconPayload): void {
+    try {
+      const body = JSON.stringify(payload);
+      if (navigator.sendBeacon) {
+        const blob = new Blob([body], { type: 'application/json' });
+        navigator.sendBeacon(beaconUrl, blob);
+        return;
+      }
+      void fetch(beaconUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+        keepalive: true,
+        mode: 'no-cors',
+      }).catch((err) => {
+        console.warn('[munin-tracker] beacon fetch failed:', err);
+      });
+    } catch (err) {
+      console.warn('[munin-tracker] failed to send beacon:', err);
+    }
+  }
+
+  function readUtm(): { source?: string; medium?: string; campaign?: string } {
+    try {
+      const p = new URLSearchParams(location.search);
+      return {
+        source: p.get('utm_source') || undefined,
+        medium: p.get('utm_medium') || undefined,
+        campaign: p.get('utm_campaign') || undefined,
+      };
+    } catch {
+      return {};
+    }
+  }
+
+  function trackView(subjectId: string, attrs: TrackAttrs = {}): void {
+    send({
+      key: key!,
+      subjectType: attrs.subjectType || subjectType,
+      subjectId,
+      path: attrs.path || location.pathname + location.search,
+      referrer: attrs.referrer !== undefined ? attrs.referrer : initialReferrer,
+      visitorId,
+      locale: doc.documentElement.lang || undefined,
+      dwellMs: attrs.dwellMs,
+      readDepth: attrs.readDepth,
+      utm: attrs.utm || readUtm(),
+      metadata: attrs.metadata,
+    });
+  }
+
+  function trackPageView(): void {
+    trackView(location.pathname);
+  }
+
+  if (doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', trackPageView, { once: true });
+  } else {
+    trackPageView();
+  }
+
+  if (spa) {
+    const origPush = history.pushState.bind(history);
+    const origReplace = history.replaceState.bind(history);
+    function onRouteChange(): void {
+      if (location.pathname === lastPath) return;
+      const dwell = Date.now() - pageEnter;
+      pageEnter = Date.now();
+      lastPath = location.pathname;
+      trackView(location.pathname, { dwellMs: dwell, referrer: null });
+    }
+    history.pushState = function (...args): void {
+      origPush(...args);
+      onRouteChange();
+    };
+    history.replaceState = function (...args): void {
+      origReplace(...args);
+      onRouteChange();
+    };
+    addEventListener('popstate', onRouteChange);
+  }
+
+  addEventListener('pagehide', () => {
+    const dwell = Date.now() - pageEnter;
+    trackView(lastPath, { dwellMs: dwell, referrer: null });
+  });
+
+  const w = window as Window & { mn?: MuninGlobal };
+  const mn: MuninGlobal = w.mn ?? (w.mn = {} as MuninGlobal);
+  mn.track = trackView;
+  mn.trackPageView = trackPageView;
+})();
+
+export {};
+

--- a/apps/analytics-tracker/tsconfig.json
+++ b/apps/analytics-tracker/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@getmunin/tsconfig/base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "outDir": "dist",
+    "noEmit": true,
+    "experimentalDecorators": false,
+    "emitDecoratorMetadata": false
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/apps/analytics-tracker/vite.config.ts
+++ b/apps/analytics-tracker/vite.config.ts
@@ -1,0 +1,87 @@
+import { defineConfig } from 'vite';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, renameSync, readdirSync, unlinkSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+/**
+ * Builds a single IIFE bundle the analytics tracker loads as
+ * `<script src=…>`. Mirrors the chat-widget pipeline.
+ *
+ * Output:
+ *   dist/tracker.<sha>.js       – the bundle, content-hashed for
+ *                                 immutable CDN caching.
+ *   dist/tracker.<sha>.js.map   – source map.
+ *   dist/manifest.json          – { current: "tracker.<sha>.js", sha,
+ *                                 builtAt }; the backend reads this at
+ *                                 boot to wire the unhashed redirect.
+ */
+export default defineConfig(({ mode }) => ({
+  resolve: {
+    conditions: mode === 'development' ? ['development'] : [],
+  },
+  build: {
+    target: 'es2020',
+    cssCodeSplit: false,
+    sourcemap: true,
+    minify: 'esbuild',
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, 'src/tracker.ts'),
+      name: 'MuninAnalyticsTracker',
+      formats: ['iife'],
+      fileName: () => 'tracker.js',
+    },
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: true,
+      },
+    },
+  },
+  plugins: [
+    {
+      name: 'munin-tracker-content-hash',
+      writeBundle(_options, bundle) {
+        const distDir = resolve(__dirname, 'dist');
+        const jsAsset = bundle['tracker.js'];
+        if (!jsAsset || jsAsset.type !== 'chunk') {
+          throw new Error('expected tracker.js chunk in bundle');
+        }
+        const code: string = jsAsset.code;
+        const sha = createHash('sha256').update(code).digest('hex').slice(0, 12);
+
+        const sourceJs = join(distDir, 'tracker.js');
+        const targetJs = join(distDir, `tracker.${sha}.js`);
+        const sourceMap = join(distDir, 'tracker.js.map');
+        const targetMap = join(distDir, `tracker.${sha}.js.map`);
+
+        renameSync(sourceJs, targetJs);
+        try {
+          const patched = readFileSync(targetJs, 'utf8').replace(
+            /\/\/# sourceMappingURL=tracker\.js\.map/,
+            `//# sourceMappingURL=tracker.${sha}.js.map`,
+          );
+          writeFileSync(targetJs, patched);
+          renameSync(sourceMap, targetMap);
+        } catch {
+          // sourcemap may be disabled; ignore
+        }
+
+        const manifest = {
+          current: `tracker.${sha}.js`,
+          sha,
+          builtAt: new Date().toISOString(),
+        };
+        writeFileSync(join(distDir, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+
+        for (const file of readdirSync(distDir)) {
+          if (file === manifest.current) continue;
+          if (file === `${manifest.current}.map`) continue;
+          if (file === 'manifest.json') continue;
+          if (/^tracker\.[a-f0-9]{12}\.js(\.map)?$/.test(file)) {
+            unlinkSync(join(distDir, file));
+          }
+        }
+      },
+    },
+  ],
+}));

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "prebuild": "node scripts/copy-widget.mjs",
+    "prebuild": "node scripts/copy-widget.mjs && node scripts/copy-tracker.mjs",
     "build": "nest build",
     "dev": "node --import @swc-node/register/esm-register --watch --conditions=development src/main.ts",
     "start": "node dist/main.js",
@@ -18,6 +18,7 @@
   "dependencies": {
     "@better-auth/oauth-provider": "^1.6.10",
     "@getmunin/agent-host": "workspace:*",
+    "@getmunin/analytics-tracker": "workspace:*",
     "@getmunin/backend-core": "workspace:*",
     "@getmunin/chat-widget": "workspace:*",
     "@getmunin/core": "workspace:*",

--- a/apps/backend/scripts/copy-tracker.mjs
+++ b/apps/backend/scripts/copy-tracker.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Build-time copy of @getmunin/analytics-tracker's hashed bundle into the
+ * backend's public/tracker/ directory. Runs as `prebuild` so the bundle
+ * is in place before nest build packages dist/.
+ *
+ * Reads `node_modules/@getmunin/analytics-tracker/dist/manifest.json` for
+ * the current hash, copies:
+ *   tracker.<sha>.js      — content-hashed bundle
+ *   tracker.<sha>.js.map  — sourcemap (best-effort; no error if absent)
+ *   manifest.json         — { current, sha, builtAt }
+ *
+ * Older hashed bundles in the destination are left in place so in-flight
+ * clients holding a stale `<sha>` URL can still resolve it for a while.
+ *
+ * Exit codes:
+ *   0  – copied successfully (or no change needed).
+ *   1  – source manifest / bundle missing — fail the build, don't ship a
+ *        backend without a tracker asset.
+ */
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const BACKEND_ROOT = resolve(SCRIPT_DIR, '..');
+const SRC_DIR = resolve(
+  BACKEND_ROOT,
+  'node_modules',
+  '@getmunin',
+  'analytics-tracker',
+  'dist',
+);
+const DEST_DIR = resolve(BACKEND_ROOT, 'public', 'tracker');
+
+main();
+
+function main() {
+  if (!existsSync(SRC_DIR)) {
+    console.error(`[copy-tracker] missing source dir: ${SRC_DIR}`);
+    console.error(
+      `[copy-tracker] run \`pnpm --filter @getmunin/analytics-tracker build\` first or rely on the workspace ^build chain.`,
+    );
+    process.exit(1);
+  }
+
+  const manifestPath = join(SRC_DIR, 'manifest.json');
+  if (!existsSync(manifestPath)) {
+    console.error(`[copy-tracker] missing manifest.json at ${manifestPath}`);
+    process.exit(1);
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (!manifest || typeof manifest !== 'object' || typeof manifest.current !== 'string') {
+    console.error(`[copy-tracker] manifest.json missing "current" field`);
+    process.exit(1);
+  }
+
+  if (!/^tracker\.[a-f0-9]{12}\.js$/.test(manifest.current)) {
+    console.error(
+      `[copy-tracker] manifest.current does not match expected pattern: ${manifest.current}`,
+    );
+    process.exit(1);
+  }
+
+  const bundlePath = join(SRC_DIR, manifest.current);
+  if (!existsSync(bundlePath)) {
+    console.error(`[copy-tracker] bundle missing: ${bundlePath}`);
+    process.exit(1);
+  }
+
+  mkdirSync(DEST_DIR, { recursive: true });
+
+  copyFileSync(bundlePath, join(DEST_DIR, manifest.current));
+
+  const mapPath = `${bundlePath}.map`;
+  if (existsSync(mapPath)) {
+    copyFileSync(mapPath, join(DEST_DIR, `${manifest.current}.map`));
+  }
+
+  writeFileSync(join(DEST_DIR, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+
+  console.log(`[copy-tracker] copied ${manifest.current} → ${DEST_DIR}`);
+}

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -1398,6 +1398,45 @@
         "security": []
       }
     },
+    "/v1/a/t/{key}.gif": {
+      "get": {
+        "operationId": "AnalyticsTrackerController_trackerPixel",
+        "parameters": [
+          {
+            "name": "key",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AnalyticsTracker"
+        ],
+        "security": []
+      }
+    },
+    "/v1/a/t": {
+      "post": {
+        "operationId": "AnalyticsTrackerController_trackerBeacon",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AnalyticsTracker"
+        ],
+        "security": []
+      }
+    },
     "/v1/orgs/me/invitations": {
       "post": {
         "operationId": "InvitationsController_create",

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -1034,6 +1034,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "visitor_id",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1090,6 +1098,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "tracking",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1133,6 +1149,14 @@
           },
           {
             "name": "locale",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tracking",
             "required": true,
             "in": "query",
             "schema": {
@@ -1333,6 +1357,45 @@
             "session": []
           }
         ]
+      }
+    },
+    "/v1/a/v/{token}.gif": {
+      "get": {
+        "operationId": "AnalyticsViewsController_pixel",
+        "parameters": [
+          {
+            "name": "token",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AnalyticsViews"
+        ],
+        "security": []
+      }
+    },
+    "/v1/a/v": {
+      "post": {
+        "operationId": "AnalyticsViewsController_beacon",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AnalyticsViews"
+        ],
+        "security": []
       }
     },
     "/v1/orgs/me/invitations": {

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -15,11 +15,12 @@ const JSON_BODY_LIMIT = '4mb';
 const DEFAULT_DEV_WEB_ORIGINS = ['http://localhost:3000', 'http://127.0.0.1:3000'];
 
 /**
- * Hashed widget bundles match `widget.<12-hex-sha>.js[.map]?`. Anything
- * else hitting `/widget/...` is rejected with 404 — no path traversal
- * surface, no accidental directory listing.
+ * Hashed widget / tracker bundles match `<name>.<12-hex-sha>.js[.map]?`.
+ * Anything else hitting `/widget/...` or `/tracker/...` is rejected with
+ * 404 — no path traversal surface, no accidental directory listing.
  */
 const HASHED_WIDGET_FILE_RE = /^widget\.[a-f0-9]{12}\.js(\.map)?$/;
+const HASHED_TRACKER_FILE_RE = /^tracker\.[a-f0-9]{12}\.js(\.map)?$/;
 
 export function readAllowedOrigins(): string[] | true {
   const env = process.env.MUNIN_CORS_ORIGINS;
@@ -55,6 +56,14 @@ export interface CreateAppOptions extends NestApplicationOptions {
    */
   widgetAssetDir?: string;
   /**
+   * Absolute path to the directory holding the analytics-tracker's hashed
+   * bundle + manifest.json. Defaults to `<cwd>/public/tracker` which
+   * matches `apps/backend/public/tracker/` after the prebuild copy step.
+   * Same shape as `widgetAssetDir`. Missing manifest → 503 on
+   * `/tracker.js`, rest of API still boots.
+   */
+  trackerAssetDir?: string;
+  /**
    * Absolute path to the directory holding the MCP host's brand icons —
    * `favicon.ico`, `icon.png`, `apple-icon.png`. Served at the root paths
    * `/favicon.ico`, `/icon.png`, `/apple-icon.png` with a long cache.
@@ -73,6 +82,8 @@ export interface CreateAppOptions extends NestApplicationOptions {
  *     `publicUrlFor()`.
  *   - Chat-widget bundle: `/widget/<sha>.js` (immutable, year-long cache)
  *     and `/widget.js` (302 redirect to the current sha, short cache).
+ *   - Analytics-tracker bundle: same shape at `/tracker/<sha>.js` and
+ *     `/tracker.js`.
  *
  * The caller supplies their AppModule (single-tenant for OSS, multi-tenant
  * for cloud). Both editions go through this factory so tests, prod, and
@@ -82,7 +93,7 @@ export async function createApp(
   appModule: Type<unknown>,
   opts: CreateAppOptions = {},
 ): Promise<INestApplication> {
-  const { widgetAssetDir, iconAssetDir, ...nestOpts } = opts;
+  const { widgetAssetDir, trackerAssetDir, iconAssetDir, ...nestOpts } = opts;
   const app = await NestFactory.create<NestExpressApplication>(appModule, {
     rawBody: true,
     ...nestOpts,
@@ -108,8 +119,12 @@ export async function createApp(
   }
 
   const resolvedWidgetDir = resolve(widgetAssetDir ?? join(process.cwd(), 'public', 'widget'));
-  app.use('/widget.js', widgetRedirectMiddleware(resolvedWidgetDir));
-  app.use('/widget', widgetBundleMiddleware(resolvedWidgetDir));
+  app.use('/widget.js', hashedBundleRedirectMiddleware(resolvedWidgetDir, HASHED_WIDGET_FILE_RE, '/widget'));
+  app.use('/widget', hashedBundleServeMiddleware(resolvedWidgetDir, HASHED_WIDGET_FILE_RE));
+
+  const resolvedTrackerDir = resolve(trackerAssetDir ?? join(process.cwd(), 'public', 'tracker'));
+  app.use('/tracker.js', hashedBundleRedirectMiddleware(resolvedTrackerDir, HASHED_TRACKER_FILE_RE, '/tracker'));
+  app.use('/tracker', hashedBundleServeMiddleware(resolvedTrackerDir, HASHED_TRACKER_FILE_RE));
 
   const resolvedIconDir = resolve(iconAssetDir ?? join(process.cwd(), 'public', 'icons'));
   app.use(brandIconMiddleware(resolvedIconDir));
@@ -122,6 +137,9 @@ export function isPublicCorsPath(path: string): boolean {
     path === '/widget.js' ||
     path.startsWith('/widget/') ||
     path.startsWith('/v1/widget') ||
+    path === '/tracker.js' ||
+    path.startsWith('/tracker/') ||
+    path.startsWith('/v1/a/') ||
     path === '/mcp' ||
     path.startsWith('/mcp/') ||
     path.startsWith('/.well-known/oauth-') ||
@@ -313,17 +331,20 @@ function staticAssetsMiddleware(storage: LocalFsStorage) {
  * a server restart. Returns `null` if the manifest is missing or
  * malformed — the route handlers translate that to a 503.
  */
-function manifestReader(widgetDir: string): () => Promise<{ current: string } | null> {
+function manifestReader(
+  bundleDir: string,
+  hashedFileRe: RegExp,
+): () => Promise<{ current: string } | null> {
   let cached: { current: string } | null = null;
   let cachedMtime = -1;
   return async () => {
-    const path = join(widgetDir, 'manifest.json');
+    const path = join(bundleDir, 'manifest.json');
     try {
       const info = await stat(path);
       if (info.mtimeMs !== cachedMtime) {
         const raw = await readFile(path, 'utf8');
         const parsed = JSON.parse(raw) as { current?: unknown };
-        if (typeof parsed.current === 'string' && HASHED_WIDGET_FILE_RE.test(parsed.current)) {
+        if (typeof parsed.current === 'string' && hashedFileRe.test(parsed.current)) {
           cached = { current: parsed.current };
           cachedMtime = info.mtimeMs;
         } else {
@@ -339,8 +360,12 @@ function manifestReader(widgetDir: string): () => Promise<{ current: string } | 
   };
 }
 
-function widgetRedirectMiddleware(widgetDir: string) {
-  const readManifest = manifestReader(widgetDir);
+function hashedBundleRedirectMiddleware(
+  bundleDir: string,
+  hashedFileRe: RegExp,
+  redirectBase: string,
+) {
+  const readManifest = manifestReader(bundleDir, hashedFileRe);
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       next();
@@ -354,23 +379,23 @@ function widgetRedirectMiddleware(widgetDir: string) {
     }
     res.setHeader('access-control-allow-origin', '*');
     res.setHeader('cache-control', 'public, max-age=300, must-revalidate');
-    res.redirect(302, `/widget/${manifest.current}`);
+    res.redirect(302, `${redirectBase}/${manifest.current}`);
   };
 }
 
-function widgetBundleMiddleware(widgetDir: string) {
+function hashedBundleServeMiddleware(bundleDir: string, hashedFileRe: RegExp) {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       next();
       return;
     }
     const file = req.path.replace(/^\/+/, '');
-    if (!HASHED_WIDGET_FILE_RE.test(file)) {
+    if (!hashedFileRe.test(file)) {
       res.status(404).end();
       return;
     }
-    const filePath = resolve(join(widgetDir, file));
-    if (!filePath.startsWith(resolve(widgetDir))) {
+    const filePath = resolve(join(bundleDir, file));
+    if (!filePath.startsWith(resolve(bundleDir))) {
       res.status(404).end();
       return;
     }

--- a/packages/backend-core/src/control/analytics-tracker.controller.ts
+++ b/packages/backend-core/src/control/analytics-tracker.controller.ts
@@ -1,0 +1,199 @@
+import {
+  Body,
+  Get,
+  HttpCode,
+  Headers,
+  Inject,
+  Param,
+  Post,
+  Query,
+  Res,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { and, eq, isNull } from 'drizzle-orm';
+import { schema, type Db } from '@getmunin/db';
+import { hashSecret, isWellFormedKey, keyPrefix, looksLikeBot } from '@getmunin/core';
+import { PublicController } from '../common/auth/auth.guard.ts';
+import { DB } from '../common/db/db.module.ts';
+import { AnalyticsService } from '../modules/analytics/analytics.service.ts';
+
+const TRANSPARENT_GIF = Buffer.from(
+  'R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+  'base64',
+);
+
+const DEFAULT_SUBJECT_TYPE = 'page';
+
+interface TrackerBeaconBody {
+  key?: string;
+  subjectType?: string;
+  subjectId?: string;
+  path?: string;
+  referrer?: string;
+  visitorId?: string;
+  locale?: string;
+  dwellMs?: number;
+  readDepth?: number;
+  utm?: {
+    source?: string;
+    medium?: string;
+    campaign?: string;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+interface ResolvedTracker {
+  trackerId: string;
+  orgId: string;
+  apiKeyId: string;
+  allowedOrigins: string[];
+}
+
+@PublicController('v1/a', { throttle: true })
+export class AnalyticsTrackerController {
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
+  ) {}
+
+  @Get('t/:key.gif')
+  async trackerPixel(
+    @Param('key') key: string,
+    @Headers('user-agent') userAgent: string | undefined,
+    @Headers('referer') referer: string | undefined,
+    @Headers('origin') origin: string | undefined,
+    @Query('s') subjectId: string | undefined,
+    @Query('t') subjectType: string | undefined,
+    @Query('v') visitorId: string | undefined,
+    @Res() res: Response,
+  ): Promise<void> {
+    sendPixel(res);
+    if (looksLikeBot(userAgent)) return;
+    if (!subjectId) return;
+    const tracker = await this.resolveTrackerKey(key);
+    if (!tracker) return;
+    if (!originIsAllowed(tracker.allowedOrigins, origin)) return;
+
+    await this.analytics.recordView({
+      orgId: tracker.orgId,
+      subjectType: subjectType || DEFAULT_SUBJECT_TYPE,
+      subjectId,
+      source: 'tracker',
+      referrer: referer ?? null,
+      visitorId: visitorId ?? null,
+      userAgentClass: 'browser',
+    });
+  }
+
+  @Post('t')
+  @HttpCode(204)
+  async trackerBeacon(
+    @Body() body: TrackerBeaconBody,
+    @Headers('user-agent') userAgent: string | undefined,
+    @Headers('referer') referer: string | undefined,
+    @Headers('origin') origin: string | undefined,
+  ): Promise<void> {
+    if (looksLikeBot(userAgent)) return;
+    if (!body || typeof body.key !== 'string' || typeof body.subjectId !== 'string') return;
+    const tracker = await this.resolveTrackerKey(body.key);
+    if (!tracker) return;
+    if (!originIsAllowed(tracker.allowedOrigins, origin)) return;
+
+    await this.analytics.recordView({
+      orgId: tracker.orgId,
+      subjectType: body.subjectType || DEFAULT_SUBJECT_TYPE,
+      subjectId: body.subjectId,
+      source: 'tracker',
+      path: body.path ?? null,
+      locale: body.locale ?? null,
+      referrer: body.referrer ?? referer ?? null,
+      visitorId: body.visitorId ?? null,
+      dwellMs: typeof body.dwellMs === 'number' ? body.dwellMs : null,
+      readDepth: typeof body.readDepth === 'number' ? body.readDepth : null,
+      utmSource: body.utm?.source ?? null,
+      utmMedium: body.utm?.medium ?? null,
+      utmCampaign: body.utm?.campaign ?? null,
+      userAgentClass: 'tracker',
+      metadata: body.metadata ?? null,
+    });
+  }
+
+  private async resolveTrackerKey(rawKey: string): Promise<ResolvedTracker | null> {
+    if (!rawKey || !isWellFormedKey(rawKey) || !rawKey.startsWith('mn_track_')) return null;
+    try {
+      const rows = await this.db
+        .select({
+          apiKeyId: schema.apiKeys.id,
+          orgId: schema.apiKeys.orgId,
+          trackerId: schema.analyticsTrackers.id,
+          allowedOrigins: schema.analyticsTrackers.allowedOrigins,
+        })
+        .from(schema.apiKeys)
+        .innerJoin(
+          schema.analyticsTrackers,
+          eq(schema.apiKeys.trackerId, schema.analyticsTrackers.id),
+        )
+        .where(
+          and(
+            eq(schema.apiKeys.keyPrefix, keyPrefix(rawKey)),
+            eq(schema.apiKeys.keyHash, hashSecret(rawKey)),
+            eq(schema.apiKeys.type, 'track'),
+            isNull(schema.apiKeys.revokedAt),
+          ),
+        )
+        .limit(1);
+      const row = rows[0];
+      if (!row || !row.orgId) return null;
+      void this.db
+        .update(schema.apiKeys)
+        .set({ lastUsedAt: new Date() })
+        .where(eq(schema.apiKeys.id, row.apiKeyId))
+        .then(undefined, () => undefined);
+      return {
+        trackerId: row.trackerId,
+        orgId: row.orgId,
+        apiKeyId: row.apiKeyId,
+        allowedOrigins: row.allowedOrigins,
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function originIsAllowed(
+  allowedOrigins: readonly string[],
+  origin: string | undefined,
+): boolean {
+  const list = allowedOrigins ?? [];
+  if (list.length === 0) {
+    return !requireTrackerAllowlist();
+  }
+  if (!origin) return false;
+  let viewerOrigin: string;
+  try {
+    viewerOrigin = new URL(origin).origin;
+  } catch {
+    return false;
+  }
+  return list.some((entry) => {
+    try {
+      return new URL(entry).origin === viewerOrigin;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function requireTrackerAllowlist(): boolean {
+  const raw = process.env.MUNIN_TRACKER_REQUIRE_ALLOWLIST?.trim().toLowerCase();
+  return raw === '1' || raw === 'true';
+}
+
+function sendPixel(res: Response): void {
+  res.setHeader('Content-Type', 'image/gif');
+  res.setHeader('Content-Length', String(TRANSPARENT_GIF.length));
+  res.setHeader('Cache-Control', 'no-store, private, max-age=0');
+  res.setHeader('Pragma', 'no-cache');
+  res.status(200).end(TRANSPARENT_GIF);
+}

--- a/packages/backend-core/src/control/analytics-views.controller.ts
+++ b/packages/backend-core/src/control/analytics-views.controller.ts
@@ -1,0 +1,114 @@
+import {
+  Body,
+  Get,
+  HttpCode,
+  Headers,
+  Inject,
+  Param,
+  Post,
+  Res,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { ViewTokenError, looksLikeBot, verifyViewToken } from '@getmunin/core';
+import { PublicController } from '../common/auth/auth.guard.ts';
+import { AnalyticsService } from '../modules/analytics/analytics.service.ts';
+
+const TRANSPARENT_GIF = Buffer.from(
+  'R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+  'base64',
+);
+
+interface BeaconBody {
+  token?: string;
+  path?: string;
+  referrer?: string;
+  visitorId?: string;
+  locale?: string;
+  dwellMs?: number;
+  readDepth?: number;
+  utm?: {
+    source?: string;
+    medium?: string;
+    campaign?: string;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+@PublicController('v1/a/v', { throttle: true })
+export class AnalyticsViewsController {
+  constructor(@Inject(AnalyticsService) private readonly analytics: AnalyticsService) {}
+
+  @Get(':token.gif')
+  async pixel(
+    @Param('token') token: string,
+    @Headers('user-agent') userAgent: string | undefined,
+    @Headers('referer') referer: string | undefined,
+    @Res() res: Response,
+  ): Promise<void> {
+    sendPixel(res);
+    if (looksLikeBot(userAgent)) return;
+    if (!token) return;
+
+    let payload;
+    try {
+      payload = verifyViewToken(token);
+    } catch (err) {
+      if (err instanceof ViewTokenError) return;
+      throw err;
+    }
+
+    await this.analytics.recordView({
+      orgId: payload.orgId,
+      subjectType: payload.subjectType,
+      subjectId: payload.subjectId,
+      source: 'pixel',
+      referrer: referer ?? null,
+      userAgentClass: 'browser',
+    });
+  }
+
+  @Post()
+  @HttpCode(204)
+  async beacon(
+    @Body() body: BeaconBody,
+    @Headers('user-agent') userAgent: string | undefined,
+    @Headers('referer') referer: string | undefined,
+  ): Promise<void> {
+    if (looksLikeBot(userAgent)) return;
+    if (!body || typeof body.token !== 'string') return;
+
+    let payload;
+    try {
+      payload = verifyViewToken(body.token);
+    } catch (err) {
+      if (err instanceof ViewTokenError) return;
+      throw err;
+    }
+
+    await this.analytics.recordView({
+      orgId: payload.orgId,
+      subjectType: payload.subjectType,
+      subjectId: payload.subjectId,
+      source: 'beacon',
+      path: body.path ?? null,
+      locale: body.locale ?? null,
+      referrer: body.referrer ?? referer ?? null,
+      visitorId: body.visitorId ?? null,
+      dwellMs: typeof body.dwellMs === 'number' ? body.dwellMs : null,
+      readDepth: typeof body.readDepth === 'number' ? body.readDepth : null,
+      utmSource: body.utm?.source ?? null,
+      utmMedium: body.utm?.medium ?? null,
+      utmCampaign: body.utm?.campaign ?? null,
+      userAgentClass: 'sdk',
+      metadata: body.metadata ?? null,
+    });
+  }
+}
+
+function sendPixel(res: Response): void {
+  res.setHeader('Content-Type', 'image/gif');
+  res.setHeader('Content-Length', String(TRANSPARENT_GIF.length));
+  res.setHeader('Cache-Control', 'no-store, private, max-age=0');
+  res.setHeader('Pragma', 'no-cache');
+  res.status(200).end(TRANSPARENT_GIF);
+}

--- a/packages/backend-core/src/control/cms-delivery.controller.ts
+++ b/packages/backend-core/src/control/cms-delivery.controller.ts
@@ -11,9 +11,11 @@ import {
 import type { Request, Response } from 'express';
 import { schema, type Db } from '@getmunin/db';
 import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
+import { readApiBaseUrl, signViewToken } from '@getmunin/core';
 import { PublicController } from '../common/auth/auth.guard.ts';
 import { DB } from '../common/db/db.module.ts';
 import { CmsSearchService } from '../modules/cms/cms.search.ts';
+import { AnalyticsService } from '../modules/analytics/analytics.service.ts';
 import {
   applyAssetExpansion,
   collectAssetIds,
@@ -39,6 +41,7 @@ export class CmsDeliveryController {
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(CmsSearchService) private readonly search: CmsSearchService,
+    @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
   ) {}
 
   @Get(':orgId/collections')
@@ -67,10 +70,11 @@ export class CmsDeliveryController {
     @Query('collection') collection?: string,
     @Query('locale') locale?: string,
     @Query('limit') limit?: string,
+    @Query('visitor_id') visitorId?: string,
   ) {
     if (!q || !q.trim()) return [];
     const org = await this.resolveOrg(orgId);
-    return this.search.search(
+    const hits = await this.search.search(
       {
         query: q,
         collection,
@@ -80,6 +84,15 @@ export class CmsDeliveryController {
       },
       { orgId: org.id },
     );
+    void this.analytics.recordSearch({
+      orgId: org.id,
+      subjectType: 'cms',
+      query: q,
+      resultCount: hits.length,
+      locale,
+      visitorId,
+    });
+    return hits;
   }
 
   @Get(':orgId/:collectionSlug')
@@ -91,6 +104,7 @@ export class CmsDeliveryController {
     @Query('locale') locale?: string,
     @Query('limit') limit?: string,
     @Query('before') before?: string,
+    @Query('tracking') tracking?: string,
   ) {
     const { org, collection } = await this.resolveOrgCollection(orgId, collectionSlug);
     const filters: SQL[] = [
@@ -112,7 +126,9 @@ export class CmsDeliveryController {
       .limit(take);
 
     const fields = collection.fields as FieldDef[];
+    const trackingOn = trackingEnabled(tracking);
     const projected = rows.map((r) => ({
+      id: r.id,
       slug: r.slug,
       locale: r.locale,
       data: projectData(fields, r.data),
@@ -121,9 +137,10 @@ export class CmsDeliveryController {
       updatedAt: r.updatedAt.toISOString(),
     }));
     const assets = await this.fetchAssets(org.id, fields, projected.map((p) => p.data));
-    const items = projected.map((p) => ({
+    const items = projected.map(({ id, ...p }) => ({
       ...p,
       data: applyAssetExpansion(fields, p.data, assets),
+      ...(trackingOn ? { _tracking: buildTracking(org.id, id) } : {}),
     }));
 
     const etag = computeEtag(rows.map((r) => r.updatedAt.getTime()));
@@ -140,6 +157,7 @@ export class CmsDeliveryController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
     @Query('locale') locale?: string,
+    @Query('tracking') tracking?: string,
   ) {
     const { org, collection } = await this.resolveOrgCollection(orgId, collectionSlug);
     const filters: SQL[] = [
@@ -172,6 +190,7 @@ export class CmsDeliveryController {
       version: row.version,
       publishedAt: row.publishedAt?.toISOString() ?? null,
       updatedAt: row.updatedAt.toISOString(),
+      ...(trackingEnabled(tracking) ? { _tracking: buildTracking(org.id, row.id) } : {}),
     };
   }
 
@@ -242,5 +261,27 @@ function handleEtag(req: Request, res: Response, etag: string): boolean {
 
 function setCdnHeaders(res: Response): void {
   res.setHeader('cache-control', 'public, max-age=60, stale-while-revalidate=600');
+}
+
+function trackingEnabled(flag: string | undefined): boolean {
+  if (!process.env.MUNIN_KEY_PEPPER) return false;
+  if (flag === '0' || flag === 'false' || flag === 'off') return false;
+  return true;
+}
+
+function buildTracking(
+  orgId: string,
+  entryId: string,
+): { pixelUrl: string; beaconUrl: string } | undefined {
+  try {
+    const token = signViewToken({ orgId, subjectType: 'cms_entry', subjectId: entryId });
+    const base = readApiBaseUrl();
+    return {
+      pixelUrl: `${base}/v1/a/v/${token}.gif`,
+      beaconUrl: `${base}/v1/a/v`,
+    };
+  } catch {
+    return undefined;
+  }
 }
 

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -176,6 +176,15 @@ interface OrgFixture {
 
     it('widget key cannot mint admin API keys', async () => {
       const widgetKey = buildApiKey('widget');
+      const [channel] = await db
+        .insert(schema.convChannels)
+        .values({
+          orgId: orgA.id,
+          type: 'chat',
+          vendor: 'munin',
+          name: 'cp-widget-escalation-channel',
+        })
+        .returning();
       await db.insert(schema.apiKeys).values({
         orgId: orgA.id,
         type: 'widget',
@@ -183,6 +192,7 @@ interface OrgFixture {
         keyHash: hashSecret(widgetKey),
         keyPrefix: keyPrefix(widgetKey),
         scopes: ['conv:widget:write'],
+        channelId: channel!.id,
       });
 
       const create = await fetch(`${baseUrl}/v1/api-keys`, {
@@ -226,6 +236,15 @@ interface OrgFixture {
   describe('control-plane guard on other admin routes', () => {
     it('widget key cannot list channels or enqueue curator jobs', async () => {
       const widgetKey = buildApiKey('widget');
+      const [channel] = await db
+        .insert(schema.convChannels)
+        .values({
+          orgId: orgA.id,
+          type: 'chat',
+          vendor: 'munin',
+          name: 'cp-widget-cross-route-channel',
+        })
+        .returning();
       await db.insert(schema.apiKeys).values({
         orgId: orgA.id,
         type: 'widget',
@@ -233,6 +252,7 @@ interface OrgFixture {
         keyHash: hashSecret(widgetKey),
         keyPrefix: keyPrefix(widgetKey),
         scopes: ['conv:widget:write'],
+        channelId: channel!.id,
       });
       const channels = await fetch(`${baseUrl}/v1/conversations/channels`, {
         headers: authHeaders(widgetKey),

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -14,6 +14,7 @@ import { WebhooksController } from './webhooks.controller.ts';
 import { CmsDeliveryController } from './cms-delivery.controller.ts';
 import { CmsDraftsController } from './cms-drafts.controller.ts';
 import { AnalyticsViewsController } from './analytics-views.controller.ts';
+import { AnalyticsTrackerController } from './analytics-tracker.controller.ts';
 import { AnalyticsModule } from '../modules/analytics/analytics.module.ts';
 import { CmsModule } from '../modules/cms/cms.module.ts';
 import { ConvModule } from '../modules/conv/conv.module.ts';
@@ -83,6 +84,7 @@ import { AuthProvidersController } from './auth-providers.controller.ts';
     CmsDeliveryController,
     CmsDraftsController,
     AnalyticsViewsController,
+    AnalyticsTrackerController,
     InvitationsController,
     AcceptInvitationController,
     MembersController,

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -13,6 +13,8 @@ import { ExportController } from './export.controller.ts';
 import { WebhooksController } from './webhooks.controller.ts';
 import { CmsDeliveryController } from './cms-delivery.controller.ts';
 import { CmsDraftsController } from './cms-drafts.controller.ts';
+import { AnalyticsViewsController } from './analytics-views.controller.ts';
+import { AnalyticsModule } from '../modules/analytics/analytics.module.ts';
 import { CmsModule } from '../modules/cms/cms.module.ts';
 import { ConvModule } from '../modules/conv/conv.module.ts';
 import { CrmModule } from '../modules/crm/crm.module.ts';
@@ -54,6 +56,7 @@ import { AuthProvidersController } from './auth-providers.controller.ts';
  */
 @Module({
   imports: [
+    AnalyticsModule,
     CmsModule,
     ConvModule,
     CrmModule,
@@ -79,6 +82,7 @@ import { AuthProvidersController } from './auth-providers.controller.ts';
     WebhooksController,
     CmsDeliveryController,
     CmsDraftsController,
+    AnalyticsViewsController,
     InvitationsController,
     AcceptInvitationController,
     MembersController,

--- a/packages/backend-core/src/control/email-opens.controller.ts
+++ b/packages/backend-core/src/control/email-opens.controller.ts
@@ -6,6 +6,7 @@ import {
   ActorIdentity,
   EmailOpenTokenError,
   WebhookDispatcher,
+  looksLikeBot,
   verifyEmailOpenToken,
   withContext,
   type RequestContext,
@@ -18,8 +19,6 @@ const TRANSPARENT_GIF = Buffer.from(
   'R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
   'base64',
 );
-
-const BOT_UA = /\b(bot|crawler|spider|preview|linkcheck|monitor)\b/i;
 
 @Controller('v1/c/o')
 export class EmailOpensController {
@@ -37,7 +36,7 @@ export class EmailOpensController {
   ): Promise<void> {
     sendPixel(res);
     if (!token) return;
-    if (userAgent && BOT_UA.test(userAgent)) return;
+    if (looksLikeBot(userAgent)) return;
 
     let payload;
     try {

--- a/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
+++ b/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
@@ -34,6 +34,7 @@ function buildInstructions(adminSkills: ReadonlyArray<{ uri: string; name: strin
     '  • Conversations (conv_*)       — channels, messages, assignments',
     '  • CRM (crm_*)                  — contacts, companies, deals, activities',
     '  • CMS (cms_*)                  — collections, entries, assets, locales',
+    '  • Analytics (analytics_*)      — tracker keys, page-view + search events',
     '  • Org & access                 — api_keys, end_users, invitations, members, memberships',
     '',
     'Multi-step workflows have detailed skills. Call `resources/list` to discover',

--- a/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
+++ b/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
@@ -22,6 +22,7 @@ const EXPECTED_BY_MODULE: Record<string, RegExp> = {
   crm: /^crm_/,
   cms: /^cms_/,
   outreach: /^outreach_/,
+  analytics: /^analytics_/,
   system: /^system_/,
   webhooks: /^webhooks_/,
 };
@@ -32,6 +33,7 @@ const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
   crm: 25,
   cms: 20,
   outreach: 7,
+  analytics: 6,
   system: 4,
   webhooks: 7,
 };
@@ -111,6 +113,7 @@ const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
         crm: 'CRM:',
         cms: 'CMS:',
         outreach: 'Outreach:',
+        analytics: 'Analytics:',
         system: 'System ',
         webhooks: 'Webhooks:',
       };

--- a/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
+++ b/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
@@ -1,0 +1,289 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { createApp } from '../../bootstrap-app.ts';
+import { AppModule } from '../../app.module.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run analytics tracker tests.';
+
+(skipReason ? describe.skip : describe)('Analytics tracker integration: public-key ingest', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let adminKey: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED = '1';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Analytics IT Org' })
+      .returning();
+    orgId = org!.id;
+
+    adminKey = buildApiKey('admin');
+    await db.insert(schema.apiKeys).values({
+      orgId,
+      type: 'admin',
+      name: 'analytics-it-admin',
+      keyHash: hashSecret(adminKey),
+      keyPrefix: keyPrefix(adminKey),
+      scopes: ['*'],
+    });
+
+    app = await createApp(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  async function withClient<T>(token: string, fn: (c: Client) => Promise<T>): Promise<T> {
+    const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+      requestInit: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const c = new Client({ name: 'munin-it', version: '0.0.0' });
+    await c.connect(transport);
+    try {
+      return await fn(c);
+    } finally {
+      await transport.close();
+      await c.close();
+    }
+  }
+
+  it('mint tracker → tracker.js served → pixel + beacon record rows; bot/invalid key dropped', async () => {
+    const minted = await withClient(adminKey, async (c) => {
+      return parseToolResult<{ id: string; trackerKey: string; keyPrefix: string }>(
+        await c.callTool({
+          name: 'analytics_create_tracker',
+          arguments: { name: 'getmunin.com landing' },
+        }),
+      );
+    });
+    expect(minted.trackerKey).toMatch(/^mn_track_[A-Za-z0-9_-]+$/);
+
+    // The `/tracker.js` route is wired by bootstrap-app.ts (mirroring
+    // `/widget.js`) and reads `public/tracker/manifest.json`. In tests
+    // we don't run the prebuild copy, so it 503s — that's exercised by
+    // the bootstrap-app middleware unit tests instead.
+
+    const beforePixel = await countTrackerEvents(db, orgId);
+    const pixel = await fetch(
+      `${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=pricing&t=page&v=visitor-1`,
+    );
+    expect(pixel.status).toBe(200);
+    expect(pixel.headers.get('content-type')).toBe('image/gif');
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > beforePixel);
+
+    const pixelBot = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=pricing`, {
+      headers: { 'user-agent': 'Googlebot/2.1' },
+    });
+    expect(pixelBot.status).toBe(200);
+    expect(await countTrackerEvents(db, orgId)).toBe(beforePixel + 1);
+
+    const beforeBeacon = await countTrackerEvents(db, orgId);
+    const beacon = await fetch(`${baseUrl}/v1/a/t`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        key: minted.trackerKey,
+        subjectType: 'page',
+        subjectId: 'pricing',
+        path: '/pricing',
+        referrer: 'https://google.com',
+        visitorId: 'visitor-2',
+        dwellMs: 8000,
+        readDepth: 60,
+        utm: { source: 'reddit', medium: 'social', campaign: 'launch' },
+        metadata: { variant: 'b' },
+      }),
+    });
+    expect(beacon.status).toBe(204);
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > beforeBeacon);
+    const beaconRow = await db
+      .select()
+      .from(schema.analyticsViewEvents)
+      .where(sql`org_id = ${orgId} AND source = 'tracker' AND visitor_id = 'visitor-2'`)
+      .limit(1);
+    expect(beaconRow[0]?.dwellMs).toBe(8000);
+    expect(beaconRow[0]?.readDepth).toBe(60);
+    expect(beaconRow[0]?.utmSource).toBe('reddit');
+    expect(beaconRow[0]?.subjectType).toBe('page');
+    expect(beaconRow[0]?.metadata).toMatchObject({ variant: 'b' });
+
+    const badKey = 'mn_track_invalid_xxx';
+    const beforeBad = await countTrackerEvents(db, orgId);
+    const bad = await fetch(`${baseUrl}/v1/a/t/${badKey}.gif?s=pricing`);
+    expect(bad.status).toBe(200);
+    expect(await countTrackerEvents(db, orgId)).toBe(beforeBad);
+  }, 30_000);
+
+  it('revoked tracker key stops recording', async () => {
+    const minted = await withClient(adminKey, async (c) => {
+      return parseToolResult<{ id: string; trackerKey: string }>(
+        await c.callTool({
+          name: 'analytics_create_tracker',
+          arguments: { name: 'short-lived' },
+        }),
+      );
+    });
+    const before = await countTrackerEvents(db, orgId);
+    await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`);
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > before);
+
+    await withClient(adminKey, async (c) => {
+      const res = parseToolResult<{ revoked: boolean }>(
+        await c.callTool({
+          name: 'analytics_revoke_tracker',
+          arguments: { trackerId: minted.id },
+        }),
+      );
+      expect(res.revoked).toBe(true);
+    });
+
+    const afterRevoke = await countTrackerEvents(db, orgId);
+    await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await countTrackerEvents(db, orgId)).toBe(afterRevoke);
+  }, 30_000);
+
+  it('origin allowlist gates pixel + beacon', async () => {
+    const minted = await withClient(adminKey, async (c) => {
+      return parseToolResult<{ id: string; trackerKey: string; allowedOrigins: string[] }>(
+        await c.callTool({
+          name: 'analytics_create_tracker',
+          arguments: {
+            name: 'gated tracker',
+            allowedOrigins: ['https://customer.example'],
+          },
+        }),
+      );
+    });
+    expect(minted.allowedOrigins).toEqual(['https://customer.example']);
+
+    const allowedBefore = await countTrackerEvents(db, orgId);
+    const allowed = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`, {
+      headers: { origin: 'https://customer.example' },
+    });
+    expect(allowed.status).toBe(200);
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > allowedBefore);
+
+    const beforeDenied = await countTrackerEvents(db, orgId);
+    const denied = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`, {
+      headers: { origin: 'https://attacker.example' },
+    });
+    expect(denied.status).toBe(200);
+
+    const missing = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`);
+    expect(missing.status).toBe(200);
+
+    const beaconDenied = await fetch(`${baseUrl}/v1/a/t`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: 'https://attacker.example' },
+      body: JSON.stringify({ key: minted.trackerKey, subjectId: 'home' }),
+    });
+    expect(beaconDenied.status).toBe(204);
+
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await countTrackerEvents(db, orgId)).toBe(beforeDenied);
+
+    await withClient(adminKey, async (c) => {
+      const updated = parseToolResult<{ allowedOrigins: string[] }>(
+        await c.callTool({
+          name: 'analytics_update_tracker',
+          arguments: { trackerId: minted.id, allowedOrigins: [] },
+        }),
+      );
+      expect(updated.allowedOrigins).toEqual([]);
+    });
+
+    const beforeOpen = await countTrackerEvents(db, orgId);
+    const openAccess = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`, {
+      headers: { origin: 'https://anything.example' },
+    });
+    expect(openAccess.status).toBe(200);
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > beforeOpen);
+  }, 30_000);
+
+  it('MUNIN_TRACKER_REQUIRE_ALLOWLIST=1 fail-closes empty allowlists', async () => {
+    const minted = await withClient(adminKey, async (c) => {
+      return parseToolResult<{ id: string; trackerKey: string }>(
+        await c.callTool({
+          name: 'analytics_create_tracker',
+          arguments: { name: 'no-allowlist' },
+        }),
+      );
+    });
+
+    process.env.MUNIN_TRACKER_REQUIRE_ALLOWLIST = '1';
+    try {
+      const before = await countTrackerEvents(db, orgId);
+      const res = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`, {
+        headers: { origin: 'https://anything.example' },
+      });
+      expect(res.status).toBe(200);
+      await new Promise((r) => setTimeout(r, 200));
+      expect(await countTrackerEvents(db, orgId)).toBe(before);
+    } finally {
+      delete process.env.MUNIN_TRACKER_REQUIRE_ALLOWLIST;
+    }
+  }, 30_000);
+});
+
+async function countTrackerEvents(
+  db: ReturnType<typeof createDb>,
+  orgId: string,
+): Promise<number> {
+  const r = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(schema.analyticsViewEvents)
+    .where(sql`org_id = ${orgId} AND source = 'tracker'`);
+  return r[0]?.n ?? 0;
+}
+
+async function waitFor(check: () => Promise<boolean>, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error('waitFor: condition not met before timeout');
+}
+
+function parseToolResult<T>(result: unknown): T {
+  const r = result as { content?: Array<{ type: string; text?: string }> };
+  const text = r.content?.[0]?.text ?? '';
+  return JSON.parse(text) as T;
+}

--- a/packages/backend-core/src/modules/analytics/analytics.module.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AnalyticsService } from './analytics.service.ts';
+import { AnalyticsAdminTools } from './analytics.tools.ts';
 
 @Module({
-  providers: [AnalyticsService],
+  providers: [AnalyticsService, AnalyticsAdminTools],
   exports: [AnalyticsService],
 })
 export class AnalyticsModule {}

--- a/packages/backend-core/src/modules/analytics/analytics.module.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AnalyticsService } from './analytics.service.ts';
+
+@Module({
+  providers: [AnalyticsService],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/packages/backend-core/src/modules/analytics/analytics.service.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.service.ts
@@ -1,0 +1,95 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { schema, type Db } from '@getmunin/db';
+import { DB } from '../../common/db/db.module.ts';
+
+export interface RecordViewInput {
+  orgId: string;
+  subjectType: string;
+  subjectId: string;
+  source: 'pixel' | 'beacon';
+  path?: string | null;
+  locale?: string | null;
+  referrer?: string | null;
+  utmSource?: string | null;
+  utmMedium?: string | null;
+  utmCampaign?: string | null;
+  visitorId?: string | null;
+  userAgentClass?: string | null;
+  dwellMs?: number | null;
+  readDepth?: number | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface RecordSearchInput {
+  orgId: string;
+  subjectType: string;
+  query: string;
+  resultCount: number;
+  locale?: string | null;
+  visitorId?: string | null;
+}
+
+@Injectable()
+export class AnalyticsService {
+  private readonly logger = new Logger(AnalyticsService.name);
+
+  constructor(@Inject(DB) private readonly db: Db) {}
+
+  async recordView(input: RecordViewInput): Promise<void> {
+    try {
+      await this.db.insert(schema.analyticsViewEvents).values({
+        orgId: input.orgId,
+        subjectType: input.subjectType.slice(0, 32),
+        subjectId: input.subjectId,
+        source: input.source,
+        path: truncate(input.path, 512),
+        locale: truncate(input.locale, 16),
+        referrer: truncate(input.referrer, 512),
+        utmSource: truncate(input.utmSource, 128),
+        utmMedium: truncate(input.utmMedium, 128),
+        utmCampaign: truncate(input.utmCampaign, 128),
+        visitorId: truncate(input.visitorId, 64),
+        userAgentClass: truncate(input.userAgentClass, 16),
+        dwellMs: clampInt(input.dwellMs, 0, 24 * 60 * 60 * 1000),
+        readDepth: clampInt(input.readDepth, 0, 100),
+        metadata: input.metadata ?? null,
+      });
+    } catch (err) {
+      this.logger.warn(`analytics.view.record_failed: ${(err as Error).message}`);
+    }
+  }
+
+  async recordSearch(input: RecordSearchInput): Promise<void> {
+    try {
+      const q = input.query.trim();
+      if (!q) return;
+      await this.db.insert(schema.analyticsSearchEvents).values({
+        orgId: input.orgId,
+        subjectType: input.subjectType.slice(0, 32),
+        query: q.slice(0, 256),
+        locale: truncate(input.locale, 16),
+        resultCount: Math.max(0, Math.floor(input.resultCount)),
+        visitorId: truncate(input.visitorId, 64),
+      });
+    } catch (err) {
+      this.logger.warn(`analytics.search.record_failed: ${(err as Error).message}`);
+    }
+  }
+}
+
+function truncate(value: string | null | undefined, max: number): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, max);
+}
+
+function clampInt(
+  value: number | null | undefined,
+  min: number,
+  max: number,
+): number | null {
+  if (value === null || value === undefined) return null;
+  if (!Number.isFinite(value)) return null;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}

--- a/packages/backend-core/src/modules/analytics/analytics.service.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.service.ts
@@ -6,7 +6,7 @@ export interface RecordViewInput {
   orgId: string;
   subjectType: string;
   subjectId: string;
-  source: 'pixel' | 'beacon';
+  source: 'pixel' | 'beacon' | 'tracker';
   path?: string | null;
   locale?: string | null;
   referrer?: string | null;

--- a/packages/backend-core/src/modules/analytics/analytics.tools.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.tools.ts
@@ -1,0 +1,387 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { z } from 'zod';
+import { McpTool } from '@getmunin/mcp-toolkit';
+import { schema } from '@getmunin/db';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { buildApiKey, getCurrentContext, hashSecret, keyPrefix } from '@getmunin/core';
+
+const CreateTrackerInput = z.object({
+  name: z.string().min(1).max(120),
+  allowedOrigins: z.array(z.string().url()).optional(),
+});
+
+const UpdateTrackerInput = z.object({
+  trackerId: z.string(),
+  name: z.string().min(1).max(120).optional(),
+  allowedOrigins: z.array(z.string().url()).optional(),
+});
+
+const RevokeTrackerInput = z.object({
+  trackerId: z.string(),
+});
+
+interface TrackerSummary {
+  id: string;
+  name: string;
+  allowedOrigins: string[];
+  keyPrefix: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+}
+
+interface CreateTrackerResult extends TrackerSummary {
+  trackerKey: string;
+}
+
+@Injectable()
+export class AnalyticsAdminTools {
+  @McpTool({
+    name: 'analytics_create_tracker',
+    title: 'Analytics: Create tracker key',
+    description:
+      'Create a tracker and mint a public `mn_track_*` API key bound to it. The key is safe to embed in `<script>` tags or mobile clients — it can only write page-view events scoped to your org, never read them. `allowedOrigins` is an optional list of full origins (`https://example.com`) the tracker will accept; when empty, any origin is accepted (set `MUNIN_TRACKER_REQUIRE_ALLOWLIST=1` to fail-closed instead). Returns the plaintext key once; store it where it needs to be embedded.',
+    audiences: ['admin'],
+    scopes: ['analytics:write'],
+    input: CreateTrackerInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  async createTracker(args: z.infer<typeof CreateTrackerInput>): Promise<CreateTrackerResult> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const [tracker] = await ctx.db
+      .insert(schema.analyticsTrackers)
+      .values({
+        orgId: actor.orgId,
+        name: args.name,
+        allowedOrigins: args.allowedOrigins ?? [],
+      })
+      .returning();
+    const rawKey = buildApiKey('track');
+    const [key] = await ctx.db
+      .insert(schema.apiKeys)
+      .values({
+        orgId: actor.orgId,
+        type: 'track',
+        name: args.name,
+        keyHash: hashSecret(rawKey),
+        keyPrefix: keyPrefix(rawKey),
+        scopes: ['analytics:track:write'],
+        audiences: ['public'],
+        trackerId: tracker!.id,
+        createdByUserId: actor.userId ?? null,
+      })
+      .returning();
+    return {
+      id: tracker!.id,
+      name: tracker!.name,
+      allowedOrigins: tracker!.allowedOrigins,
+      keyPrefix: key!.keyPrefix,
+      createdAt: tracker!.createdAt.toISOString(),
+      lastUsedAt: null,
+      revokedAt: null,
+      trackerKey: rawKey,
+    };
+  }
+
+  @McpTool({
+    name: 'analytics_list_trackers',
+    title: 'Analytics: List tracker keys',
+    description:
+      'List analytics trackers for the current org with their key prefix, allowed origins, and revocation state. Plaintext keys are never returned; rotate via `analytics_revoke_tracker` + `analytics_create_tracker`.',
+    audiences: ['admin'],
+    scopes: ['analytics:read'],
+    input: z.object({ includeRevoked: z.boolean().optional() }),
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  async listTrackers(args: { includeRevoked?: boolean }): Promise<TrackerSummary[]> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db
+      .select({
+        id: schema.analyticsTrackers.id,
+        name: schema.analyticsTrackers.name,
+        allowedOrigins: schema.analyticsTrackers.allowedOrigins,
+        createdAt: schema.analyticsTrackers.createdAt,
+        keyPrefix: schema.apiKeys.keyPrefix,
+        lastUsedAt: schema.apiKeys.lastUsedAt,
+        revokedAt: schema.apiKeys.revokedAt,
+      })
+      .from(schema.analyticsTrackers)
+      .leftJoin(
+        schema.apiKeys,
+        and(
+          eq(schema.apiKeys.trackerId, schema.analyticsTrackers.id),
+          eq(schema.apiKeys.type, 'track'),
+        ),
+      )
+      .where(eq(schema.analyticsTrackers.orgId, actor.orgId));
+    return rows
+      .filter((r) => args.includeRevoked || r.revokedAt === null)
+      .map((r) => ({
+        id: r.id,
+        name: r.name,
+        allowedOrigins: r.allowedOrigins,
+        keyPrefix: r.keyPrefix,
+        createdAt: r.createdAt.toISOString(),
+        lastUsedAt: r.lastUsedAt?.toISOString() ?? null,
+        revokedAt: r.revokedAt?.toISOString() ?? null,
+      }));
+  }
+
+  @McpTool({
+    name: 'analytics_update_tracker',
+    title: 'Analytics: Update tracker config',
+    description:
+      'Update a tracker\'s display name and/or `allowedOrigins`. The bound API key is unchanged — rotate via `analytics_revoke_tracker` + `analytics_create_tracker`.',
+    audiences: ['admin'],
+    scopes: ['analytics:write'],
+    input: UpdateTrackerInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  async updateTracker(args: z.infer<typeof UpdateTrackerInput>): Promise<TrackerSummary> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const patch: { name?: string; allowedOrigins?: string[]; updatedAt: Date } = {
+      updatedAt: new Date(),
+    };
+    if (args.name !== undefined) patch.name = args.name;
+    if (args.allowedOrigins !== undefined) patch.allowedOrigins = args.allowedOrigins;
+    const [updated] = await ctx.db
+      .update(schema.analyticsTrackers)
+      .set(patch)
+      .where(
+        and(
+          eq(schema.analyticsTrackers.id, args.trackerId),
+          eq(schema.analyticsTrackers.orgId, actor.orgId),
+        ),
+      )
+      .returning();
+    if (!updated) throw new NotFoundException(`tracker ${args.trackerId} not found`);
+    const [key] = await ctx.db
+      .select({
+        keyPrefix: schema.apiKeys.keyPrefix,
+        lastUsedAt: schema.apiKeys.lastUsedAt,
+        revokedAt: schema.apiKeys.revokedAt,
+      })
+      .from(schema.apiKeys)
+      .where(
+        and(eq(schema.apiKeys.trackerId, args.trackerId), eq(schema.apiKeys.type, 'track')),
+      )
+      .limit(1);
+    return {
+      id: updated.id,
+      name: updated.name,
+      allowedOrigins: updated.allowedOrigins,
+      keyPrefix: key?.keyPrefix ?? null,
+      createdAt: updated.createdAt.toISOString(),
+      lastUsedAt: key?.lastUsedAt?.toISOString() ?? null,
+      revokedAt: key?.revokedAt?.toISOString() ?? null,
+    };
+  }
+
+  @McpTool({
+    name: 'analytics_top_subjects',
+    title: 'Analytics: Top subjects by view count',
+    description:
+      'List the most-viewed subjects (CMS entries, landing pages, etc.) over a recent window. Use this to see what content is actually getting traffic. Filter by `subjectType` to scope to one surface (e.g. `cms_entry`).',
+    audiences: ['admin'],
+    scopes: ['analytics:read'],
+    input: z.object({
+      subjectType: z.string().max(32).optional(),
+      sinceDays: z.number().int().min(1).max(365).default(30),
+      limit: z.number().int().min(1).max(200).default(20),
+      source: z.enum(['pixel', 'beacon', 'tracker']).optional(),
+    }),
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  async topSubjects(args: {
+    subjectType?: string;
+    sinceDays: number;
+    limit: number;
+    source?: 'pixel' | 'beacon' | 'tracker';
+  }): Promise<
+    Array<{ subjectType: string; subjectId: string; views: number; visitors: number }>
+  > {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const conditions = [
+      sql`org_id = ${actor.orgId}`,
+      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
+    ];
+    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
+    if (args.source) conditions.push(sql`source = ${args.source}`);
+    const where = sql.join(conditions, sql` AND `);
+    const rows = await ctx.db.execute<{
+      subject_type: string;
+      subject_id: string;
+      views: number;
+      visitors: number;
+    }>(sql`
+      SELECT subject_type, subject_id,
+             COUNT(*)::int AS views,
+             COUNT(DISTINCT visitor_id)::int AS visitors
+      FROM analytics_view_events
+      WHERE ${where}
+      GROUP BY subject_type, subject_id
+      ORDER BY views DESC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      subjectType: r.subject_type,
+      subjectId: r.subject_id,
+      views: r.views,
+      visitors: r.visitors,
+    }));
+  }
+
+  @McpTool({
+    name: 'analytics_subject_engagement',
+    title: 'Analytics: Engagement for one subject',
+    description:
+      'View counts, unique visitors, and average dwell/read-depth for one subject (e.g. one CMS entry) over a recent window. Use this when judging whether a stale entry should be refreshed or archived.',
+    audiences: ['admin'],
+    scopes: ['analytics:read'],
+    input: z.object({
+      subjectType: z.string().max(32),
+      subjectId: z.string(),
+      sinceDays: z.number().int().min(1).max(365).default(90),
+    }),
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  async subjectEngagement(args: {
+    subjectType: string;
+    subjectId: string;
+    sinceDays: number;
+  }): Promise<{
+    views: number;
+    visitors: number;
+    avgDwellMs: number | null;
+    avgReadDepth: number | null;
+    lastViewAt: string | null;
+  }> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db.execute<{
+      views: number;
+      visitors: number;
+      avg_dwell_ms: number | null;
+      avg_read_depth: number | null;
+      last_view_at: Date | null;
+    }>(sql`
+      SELECT COUNT(*)::int AS views,
+             COUNT(DISTINCT visitor_id)::int AS visitors,
+             AVG(dwell_ms) FILTER (WHERE dwell_ms IS NOT NULL) AS avg_dwell_ms,
+             AVG(read_depth) FILTER (WHERE read_depth IS NOT NULL) AS avg_read_depth,
+             MAX(created_at) AS last_view_at
+      FROM analytics_view_events
+      WHERE org_id = ${actor.orgId}
+        AND subject_type = ${args.subjectType}
+        AND subject_id = ${args.subjectId}
+        AND created_at > NOW() - (${args.sinceDays} || ' days')::interval
+    `);
+    const r = rows[0]!;
+    return {
+      views: r.views,
+      visitors: r.visitors,
+      avgDwellMs: r.avg_dwell_ms !== null ? Math.round(Number(r.avg_dwell_ms)) : null,
+      avgReadDepth: r.avg_read_depth !== null ? Math.round(Number(r.avg_read_depth)) : null,
+      lastViewAt: r.last_view_at ? r.last_view_at.toISOString() : null,
+    };
+  }
+
+  @McpTool({
+    name: 'analytics_zero_result_searches',
+    title: 'Analytics: Zero-result search queries',
+    description:
+      'List recent public search queries that returned zero results. The single best input for "what should we write about next" — readers are asking but Munin has no answer.',
+    audiences: ['admin'],
+    scopes: ['analytics:read'],
+    input: z.object({
+      subjectType: z.string().max(32).optional(),
+      sinceDays: z.number().int().min(1).max(365).default(30),
+      limit: z.number().int().min(1).max(200).default(50),
+    }),
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  async zeroResultSearches(args: {
+    subjectType?: string;
+    sinceDays: number;
+    limit: number;
+  }): Promise<Array<{ query: string; occurrences: number; lastSeenAt: string }>> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const conditions = [
+      sql`org_id = ${actor.orgId}`,
+      sql`result_count = 0`,
+      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
+    ];
+    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
+    const where = sql.join(conditions, sql` AND `);
+    const rows = await ctx.db.execute<{
+      query: string;
+      occurrences: number;
+      last_seen_at: Date;
+    }>(sql`
+      SELECT query,
+             COUNT(*)::int AS occurrences,
+             MAX(created_at) AS last_seen_at
+      FROM analytics_search_events
+      WHERE ${where}
+      GROUP BY query
+      ORDER BY occurrences DESC, last_seen_at DESC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      query: r.query,
+      occurrences: r.occurrences,
+      lastSeenAt: r.last_seen_at.toISOString(),
+    }));
+  }
+
+  @McpTool({
+    name: 'analytics_revoke_tracker',
+    title: 'Analytics: Revoke tracker key',
+    description:
+      'Revoke the API key bound to a tracker. After this, the key is rejected by the ingest endpoints — any pages still embedding it will silently fail to record views. The tracker row stays for audit.',
+    audiences: ['admin'],
+    scopes: ['analytics:write'],
+    input: RevokeTrackerInput,
+    readOnlyHint: false,
+    destructiveHint: true,
+  })
+  async revokeTracker(args: z.infer<typeof RevokeTrackerInput>): Promise<{ revoked: boolean }> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const tracker = await ctx.db
+      .select({ id: schema.analyticsTrackers.id })
+      .from(schema.analyticsTrackers)
+      .where(
+        and(
+          eq(schema.analyticsTrackers.id, args.trackerId),
+          eq(schema.analyticsTrackers.orgId, actor.orgId),
+        ),
+      )
+      .limit(1);
+    if (!tracker[0]) return { revoked: false };
+    const result = await ctx.db
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(
+          eq(schema.apiKeys.trackerId, args.trackerId),
+          eq(schema.apiKeys.orgId, actor.orgId),
+          eq(schema.apiKeys.type, 'track'),
+          isNull(schema.apiKeys.revokedAt),
+        ),
+      )
+      .returning({ id: schema.apiKeys.id });
+    return { revoked: result.length > 0 };
+  }
+}

--- a/packages/backend-core/src/modules/analytics/skills/track-website-traffic.md
+++ b/packages/backend-core/src/modules/analytics/skills/track-website-traffic.md
@@ -1,0 +1,161 @@
+---
+title: Analytics: Track website traffic
+description: Mint a public `mn_track_*` API key, drop the one-line tracker script into your site, and query view events to understand what readers engage with.
+audiences: [admin]
+---
+
+# Track website traffic
+
+Add page-view tracking to a landing page, marketing site, docs site, or app shell. The integration is one line of HTML — same ergonomics as the chat widget. Events land in `analytics_view_events` keyed by `subject_type='page'` and a `subject_id` you control (typically the URL path).
+
+Use this when you want to answer questions like:
+- Which pages do readers actually spend time on?
+- Where is traffic coming from (referrer, UTM)?
+- What's the difference between the 100 readers who bounce and the 10 who scroll all the way?
+
+For tracking content served by Munin's CMS delivery API, you don't need this — every entry response already ships a `_tracking` block (see "Related"). Use this skill when the page is *not* served by Munin (your marketing site, a partner's docs, a static landing page).
+
+## 1. Mint a tracker key
+
+```jsonc
+{
+  "name": "analytics_create_tracker",
+  "arguments": {
+    "name": "getmunin.com landing",
+    "allowedOrigins": ["https://getmunin.com"]
+  }
+}
+```
+
+Response includes `trackerKey: "mn_track_…"` — shown once. The key is **public** — safe to embed in HTML, mobile clients, anything browsers can see. It can only write view events scoped to your org, never read them.
+
+**`allowedOrigins`** is required — the ingest endpoints reject any request whose `Origin` header doesn't match one of the listed full origins (scheme + host + port, exact match — no wildcards or path prefixes). Multi-environment? List each one (`https://getmunin.com`, `https://dev.getmunin.com`, `http://localhost:3000`).
+
+The `Origin` header is browser-set and trivially spoofable via curl — origin allowlisting stops casual JS-from-another-site abuse but is not a security boundary on its own. The real defences are key rotation (`analytics_revoke_tracker`) and per-IP rate-limiting at the ingest layer.
+
+Edit later with `analytics_update_tracker({trackerId, allowedOrigins})`. Rotate with `analytics_revoke_tracker` + a fresh `analytics_create_tracker`. List with `analytics_list_trackers`.
+
+## 2. Drop the script tag
+
+```html
+<script async
+  src="https://api.your-munin.example/tracker.js"
+  data-key="mn_track_…">
+</script>
+```
+
+That's it. The script auto-fires a page view on `DOMContentLoaded` and writes a row to `analytics_view_events` with:
+
+- `subject_type='page'`, `subject_id=<location.pathname>`
+- `path=<location.pathname + location.search>`
+- `referrer=<document.referrer>` (initial entry only)
+- `visitor_id=<random uuid stored in localStorage>`
+- `utm_source` / `utm_medium` / `utm_campaign` (parsed from `?utm_*` query params)
+- `locale=<html lang>`
+- `source='tracker'`
+- `dwell_ms` (best-effort, fired on `pagehide`)
+
+`Cache-Control: public, max-age=3600` on `tracker.js` so the CDN serves the bundle without hitting your backend per request.
+
+### Optional data attributes
+
+- `data-subject-type="docs"` — override the default `'page'` subject type. Useful when you have multiple surfaces sharing one tracker key.
+- `data-spa="true"` — auto-track route changes in single-page apps. The script monkey-patches `history.pushState` / `replaceState` and fires a view per route transition (with a `dwell_ms` for the previous route).
+- `data-api="https://api.your-munin.example"` — override the API base. Defaults to the origin the script was loaded from.
+
+## 3. Custom events from JavaScript
+
+For SPA route changes or arbitrary "this thing happened on the page" events, the script exposes a global:
+
+```javascript
+window.mn.track('checkout-step-2', {
+  dwellMs: 12_000,
+  readDepth: 80,
+  metadata: { variant: 'b' },
+});
+```
+
+The first argument is `subjectId`. The second is an attribute bag:
+- `subjectType` — defaults to the `data-subject-type` on the script tag.
+- `path`, `referrer` — defaults to the current location and the initial referrer.
+- `dwellMs`, `readDepth`, `metadata` — pass through unchanged.
+- `utm` — falls back to URL `?utm_*` params if not provided.
+
+`mn.trackPageView()` is also exposed for the rare case where you want to re-fire the page view manually.
+
+## 4. Query the data
+
+Three admin-only MCP tools cover the questions you'll ask first:
+
+```jsonc
+// Which pages get the most traffic?
+{ "name": "analytics_top_subjects",
+  "arguments": { "subjectType": "page", "source": "tracker", "sinceDays": 7, "limit": 50 } }
+```
+
+Returns `[{ subjectType, subjectId, views, visitors }]` ordered by view count.
+
+```jsonc
+// How is one specific page performing?
+{ "name": "analytics_subject_engagement",
+  "arguments": { "subjectType": "page", "subjectId": "/pricing", "sinceDays": 30 } }
+```
+
+Returns `{ views, visitors, avgDwellMs, avgReadDepth, lastViewAt }` — combine views (volume) with dwell + depth (quality) to separate "lots of bounces" from "fewer but engaged readers."
+
+```jsonc
+// What were people searching for that we don't have content for?
+{ "name": "analytics_zero_result_searches",
+  "arguments": { "sinceDays": 30, "limit": 50 } }
+```
+
+Returns `[{ query, occurrences, lastSeenAt }]`. The single best signal for "what should we write next" — readers asked and Munin had nothing to show them.
+
+For anything more bespoke (UTM-source breakdowns, custom funnels, time-series), the events sit in `analytics_view_events` and `analytics_search_events`; query them directly from a DB client. The MCP tools cover the common questions; the table covers the long tail.
+
+## 5. Server-side / SDK ingestion
+
+For surfaces that can't run JS (server-rendered emails, mobile native, IoT), call the beacon endpoint directly:
+
+```bash
+curl -X POST https://api.your-munin.example/v1/a/t \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "mn_track_…",
+    "subjectType": "page",
+    "subjectId": "/pricing",
+    "referrer": "https://news.ycombinator.com/",
+    "visitorId": "v-xyz",
+    "utm": { "source": "hn" }
+  }'
+```
+
+Or for a 1×1 pixel embedded in HTML emails / image tags:
+
+```html
+<img src="https://api.your-munin.example/v1/a/t/mn_track_…?s=/pricing&v=v-xyz" alt="" width="1" height="1">
+```
+
+The pixel path takes `s` (subjectId, required), `t` (subjectType, defaults to `'page'`), `v` (visitorId, optional). Both routes filter known bot user-agents and rate-limit per IP.
+
+## 6. Operations
+
+| Task | How |
+|---|---|
+| Rotate a key | `analytics_revoke_tracker({trackerId})` then `analytics_create_tracker({name})`. Old key 401s immediately. |
+| Audit which keys exist | `analytics_list_trackers({})`. Returns id, name, prefix, last-used, revoked-at. |
+| Disable a single page from tracking | Remove the script tag from that page. The script is per-page-load opt-in. |
+| Delete a visitor's data | `DELETE FROM analytics_view_events WHERE visitor_id = $1`. No PII is stored beyond the random uuid — but if a regulator-grade deletion is needed, this is the path. |
+
+## What NOT to do
+
+- **Don't ship the key as `NEXT_PUBLIC_…` and pretend it's a secret.** It's public by design. Treat it like a Google Analytics measurement id — visible in the page source is normal. The org-scoped write-only authorization is the entire safety story.
+- **Don't reuse the same key across orgs.** Each customer org mints its own. Cross-org leakage isn't possible because the key resolves to one `org_id`.
+- **Don't rely on `dwell_ms` for anything precision-critical.** It's best-effort, fired on `pagehide`. Mobile Safari and aggressive ad-blockers can swallow the unload beacon. Use it for relative ranking, not exact dwell times.
+- **Don't put PII in `subject_id` or `metadata`.** Treat them as URL-shaped and tag-shaped respectively. Anything you embed there will sit in an analytics table you'll later query without auth context.
+
+## Related
+
+- `skill://cms/publish-entry` — when content is served by Munin's CMS delivery API, the response already ships a `_tracking` block. No script tag needed.
+- `skill://cms/review-stale-entries` — periodic curator pass that consults view data to decide whether stale published entries should be refreshed or archived.
+- `skill://conv/setup-chat-widget` — sibling drop-in script (chat widget); identical key-rotation ergonomics.

--- a/packages/backend-core/src/modules/cms/cms.integration.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.integration.test.ts
@@ -424,7 +424,142 @@ const skipReason = TEST_URL
       expect(names.find((n) => n.startsWith('cms_'))).toBeFalsy();
     });
   }, 30_000);
+
+  it('analytics: delivery returns _tracking, pixel records a view, beacon records rich attrs', async () => {
+    await withClient(adminKey, async (c) => {
+      await c.callTool({
+        name: 'cms_create_entry',
+        arguments: {
+          collection: 'pages',
+          slug: 'tracked-page',
+          data: { title: 'Tracked', slug: 'tracked-page', body: 'Body.' },
+          status: 'published',
+        },
+      });
+    });
+
+    const res = await fetchUntil(
+      `${baseUrl}/v1/cms/${orgId}/pages/tracked-page`,
+      (r) => r.status === 200,
+    );
+    const entry = (await res.json()) as {
+      _tracking?: { pixelUrl: string; beaconUrl: string };
+    };
+    expect(entry._tracking?.pixelUrl).toMatch(/\/v1\/a\/v\/.+\.gif$/);
+    expect(entry._tracking?.beaconUrl).toMatch(/\/v1\/a\/v$/);
+
+    const pixelUrl = retarget(entry._tracking!.pixelUrl, baseUrl);
+    const beaconUrl = retarget(entry._tracking!.beaconUrl, baseUrl);
+
+    const beforePixel = await countViewEvents(db, orgId, 'pixel');
+    const pixel = await fetch(pixelUrl);
+    expect(pixel.status).toBe(200);
+    expect(pixel.headers.get('content-type')).toBe('image/gif');
+    await waitFor(async () => (await countViewEvents(db, orgId, 'pixel')) > beforePixel);
+
+    const pixelBot = await fetch(pixelUrl, {
+      headers: { 'user-agent': 'Googlebot/2.1' },
+    });
+    expect(pixelBot.status).toBe(200);
+    const afterBot = await countViewEvents(db, orgId, 'pixel');
+    expect(afterBot).toBe(beforePixel + 1);
+
+    const beforeBeacon = await countViewEvents(db, orgId, 'beacon');
+    const tokenMatch = pixelUrl.match(/\/v1\/a\/v\/(.+)\.gif$/);
+    const token = tokenMatch![1]!;
+    const beacon = await fetch(beaconUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        token,
+        referrer: 'https://example.com/blog',
+        visitorId: 'visitor-xyz',
+        dwellMs: 42_000,
+        readDepth: 75,
+        utm: { source: 'twitter', medium: 'social', campaign: 'launch' },
+      }),
+    });
+    expect(beacon.status).toBe(204);
+    await waitFor(async () => (await countViewEvents(db, orgId, 'beacon')) > beforeBeacon);
+
+    const beaconRow = await db
+      .select()
+      .from(schema.analyticsViewEvents)
+      .where(sql`org_id = ${orgId} AND source = 'beacon' AND visitor_id = 'visitor-xyz'`)
+      .limit(1);
+    expect(beaconRow[0]?.dwellMs).toBe(42_000);
+    expect(beaconRow[0]?.readDepth).toBe(75);
+    expect(beaconRow[0]?.utmSource).toBe('twitter');
+    expect(beaconRow[0]?.subjectType).toBe('cms_entry');
+
+    const tampered = token.replace(/.$/, (c) => (c === 'a' ? 'b' : 'a'));
+    const bad = await fetch(beaconUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: tampered, visitorId: 'should-not-write' }),
+    });
+    expect(bad.status).toBe(204);
+    const tamperedCount = await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(schema.analyticsViewEvents)
+      .where(sql`org_id = ${orgId} AND visitor_id = 'should-not-write'`);
+    expect(tamperedCount[0]?.n ?? 0).toBe(0);
+  }, 30_000);
+
+  it('analytics: ?tracking=0 suppresses the _tracking block', async () => {
+    const res = await fetch(`${baseUrl}/v1/cms/${orgId}/pages/tracked-page?tracking=0`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { _tracking?: unknown };
+    expect(json._tracking).toBeUndefined();
+  }, 30_000);
+
+  it('analytics: public search logs every query with its result_count', async () => {
+    const q = `analytics_probe_${Date.now()}`;
+    const res = await fetch(
+      `${baseUrl}/v1/cms/${orgId}/search?q=${encodeURIComponent(q)}&collection=pages&visitor_id=probe-v`,
+    );
+    expect(res.status).toBe(200);
+    const hits = (await res.json()) as unknown[];
+    await waitFor(async () => {
+      const rows = await db
+        .select()
+        .from(schema.analyticsSearchEvents)
+        .where(sql`org_id = ${orgId} AND query = ${q}`)
+        .limit(1);
+      return (
+        rows.length > 0 &&
+        rows[0]!.resultCount === hits.length &&
+        rows[0]!.subjectType === 'cms' &&
+        rows[0]!.visitorId === 'probe-v'
+      );
+    });
+  }, 30_000);
 });
+
+function retarget(url: string, baseUrl: string): string {
+  return url.replace(/^https?:\/\/[^/]+/, baseUrl);
+}
+
+async function countViewEvents(
+  db: ReturnType<typeof createDb>,
+  orgId: string,
+  source: 'pixel' | 'beacon',
+): Promise<number> {
+  const r = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(schema.analyticsViewEvents)
+    .where(sql`org_id = ${orgId} AND source = ${source}`);
+  return r[0]?.n ?? 0;
+}
+
+async function waitFor(check: () => Promise<boolean>, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error('waitFor: condition not met before timeout');
+}
 
 function parseToolResult<T>(result: unknown): T {
   const r = result as { content?: Array<{ type: string; text?: string }> };

--- a/packages/backend-core/src/modules/cms/skills/review-stale-entries.md
+++ b/packages/backend-core/src/modules/cms/skills/review-stale-entries.md
@@ -53,18 +53,28 @@ For each draft older than the collection's threshold, decide:
 { "name": "cms_list_entries", "arguments": { "status": "published", "limit": 200 } }
 ```
 
-For each entry older than the collection's threshold (per Step 1's per-collection velocity), check inbound references:
+For each entry older than the collection's threshold (per Step 1's per-collection velocity), check inbound references *and* reader engagement (if the delivery API is tracked — see `skill://analytics/track-website-traffic`):
 
 ```jsonc
 { "name": "cms_list_inbound_references", "arguments": { "entryId": "cme_..." } }
 ```
 
-Then judge:
+```jsonc
+{ "name": "analytics_subject_engagement",
+  "arguments": { "subjectType": "cms_entry", "subjectId": "cme_...", "sinceDays": 90 } }
+```
 
-- **Still load-bearing** — has many inbound references from active entries, or is in a top-level navigation collection. Recommend `refresh` (the operator should re-read it for accuracy) rather than archiving.
-- **Superseded but referenced** — newer entries cover the same topic and are linked-to in the same neighborhood. Recommend `archive` (`cms_unpublish_entry`) but flag the inbound references so the operator can decide whether to redirect or delete them.
-- **Orphaned** — no inbound references and `updatedAt` very old. Recommend `delete` (`cms_delete_entry`).
-- **Time-bound** — title or body references a date/event that has passed (campaign, version-specific docs). Recommend `archive` or `delete` with high confidence.
+Response: `{ views, visitors, avgDwellMs, avgReadDepth, lastViewAt }`. If analytics isn't wired up the values come back as 0 / null — fall back to the inbound-references signal alone.
+
+Then judge — combine the structural signal (inbound refs) with the behavioral signal (views/dwell):
+
+- **Still load-bearing** — many inbound references *and* meaningful views in the last 90 days. Recommend `refresh` (the operator should re-read it for accuracy) rather than archiving.
+- **Quietly important** — few inbound references but consistent traffic. Recommend `refresh` — readers find it via search/direct, the graph just doesn't reflect that.
+- **Superseded but referenced** — newer entries cover the same topic and are linked-to in the same neighborhood; views are trending down. Recommend `archive` (`cms_unpublish_entry`) but flag the inbound references so the operator can decide whether to redirect or delete them.
+- **Orphaned** — no inbound references, no recent views, and `updatedAt` very old. Recommend `delete` (`cms_delete_entry`).
+- **Time-bound** — title or body references a date/event that has passed (campaign, version-specific docs). Recommend `archive` or `delete` with high confidence regardless of view count (residual traffic to expired content is usually a sign of stale external links, not value).
+
+A useful complement: `analytics_zero_result_searches({sinceDays: 90})` surfaces the queries readers asked that returned nothing. If a stale entry is the closest match to a frequent zero-result query, that's a strong "refresh + retitle" signal — readers want this content, they just can't find it.
 
 ## Step 4 — orphaned assets
 

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -5,13 +5,13 @@ import {
   ActorIdentity,
   WebhookDispatcher,
   parseEnvInt,
+  readApiBaseUrl,
   resolvePublicHost,
   signEmailOpenToken,
   withContext,
   type Mailer,
   type RequestContext,
 } from '@getmunin/core';
-import { readPublicBaseUrl } from '../../../oauth/oauth.constants.ts';
 import { ImapFlow } from 'imapflow';
 import { simpleParser, type ParsedMail, type AddressObject } from 'mailparser';
 import { randomUUID } from 'node:crypto';
@@ -568,7 +568,7 @@ function trackerUrlFor(
       orgId: ctx.channel.orgId,
       deliveryId: ctx.delivery.id,
     });
-    return `${readPublicBaseUrl()}/v1/c/o/${token}.gif`;
+    return `${readApiBaseUrl()}/v1/c/o/${token}.gif`;
   } catch {
     return undefined;
   }

--- a/packages/backend-core/src/modules/conv/skills/setup-chat-widget.md
+++ b/packages/backend-core/src/modules/conv/skills/setup-chat-widget.md
@@ -20,6 +20,8 @@ Call `conv_widget_create_channel`:
 
 Response includes `widgetKey: "mn_widget_…"` — shown once. Store it server-side.
 
+`originAllowlist` is required — the widget ingest endpoint rejects any request whose `Origin` header doesn't match one of the listed full origins (scheme + host + port, exact match). List every environment that should be allowed to ingest (`https://customer.example`, `https://staging.customer.example`, etc.).
+
 The widget key is bound to this channel via `api_keys.channel_id`. Rotate with `conv_widget_rotate_key`; update origins with `conv_widget_update_channel`.
 
 ## 2. Push transcripts from the agent

--- a/packages/backend-core/src/modules/playbooks/skills/publish-and-distribute.md
+++ b/packages/backend-core/src/modules/playbooks/skills/publish-and-distribute.md
@@ -126,3 +126,4 @@ The published entry should be there too. If both surface and the announcement wa
 - `skill://cms/publish-entry` — the publish half.
 - `skill://kb/import-articles-in-bulk` — bulk mirroring for catch-up imports.
 - `skill://conv/setup-email-and-widget-channels` — making sure the announcement channel exists.
+- `skill://analytics/track-website-traffic` — measure which published entries actually get read; feed that signal back into the next quarter's review.

--- a/packages/backend-core/src/oauth/oauth.constants.ts
+++ b/packages/backend-core/src/oauth/oauth.constants.ts
@@ -31,10 +31,6 @@ export function authorizationServerUrl(): string {
   return parsePublicUrl().origin;
 }
 
-export function readPublicBaseUrl(): string {
-  return authorizationServerUrl();
-}
-
 export function resourceMetadataUrl(): string {
   return `${authorizationServerUrl()}/.well-known/oauth-protected-resource`;
 }

--- a/packages/core/src/crypto/keys.ts
+++ b/packages/core/src/crypto/keys.ts
@@ -5,6 +5,7 @@ import { randomToken } from './primitives.ts';
  *
  *   kind = 'admin' | 'dlg' (delegated end-user, short-lived)
  *        | 'widget' (chat-widget channel binding; api_keys.channel_id is set)
+ *        | 'track' (public analytics tracker key; safe to embed in browsers)
  *
  * The `'part'` kind exists in the type union for downstream packages
  * that mint partner-style credentials; OSS does not produce or accept
@@ -16,7 +17,7 @@ import { randomToken } from './primitives.ts';
  * bits of entropy).
  */
 
-export type KeyKind = 'admin' | 'part' | 'dlg' | 'widget';
+export type KeyKind = 'admin' | 'part' | 'dlg' | 'widget' | 'track';
 
 const PREFIX_LENGTH = 8;
 
@@ -30,5 +31,5 @@ export function keyPrefix(rawKey: string): string {
 }
 
 export function isWellFormedKey(rawKey: string): boolean {
-  return /^mn_(admin|part|dlg|widget)_[A-Za-z0-9_-]+$/.test(rawKey);
+  return /^mn_(admin|part|dlg|widget|track)_[A-Za-z0-9_-]+$/.test(rawKey);
 }

--- a/packages/core/src/crypto/view-token.test.ts
+++ b/packages/core/src/crypto/view-token.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { signViewToken, verifyViewToken, ViewTokenError } from './view-token.ts';
+
+const PEPPER = 'test-pepper-do-not-use-in-prod';
+
+describe('view tokens', () => {
+  it('round-trips a signed token', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b' },
+      PEPPER,
+    );
+    const payload = verifyViewToken(token, PEPPER);
+    expect(payload.orgId).toBe('org_a');
+    expect(payload.subjectType).toBe('cms_entry');
+    expect(payload.subjectId).toBe('cme_b');
+    expect(payload.issuedAt).toBeGreaterThan(0);
+  });
+
+  it('rejects a token signed with a different pepper', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b' },
+      PEPPER,
+    );
+    expect(() => verifyViewToken(token, 'other-pepper')).toThrow(ViewTokenError);
+  });
+
+  it('rejects a tampered subject', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b' },
+      PEPPER,
+    );
+    const tampered = token.replace('cme_b', 'cme_evil');
+    expect(() => verifyViewToken(tampered, PEPPER)).toThrow(ViewTokenError);
+  });
+
+  it('rejects a tampered subjectType', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b' },
+      PEPPER,
+    );
+    const tampered = token.replace('cms_entry', 'landing');
+    expect(() => verifyViewToken(tampered, PEPPER)).toThrow(ViewTokenError);
+  });
+
+  it('rejects malformed tokens', () => {
+    expect(() => verifyViewToken('garbage', PEPPER)).toThrow(ViewTokenError);
+    expect(() => verifyViewToken('a.b.c.d', PEPPER)).toThrow(ViewTokenError);
+  });
+
+  it('rejects field values containing dots or whitespace', () => {
+    expect(() =>
+      signViewToken({ orgId: 'org.a', subjectType: 'x', subjectId: 'y' }, PEPPER),
+    ).toThrow();
+    expect(() =>
+      signViewToken({ orgId: 'org_a', subjectType: 'x y', subjectId: 'y' }, PEPPER),
+    ).toThrow();
+  });
+
+  it('preserves a caller-supplied issuedAt', () => {
+    const token = signViewToken(
+      { orgId: 'org_a', subjectType: 'cms_entry', subjectId: 'cme_b', issuedAt: 1700000000 },
+      PEPPER,
+    );
+    const payload = verifyViewToken(token, PEPPER);
+    expect(payload.issuedAt).toBe(1700000000);
+  });
+});

--- a/packages/core/src/crypto/view-token.ts
+++ b/packages/core/src/crypto/view-token.ts
@@ -1,0 +1,49 @@
+import { signHmac, timingSafeEqual } from './primitives.ts';
+
+const VERSION = 'v1';
+
+export interface ViewTokenPayload {
+  orgId: string;
+  subjectType: string;
+  subjectId: string;
+  issuedAt: number;
+}
+
+export class ViewTokenError extends Error {
+  readonly code = 'view_token_invalid';
+  constructor(message: string) {
+    super(`view_token_invalid: ${message}`);
+  }
+}
+
+export function signViewToken(
+  payload: Omit<ViewTokenPayload, 'issuedAt'> & { issuedAt?: number },
+  pepper?: string,
+): string {
+  const secret = pepper ?? process.env.MUNIN_KEY_PEPPER ?? '';
+  if (!secret) throw new Error('MUNIN_KEY_PEPPER is required to sign view tokens');
+  const issuedAt = payload.issuedAt ?? Math.floor(Date.now() / 1000);
+  for (const v of [payload.orgId, payload.subjectType, payload.subjectId]) {
+    if (!v || /[.\s]/.test(v)) {
+      throw new Error('view token fields must be non-empty and contain no dots or whitespace');
+    }
+  }
+  const body = `${VERSION}.${payload.orgId}.${payload.subjectType}.${payload.subjectId}.${issuedAt}`;
+  const sig = signHmac(body, secret);
+  return `${body}.${sig}`;
+}
+
+export function verifyViewToken(token: string, pepper?: string): ViewTokenPayload {
+  const secret = pepper ?? process.env.MUNIN_KEY_PEPPER ?? '';
+  if (!secret) throw new ViewTokenError('server pepper not configured');
+  const parts = token.split('.');
+  if (parts.length !== 6) throw new ViewTokenError('malformed token');
+  const [version, orgId, subjectType, subjectId, issuedAtStr, sig] = parts;
+  if (version !== VERSION) throw new ViewTokenError(`unknown version ${version}`);
+  const body = `${version}.${orgId}.${subjectType}.${subjectId}.${issuedAtStr}`;
+  const expected = signHmac(body, secret);
+  if (!timingSafeEqual(expected, sig!)) throw new ViewTokenError('signature mismatch');
+  const issuedAt = Number(issuedAtStr);
+  if (!Number.isFinite(issuedAt)) throw new ViewTokenError('issuedAt not numeric');
+  return { orgId: orgId!, subjectType: subjectType!, subjectId: subjectId!, issuedAt };
+}

--- a/packages/core/src/env/api-url.ts
+++ b/packages/core/src/env/api-url.ts
@@ -1,0 +1,6 @@
+const LOCAL_FALLBACK = 'http://localhost:3001';
+
+export function readApiBaseUrl(): string {
+  const raw = process.env.MUNIN_API_URL ?? LOCAL_FALLBACK;
+  return raw.replace(/\/+$/, '');
+}

--- a/packages/core/src/env/index.ts
+++ b/packages/core/src/env/index.ts
@@ -7,3 +7,4 @@ export {
   type ParseEnvCronOptions,
   type ParseEnvIntOptions,
 } from './parse.ts';
+export { readApiBaseUrl } from './api-url.ts';

--- a/packages/core/src/http/bot-ua.ts
+++ b/packages/core/src/http/bot-ua.ts
@@ -1,0 +1,6 @@
+export const BOT_UA = /\b(bot|crawler|spider|preview|linkcheck|monitor)\b/i;
+
+export function looksLikeBot(userAgent: string | undefined | null): boolean {
+  if (!userAgent) return false;
+  return BOT_UA.test(userAgent);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,13 @@ export {
   signEmailOpenToken,
   verifyEmailOpenToken,
 } from './crypto/email-open-token.ts';
+export {
+  type ViewTokenPayload,
+  ViewTokenError,
+  signViewToken,
+  verifyViewToken,
+} from './crypto/view-token.ts';
+export { BOT_UA, looksLikeBot } from './http/bot-ua.ts';
 
 export {
   type EmbeddingProvider,
@@ -80,6 +87,7 @@ export {
   parseEnvCron,
   parseEnvDisableFlag,
   parseEnvInt,
+  readApiBaseUrl,
   type ParseEnvBoolOptions,
   type ParseEnvCronOptions,
   type ParseEnvIntOptions,

--- a/packages/db/drizzle/0035_analytics_events.sql
+++ b/packages/db/drizzle/0035_analytics_events.sql
@@ -1,0 +1,56 @@
+-- Analytics: append-only event tables for delivered page views and search
+-- invocations. Polymorphic via (subject_type, subject_id) so CMS entries,
+-- landing pages, dashboard routes, etc. all share the same ingest path.
+-- Bot traffic is filtered upstream; IPs are intentionally not stored.
+
+CREATE TABLE IF NOT EXISTS "analytics_view_events" (
+    "id" text PRIMARY KEY NOT NULL,
+    "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+    "subject_type" varchar(32) NOT NULL,
+    "subject_id" text NOT NULL,
+    "path" varchar(512),
+    "locale" varchar(16),
+    "referrer" varchar(512),
+    "utm_source" varchar(128),
+    "utm_medium" varchar(128),
+    "utm_campaign" varchar(128),
+    "visitor_id" varchar(64),
+    "user_agent_class" varchar(16),
+    "dwell_ms" integer,
+    "read_depth" integer,
+    "source" varchar(8) NOT NULL,
+    "metadata" jsonb,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT "analytics_view_events_source_chk" CHECK ("source" IN ('pixel', 'beacon')),
+    CONSTRAINT "analytics_view_events_read_depth_chk"
+        CHECK ("read_depth" IS NULL OR ("read_depth" >= 0 AND "read_depth" <= 100))
+);
+
+CREATE INDEX IF NOT EXISTS "analytics_view_events_org_idx"
+    ON "analytics_view_events" ("org_id", "created_at");
+
+CREATE INDEX IF NOT EXISTS "analytics_view_events_subject_idx"
+    ON "analytics_view_events" ("org_id", "subject_type", "subject_id", "created_at");
+
+CREATE INDEX IF NOT EXISTS "analytics_view_events_type_idx"
+    ON "analytics_view_events" ("org_id", "subject_type", "created_at");
+
+CREATE TABLE IF NOT EXISTS "analytics_search_events" (
+    "id" text PRIMARY KEY NOT NULL,
+    "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+    "subject_type" varchar(32) NOT NULL,
+    "query" varchar(256) NOT NULL,
+    "locale" varchar(16),
+    "result_count" integer NOT NULL,
+    "visitor_id" varchar(64),
+    "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "analytics_search_events_zero_idx"
+    ON "analytics_search_events" ("org_id", "subject_type", "result_count", "created_at");
+
+CREATE INDEX IF NOT EXISTS "analytics_search_events_org_idx"
+    ON "analytics_search_events" ("org_id", "created_at");
+
+-- RLS policies live in src/sql/analytics.sql so they run AFTER the
+-- app_bypass_rls() / app_org_id() helpers are defined.

--- a/packages/db/drizzle/0036_analytics_trackers.sql
+++ b/packages/db/drizzle/0036_analytics_trackers.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS "analytics_trackers" (
+    "id" text PRIMARY KEY NOT NULL,
+    "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+    "name" text NOT NULL,
+    "allowed_origins" jsonb NOT NULL DEFAULT '[]'::jsonb,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "analytics_trackers_org_idx"
+    ON "analytics_trackers" ("org_id");
+
+ALTER TABLE "api_keys"
+    ADD COLUMN IF NOT EXISTS "tracker_id" text
+        REFERENCES "analytics_trackers"("id") ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS "api_keys_tracker_idx"
+    ON "api_keys" ("tracker_id");
+
+ALTER TABLE "analytics_view_events"
+    DROP CONSTRAINT IF EXISTS "analytics_view_events_source_chk";
+
+ALTER TABLE "analytics_view_events"
+    ADD CONSTRAINT "analytics_view_events_source_chk"
+    CHECK ("source" IN ('pixel', 'beacon', 'tracker'));
+
+ALTER TABLE "api_keys"
+    DROP CONSTRAINT IF EXISTS "api_keys_track_requires_tracker_chk";
+
+ALTER TABLE "api_keys"
+    ADD CONSTRAINT "api_keys_track_requires_tracker_chk"
+    CHECK ("type" <> 'track' OR "tracker_id" IS NOT NULL);
+
+ALTER TABLE "api_keys"
+    DROP CONSTRAINT IF EXISTS "api_keys_widget_requires_channel_chk";
+
+ALTER TABLE "api_keys"
+    ADD CONSTRAINT "api_keys_widget_requires_channel_chk"
+    CHECK ("type" <> 'widget' OR "channel_id" IS NOT NULL) NOT VALID;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1780600000000,
       "tag": "0035_analytics_events",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1780700000000,
+      "tag": "0036_analytics_trackers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1780500000000,
       "tag": "0034_org_alerts",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1780600000000,
+      "tag": "0035_analytics_events",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -35,6 +35,7 @@ export async function runMigrations(connectionString: string, migrationsFolder?:
   const cmsPath = resolve(sqlDir, 'cms.sql');
   const convChannelsPath = resolve(sqlDir, 'conv-channels.sql');
   const outreachPath = resolve(sqlDir, 'outreach.sql');
+  const analyticsPath = resolve(sqlDir, 'analytics.sql');
 
   const client = postgres(connectionString, { max: 1 });
   const db = drizzle(client);
@@ -57,6 +58,7 @@ export async function runMigrations(connectionString: string, migrationsFolder?:
   await client.unsafe(readFileSync(cmsPath, 'utf8'));
   await client.unsafe(readFileSync(convChannelsPath, 'utf8'));
   await client.unsafe(readFileSync(outreachPath, 'utf8'));
+  await client.unsafe(readFileSync(analyticsPath, 'utf8'));
 
   // 4. App role (idempotent). Password defaults to the role name; override
   //    via MUNIN_APP_PASSWORD for non-dev deployments.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -444,6 +444,9 @@ export const apiKeys = pgTable(
     channelId: text('channel_id').references((): AnyPgColumn => convChannels.id, {
       onDelete: 'cascade',
     }),
+    trackerId: text('tracker_id').references((): AnyPgColumn => analyticsTrackers.id, {
+      onDelete: 'cascade',
+    }),
     lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
     revokedAt: timestamp('revoked_at', { withTimezone: true }),
     createdByUserId: text('created_by_user_id').references(() => users.id, { onDelete: 'set null' }),
@@ -453,6 +456,7 @@ export const apiKeys = pgTable(
     orgIdx: index('api_keys_org_idx').on(t.orgId),
     prefixIdx: index('api_keys_prefix_idx').on(t.keyPrefix),
     channelIdx: index('api_keys_channel_idx').on(t.channelId),
+    trackerIdx: index('api_keys_tracker_idx').on(t.trackerId),
   }),
 );
 
@@ -1503,6 +1507,23 @@ export const cmsReferences = pgTable(
 // routes, and other surfaces use their own subject types without
 // schema changes. Append-only; aggregation/rollups are deferred.
 
+export const analyticsTrackers = pgTable(
+  'analytics_trackers',
+  {
+    id: id('atr'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    allowedOrigins: jsonb('allowed_origins').$type<string[]>().notNull().default([]),
+    createdAt,
+    updatedAt,
+  },
+  (t) => ({
+    orgIdx: index('analytics_trackers_org_idx').on(t.orgId),
+  }),
+);
+
 export const analyticsViewEvents = pgTable(
   'analytics_view_events',
   {
@@ -1843,6 +1864,7 @@ export const allTables = {
   cmsAssets,
   cmsLocales,
   cmsReferences,
+  analyticsTrackers,
   analyticsViewEvents,
   analyticsSearchEvents,
   curatorJobs,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1497,6 +1497,76 @@ export const cmsReferences = pgTable(
   }),
 );
 
+// ───────────────────────────── Analytics ─────────────────────────────
+// Polymorphic page-view and search events. The first consumer is the
+// CMS delivery API (subject_type='cms_entry'); landing pages, dashboard
+// routes, and other surfaces use their own subject types without
+// schema changes. Append-only; aggregation/rollups are deferred.
+
+export const analyticsViewEvents = pgTable(
+  'analytics_view_events',
+  {
+    id: id('avw'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    subjectType: varchar('subject_type', { length: 32 }).notNull(),
+    subjectId: text('subject_id').notNull(),
+    path: varchar('path', { length: 512 }),
+    locale: varchar('locale', { length: 16 }),
+    referrer: varchar('referrer', { length: 512 }),
+    utmSource: varchar('utm_source', { length: 128 }),
+    utmMedium: varchar('utm_medium', { length: 128 }),
+    utmCampaign: varchar('utm_campaign', { length: 128 }),
+    visitorId: varchar('visitor_id', { length: 64 }),
+    userAgentClass: varchar('user_agent_class', { length: 16 }),
+    dwellMs: integer('dwell_ms'),
+    readDepth: integer('read_depth'),
+    source: varchar('source', { length: 8 }).notNull(),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    createdAt,
+  },
+  (t) => ({
+    orgIdx: index('analytics_view_events_org_idx').on(t.orgId, t.createdAt),
+    subjectIdx: index('analytics_view_events_subject_idx').on(
+      t.orgId,
+      t.subjectType,
+      t.subjectId,
+      t.createdAt,
+    ),
+    typeIdx: index('analytics_view_events_type_idx').on(
+      t.orgId,
+      t.subjectType,
+      t.createdAt,
+    ),
+  }),
+);
+
+export const analyticsSearchEvents = pgTable(
+  'analytics_search_events',
+  {
+    id: id('asr'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    subjectType: varchar('subject_type', { length: 32 }).notNull(),
+    query: varchar('query', { length: 256 }).notNull(),
+    locale: varchar('locale', { length: 16 }),
+    resultCount: integer('result_count').notNull(),
+    visitorId: varchar('visitor_id', { length: 64 }),
+    createdAt,
+  },
+  (t) => ({
+    zeroResultIdx: index('analytics_search_events_zero_idx').on(
+      t.orgId,
+      t.subjectType,
+      t.resultCount,
+      t.createdAt,
+    ),
+    orgIdx: index('analytics_search_events_org_idx').on(t.orgId, t.createdAt),
+  }),
+);
+
 // ───────────────────────────── Curator jobs ──────────────────────────
 // Persistent queue for curator background jobs. The bundled in-process
 // runner (or any admin-authenticated runner) claims pending rows via
@@ -1773,6 +1843,8 @@ export const allTables = {
   cmsAssets,
   cmsLocales,
   cmsReferences,
+  analyticsViewEvents,
+  analyticsSearchEvents,
   curatorJobs,
   systemConfig,
   feedbackOutbox,

--- a/packages/db/src/sql/analytics.sql
+++ b/packages/db/src/sql/analytics.sql
@@ -23,3 +23,13 @@ CREATE POLICY tenant_isolation ON analytics_search_events
     OR (org_id = app_org_id() AND app_end_user_id() = '')
   )
   WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
+ALTER TABLE analytics_trackers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE analytics_trackers FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON analytics_trackers;
+CREATE POLICY tenant_isolation ON analytics_trackers
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());

--- a/packages/db/src/sql/analytics.sql
+++ b/packages/db/src/sql/analytics.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- Analytics module RLS policies.
+-- Org-scoped, admin-only. Write path is the public ingest endpoint, which
+-- uses the service-role DB and bypasses RLS; reads are admin-side only.
+-- ============================================================================
+
+ALTER TABLE analytics_view_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE analytics_view_events FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON analytics_view_events;
+CREATE POLICY tenant_isolation ON analytics_view_events
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
+ALTER TABLE analytics_search_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE analytics_search_events FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON analytics_search_events;
+CREATE POLICY tenant_isolation ON analytics_search_events
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,36 @@ importers:
         specifier: ^8.59.1
         version: 8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
 
+  apps/analytics-tracker:
+    devDependencies:
+      '@getmunin/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@getmunin/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      eslint:
+        specifier: ^9.10.0
+        version: 9.39.4(jiti@1.21.7)
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.5.0
+        version: 8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      vite:
+        specifier: ^6.4.2
+        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+
   apps/backend:
     dependencies:
       '@better-auth/oauth-provider':
@@ -62,6 +92,9 @@ importers:
       '@getmunin/agent-host':
         specifier: workspace:*
         version: link:../../packages/agent-host
+      '@getmunin/analytics-tracker':
+        specifier: workspace:*
+        version: link:../analytics-tracker
       '@getmunin/backend-core':
         specifier: workspace:*
         version: link:../../packages/backend-core


### PR DESCRIPTION
> **Forward-port** of PR #357, which was merged into the stacked base \`feat/analytics-module\` instead of \`main\`. Squash this on merge — main already has PR #356's content, and a squash collapses #357's commits into one clean entry without re-introducing the pre-squash PR #356 commit.

## Summary

Everything from [PR #357](https://github.com/getmunin/munin/pull/357):

- **Drop-in tracker script** (\`apps/analytics-tracker/\`) — Vite IIFE bundle, content-hashed, served at \`/tracker.js\` via the same redirect-then-immutable pattern as \`/widget.js\`. \`<script async src=".../tracker.js" data-key="mn_track_…">\` is the embed line.
- **\`analytics_trackers\` entity** mirroring the chat-widget pattern: \`api_keys.tracker_id\` FK + per-tracker \`allowedOrigins\` enforced on every ingest request.
- **Origin allowlist** via \`originIsAllowed()\` in the analytics-tracker controller; \`MUNIN_TRACKER_REQUIRE_ALLOWLIST=1\` flips empty lists to fail-closed (symmetric with the existing \`MUNIN_WIDGET_REQUIRE_ALLOWLIST\`).
- **Schema-enforced integrity**: CHECK constraints on \`api_keys\` so \`type='track'\` requires \`tracker_id\` and \`type='widget'\` requires \`channel_id\` (the latter \`NOT VALID\` for legacy tolerance).
- **MCP tools**: \`analytics_create_tracker\`, \`analytics_update_tracker\`, \`analytics_list_trackers\`, \`analytics_revoke_tracker\`, plus the read tools \`analytics_top_subjects\`, \`analytics_subject_engagement\`, \`analytics_zero_result_searches\`.
- **\`MUNIN_API_URL\` helper** (\`readApiBaseUrl()\`) — fixes a latent bug where pixel URLs (email open + CMS analytics) pointed at the MCP host on split-host deployments.
- **Skills**: new \`skill://analytics/track-website-traffic\`; \`skill://cms/review-stale-entries\` updated to consult \`analytics_subject_engagement\`; chat-widget skill updated to mark \`originAllowlist\` as required (no env-var leakage to agents).
- **\`.env.example\`** documents \`MUNIN_API_URL\`, \`MUNIN_WIDGET_REQUIRE_ALLOWLIST\`, \`MUNIN_TRACKER_REQUIRE_ALLOWLIST\`.

## Test plan

- [x] 734/734 backend-core tests pass on a fresh DB (verified locally before opening #357).
- [x] \`pnpm typecheck\` clean across the workspace.
- [x] \`pnpm -F @getmunin/analytics-tracker build\` produces a 2 KB / 1 KB gzip content-hashed bundle.
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)