### PR TITLE
feat(analytics): tracker entity, drop-in script, origin allowlist

### DIFF
--- a/.changeset/analytics-tracker-drop-in-script.md
+++ b/.changeset/analytics-tracker-drop-in-script.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/core': minor
+'@getmunin/db': minor
+---
+
+Add a drop-in tracker script for arbitrary web pages — same ergonomics as the chat widget. `analytics_create_tracker` mints a public `mn_track_*` API key, then a single `<script async src=".../v1/a/tracker.js" data-key="mn_track_…">` tag auto-fires page views, tracks dwell on `pagehide`, and exposes `window.mn.track(subjectId, attrs)` for SPA route changes. Events land in `analytics_view_events` with `source='tracker'`. Tracker keys are write-only and org-scoped — safe to embed in browsers.
+
+Also adds three admin read tools: `analytics_top_subjects` (most-viewed pages/entries), `analytics_subject_engagement` (views/dwell/depth for one subject), `analytics_zero_result_searches` (queries readers asked that returned nothing — the best "what to write next" signal). The `cms/review-stale-entries` skill now consults `analytics_subject_engagement` to judge refresh-vs-archive instead of relying on inbound references alone; a new `skill://analytics/track-website-traffic` walks operators through the full setup.

--- a/.env.example
+++ b/.env.example
@@ -206,6 +206,17 @@ MUNIN_QUOTAS_ENABLED=false
 # MUNIN_PUBLIC_THROTTLE_MIN=60
 # MUNIN_PUBLIC_THROTTLE_HOUR=1000
 
+# --- Origin allowlist enforcement --------------------------------------
+# Chat-widget channels (conv_channels.config.originAllowlist) and
+# analytics trackers (analytics_trackers.allowed_origins) each carry an
+# optional allowed-origins list. Empty list = accept any origin (dev
+# default). Set the matching env var to "1" in production to make empty
+# lists fail-closed — any widget channel or tracker without explicit
+# origins refuses all ingest requests until the operator sets the list
+# via conv_widget_update_channel / analytics_update_tracker.
+# MUNIN_WIDGET_REQUIRE_ALLOWLIST=0
+# MUNIN_TRACKER_REQUIRE_ALLOWLIST=0
+
 # --- Web ----------------------------------------------------------------
 WEB_PORT=3000
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 > MCP-first customer platform made for the agentic era. The agent is the UI.
 
-Munin is an open-source customer platform built for the agentic era (Knowledge Base, Conversations, CRM, CMS, Outreach) where the only interface is via AI agents. There is no traditional admin UI for the apps themselves — every action runs through MCP tools, callable from any MCP-compatible client.
+Munin is an open-source customer platform built for the agentic era (Knowledge Base, Conversations, CRM, CMS, Outreach, Analytics) where the only interface is via AI agents. There is no traditional admin UI for the apps themselves — every action runs through MCP tools, callable from any MCP-compatible client.
 
 ## What's in the box
 
 - **Knowledge Base** — markdown documents, hybrid search (BM25 + pgvector embeddings), per-document audience scoping.
 - **Conversations** — multi-channel threads (email, voice via Vapi, SMS via Twilio/MessageBird, chat widget) routed to end-users, assignable, agent-resolvable, with handover state and webhook fan-out.
 - **CRM** — contacts, companies, deals, activities, pipelines, segments, plus a merge-proposal queue the `clean-contact-data` curator runs against.
-- **CMS** — agent-authored content collections with field schemas, localized entries, scheduled publishing, an asset library backed by S3-compatible storage, and a public delivery API.
+- **CMS** — agent-authored content collections with field schemas, localized entries, scheduled publishing, an asset library backed by S3-compatible storage, and a public delivery API that ships a `_tracking` block on every entry for built-in engagement signal.
 - **Outreach** — propose-only outbound emails: campaigns + segments + drafts queued for human approval; never auto-sends.
+- **Analytics** — polymorphic page-view + search-query ingestion. CMS delivery wires in for free; arbitrary pages drop in a `<script src="…/tracker.js" data-key="mn_track_…">` tag. Read tools (`analytics_top_subjects`, `analytics_subject_engagement`, `analytics_zero_result_searches`) feed the "what should we write next" loop into curator skills like `cms/review-stale-entries`.
 - **Curator** — durable background job queue running skills (KB curation, CRM hygiene, contact extraction, stale-content review, outreach drafts) on a schedule with retry + dead-letter.
 - **Playbooks + skills** — packaged markdown procedures (`skill://module/<verb-object>`) the agent reads via MCP resources to follow multi-step flows.
 - **Cross-cutting** — audit log, webhooks, team invites, OAuth 2.1 dynamic-client registration, BetterAuth-backed sign-in.
@@ -82,13 +83,13 @@ Once you've signed up (hosted) or run `docker compose up` (self-host), point you
 }
 ```
 
-(For the hosted version, swap in `https://mcp.getmunin.com`.) The first call triggers an OAuth consent screen in your browser, then your agent has the full tool surface — Knowledge Base, Conversations, CRM, CMS, Outreach.
+(For the hosted version, swap in `https://mcp.getmunin.com`.) The first call triggers an OAuth consent screen in your browser, then your agent has the full tool surface — Knowledge Base, Conversations, CRM, CMS, Outreach, Analytics.
 
 ## Two trust contexts, one MCP endpoint
 
 The same `/mcp` endpoint serves two distinct callers, audience-aware:
 
-- **Admin agents** (Claude Desktop, Cursor, internal automation) — OAuth-authorized by you. Full tool surface, scope-gated per `kb:*`, `conv:*`, `crm:*`, `cms:*`, `outreach:*`.
+- **Admin agents** (Claude Desktop, Cursor, internal automation) — OAuth-authorized by you. Full tool surface, scope-gated per `kb:*`, `conv:*`, `crm:*`, `cms:*`, `outreach:*`, `analytics:*`.
 - **End-user agents** (your voice AI, web chatbot, mobile app helper) — short-lived delegated tokens minted server-side from your backend, scoped to one of your end-users. Only self-service tools (read your own contact, send a message in your own conversation).
 
 See `packages/backend-core/src/control/delegated-token.controller.ts` for the token-mint API. The `@getmunin/sdk` Node client wraps it.
@@ -98,7 +99,8 @@ See `packages/backend-core/src/control/delegated-token.controller.ts` for the to
 - `apps/backend` — thin NestJS entry composing `@getmunin/backend-core` modules with single-tenant `AuthModule`. Exposes the MCP server (Streamable HTTP), OAuth 2.1 + OIDC discovery, and the control-plane REST API on port 3001.
 - `apps/web` — Next.js dashboard + landing on port 3000.
 - `apps/chat-widget` — embeddable browser widget that consumes a `mn_widget_*` key and the widget ingest API.
-- `packages/backend-core` — every shared NestJS module (KB, Conversations, CRM, CMS, Outreach, Curator, Web, Playbooks, MCP, control plane, audit, tenancy, RLS, mailer, storage, webhooks, rate limit, quotas, OAuth) plus `createApp` and the `createAuthController` helper. Cloud composes the same modules with multi-tenant auth.
+- `apps/analytics-tracker` — embeddable browser tracker, served at `/tracker.js`, that consumes a public `mn_track_*` key and writes page-view events.
+- `packages/backend-core` — every shared NestJS module (KB, Conversations, CRM, CMS, Outreach, Analytics, Curator, Web, Playbooks, MCP, control plane, audit, tenancy, RLS, mailer, storage, webhooks, rate limit, quotas, OAuth) plus `createApp` and the `createAuthController` helper. Cloud composes the same modules with multi-tenant auth.
 - `packages/dashboard-pages` — dashboard page components shared between OSS and cloud webs.
 - `packages/ui` — design-system primitives (shadcn-style).
 - `packages/{core, db, types, sdk, mcp-toolkit}` — non-Nest building blocks: actor identity + tenancy GUCs, Drizzle schema + migrations, shared types, Node client SDK, MCP `@McpTool` / `@SkillRegistry` decorators.

--- a/apps/analytics-tracker/eslint.config.mjs
+++ b/apps/analytics-tracker/eslint.config.mjs
@@ -3,6 +3,6 @@ import base from '@getmunin/eslint-config';
 export default [
   ...base,
   {
-    ignores: ['scripts/**/*.mjs', 'eslint.config.mjs'],
+    ignores: ['eslint.config.mjs'],
   },
 ];

--- a/apps/analytics-tracker/package.json
+++ b/apps/analytics-tracker/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@getmunin/analytics-tracker",
+  "version": "4.33.0",
+  "license": "MIT",
+  "description": "Drop-in browser analytics tracker for self-hosted Munin. Built as a single content-hashed IIFE bundle and served by the Munin backend.",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getmunin/munin.git",
+    "directory": "apps/analytics-tracker"
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch --mode development",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "devDependencies": {
+    "@getmunin/eslint-config": "workspace:*",
+    "@getmunin/tsconfig": "workspace:*",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.10.0",
+    "happy-dom": "^20.9.0",
+    "typescript": "^5.6.0",
+    "typescript-eslint": "^8.5.0",
+    "vite": "^6.4.2",
+    "vitest": "^4.1.0"
+  }
+}

--- a/apps/analytics-tracker/src/tracker.ts
+++ b/apps/analytics-tracker/src/tracker.ts
@@ -1,0 +1,185 @@
+/**
+ * Munin analytics tracker — drop-in browser script.
+ *
+ * Embedded as `<script async src="…/tracker.js" data-key="mn_track_…">`.
+ * Auto-fires a page view on DOMContentLoaded, captures referrer + UTM +
+ * locale, persists a random visitor id in localStorage, and reports
+ * best-effort dwell time on `pagehide`. Optional SPA mode hooks
+ * `history.pushState` / `replaceState` so route changes fire fresh
+ * views.
+ *
+ * Exposes `window.mn.track(subjectId, attrs)` for custom events.
+ */
+
+interface TrackAttrs {
+  subjectType?: string;
+  path?: string;
+  referrer?: string | null;
+  dwellMs?: number;
+  readDepth?: number;
+  utm?: { source?: string; medium?: string; campaign?: string };
+  metadata?: Record<string, unknown>;
+}
+
+interface BeaconPayload {
+  key: string;
+  subjectType: string;
+  subjectId: string;
+  path: string;
+  referrer: string | null;
+  visitorId: string | null;
+  locale: string | undefined;
+  dwellMs?: number;
+  readDepth?: number;
+  utm: { source?: string; medium?: string; campaign?: string };
+  metadata?: Record<string, unknown>;
+}
+
+interface MuninGlobal {
+  track: (subjectId: string, attrs?: TrackAttrs) => void;
+  trackPageView: () => void;
+}
+
+const VISITOR_KEY = 'mn.vid';
+
+(function init(): void {
+  const doc = document;
+  const script = doc.currentScript as HTMLScriptElement | null;
+  if (!script) {
+    console.warn('[munin-tracker] document.currentScript unavailable; tracker disabled');
+    return;
+  }
+  const key = script.getAttribute('data-key');
+  if (!key) {
+    console.warn('[munin-tracker] data-key attribute missing on script tag; tracker disabled');
+    return;
+  }
+
+  let apiBase = script.getAttribute('data-api');
+  if (!apiBase) {
+    try {
+      apiBase = new URL(script.src).origin;
+    } catch (err) {
+      console.warn('[munin-tracker] could not resolve data-api or script.src origin:', err);
+      return;
+    }
+  }
+  apiBase = apiBase.replace(/\/+$/, '');
+
+  const subjectType = script.getAttribute('data-subject-type') || 'page';
+  const spa = script.getAttribute('data-spa') === 'true';
+  const beaconUrl = apiBase + '/v1/a/t';
+
+  let visitorId: string | null = null;
+  try {
+    visitorId = localStorage.getItem(VISITOR_KEY);
+    if (!visitorId) {
+      visitorId =
+        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? crypto.randomUUID()
+          : 'v-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+      localStorage.setItem(VISITOR_KEY, visitorId);
+    }
+  } catch {
+    visitorId = null;
+  }
+
+  const initialReferrer = doc.referrer || null;
+  let pageEnter = Date.now();
+  let lastPath = location.pathname;
+
+  function send(payload: BeaconPayload): void {
+    try {
+      const body = JSON.stringify(payload);
+      if (navigator.sendBeacon) {
+        const blob = new Blob([body], { type: 'application/json' });
+        navigator.sendBeacon(beaconUrl, blob);
+        return;
+      }
+      void fetch(beaconUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+        keepalive: true,
+        mode: 'no-cors',
+      }).catch((err) => {
+        console.warn('[munin-tracker] beacon fetch failed:', err);
+      });
+    } catch (err) {
+      console.warn('[munin-tracker] failed to send beacon:', err);
+    }
+  }
+
+  function readUtm(): { source?: string; medium?: string; campaign?: string } {
+    try {
+      const p = new URLSearchParams(location.search);
+      return {
+        source: p.get('utm_source') || undefined,
+        medium: p.get('utm_medium') || undefined,
+        campaign: p.get('utm_campaign') || undefined,
+      };
+    } catch {
+      return {};
+    }
+  }
+
+  function trackView(subjectId: string, attrs: TrackAttrs = {}): void {
+    send({
+      key: key!,
+      subjectType: attrs.subjectType || subjectType,
+      subjectId,
+      path: attrs.path || location.pathname + location.search,
+      referrer: attrs.referrer !== undefined ? attrs.referrer : initialReferrer,
+      visitorId,
+      locale: doc.documentElement.lang || undefined,
+      dwellMs: attrs.dwellMs,
+      readDepth: attrs.readDepth,
+      utm: attrs.utm || readUtm(),
+      metadata: attrs.metadata,
+    });
+  }
+
+  function trackPageView(): void {
+    trackView(location.pathname);
+  }
+
+  if (doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', trackPageView, { once: true });
+  } else {
+    trackPageView();
+  }
+
+  if (spa) {
+    const origPush = history.pushState.bind(history);
+    const origReplace = history.replaceState.bind(history);
+    function onRouteChange(): void {
+      if (location.pathname === lastPath) return;
+      const dwell = Date.now() - pageEnter;
+      pageEnter = Date.now();
+      lastPath = location.pathname;
+      trackView(location.pathname, { dwellMs: dwell, referrer: null });
+    }
+    history.pushState = function (...args): void {
+      origPush(...args);
+      onRouteChange();
+    };
+    history.replaceState = function (...args): void {
+      origReplace(...args);
+      onRouteChange();
+    };
+    addEventListener('popstate', onRouteChange);
+  }
+
+  addEventListener('pagehide', () => {
+    const dwell = Date.now() - pageEnter;
+    trackView(lastPath, { dwellMs: dwell, referrer: null });
+  });
+
+  const w = window as Window & { mn?: MuninGlobal };
+  const mn: MuninGlobal = w.mn ?? (w.mn = {} as MuninGlobal);
+  mn.track = trackView;
+  mn.trackPageView = trackPageView;
+})();
+
+export {};
+

--- a/apps/analytics-tracker/tsconfig.json
+++ b/apps/analytics-tracker/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@getmunin/tsconfig/base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "outDir": "dist",
+    "noEmit": true,
+    "experimentalDecorators": false,
+    "emitDecoratorMetadata": false
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/apps/analytics-tracker/vite.config.ts
+++ b/apps/analytics-tracker/vite.config.ts
@@ -1,0 +1,87 @@
+import { defineConfig } from 'vite';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, renameSync, readdirSync, unlinkSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+/**
+ * Builds a single IIFE bundle the analytics tracker loads as
+ * `<script src=…>`. Mirrors the chat-widget pipeline.
+ *
+ * Output:
+ *   dist/tracker.<sha>.js       – the bundle, content-hashed for
+ *                                 immutable CDN caching.
+ *   dist/tracker.<sha>.js.map   – source map.
+ *   dist/manifest.json          – { current: "tracker.<sha>.js", sha,
+ *                                 builtAt }; the backend reads this at
+ *                                 boot to wire the unhashed redirect.
+ */
+export default defineConfig(({ mode }) => ({
+  resolve: {
+    conditions: mode === 'development' ? ['development'] : [],
+  },
+  build: {
+    target: 'es2020',
+    cssCodeSplit: false,
+    sourcemap: true,
+    minify: 'esbuild',
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, 'src/tracker.ts'),
+      name: 'MuninAnalyticsTracker',
+      formats: ['iife'],
+      fileName: () => 'tracker.js',
+    },
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: true,
+      },
+    },
+  },
+  plugins: [
+    {
+      name: 'munin-tracker-content-hash',
+      writeBundle(_options, bundle) {
+        const distDir = resolve(__dirname, 'dist');
+        const jsAsset = bundle['tracker.js'];
+        if (!jsAsset || jsAsset.type !== 'chunk') {
+          throw new Error('expected tracker.js chunk in bundle');
+        }
+        const code: string = jsAsset.code;
+        const sha = createHash('sha256').update(code).digest('hex').slice(0, 12);
+
+        const sourceJs = join(distDir, 'tracker.js');
+        const targetJs = join(distDir, `tracker.${sha}.js`);
+        const sourceMap = join(distDir, 'tracker.js.map');
+        const targetMap = join(distDir, `tracker.${sha}.js.map`);
+
+        renameSync(sourceJs, targetJs);
+        try {
+          const patched = readFileSync(targetJs, 'utf8').replace(
+            /\/\/# sourceMappingURL=tracker\.js\.map/,
+            `//# sourceMappingURL=tracker.${sha}.js.map`,
+          );
+          writeFileSync(targetJs, patched);
+          renameSync(sourceMap, targetMap);
+        } catch {
+          // sourcemap may be disabled; ignore
+        }
+
+        const manifest = {
+          current: `tracker.${sha}.js`,
+          sha,
+          builtAt: new Date().toISOString(),
+        };
+        writeFileSync(join(distDir, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+
+        for (const file of readdirSync(distDir)) {
+          if (file === manifest.current) continue;
+          if (file === `${manifest.current}.map`) continue;
+          if (file === 'manifest.json') continue;
+          if (/^tracker\.[a-f0-9]{12}\.js(\.map)?$/.test(file)) {
+            unlinkSync(join(distDir, file));
+          }
+        }
+      },
+    },
+  ],
+}));

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "prebuild": "node scripts/copy-widget.mjs",
+    "prebuild": "node scripts/copy-widget.mjs && node scripts/copy-tracker.mjs",
     "build": "nest build",
     "dev": "node --import @swc-node/register/esm-register --watch --conditions=development src/main.ts",
     "start": "node dist/main.js",
@@ -18,6 +18,7 @@
   "dependencies": {
     "@better-auth/oauth-provider": "^1.6.10",
     "@getmunin/agent-host": "workspace:*",
+    "@getmunin/analytics-tracker": "workspace:*",
     "@getmunin/backend-core": "workspace:*",
     "@getmunin/chat-widget": "workspace:*",
     "@getmunin/core": "workspace:*",

--- a/apps/backend/scripts/copy-tracker.mjs
+++ b/apps/backend/scripts/copy-tracker.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Build-time copy of @getmunin/analytics-tracker's hashed bundle into the
+ * backend's public/tracker/ directory. Runs as `prebuild` so the bundle
+ * is in place before nest build packages dist/.
+ *
+ * Reads `node_modules/@getmunin/analytics-tracker/dist/manifest.json` for
+ * the current hash, copies:
+ *   tracker.<sha>.js      — content-hashed bundle
+ *   tracker.<sha>.js.map  — sourcemap (best-effort; no error if absent)
+ *   manifest.json         — { current, sha, builtAt }
+ *
+ * Older hashed bundles in the destination are left in place so in-flight
+ * clients holding a stale `<sha>` URL can still resolve it for a while.
+ *
+ * Exit codes:
+ *   0  – copied successfully (or no change needed).
+ *   1  – source manifest / bundle missing — fail the build, don't ship a
+ *        backend without a tracker asset.
+ */
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const BACKEND_ROOT = resolve(SCRIPT_DIR, '..');
+const SRC_DIR = resolve(
+  BACKEND_ROOT,
+  'node_modules',
+  '@getmunin',
+  'analytics-tracker',
+  'dist',
+);
+const DEST_DIR = resolve(BACKEND_ROOT, 'public', 'tracker');
+
+main();
+
+function main() {
+  if (!existsSync(SRC_DIR)) {
+    console.error(`[copy-tracker] missing source dir: ${SRC_DIR}`);
+    console.error(
+      `[copy-tracker] run \`pnpm --filter @getmunin/analytics-tracker build\` first or rely on the workspace ^build chain.`,
+    );
+    process.exit(1);
+  }
+
+  const manifestPath = join(SRC_DIR, 'manifest.json');
+  if (!existsSync(manifestPath)) {
+    console.error(`[copy-tracker] missing manifest.json at ${manifestPath}`);
+    process.exit(1);
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (!manifest || typeof manifest !== 'object' || typeof manifest.current !== 'string') {
+    console.error(`[copy-tracker] manifest.json missing "current" field`);
+    process.exit(1);
+  }
+
+  if (!/^tracker\.[a-f0-9]{12}\.js$/.test(manifest.current)) {
+    console.error(
+      `[copy-tracker] manifest.current does not match expected pattern: ${manifest.current}`,
+    );
+    process.exit(1);
+  }
+
+  const bundlePath = join(SRC_DIR, manifest.current);
+  if (!existsSync(bundlePath)) {
+    console.error(`[copy-tracker] bundle missing: ${bundlePath}`);
+    process.exit(1);
+  }
+
+  mkdirSync(DEST_DIR, { recursive: true });
+
+  copyFileSync(bundlePath, join(DEST_DIR, manifest.current));
+
+  const mapPath = `${bundlePath}.map`;
+  if (existsSync(mapPath)) {
+    copyFileSync(mapPath, join(DEST_DIR, `${manifest.current}.map`));
+  }
+
+  writeFileSync(join(DEST_DIR, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+
+  console.log(`[copy-tracker] copied ${manifest.current} → ${DEST_DIR}`);
+}

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -1398,6 +1398,45 @@
         "security": []
       }
     },
+    "/v1/a/t/{key}.gif": {
+      "get": {
+        "operationId": "AnalyticsTrackerController_trackerPixel",
+        "parameters": [
+          {
+            "name": "key",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AnalyticsTracker"
+        ],
+        "security": []
+      }
+    },
+    "/v1/a/t": {
+      "post": {
+        "operationId": "AnalyticsTrackerController_trackerBeacon",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AnalyticsTracker"
+        ],
+        "security": []
+      }
+    },
     "/v1/orgs/me/invitations": {
       "post": {
         "operationId": "InvitationsController_create",

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -15,11 +15,12 @@ const JSON_BODY_LIMIT = '4mb';
 const DEFAULT_DEV_WEB_ORIGINS = ['http://localhost:3000', 'http://127.0.0.1:3000'];
 
 /**
- * Hashed widget bundles match `widget.<12-hex-sha>.js[.map]?`. Anything
- * else hitting `/widget/...` is rejected with 404 — no path traversal
- * surface, no accidental directory listing.
+ * Hashed widget / tracker bundles match `<name>.<12-hex-sha>.js[.map]?`.
+ * Anything else hitting `/widget/...` or `/tracker/...` is rejected with
+ * 404 — no path traversal surface, no accidental directory listing.
  */
 const HASHED_WIDGET_FILE_RE = /^widget\.[a-f0-9]{12}\.js(\.map)?$/;
+const HASHED_TRACKER_FILE_RE = /^tracker\.[a-f0-9]{12}\.js(\.map)?$/;
 
 export function readAllowedOrigins(): string[] | true {
   const env = process.env.MUNIN_CORS_ORIGINS;
@@ -55,6 +56,14 @@ export interface CreateAppOptions extends NestApplicationOptions {
    */
   widgetAssetDir?: string;
   /**
+   * Absolute path to the directory holding the analytics-tracker's hashed
+   * bundle + manifest.json. Defaults to `<cwd>/public/tracker` which
+   * matches `apps/backend/public/tracker/` after the prebuild copy step.
+   * Same shape as `widgetAssetDir`. Missing manifest → 503 on
+   * `/tracker.js`, rest of API still boots.
+   */
+  trackerAssetDir?: string;
+  /**
    * Absolute path to the directory holding the MCP host's brand icons —
    * `favicon.ico`, `icon.png`, `apple-icon.png`. Served at the root paths
    * `/favicon.ico`, `/icon.png`, `/apple-icon.png` with a long cache.
@@ -73,6 +82,8 @@ export interface CreateAppOptions extends NestApplicationOptions {
  *     `publicUrlFor()`.
  *   - Chat-widget bundle: `/widget/<sha>.js` (immutable, year-long cache)
  *     and `/widget.js` (302 redirect to the current sha, short cache).
+ *   - Analytics-tracker bundle: same shape at `/tracker/<sha>.js` and
+ *     `/tracker.js`.
  *
  * The caller supplies their AppModule (single-tenant for OSS, multi-tenant
  * for cloud). Both editions go through this factory so tests, prod, and
@@ -82,7 +93,7 @@ export async function createApp(
   appModule: Type<unknown>,
   opts: CreateAppOptions = {},
 ): Promise<INestApplication> {
-  const { widgetAssetDir, iconAssetDir, ...nestOpts } = opts;
+  const { widgetAssetDir, trackerAssetDir, iconAssetDir, ...nestOpts } = opts;
   const app = await NestFactory.create<NestExpressApplication>(appModule, {
     rawBody: true,
     ...nestOpts,
@@ -108,8 +119,12 @@ export async function createApp(
   }
 
   const resolvedWidgetDir = resolve(widgetAssetDir ?? join(process.cwd(), 'public', 'widget'));
-  app.use('/widget.js', widgetRedirectMiddleware(resolvedWidgetDir));
-  app.use('/widget', widgetBundleMiddleware(resolvedWidgetDir));
+  app.use('/widget.js', hashedBundleRedirectMiddleware(resolvedWidgetDir, HASHED_WIDGET_FILE_RE, '/widget'));
+  app.use('/widget', hashedBundleServeMiddleware(resolvedWidgetDir, HASHED_WIDGET_FILE_RE));
+
+  const resolvedTrackerDir = resolve(trackerAssetDir ?? join(process.cwd(), 'public', 'tracker'));
+  app.use('/tracker.js', hashedBundleRedirectMiddleware(resolvedTrackerDir, HASHED_TRACKER_FILE_RE, '/tracker'));
+  app.use('/tracker', hashedBundleServeMiddleware(resolvedTrackerDir, HASHED_TRACKER_FILE_RE));
 
   const resolvedIconDir = resolve(iconAssetDir ?? join(process.cwd(), 'public', 'icons'));
   app.use(brandIconMiddleware(resolvedIconDir));
@@ -122,6 +137,9 @@ export function isPublicCorsPath(path: string): boolean {
     path === '/widget.js' ||
     path.startsWith('/widget/') ||
     path.startsWith('/v1/widget') ||
+    path === '/tracker.js' ||
+    path.startsWith('/tracker/') ||
+    path.startsWith('/v1/a/') ||
     path === '/mcp' ||
     path.startsWith('/mcp/') ||
     path.startsWith('/.well-known/oauth-') ||
@@ -313,17 +331,20 @@ function staticAssetsMiddleware(storage: LocalFsStorage) {
  * a server restart. Returns `null` if the manifest is missing or
  * malformed — the route handlers translate that to a 503.
  */
-function manifestReader(widgetDir: string): () => Promise<{ current: string } | null> {
+function manifestReader(
+  bundleDir: string,
+  hashedFileRe: RegExp,
+): () => Promise<{ current: string } | null> {
   let cached: { current: string } | null = null;
   let cachedMtime = -1;
   return async () => {
-    const path = join(widgetDir, 'manifest.json');
+    const path = join(bundleDir, 'manifest.json');
     try {
       const info = await stat(path);
       if (info.mtimeMs !== cachedMtime) {
         const raw = await readFile(path, 'utf8');
         const parsed = JSON.parse(raw) as { current?: unknown };
-        if (typeof parsed.current === 'string' && HASHED_WIDGET_FILE_RE.test(parsed.current)) {
+        if (typeof parsed.current === 'string' && hashedFileRe.test(parsed.current)) {
           cached = { current: parsed.current };
           cachedMtime = info.mtimeMs;
         } else {
@@ -339,8 +360,12 @@ function manifestReader(widgetDir: string): () => Promise<{ current: string } | 
   };
 }
 
-function widgetRedirectMiddleware(widgetDir: string) {
-  const readManifest = manifestReader(widgetDir);
+function hashedBundleRedirectMiddleware(
+  bundleDir: string,
+  hashedFileRe: RegExp,
+  redirectBase: string,
+) {
+  const readManifest = manifestReader(bundleDir, hashedFileRe);
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       next();
@@ -354,23 +379,23 @@ function widgetRedirectMiddleware(widgetDir: string) {
     }
     res.setHeader('access-control-allow-origin', '*');
     res.setHeader('cache-control', 'public, max-age=300, must-revalidate');
-    res.redirect(302, `/widget/${manifest.current}`);
+    res.redirect(302, `${redirectBase}/${manifest.current}`);
   };
 }
 
-function widgetBundleMiddleware(widgetDir: string) {
+function hashedBundleServeMiddleware(bundleDir: string, hashedFileRe: RegExp) {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       next();
       return;
     }
     const file = req.path.replace(/^\/+/, '');
-    if (!HASHED_WIDGET_FILE_RE.test(file)) {
+    if (!hashedFileRe.test(file)) {
       res.status(404).end();
       return;
     }
-    const filePath = resolve(join(widgetDir, file));
-    if (!filePath.startsWith(resolve(widgetDir))) {
+    const filePath = resolve(join(bundleDir, file));
+    if (!filePath.startsWith(resolve(bundleDir))) {
       res.status(404).end();
       return;
     }

--- a/packages/backend-core/src/control/analytics-tracker.controller.ts
+++ b/packages/backend-core/src/control/analytics-tracker.controller.ts
@@ -1,0 +1,199 @@
+import {
+  Body,
+  Get,
+  HttpCode,
+  Headers,
+  Inject,
+  Param,
+  Post,
+  Query,
+  Res,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { and, eq, isNull } from 'drizzle-orm';
+import { schema, type Db } from '@getmunin/db';
+import { hashSecret, isWellFormedKey, keyPrefix, looksLikeBot } from '@getmunin/core';
+import { PublicController } from '../common/auth/auth.guard.ts';
+import { DB } from '../common/db/db.module.ts';
+import { AnalyticsService } from '../modules/analytics/analytics.service.ts';
+
+const TRANSPARENT_GIF = Buffer.from(
+  'R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+  'base64',
+);
+
+const DEFAULT_SUBJECT_TYPE = 'page';
+
+interface TrackerBeaconBody {
+  key?: string;
+  subjectType?: string;
+  subjectId?: string;
+  path?: string;
+  referrer?: string;
+  visitorId?: string;
+  locale?: string;
+  dwellMs?: number;
+  readDepth?: number;
+  utm?: {
+    source?: string;
+    medium?: string;
+    campaign?: string;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+interface ResolvedTracker {
+  trackerId: string;
+  orgId: string;
+  apiKeyId: string;
+  allowedOrigins: string[];
+}
+
+@PublicController('v1/a', { throttle: true })
+export class AnalyticsTrackerController {
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
+  ) {}
+
+  @Get('t/:key.gif')
+  async trackerPixel(
+    @Param('key') key: string,
+    @Headers('user-agent') userAgent: string | undefined,
+    @Headers('referer') referer: string | undefined,
+    @Headers('origin') origin: string | undefined,
+    @Query('s') subjectId: string | undefined,
+    @Query('t') subjectType: string | undefined,
+    @Query('v') visitorId: string | undefined,
+    @Res() res: Response,
+  ): Promise<void> {
+    sendPixel(res);
+    if (looksLikeBot(userAgent)) return;
+    if (!subjectId) return;
+    const tracker = await this.resolveTrackerKey(key);
+    if (!tracker) return;
+    if (!originIsAllowed(tracker.allowedOrigins, origin)) return;
+
+    await this.analytics.recordView({
+      orgId: tracker.orgId,
+      subjectType: subjectType || DEFAULT_SUBJECT_TYPE,
+      subjectId,
+      source: 'tracker',
+      referrer: referer ?? null,
+      visitorId: visitorId ?? null,
+      userAgentClass: 'browser',
+    });
+  }
+
+  @Post('t')
+  @HttpCode(204)
+  async trackerBeacon(
+    @Body() body: TrackerBeaconBody,
+    @Headers('user-agent') userAgent: string | undefined,
+    @Headers('referer') referer: string | undefined,
+    @Headers('origin') origin: string | undefined,
+  ): Promise<void> {
+    if (looksLikeBot(userAgent)) return;
+    if (!body || typeof body.key !== 'string' || typeof body.subjectId !== 'string') return;
+    const tracker = await this.resolveTrackerKey(body.key);
+    if (!tracker) return;
+    if (!originIsAllowed(tracker.allowedOrigins, origin)) return;
+
+    await this.analytics.recordView({
+      orgId: tracker.orgId,
+      subjectType: body.subjectType || DEFAULT_SUBJECT_TYPE,
+      subjectId: body.subjectId,
+      source: 'tracker',
+      path: body.path ?? null,
+      locale: body.locale ?? null,
+      referrer: body.referrer ?? referer ?? null,
+      visitorId: body.visitorId ?? null,
+      dwellMs: typeof body.dwellMs === 'number' ? body.dwellMs : null,
+      readDepth: typeof body.readDepth === 'number' ? body.readDepth : null,
+      utmSource: body.utm?.source ?? null,
+      utmMedium: body.utm?.medium ?? null,
+      utmCampaign: body.utm?.campaign ?? null,
+      userAgentClass: 'tracker',
+      metadata: body.metadata ?? null,
+    });
+  }
+
+  private async resolveTrackerKey(rawKey: string): Promise<ResolvedTracker | null> {
+    if (!rawKey || !isWellFormedKey(rawKey) || !rawKey.startsWith('mn_track_')) return null;
+    try {
+      const rows = await this.db
+        .select({
+          apiKeyId: schema.apiKeys.id,
+          orgId: schema.apiKeys.orgId,
+          trackerId: schema.analyticsTrackers.id,
+          allowedOrigins: schema.analyticsTrackers.allowedOrigins,
+        })
+        .from(schema.apiKeys)
+        .innerJoin(
+          schema.analyticsTrackers,
+          eq(schema.apiKeys.trackerId, schema.analyticsTrackers.id),
+        )
+        .where(
+          and(
+            eq(schema.apiKeys.keyPrefix, keyPrefix(rawKey)),
+            eq(schema.apiKeys.keyHash, hashSecret(rawKey)),
+            eq(schema.apiKeys.type, 'track'),
+            isNull(schema.apiKeys.revokedAt),
+          ),
+        )
+        .limit(1);
+      const row = rows[0];
+      if (!row || !row.orgId) return null;
+      void this.db
+        .update(schema.apiKeys)
+        .set({ lastUsedAt: new Date() })
+        .where(eq(schema.apiKeys.id, row.apiKeyId))
+        .then(undefined, () => undefined);
+      return {
+        trackerId: row.trackerId,
+        orgId: row.orgId,
+        apiKeyId: row.apiKeyId,
+        allowedOrigins: row.allowedOrigins,
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function originIsAllowed(
+  allowedOrigins: readonly string[],
+  origin: string | undefined,
+): boolean {
+  const list = allowedOrigins ?? [];
+  if (list.length === 0) {
+    return !requireTrackerAllowlist();
+  }
+  if (!origin) return false;
+  let viewerOrigin: string;
+  try {
+    viewerOrigin = new URL(origin).origin;
+  } catch {
+    return false;
+  }
+  return list.some((entry) => {
+    try {
+      return new URL(entry).origin === viewerOrigin;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function requireTrackerAllowlist(): boolean {
+  const raw = process.env.MUNIN_TRACKER_REQUIRE_ALLOWLIST?.trim().toLowerCase();
+  return raw === '1' || raw === 'true';
+}
+
+function sendPixel(res: Response): void {
+  res.setHeader('Content-Type', 'image/gif');
+  res.setHeader('Content-Length', String(TRANSPARENT_GIF.length));
+  res.setHeader('Cache-Control', 'no-store, private, max-age=0');
+  res.setHeader('Pragma', 'no-cache');
+  res.status(200).end(TRANSPARENT_GIF);
+}

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -176,6 +176,15 @@ interface OrgFixture {
 
     it('widget key cannot mint admin API keys', async () => {
       const widgetKey = buildApiKey('widget');
+      const [channel] = await db
+        .insert(schema.convChannels)
+        .values({
+          orgId: orgA.id,
+          type: 'chat',
+          vendor: 'munin',
+          name: 'cp-widget-escalation-channel',
+        })
+        .returning();
       await db.insert(schema.apiKeys).values({
         orgId: orgA.id,
         type: 'widget',
@@ -183,6 +192,7 @@ interface OrgFixture {
         keyHash: hashSecret(widgetKey),
         keyPrefix: keyPrefix(widgetKey),
         scopes: ['conv:widget:write'],
+        channelId: channel!.id,
       });
 
       const create = await fetch(`${baseUrl}/v1/api-keys`, {
@@ -226,6 +236,15 @@ interface OrgFixture {
   describe('control-plane guard on other admin routes', () => {
     it('widget key cannot list channels or enqueue curator jobs', async () => {
       const widgetKey = buildApiKey('widget');
+      const [channel] = await db
+        .insert(schema.convChannels)
+        .values({
+          orgId: orgA.id,
+          type: 'chat',
+          vendor: 'munin',
+          name: 'cp-widget-cross-route-channel',
+        })
+        .returning();
       await db.insert(schema.apiKeys).values({
         orgId: orgA.id,
         type: 'widget',
@@ -233,6 +252,7 @@ interface OrgFixture {
         keyHash: hashSecret(widgetKey),
         keyPrefix: keyPrefix(widgetKey),
         scopes: ['conv:widget:write'],
+        channelId: channel!.id,
       });
       const channels = await fetch(`${baseUrl}/v1/conversations/channels`, {
         headers: authHeaders(widgetKey),

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -14,6 +14,7 @@ import { WebhooksController } from './webhooks.controller.ts';
 import { CmsDeliveryController } from './cms-delivery.controller.ts';
 import { CmsDraftsController } from './cms-drafts.controller.ts';
 import { AnalyticsViewsController } from './analytics-views.controller.ts';
+import { AnalyticsTrackerController } from './analytics-tracker.controller.ts';
 import { AnalyticsModule } from '../modules/analytics/analytics.module.ts';
 import { CmsModule } from '../modules/cms/cms.module.ts';
 import { ConvModule } from '../modules/conv/conv.module.ts';
@@ -83,6 +84,7 @@ import { AuthProvidersController } from './auth-providers.controller.ts';
     CmsDeliveryController,
     CmsDraftsController,
     AnalyticsViewsController,
+    AnalyticsTrackerController,
     InvitationsController,
     AcceptInvitationController,
     MembersController,

--- a/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
+++ b/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
@@ -34,6 +34,7 @@ function buildInstructions(adminSkills: ReadonlyArray<{ uri: string; name: strin
     '  • Conversations (conv_*)       — channels, messages, assignments',
     '  • CRM (crm_*)                  — contacts, companies, deals, activities',
     '  • CMS (cms_*)                  — collections, entries, assets, locales',
+    '  • Analytics (analytics_*)      — tracker keys, page-view + search events',
     '  • Org & access                 — api_keys, end_users, invitations, members, memberships',
     '',
     'Multi-step workflows have detailed skills. Call `resources/list` to discover',

--- a/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
+++ b/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
@@ -22,6 +22,7 @@ const EXPECTED_BY_MODULE: Record<string, RegExp> = {
   crm: /^crm_/,
   cms: /^cms_/,
   outreach: /^outreach_/,
+  analytics: /^analytics_/,
   system: /^system_/,
   webhooks: /^webhooks_/,
 };
@@ -32,6 +33,7 @@ const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
   crm: 25,
   cms: 20,
   outreach: 7,
+  analytics: 6,
   system: 4,
   webhooks: 7,
 };
@@ -111,6 +113,7 @@ const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
         crm: 'CRM:',
         cms: 'CMS:',
         outreach: 'Outreach:',
+        analytics: 'Analytics:',
         system: 'System ',
         webhooks: 'Webhooks:',
       };

--- a/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
+++ b/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
@@ -1,0 +1,289 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { createApp } from '../../bootstrap-app.ts';
+import { AppModule } from '../../app.module.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run analytics tracker tests.';
+
+(skipReason ? describe.skip : describe)('Analytics tracker integration: public-key ingest', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let adminKey: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED = '1';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Analytics IT Org' })
+      .returning();
+    orgId = org!.id;
+
+    adminKey = buildApiKey('admin');
+    await db.insert(schema.apiKeys).values({
+      orgId,
+      type: 'admin',
+      name: 'analytics-it-admin',
+      keyHash: hashSecret(adminKey),
+      keyPrefix: keyPrefix(adminKey),
+      scopes: ['*'],
+    });
+
+    app = await createApp(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  async function withClient<T>(token: string, fn: (c: Client) => Promise<T>): Promise<T> {
+    const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+      requestInit: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const c = new Client({ name: 'munin-it', version: '0.0.0' });
+    await c.connect(transport);
+    try {
+      return await fn(c);
+    } finally {
+      await transport.close();
+      await c.close();
+    }
+  }
+
+  it('mint tracker → tracker.js served → pixel + beacon record rows; bot/invalid key dropped', async () => {
+    const minted = await withClient(adminKey, async (c) => {
+      return parseToolResult<{ id: string; trackerKey: string; keyPrefix: string }>(
+        await c.callTool({
+          name: 'analytics_create_tracker',
+          arguments: { name: 'getmunin.com landing' },
+        }),
+      );
+    });
+    expect(minted.trackerKey).toMatch(/^mn_track_[A-Za-z0-9_-]+$/);
+
+    // The `/tracker.js` route is wired by bootstrap-app.ts (mirroring
+    // `/widget.js`) and reads `public/tracker/manifest.json`. In tests
+    // we don't run the prebuild copy, so it 503s — that's exercised by
+    // the bootstrap-app middleware unit tests instead.
+
+    const beforePixel = await countTrackerEvents(db, orgId);
+    const pixel = await fetch(
+      `${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=pricing&t=page&v=visitor-1`,
+    );
+    expect(pixel.status).toBe(200);
+    expect(pixel.headers.get('content-type')).toBe('image/gif');
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > beforePixel);
+
+    const pixelBot = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=pricing`, {
+      headers: { 'user-agent': 'Googlebot/2.1' },
+    });
+    expect(pixelBot.status).toBe(200);
+    expect(await countTrackerEvents(db, orgId)).toBe(beforePixel + 1);
+
+    const beforeBeacon = await countTrackerEvents(db, orgId);
+    const beacon = await fetch(`${baseUrl}/v1/a/t`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        key: minted.trackerKey,
+        subjectType: 'page',
+        subjectId: 'pricing',
+        path: '/pricing',
+        referrer: 'https://google.com',
+        visitorId: 'visitor-2',
+        dwellMs: 8000,
+        readDepth: 60,
+        utm: { source: 'reddit', medium: 'social', campaign: 'launch' },
+        metadata: { variant: 'b' },
+      }),
+    });
+    expect(beacon.status).toBe(204);
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > beforeBeacon);
+    const beaconRow = await db
+      .select()
+      .from(schema.analyticsViewEvents)
+      .where(sql`org_id = ${orgId} AND source = 'tracker' AND visitor_id = 'visitor-2'`)
+      .limit(1);
+    expect(beaconRow[0]?.dwellMs).toBe(8000);
+    expect(beaconRow[0]?.readDepth).toBe(60);
+    expect(beaconRow[0]?.utmSource).toBe('reddit');
+    expect(beaconRow[0]?.subjectType).toBe('page');
+    expect(beaconRow[0]?.metadata).toMatchObject({ variant: 'b' });
+
+    const badKey = 'mn_track_invalid_xxx';
+    const beforeBad = await countTrackerEvents(db, orgId);
+    const bad = await fetch(`${baseUrl}/v1/a/t/${badKey}.gif?s=pricing`);
+    expect(bad.status).toBe(200);
+    expect(await countTrackerEvents(db, orgId)).toBe(beforeBad);
+  }, 30_000);
+
+  it('revoked tracker key stops recording', async () => {
+    const minted = await withClient(adminKey, async (c) => {
+      return parseToolResult<{ id: string; trackerKey: string }>(
+        await c.callTool({
+          name: 'analytics_create_tracker',
+          arguments: { name: 'short-lived' },
+        }),
+      );
+    });
+    const before = await countTrackerEvents(db, orgId);
+    await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`);
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > before);
+
+    await withClient(adminKey, async (c) => {
+      const res = parseToolResult<{ revoked: boolean }>(
+        await c.callTool({
+          name: 'analytics_revoke_tracker',
+          arguments: { trackerId: minted.id },
+        }),
+      );
+      expect(res.revoked).toBe(true);
+    });
+
+    const afterRevoke = await countTrackerEvents(db, orgId);
+    await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await countTrackerEvents(db, orgId)).toBe(afterRevoke);
+  }, 30_000);
+
+  it('origin allowlist gates pixel + beacon', async () => {
+    const minted = await withClient(adminKey, async (c) => {
+      return parseToolResult<{ id: string; trackerKey: string; allowedOrigins: string[] }>(
+        await c.callTool({
+          name: 'analytics_create_tracker',
+          arguments: {
+            name: 'gated tracker',
+            allowedOrigins: ['https://customer.example'],
+          },
+        }),
+      );
+    });
+    expect(minted.allowedOrigins).toEqual(['https://customer.example']);
+
+    const allowedBefore = await countTrackerEvents(db, orgId);
+    const allowed = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`, {
+      headers: { origin: 'https://customer.example' },
+    });
+    expect(allowed.status).toBe(200);
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > allowedBefore);
+
+    const beforeDenied = await countTrackerEvents(db, orgId);
+    const denied = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`, {
+      headers: { origin: 'https://attacker.example' },
+    });
+    expect(denied.status).toBe(200);
+
+    const missing = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`);
+    expect(missing.status).toBe(200);
+
+    const beaconDenied = await fetch(`${baseUrl}/v1/a/t`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: 'https://attacker.example' },
+      body: JSON.stringify({ key: minted.trackerKey, subjectId: 'home' }),
+    });
+    expect(beaconDenied.status).toBe(204);
+
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await countTrackerEvents(db, orgId)).toBe(beforeDenied);
+
+    await withClient(adminKey, async (c) => {
+      const updated = parseToolResult<{ allowedOrigins: string[] }>(
+        await c.callTool({
+          name: 'analytics_update_tracker',
+          arguments: { trackerId: minted.id, allowedOrigins: [] },
+        }),
+      );
+      expect(updated.allowedOrigins).toEqual([]);
+    });
+
+    const beforeOpen = await countTrackerEvents(db, orgId);
+    const openAccess = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`, {
+      headers: { origin: 'https://anything.example' },
+    });
+    expect(openAccess.status).toBe(200);
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > beforeOpen);
+  }, 30_000);
+
+  it('MUNIN_TRACKER_REQUIRE_ALLOWLIST=1 fail-closes empty allowlists', async () => {
+    const minted = await withClient(adminKey, async (c) => {
+      return parseToolResult<{ id: string; trackerKey: string }>(
+        await c.callTool({
+          name: 'analytics_create_tracker',
+          arguments: { name: 'no-allowlist' },
+        }),
+      );
+    });
+
+    process.env.MUNIN_TRACKER_REQUIRE_ALLOWLIST = '1';
+    try {
+      const before = await countTrackerEvents(db, orgId);
+      const res = await fetch(`${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=home`, {
+        headers: { origin: 'https://anything.example' },
+      });
+      expect(res.status).toBe(200);
+      await new Promise((r) => setTimeout(r, 200));
+      expect(await countTrackerEvents(db, orgId)).toBe(before);
+    } finally {
+      delete process.env.MUNIN_TRACKER_REQUIRE_ALLOWLIST;
+    }
+  }, 30_000);
+});
+
+async function countTrackerEvents(
+  db: ReturnType<typeof createDb>,
+  orgId: string,
+): Promise<number> {
+  const r = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(schema.analyticsViewEvents)
+    .where(sql`org_id = ${orgId} AND source = 'tracker'`);
+  return r[0]?.n ?? 0;
+}
+
+async function waitFor(check: () => Promise<boolean>, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error('waitFor: condition not met before timeout');
+}
+
+function parseToolResult<T>(result: unknown): T {
+  const r = result as { content?: Array<{ type: string; text?: string }> };
+  const text = r.content?.[0]?.text ?? '';
+  return JSON.parse(text) as T;
+}

--- a/packages/backend-core/src/modules/analytics/analytics.module.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AnalyticsService } from './analytics.service.ts';
+import { AnalyticsAdminTools } from './analytics.tools.ts';
 
 @Module({
-  providers: [AnalyticsService],
+  providers: [AnalyticsService, AnalyticsAdminTools],
   exports: [AnalyticsService],
 })
 export class AnalyticsModule {}

--- a/packages/backend-core/src/modules/analytics/analytics.service.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.service.ts
@@ -6,7 +6,7 @@ export interface RecordViewInput {
   orgId: string;
   subjectType: string;
   subjectId: string;
-  source: 'pixel' | 'beacon';
+  source: 'pixel' | 'beacon' | 'tracker';
   path?: string | null;
   locale?: string | null;
   referrer?: string | null;

--- a/packages/backend-core/src/modules/analytics/analytics.tools.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.tools.ts
@@ -1,0 +1,387 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { z } from 'zod';
+import { McpTool } from '@getmunin/mcp-toolkit';
+import { schema } from '@getmunin/db';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { buildApiKey, getCurrentContext, hashSecret, keyPrefix } from '@getmunin/core';
+
+const CreateTrackerInput = z.object({
+  name: z.string().min(1).max(120),
+  allowedOrigins: z.array(z.string().url()).optional(),
+});
+
+const UpdateTrackerInput = z.object({
+  trackerId: z.string(),
+  name: z.string().min(1).max(120).optional(),
+  allowedOrigins: z.array(z.string().url()).optional(),
+});
+
+const RevokeTrackerInput = z.object({
+  trackerId: z.string(),
+});
+
+interface TrackerSummary {
+  id: string;
+  name: string;
+  allowedOrigins: string[];
+  keyPrefix: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+}
+
+interface CreateTrackerResult extends TrackerSummary {
+  trackerKey: string;
+}
+
+@Injectable()
+export class AnalyticsAdminTools {
+  @McpTool({
+    name: 'analytics_create_tracker',
+    title: 'Analytics: Create tracker key',
+    description:
+      'Create a tracker and mint a public `mn_track_*` API key bound to it. The key is safe to embed in `<script>` tags or mobile clients — it can only write page-view events scoped to your org, never read them. `allowedOrigins` is an optional list of full origins (`https://example.com`) the tracker will accept; when empty, any origin is accepted (set `MUNIN_TRACKER_REQUIRE_ALLOWLIST=1` to fail-closed instead). Returns the plaintext key once; store it where it needs to be embedded.',
+    audiences: ['admin'],
+    scopes: ['analytics:write'],
+    input: CreateTrackerInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  async createTracker(args: z.infer<typeof CreateTrackerInput>): Promise<CreateTrackerResult> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const [tracker] = await ctx.db
+      .insert(schema.analyticsTrackers)
+      .values({
+        orgId: actor.orgId,
+        name: args.name,
+        allowedOrigins: args.allowedOrigins ?? [],
+      })
+      .returning();
+    const rawKey = buildApiKey('track');
+    const [key] = await ctx.db
+      .insert(schema.apiKeys)
+      .values({
+        orgId: actor.orgId,
+        type: 'track',
+        name: args.name,
+        keyHash: hashSecret(rawKey),
+        keyPrefix: keyPrefix(rawKey),
+        scopes: ['analytics:track:write'],
+        audiences: ['public'],
+        trackerId: tracker!.id,
+        createdByUserId: actor.userId ?? null,
+      })
+      .returning();
+    return {
+      id: tracker!.id,
+      name: tracker!.name,
+      allowedOrigins: tracker!.allowedOrigins,
+      keyPrefix: key!.keyPrefix,
+      createdAt: tracker!.createdAt.toISOString(),
+      lastUsedAt: null,
+      revokedAt: null,
+      trackerKey: rawKey,
+    };
+  }
+
+  @McpTool({
+    name: 'analytics_list_trackers',
+    title: 'Analytics: List tracker keys',
+    description:
+      'List analytics trackers for the current org with their key prefix, allowed origins, and revocation state. Plaintext keys are never returned; rotate via `analytics_revoke_tracker` + `analytics_create_tracker`.',
+    audiences: ['admin'],
+    scopes: ['analytics:read'],
+    input: z.object({ includeRevoked: z.boolean().optional() }),
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  async listTrackers(args: { includeRevoked?: boolean }): Promise<TrackerSummary[]> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db
+      .select({
+        id: schema.analyticsTrackers.id,
+        name: schema.analyticsTrackers.name,
+        allowedOrigins: schema.analyticsTrackers.allowedOrigins,
+        createdAt: schema.analyticsTrackers.createdAt,
+        keyPrefix: schema.apiKeys.keyPrefix,
+        lastUsedAt: schema.apiKeys.lastUsedAt,
+        revokedAt: schema.apiKeys.revokedAt,
+      })
+      .from(schema.analyticsTrackers)
+      .leftJoin(
+        schema.apiKeys,
+        and(
+          eq(schema.apiKeys.trackerId, schema.analyticsTrackers.id),
+          eq(schema.apiKeys.type, 'track'),
+        ),
+      )
+      .where(eq(schema.analyticsTrackers.orgId, actor.orgId));
+    return rows
+      .filter((r) => args.includeRevoked || r.revokedAt === null)
+      .map((r) => ({
+        id: r.id,
+        name: r.name,
+        allowedOrigins: r.allowedOrigins,
+        keyPrefix: r.keyPrefix,
+        createdAt: r.createdAt.toISOString(),
+        lastUsedAt: r.lastUsedAt?.toISOString() ?? null,
+        revokedAt: r.revokedAt?.toISOString() ?? null,
+      }));
+  }
+
+  @McpTool({
+    name: 'analytics_update_tracker',
+    title: 'Analytics: Update tracker config',
+    description:
+      'Update a tracker\'s display name and/or `allowedOrigins`. The bound API key is unchanged — rotate via `analytics_revoke_tracker` + `analytics_create_tracker`.',
+    audiences: ['admin'],
+    scopes: ['analytics:write'],
+    input: UpdateTrackerInput,
+    readOnlyHint: false,
+    destructiveHint: false,
+  })
+  async updateTracker(args: z.infer<typeof UpdateTrackerInput>): Promise<TrackerSummary> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const patch: { name?: string; allowedOrigins?: string[]; updatedAt: Date } = {
+      updatedAt: new Date(),
+    };
+    if (args.name !== undefined) patch.name = args.name;
+    if (args.allowedOrigins !== undefined) patch.allowedOrigins = args.allowedOrigins;
+    const [updated] = await ctx.db
+      .update(schema.analyticsTrackers)
+      .set(patch)
+      .where(
+        and(
+          eq(schema.analyticsTrackers.id, args.trackerId),
+          eq(schema.analyticsTrackers.orgId, actor.orgId),
+        ),
+      )
+      .returning();
+    if (!updated) throw new NotFoundException(`tracker ${args.trackerId} not found`);
+    const [key] = await ctx.db
+      .select({
+        keyPrefix: schema.apiKeys.keyPrefix,
+        lastUsedAt: schema.apiKeys.lastUsedAt,
+        revokedAt: schema.apiKeys.revokedAt,
+      })
+      .from(schema.apiKeys)
+      .where(
+        and(eq(schema.apiKeys.trackerId, args.trackerId), eq(schema.apiKeys.type, 'track')),
+      )
+      .limit(1);
+    return {
+      id: updated.id,
+      name: updated.name,
+      allowedOrigins: updated.allowedOrigins,
+      keyPrefix: key?.keyPrefix ?? null,
+      createdAt: updated.createdAt.toISOString(),
+      lastUsedAt: key?.lastUsedAt?.toISOString() ?? null,
+      revokedAt: key?.revokedAt?.toISOString() ?? null,
+    };
+  }
+
+  @McpTool({
+    name: 'analytics_top_subjects',
+    title: 'Analytics: Top subjects by view count',
+    description:
+      'List the most-viewed subjects (CMS entries, landing pages, etc.) over a recent window. Use this to see what content is actually getting traffic. Filter by `subjectType` to scope to one surface (e.g. `cms_entry`).',
+    audiences: ['admin'],
+    scopes: ['analytics:read'],
+    input: z.object({
+      subjectType: z.string().max(32).optional(),
+      sinceDays: z.number().int().min(1).max(365).default(30),
+      limit: z.number().int().min(1).max(200).default(20),
+      source: z.enum(['pixel', 'beacon', 'tracker']).optional(),
+    }),
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  async topSubjects(args: {
+    subjectType?: string;
+    sinceDays: number;
+    limit: number;
+    source?: 'pixel' | 'beacon' | 'tracker';
+  }): Promise<
+    Array<{ subjectType: string; subjectId: string; views: number; visitors: number }>
+  > {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const conditions = [
+      sql`org_id = ${actor.orgId}`,
+      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
+    ];
+    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
+    if (args.source) conditions.push(sql`source = ${args.source}`);
+    const where = sql.join(conditions, sql` AND `);
+    const rows = await ctx.db.execute<{
+      subject_type: string;
+      subject_id: string;
+      views: number;
+      visitors: number;
+    }>(sql`
+      SELECT subject_type, subject_id,
+             COUNT(*)::int AS views,
+             COUNT(DISTINCT visitor_id)::int AS visitors
+      FROM analytics_view_events
+      WHERE ${where}
+      GROUP BY subject_type, subject_id
+      ORDER BY views DESC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      subjectType: r.subject_type,
+      subjectId: r.subject_id,
+      views: r.views,
+      visitors: r.visitors,
+    }));
+  }
+
+  @McpTool({
+    name: 'analytics_subject_engagement',
+    title: 'Analytics: Engagement for one subject',
+    description:
+      'View counts, unique visitors, and average dwell/read-depth for one subject (e.g. one CMS entry) over a recent window. Use this when judging whether a stale entry should be refreshed or archived.',
+    audiences: ['admin'],
+    scopes: ['analytics:read'],
+    input: z.object({
+      subjectType: z.string().max(32),
+      subjectId: z.string(),
+      sinceDays: z.number().int().min(1).max(365).default(90),
+    }),
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  async subjectEngagement(args: {
+    subjectType: string;
+    subjectId: string;
+    sinceDays: number;
+  }): Promise<{
+    views: number;
+    visitors: number;
+    avgDwellMs: number | null;
+    avgReadDepth: number | null;
+    lastViewAt: string | null;
+  }> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db.execute<{
+      views: number;
+      visitors: number;
+      avg_dwell_ms: number | null;
+      avg_read_depth: number | null;
+      last_view_at: Date | null;
+    }>(sql`
+      SELECT COUNT(*)::int AS views,
+             COUNT(DISTINCT visitor_id)::int AS visitors,
+             AVG(dwell_ms) FILTER (WHERE dwell_ms IS NOT NULL) AS avg_dwell_ms,
+             AVG(read_depth) FILTER (WHERE read_depth IS NOT NULL) AS avg_read_depth,
+             MAX(created_at) AS last_view_at
+      FROM analytics_view_events
+      WHERE org_id = ${actor.orgId}
+        AND subject_type = ${args.subjectType}
+        AND subject_id = ${args.subjectId}
+        AND created_at > NOW() - (${args.sinceDays} || ' days')::interval
+    `);
+    const r = rows[0]!;
+    return {
+      views: r.views,
+      visitors: r.visitors,
+      avgDwellMs: r.avg_dwell_ms !== null ? Math.round(Number(r.avg_dwell_ms)) : null,
+      avgReadDepth: r.avg_read_depth !== null ? Math.round(Number(r.avg_read_depth)) : null,
+      lastViewAt: r.last_view_at ? r.last_view_at.toISOString() : null,
+    };
+  }
+
+  @McpTool({
+    name: 'analytics_zero_result_searches',
+    title: 'Analytics: Zero-result search queries',
+    description:
+      'List recent public search queries that returned zero results. The single best input for "what should we write about next" — readers are asking but Munin has no answer.',
+    audiences: ['admin'],
+    scopes: ['analytics:read'],
+    input: z.object({
+      subjectType: z.string().max(32).optional(),
+      sinceDays: z.number().int().min(1).max(365).default(30),
+      limit: z.number().int().min(1).max(200).default(50),
+    }),
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  async zeroResultSearches(args: {
+    subjectType?: string;
+    sinceDays: number;
+    limit: number;
+  }): Promise<Array<{ query: string; occurrences: number; lastSeenAt: string }>> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const conditions = [
+      sql`org_id = ${actor.orgId}`,
+      sql`result_count = 0`,
+      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
+    ];
+    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
+    const where = sql.join(conditions, sql` AND `);
+    const rows = await ctx.db.execute<{
+      query: string;
+      occurrences: number;
+      last_seen_at: Date;
+    }>(sql`
+      SELECT query,
+             COUNT(*)::int AS occurrences,
+             MAX(created_at) AS last_seen_at
+      FROM analytics_search_events
+      WHERE ${where}
+      GROUP BY query
+      ORDER BY occurrences DESC, last_seen_at DESC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      query: r.query,
+      occurrences: r.occurrences,
+      lastSeenAt: r.last_seen_at.toISOString(),
+    }));
+  }
+
+  @McpTool({
+    name: 'analytics_revoke_tracker',
+    title: 'Analytics: Revoke tracker key',
+    description:
+      'Revoke the API key bound to a tracker. After this, the key is rejected by the ingest endpoints — any pages still embedding it will silently fail to record views. The tracker row stays for audit.',
+    audiences: ['admin'],
+    scopes: ['analytics:write'],
+    input: RevokeTrackerInput,
+    readOnlyHint: false,
+    destructiveHint: true,
+  })
+  async revokeTracker(args: z.infer<typeof RevokeTrackerInput>): Promise<{ revoked: boolean }> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const tracker = await ctx.db
+      .select({ id: schema.analyticsTrackers.id })
+      .from(schema.analyticsTrackers)
+      .where(
+        and(
+          eq(schema.analyticsTrackers.id, args.trackerId),
+          eq(schema.analyticsTrackers.orgId, actor.orgId),
+        ),
+      )
+      .limit(1);
+    if (!tracker[0]) return { revoked: false };
+    const result = await ctx.db
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(
+          eq(schema.apiKeys.trackerId, args.trackerId),
+          eq(schema.apiKeys.orgId, actor.orgId),
+          eq(schema.apiKeys.type, 'track'),
+          isNull(schema.apiKeys.revokedAt),
+        ),
+      )
+      .returning({ id: schema.apiKeys.id });
+    return { revoked: result.length > 0 };
+  }
+}

--- a/packages/backend-core/src/modules/analytics/skills/track-website-traffic.md
+++ b/packages/backend-core/src/modules/analytics/skills/track-website-traffic.md
@@ -1,0 +1,161 @@
+---
+title: Analytics: Track website traffic
+description: Mint a public `mn_track_*` API key, drop the one-line tracker script into your site, and query view events to understand what readers engage with.
+audiences: [admin]
+---
+
+# Track website traffic
+
+Add page-view tracking to a landing page, marketing site, docs site, or app shell. The integration is one line of HTML — same ergonomics as the chat widget. Events land in `analytics_view_events` keyed by `subject_type='page'` and a `subject_id` you control (typically the URL path).
+
+Use this when you want to answer questions like:
+- Which pages do readers actually spend time on?
+- Where is traffic coming from (referrer, UTM)?
+- What's the difference between the 100 readers who bounce and the 10 who scroll all the way?
+
+For tracking content served by Munin's CMS delivery API, you don't need this — every entry response already ships a `_tracking` block (see "Related"). Use this skill when the page is *not* served by Munin (your marketing site, a partner's docs, a static landing page).
+
+## 1. Mint a tracker key
+
+```jsonc
+{
+  "name": "analytics_create_tracker",
+  "arguments": {
+    "name": "getmunin.com landing",
+    "allowedOrigins": ["https://getmunin.com"]
+  }
+}
+```
+
+Response includes `trackerKey: "mn_track_…"` — shown once. The key is **public** — safe to embed in HTML, mobile clients, anything browsers can see. It can only write view events scoped to your org, never read them.
+
+**`allowedOrigins`** is required — the ingest endpoints reject any request whose `Origin` header doesn't match one of the listed full origins (scheme + host + port, exact match — no wildcards or path prefixes). Multi-environment? List each one (`https://getmunin.com`, `https://dev.getmunin.com`, `http://localhost:3000`).
+
+The `Origin` header is browser-set and trivially spoofable via curl — origin allowlisting stops casual JS-from-another-site abuse but is not a security boundary on its own. The real defences are key rotation (`analytics_revoke_tracker`) and per-IP rate-limiting at the ingest layer.
+
+Edit later with `analytics_update_tracker({trackerId, allowedOrigins})`. Rotate with `analytics_revoke_tracker` + a fresh `analytics_create_tracker`. List with `analytics_list_trackers`.
+
+## 2. Drop the script tag
+
+```html
+<script async
+  src="https://api.your-munin.example/tracker.js"
+  data-key="mn_track_…">
+</script>
+```
+
+That's it. The script auto-fires a page view on `DOMContentLoaded` and writes a row to `analytics_view_events` with:
+
+- `subject_type='page'`, `subject_id=<location.pathname>`
+- `path=<location.pathname + location.search>`
+- `referrer=<document.referrer>` (initial entry only)
+- `visitor_id=<random uuid stored in localStorage>`
+- `utm_source` / `utm_medium` / `utm_campaign` (parsed from `?utm_*` query params)
+- `locale=<html lang>`
+- `source='tracker'`
+- `dwell_ms` (best-effort, fired on `pagehide`)
+
+`Cache-Control: public, max-age=3600` on `tracker.js` so the CDN serves the bundle without hitting your backend per request.
+
+### Optional data attributes
+
+- `data-subject-type="docs"` — override the default `'page'` subject type. Useful when you have multiple surfaces sharing one tracker key.
+- `data-spa="true"` — auto-track route changes in single-page apps. The script monkey-patches `history.pushState` / `replaceState` and fires a view per route transition (with a `dwell_ms` for the previous route).
+- `data-api="https://api.your-munin.example"` — override the API base. Defaults to the origin the script was loaded from.
+
+## 3. Custom events from JavaScript
+
+For SPA route changes or arbitrary "this thing happened on the page" events, the script exposes a global:
+
+```javascript
+window.mn.track('checkout-step-2', {
+  dwellMs: 12_000,
+  readDepth: 80,
+  metadata: { variant: 'b' },
+});
+```
+
+The first argument is `subjectId`. The second is an attribute bag:
+- `subjectType` — defaults to the `data-subject-type` on the script tag.
+- `path`, `referrer` — defaults to the current location and the initial referrer.
+- `dwellMs`, `readDepth`, `metadata` — pass through unchanged.
+- `utm` — falls back to URL `?utm_*` params if not provided.
+
+`mn.trackPageView()` is also exposed for the rare case where you want to re-fire the page view manually.
+
+## 4. Query the data
+
+Three admin-only MCP tools cover the questions you'll ask first:
+
+```jsonc
+// Which pages get the most traffic?
+{ "name": "analytics_top_subjects",
+  "arguments": { "subjectType": "page", "source": "tracker", "sinceDays": 7, "limit": 50 } }
+```
+
+Returns `[{ subjectType, subjectId, views, visitors }]` ordered by view count.
+
+```jsonc
+// How is one specific page performing?
+{ "name": "analytics_subject_engagement",
+  "arguments": { "subjectType": "page", "subjectId": "/pricing", "sinceDays": 30 } }
+```
+
+Returns `{ views, visitors, avgDwellMs, avgReadDepth, lastViewAt }` — combine views (volume) with dwell + depth (quality) to separate "lots of bounces" from "fewer but engaged readers."
+
+```jsonc
+// What were people searching for that we don't have content for?
+{ "name": "analytics_zero_result_searches",
+  "arguments": { "sinceDays": 30, "limit": 50 } }
+```
+
+Returns `[{ query, occurrences, lastSeenAt }]`. The single best signal for "what should we write next" — readers asked and Munin had nothing to show them.
+
+For anything more bespoke (UTM-source breakdowns, custom funnels, time-series), the events sit in `analytics_view_events` and `analytics_search_events`; query them directly from a DB client. The MCP tools cover the common questions; the table covers the long tail.
+
+## 5. Server-side / SDK ingestion
+
+For surfaces that can't run JS (server-rendered emails, mobile native, IoT), call the beacon endpoint directly:
+
+```bash
+curl -X POST https://api.your-munin.example/v1/a/t \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "mn_track_…",
+    "subjectType": "page",
+    "subjectId": "/pricing",
+    "referrer": "https://news.ycombinator.com/",
+    "visitorId": "v-xyz",
+    "utm": { "source": "hn" }
+  }'
+```
+
+Or for a 1×1 pixel embedded in HTML emails / image tags:
+
+```html
+<img src="https://api.your-munin.example/v1/a/t/mn_track_…?s=/pricing&v=v-xyz" alt="" width="1" height="1">
+```
+
+The pixel path takes `s` (subjectId, required), `t` (subjectType, defaults to `'page'`), `v` (visitorId, optional). Both routes filter known bot user-agents and rate-limit per IP.
+
+## 6. Operations
+
+| Task | How |
+|---|---|
+| Rotate a key | `analytics_revoke_tracker({trackerId})` then `analytics_create_tracker({name})`. Old key 401s immediately. |
+| Audit which keys exist | `analytics_list_trackers({})`. Returns id, name, prefix, last-used, revoked-at. |
+| Disable a single page from tracking | Remove the script tag from that page. The script is per-page-load opt-in. |
+| Delete a visitor's data | `DELETE FROM analytics_view_events WHERE visitor_id = $1`. No PII is stored beyond the random uuid — but if a regulator-grade deletion is needed, this is the path. |
+
+## What NOT to do
+
+- **Don't ship the key as `NEXT_PUBLIC_…` and pretend it's a secret.** It's public by design. Treat it like a Google Analytics measurement id — visible in the page source is normal. The org-scoped write-only authorization is the entire safety story.
+- **Don't reuse the same key across orgs.** Each customer org mints its own. Cross-org leakage isn't possible because the key resolves to one `org_id`.
+- **Don't rely on `dwell_ms` for anything precision-critical.** It's best-effort, fired on `pagehide`. Mobile Safari and aggressive ad-blockers can swallow the unload beacon. Use it for relative ranking, not exact dwell times.
+- **Don't put PII in `subject_id` or `metadata`.** Treat them as URL-shaped and tag-shaped respectively. Anything you embed there will sit in an analytics table you'll later query without auth context.
+
+## Related
+
+- `skill://cms/publish-entry` — when content is served by Munin's CMS delivery API, the response already ships a `_tracking` block. No script tag needed.
+- `skill://cms/review-stale-entries` — periodic curator pass that consults view data to decide whether stale published entries should be refreshed or archived.
+- `skill://conv/setup-chat-widget` — sibling drop-in script (chat widget); identical key-rotation ergonomics.

--- a/packages/backend-core/src/modules/cms/skills/review-stale-entries.md
+++ b/packages/backend-core/src/modules/cms/skills/review-stale-entries.md
@@ -53,18 +53,28 @@ For each draft older than the collection's threshold, decide:
 { "name": "cms_list_entries", "arguments": { "status": "published", "limit": 200 } }
 ```
 
-For each entry older than the collection's threshold (per Step 1's per-collection velocity), check inbound references:
+For each entry older than the collection's threshold (per Step 1's per-collection velocity), check inbound references *and* reader engagement (if the delivery API is tracked — see `skill://analytics/track-website-traffic`):
 
 ```jsonc
 { "name": "cms_list_inbound_references", "arguments": { "entryId": "cme_..." } }
 ```
 
-Then judge:
+```jsonc
+{ "name": "analytics_subject_engagement",
+  "arguments": { "subjectType": "cms_entry", "subjectId": "cme_...", "sinceDays": 90 } }
+```
 
-- **Still load-bearing** — has many inbound references from active entries, or is in a top-level navigation collection. Recommend `refresh` (the operator should re-read it for accuracy) rather than archiving.
-- **Superseded but referenced** — newer entries cover the same topic and are linked-to in the same neighborhood. Recommend `archive` (`cms_unpublish_entry`) but flag the inbound references so the operator can decide whether to redirect or delete them.
-- **Orphaned** — no inbound references and `updatedAt` very old. Recommend `delete` (`cms_delete_entry`).
-- **Time-bound** — title or body references a date/event that has passed (campaign, version-specific docs). Recommend `archive` or `delete` with high confidence.
+Response: `{ views, visitors, avgDwellMs, avgReadDepth, lastViewAt }`. If analytics isn't wired up the values come back as 0 / null — fall back to the inbound-references signal alone.
+
+Then judge — combine the structural signal (inbound refs) with the behavioral signal (views/dwell):
+
+- **Still load-bearing** — many inbound references *and* meaningful views in the last 90 days. Recommend `refresh` (the operator should re-read it for accuracy) rather than archiving.
+- **Quietly important** — few inbound references but consistent traffic. Recommend `refresh` — readers find it via search/direct, the graph just doesn't reflect that.
+- **Superseded but referenced** — newer entries cover the same topic and are linked-to in the same neighborhood; views are trending down. Recommend `archive` (`cms_unpublish_entry`) but flag the inbound references so the operator can decide whether to redirect or delete them.
+- **Orphaned** — no inbound references, no recent views, and `updatedAt` very old. Recommend `delete` (`cms_delete_entry`).
+- **Time-bound** — title or body references a date/event that has passed (campaign, version-specific docs). Recommend `archive` or `delete` with high confidence regardless of view count (residual traffic to expired content is usually a sign of stale external links, not value).
+
+A useful complement: `analytics_zero_result_searches({sinceDays: 90})` surfaces the queries readers asked that returned nothing. If a stale entry is the closest match to a frequent zero-result query, that's a strong "refresh + retitle" signal — readers want this content, they just can't find it.
 
 ## Step 4 — orphaned assets
 

--- a/packages/backend-core/src/modules/conv/skills/setup-chat-widget.md
+++ b/packages/backend-core/src/modules/conv/skills/setup-chat-widget.md
@@ -20,6 +20,8 @@ Call `conv_widget_create_channel`:
 
 Response includes `widgetKey: "mn_widget_…"` — shown once. Store it server-side.
 
+`originAllowlist` is required — the widget ingest endpoint rejects any request whose `Origin` header doesn't match one of the listed full origins (scheme + host + port, exact match). List every environment that should be allowed to ingest (`https://customer.example`, `https://staging.customer.example`, etc.).
+
 The widget key is bound to this channel via `api_keys.channel_id`. Rotate with `conv_widget_rotate_key`; update origins with `conv_widget_update_channel`.
 
 ## 2. Push transcripts from the agent

--- a/packages/backend-core/src/modules/playbooks/skills/publish-and-distribute.md
+++ b/packages/backend-core/src/modules/playbooks/skills/publish-and-distribute.md
@@ -126,3 +126,4 @@ The published entry should be there too. If both surface and the announcement wa
 - `skill://cms/publish-entry` — the publish half.
 - `skill://kb/import-articles-in-bulk` — bulk mirroring for catch-up imports.
 - `skill://conv/setup-email-and-widget-channels` — making sure the announcement channel exists.
+- `skill://analytics/track-website-traffic` — measure which published entries actually get read; feed that signal back into the next quarter's review.

--- a/packages/core/src/crypto/keys.ts
+++ b/packages/core/src/crypto/keys.ts
@@ -5,6 +5,7 @@ import { randomToken } from './primitives.ts';
  *
  *   kind = 'admin' | 'dlg' (delegated end-user, short-lived)
  *        | 'widget' (chat-widget channel binding; api_keys.channel_id is set)
+ *        | 'track' (public analytics tracker key; safe to embed in browsers)
  *
  * The `'part'` kind exists in the type union for downstream packages
  * that mint partner-style credentials; OSS does not produce or accept
@@ -16,7 +17,7 @@ import { randomToken } from './primitives.ts';
  * bits of entropy).
  */
 
-export type KeyKind = 'admin' | 'part' | 'dlg' | 'widget';
+export type KeyKind = 'admin' | 'part' | 'dlg' | 'widget' | 'track';
 
 const PREFIX_LENGTH = 8;
 
@@ -30,5 +31,5 @@ export function keyPrefix(rawKey: string): string {
 }
 
 export function isWellFormedKey(rawKey: string): boolean {
-  return /^mn_(admin|part|dlg|widget)_[A-Za-z0-9_-]+$/.test(rawKey);
+  return /^mn_(admin|part|dlg|widget|track)_[A-Za-z0-9_-]+$/.test(rawKey);
 }

--- a/packages/core/src/request/credentials.test.ts
+++ b/packages/core/src/request/credentials.test.ts
@@ -44,6 +44,19 @@ const skipReason = TEST_URL
     revoked?: boolean;
   }): Promise<string> {
     const rawKey = args.rawKey ?? buildApiKey(args.type === 'widget' ? 'widget' : 'admin');
+    let channelId: string | null = null;
+    if (args.type === 'widget') {
+      const [channel] = await db
+        .insert(schema.convChannels)
+        .values({
+          orgId,
+          type: 'chat',
+          vendor: 'munin',
+          name: `cred-resolver-widget-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        })
+        .returning();
+      channelId = channel!.id;
+    }
     await db.insert(schema.apiKeys).values({
       orgId,
       type: args.type,
@@ -52,6 +65,7 @@ const skipReason = TEST_URL
       keyPrefix: keyPrefix(rawKey),
       scopes: args.scopes ?? (args.type === 'widget' ? ['conv:widget:write'] : ['*']),
       audiences: args.audiences ?? ['admin'],
+      channelId,
       revokedAt: args.revoked ? new Date() : null,
     });
     return rawKey;

--- a/packages/db/drizzle/0036_analytics_trackers.sql
+++ b/packages/db/drizzle/0036_analytics_trackers.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS "analytics_trackers" (
+    "id" text PRIMARY KEY NOT NULL,
+    "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE CASCADE,
+    "name" text NOT NULL,
+    "allowed_origins" jsonb NOT NULL DEFAULT '[]'::jsonb,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "analytics_trackers_org_idx"
+    ON "analytics_trackers" ("org_id");
+
+ALTER TABLE "api_keys"
+    ADD COLUMN IF NOT EXISTS "tracker_id" text
+        REFERENCES "analytics_trackers"("id") ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS "api_keys_tracker_idx"
+    ON "api_keys" ("tracker_id");
+
+ALTER TABLE "analytics_view_events"
+    DROP CONSTRAINT IF EXISTS "analytics_view_events_source_chk";
+
+ALTER TABLE "analytics_view_events"
+    ADD CONSTRAINT "analytics_view_events_source_chk"
+    CHECK ("source" IN ('pixel', 'beacon', 'tracker'));
+
+ALTER TABLE "api_keys"
+    DROP CONSTRAINT IF EXISTS "api_keys_track_requires_tracker_chk";
+
+ALTER TABLE "api_keys"
+    ADD CONSTRAINT "api_keys_track_requires_tracker_chk"
+    CHECK ("type" <> 'track' OR "tracker_id" IS NOT NULL);
+
+ALTER TABLE "api_keys"
+    DROP CONSTRAINT IF EXISTS "api_keys_widget_requires_channel_chk";
+
+ALTER TABLE "api_keys"
+    ADD CONSTRAINT "api_keys_widget_requires_channel_chk"
+    CHECK ("type" <> 'widget' OR "channel_id" IS NOT NULL) NOT VALID;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1780600000000,
       "tag": "0035_analytics_events",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1780700000000,
+      "tag": "0036_analytics_trackers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -436,6 +436,9 @@ export const apiKeys = pgTable(
     channelId: text('channel_id').references((): AnyPgColumn => convChannels.id, {
       onDelete: 'cascade',
     }),
+    trackerId: text('tracker_id').references((): AnyPgColumn => analyticsTrackers.id, {
+      onDelete: 'cascade',
+    }),
     lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
     revokedAt: timestamp('revoked_at', { withTimezone: true }),
     createdByUserId: text('created_by_user_id').references(() => users.id, { onDelete: 'set null' }),
@@ -445,6 +448,7 @@ export const apiKeys = pgTable(
     orgIdx: index('api_keys_org_idx').on(t.orgId),
     prefixIdx: index('api_keys_prefix_idx').on(t.keyPrefix),
     channelIdx: index('api_keys_channel_idx').on(t.channelId),
+    trackerIdx: index('api_keys_tracker_idx').on(t.trackerId),
   }),
 );
 
@@ -1495,6 +1499,23 @@ export const cmsReferences = pgTable(
 // routes, and other surfaces use their own subject types without
 // schema changes. Append-only; aggregation/rollups are deferred.
 
+export const analyticsTrackers = pgTable(
+  'analytics_trackers',
+  {
+    id: id('atr'),
+    orgId: text('org_id')
+      .notNull()
+      .references(() => orgs.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    allowedOrigins: jsonb('allowed_origins').$type<string[]>().notNull().default([]),
+    createdAt,
+    updatedAt,
+  },
+  (t) => ({
+    orgIdx: index('analytics_trackers_org_idx').on(t.orgId),
+  }),
+);
+
 export const analyticsViewEvents = pgTable(
   'analytics_view_events',
   {
@@ -1835,6 +1856,7 @@ export const allTables = {
   cmsAssets,
   cmsLocales,
   cmsReferences,
+  analyticsTrackers,
   analyticsViewEvents,
   analyticsSearchEvents,
   curatorJobs,

--- a/packages/db/src/sql/analytics.sql
+++ b/packages/db/src/sql/analytics.sql
@@ -23,3 +23,13 @@ CREATE POLICY tenant_isolation ON analytics_search_events
     OR (org_id = app_org_id() AND app_end_user_id() = '')
   )
   WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
+
+ALTER TABLE analytics_trackers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE analytics_trackers FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON analytics_trackers;
+CREATE POLICY tenant_isolation ON analytics_trackers
+  USING (
+    app_bypass_rls()
+    OR (org_id = app_org_id() AND app_end_user_id() = '')
+  )
+  WITH CHECK (app_bypass_rls() OR org_id = app_org_id());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,36 @@ importers:
         specifier: ^8.59.1
         version: 8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
 
+  apps/analytics-tracker:
+    devDependencies:
+      '@getmunin/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@getmunin/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      eslint:
+        specifier: ^9.10.0
+        version: 9.39.4(jiti@1.21.7)
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.5.0
+        version: 8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      vite:
+        specifier: ^6.4.2
+        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+
   apps/backend:
     dependencies:
       '@better-auth/oauth-provider':
@@ -62,6 +92,9 @@ importers:
       '@getmunin/agent-host':
         specifier: workspace:*
         version: link:../../packages/agent-host
+      '@getmunin/analytics-tracker':
+        specifier: workspace:*
+        version: link:../analytics-tracker
       '@getmunin/backend-core':
         specifier: workspace:*
         version: link:../../packages/backend-core


### PR DESCRIPTION
Forward-port of [PR #357](https://github.com/getmunin/munin/pull/357), which was merged into the now-deleted stacked branch \`feat/analytics-module\` instead of main. The earlier attempt (#358, closed) tried to merge that branch directly and tripped over a duplicate-of-squashed-#356 conflict. This PR applies #357's diff cleanly on top of current main.

## What lands

- **Drop-in tracker script** (\`apps/analytics-tracker/\`) — Vite IIFE bundle, content-hashed, served at \`/tracker.js\` via the same redirect-then-immutable pattern as \`/widget.js\`.
- **\`analytics_trackers\` entity** mirroring chat-widget: \`api_keys.tracker_id\` FK + per-tracker \`allowedOrigins\` enforced on every ingest.
- **Origin allowlist** via \`originIsAllowed()\` in the analytics-tracker controller; \`MUNIN_TRACKER_REQUIRE_ALLOWLIST=1\` flips empty lists to fail-closed (symmetric with existing \`MUNIN_WIDGET_REQUIRE_ALLOWLIST\`).
- **CHECK constraints** on \`api_keys\` so \`type='track'\` requires \`tracker_id\` and \`type='widget'\` requires \`channel_id\` (latter \`NOT VALID\` for legacy tolerance).
- **MCP tools**: create/update/list/revoke tracker; read tools \`analytics_top_subjects\`, \`analytics_subject_engagement\`, \`analytics_zero_result_searches\`.
- **\`MUNIN_API_URL\` helper** (\`readApiBaseUrl()\`) — pixel URLs (email + CMS analytics) now point at the API host on split-host deployments.
- **Skills**: new \`skill://analytics/track-website-traffic\`; \`skill://cms/review-stale-entries\` consults engagement data; chat-widget skill marks \`originAllowlist\` as required.
- **\`.env.example\`** documents \`MUNIN_API_URL\`, \`MUNIN_WIDGET_REQUIRE_ALLOWLIST\`, \`MUNIN_TRACKER_REQUIRE_ALLOWLIST\`.

## Test plan

- [x] 734/734 backend-core tests pass on a fresh DB (verified on #357 before merge).
- [x] \`pnpm typecheck\` clean.
- [x] \`pnpm -F @getmunin/analytics-tracker build\` produces a 2 KB / 1 KB gzip content-hashed bundle.
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)