### PR TITLE
fix(backend): gitignore prebuilt tracker bundle

### DIFF
--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -1,3 +1,7 @@
 # Built widget bundle copied in by `prebuild` (scripts/copy-widget.mjs).
 # Source of truth lives in apps/chat-widget/; never commit the artifacts.
 public/widget/
+
+# Built analytics-tracker bundle copied in by `prebuild` (scripts/copy-tracker.mjs).
+# Source of truth lives in apps/analytics-tracker/; never commit the artifacts.
+public/tracker/


### PR DESCRIPTION
The Changesets release action that runs on main pushes a commit to the \`changeset-release/main\` branch. lint-staged on the host runs ESLint over every staged + untracked file, including the just-copied \`public/tracker/tracker.<sha>.js\` artifact, which fails the lint and breaks the release job (see [failed run on #360 merge](https://github.com/getmunin/munin/actions/runs/26958822245)).

This mirrors the existing \`public/widget/\` ignore so the tracker artifact is treated the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)