### PR TITLE
feat(backend-core): dedicated api_calls_day counter for usage tile

### DIFF
--- a/.changeset/api-calls-dedicated-counter.md
+++ b/.changeset/api-calls-dedicated-counter.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Move the `/v1/usage/summary` apiCalls tile off `audit_log` onto a dedicated `api_calls_day` bucket in `rate_limit_counters`. The `AuditInterceptor` now calls `RateLimitService.record('api_calls_day')` for any non-MCP HTTP request from a non-user actor (mirrors the previous query's filters: skips `HEAD`/`OPTIONS`, `/mcp*`, dashboard browser sessions, and the same chatty polling GETs that audit already skips). The tile is now independent of `audit_log` retention, so month-over-month no longer degrades as old audit rows are pruned. No backfill — existing apiCalls history stays in `audit_log` until it ages out; the tile will show partial data for ~1 month after deploy and recover naturally.

--- a/packages/backend-core/src/common/audit/audit.interceptor.test.ts
+++ b/packages/backend-core/src/common/audit/audit.interceptor.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import { firstValueFrom, of } from 'rxjs';
-import { ActorIdentity, RequestContextStore, type RequestContext } from '@getmunin/core';
+import {
+  ActorIdentity,
+  RequestContextStore,
+  type ActorType,
+  type RequestContext,
+} from '@getmunin/core';
 import type { CallHandler, ExecutionContext } from '@nestjs/common';
 import { AuditInterceptor } from './audit.interceptor.ts';
+import type { RateLimitService } from '../rate-limit/rate-limit.service.ts';
 
 function makeContext(request: Record<string, unknown>): ExecutionContext {
   return {
@@ -14,20 +20,30 @@ function makeNext(value: unknown): CallHandler {
   return { handle: () => of(value) };
 }
 
-function makeActiveContext(): RequestContext {
+function makeActiveContext(actorType: ActorType = 'user'): RequestContext {
   return {
     db: { execute: vi.fn().mockResolvedValue(undefined) } as never,
-    actor: new ActorIdentity('user', 'usr_1', 'org_1', ['*'], ['admin']),
+    actor: new ActorIdentity(actorType, 'actor_1', 'org_1', ['*'], ['admin']),
     correlationId: 'corr-1',
   };
 }
 
+function makeInterceptor(): {
+  interceptor: AuditInterceptor;
+  record: ReturnType<typeof vi.fn>;
+  rateLimitRecord: ReturnType<typeof vi.fn>;
+} {
+  const rateLimitRecord = vi.fn().mockResolvedValue(1);
+  const rateLimit = { record: rateLimitRecord } as unknown as RateLimitService;
+  const interceptor = new AuditInterceptor(rateLimit);
+  const record = vi.fn().mockResolvedValue(undefined);
+  (interceptor as unknown as { audit: { record: typeof record } }).audit = { record };
+  return { interceptor, record, rateLimitRecord };
+}
+
 describe('AuditInterceptor double-wrap guard', () => {
   it('records exactly one audit row even if the interceptor runs twice on the same request', async () => {
-    const interceptor = new AuditInterceptor();
-    const record = vi.fn().mockResolvedValue(undefined);
-    (interceptor as unknown as { audit: { record: typeof record } }).audit = { record };
-
+    const { interceptor, record } = makeInterceptor();
     const request = {
       method: 'GET',
       url: '/v1/whoami',
@@ -53,10 +69,7 @@ describe('AuditInterceptor double-wrap guard', () => {
     '/v1/system/alerts',
     '/v1/agent-config',
   ])('skips audit for chatty GET %s', async (url) => {
-    const interceptor = new AuditInterceptor();
-    const record = vi.fn().mockResolvedValue(undefined);
-    (interceptor as unknown as { audit: { record: typeof record } }).audit = { record };
-
+    const { interceptor, record } = makeInterceptor();
     const request = { method: 'GET', url, headers: { 'user-agent': 'test' } };
 
     await RequestContextStore.run(makeActiveContext(), async () => {
@@ -67,10 +80,7 @@ describe('AuditInterceptor double-wrap guard', () => {
   });
 
   it('still audits non-polling GETs and all non-GETs on the same prefixes', async () => {
-    const interceptor = new AuditInterceptor();
-    const record = vi.fn().mockResolvedValue(undefined);
-    (interceptor as unknown as { audit: { record: typeof record } }).audit = { record };
-
+    const { interceptor, record } = makeInterceptor();
     const requests = [
       { method: 'GET', url: '/v1/whoami', headers: {} },
       { method: 'POST', url: '/v1/inbox', headers: {} },
@@ -87,10 +97,7 @@ describe('AuditInterceptor double-wrap guard', () => {
   });
 
   it('short-circuits anonymous requests (no active context)', async () => {
-    const interceptor = new AuditInterceptor();
-    const record = vi.fn().mockResolvedValue(undefined);
-    (interceptor as unknown as { audit: { record: typeof record } }).audit = { record };
-
+    const { interceptor, record } = makeInterceptor();
     const request = {
       method: 'GET',
       url: '/health',
@@ -99,5 +106,69 @@ describe('AuditInterceptor double-wrap guard', () => {
 
     await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
     expect(record).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuditInterceptor api_calls_day counter', () => {
+  it('bumps the counter for non-user actors on non-MCP HTTP traffic', async () => {
+    const { interceptor, rateLimitRecord } = makeInterceptor();
+    const request = { method: 'GET', url: '/v1/whoami', headers: {} };
+
+    await RequestContextStore.run(makeActiveContext('admin_agent'), async () => {
+      await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+    });
+
+    expect(rateLimitRecord).toHaveBeenCalledTimes(1);
+    expect(rateLimitRecord).toHaveBeenCalledWith('api_calls_day');
+  });
+
+  it('does not bump for dashboard browser (user) sessions', async () => {
+    const { interceptor, rateLimitRecord } = makeInterceptor();
+    const request = { method: 'GET', url: '/v1/whoami', headers: {} };
+
+    await RequestContextStore.run(makeActiveContext('user'), async () => {
+      await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+    });
+
+    expect(rateLimitRecord).not.toHaveBeenCalled();
+  });
+
+  it.each(['POST', 'DELETE'])('does not bump for %s /mcp tool traffic', async (verb) => {
+    const { interceptor, rateLimitRecord } = makeInterceptor();
+    const request = { method: verb, url: '/mcp', headers: {} };
+
+    await RequestContextStore.run(makeActiveContext('admin_agent'), async () => {
+      await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+    });
+
+    expect(rateLimitRecord).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '/v1/agent-health',
+    '/v1/widget/messages',
+    '/v1/inbox',
+    '/v1/usage/summary',
+  ])('does not bump for polling GET %s (mirrors existing tile semantics)', async (url) => {
+    const { interceptor, rateLimitRecord } = makeInterceptor();
+    const request = { method: 'GET', url, headers: {} };
+
+    await RequestContextStore.run(makeActiveContext('admin_agent'), async () => {
+      await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+    });
+
+    expect(rateLimitRecord).not.toHaveBeenCalled();
+  });
+
+  it('bumps once even when the interceptor runs twice on the same request', async () => {
+    const { interceptor, rateLimitRecord } = makeInterceptor();
+    const request = { method: 'POST', url: '/v1/inbox', headers: {} };
+
+    await RequestContextStore.run(makeActiveContext('admin_agent'), async () => {
+      await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+      await firstValueFrom(interceptor.intercept(makeContext(request), makeNext(null)));
+    });
+
+    expect(rateLimitRecord).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/backend-core/src/common/audit/audit.interceptor.ts
+++ b/packages/backend-core/src/common/audit/audit.interceptor.ts
@@ -1,11 +1,13 @@
 import {
   CallHandler,
   ExecutionContext,
+  Inject,
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
 import { Observable, catchError, from, mergeMap, throwError } from 'rxjs';
 import { AuditLogger, getCurrentContext } from '@getmunin/core';
+import { RateLimitService } from '../rate-limit/rate-limit.service.ts';
 
 const POLLING_GET_PREFIXES = [
   '/agent-health',
@@ -33,6 +35,10 @@ function isPollingGet(path: string): boolean {
 @Injectable()
 export class AuditInterceptor implements NestInterceptor {
   private readonly audit = new AuditLogger();
+
+  constructor(
+    @Inject(RateLimitService) private readonly rateLimit: RateLimitService,
+  ) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     let hasContext = true;
@@ -70,6 +76,16 @@ export class AuditInterceptor implements NestInterceptor {
 
     const rawUa = request.headers['user-agent'];
     const userAgent = Array.isArray(rawUa) ? rawUa[0] : rawUa;
+    const actor = getCurrentContext().actor;
+    const countApiCall = actor?.type !== 'user' && !path.startsWith('/mcp');
+
+    const recordApiCall = async (): Promise<void> => {
+      try {
+        await this.rateLimit.record('api_calls_day');
+      } catch (err) {
+        console.error('[audit] failed to bump api_calls_day:', err);
+      }
+    };
 
     return next.handle().pipe(
       mergeMap(async (value: unknown) => {
@@ -79,17 +95,21 @@ export class AuditInterceptor implements NestInterceptor {
           durationMs: Date.now() - startedAt,
           userAgent,
         });
+        if (countApiCall) await recordApiCall();
         return value;
       }),
       catchError((err: unknown) =>
         from(
-          this.audit.record({
-            method,
-            result: 'error',
-            error: err instanceof Error ? err.message : String(err),
-            durationMs: Date.now() - startedAt,
-            userAgent,
-          }),
+          (async () => {
+            await this.audit.record({
+              method,
+              result: 'error',
+              error: err instanceof Error ? err.message : String(err),
+              durationMs: Date.now() - startedAt,
+              userAgent,
+            });
+            if (countApiCall) await recordApiCall();
+          })(),
         ).pipe(mergeMap(() => throwError(() => err))),
       ),
     );

--- a/packages/backend-core/src/common/rate-limit/rate-limit.service.ts
+++ b/packages/backend-core/src/common/rate-limit/rate-limit.service.ts
@@ -31,6 +31,7 @@ type Granularity = 'minute' | 'day';
 const BUCKETS = {
   mcp_calls_minute: 'minute',
   mcp_calls_day: 'day',
+  api_calls_day: 'day',
 } as const satisfies Record<string, Granularity>;
 
 export type Bucket = keyof typeof BUCKETS;

--- a/packages/backend-core/src/control/usage-stats.controller.ts
+++ b/packages/backend-core/src/control/usage-stats.controller.ts
@@ -173,21 +173,16 @@ export class UsageStatsController {
     now: Date,
   ): Promise<UsageSummaryTile> {
     const ctx = getCurrentContext();
-    const rows = await ctx.db.execute<DailyRow>(sql`
-      SELECT to_char(date_trunc('day', created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS day,
-             count(*)::int AS value
-      FROM audit_log
+    const rows = await ctx.db.execute<DailyBigIntRow>(sql`
+      SELECT to_char(date_trunc('day', window_start AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS day,
+             sum(count)::bigint AS value
+      FROM rate_limit_counters
       WHERE org_id = ${orgId}
-        AND tool IS NULL
-        AND method IS NOT NULL
-        AND actor_type <> 'user'
-        AND method NOT LIKE 'POST /mcp%'
-        AND method NOT LIKE 'GET /mcp%'
-        AND method NOT LIKE 'DELETE /mcp%'
-        AND created_at >= ${prevMonthStart.toISOString()}::timestamptz
+        AND bucket = 'api_calls_day'
+        AND window_start >= ${prevMonthStart.toISOString()}::timestamptz
       GROUP BY 1
     `);
-    const byDay = mapDailyRows(rows);
+    const byDay = mapDailyRows(rows.map((r) => ({ day: r.day, value: Number(r.value) || 0 })));
     const monthKey = toUtcDateKey(monthStart);
     return {
       current: sumWhere(byDay, (k) => k >= monthKey),


### PR DESCRIPTION
## Summary

- Move the `/v1/usage/summary` apiCalls tile off `audit_log` onto a dedicated `api_calls_day` bucket in `rate_limit_counters`.
- `AuditInterceptor` calls `RateLimitService.record('api_calls_day')` for any non-MCP HTTP request from a non-user actor — mirrors the previous query's filters (skips `HEAD`/`OPTIONS`, `/mcp*`, dashboard browser sessions, and the same chatty polling GETs that audit already skips).
- Tile is now independent of `audit_log` retention; month-over-month no longer degrades as audit rows are pruned at 30 days.
- No backfill: tile shows partial data for ~1 month after deploy, then recovers naturally.

Stacked on top of #365 (refactor). The base for this PR will auto-update to `main` once that merges.

## Test plan

- [ ] `pnpm -F @getmunin/backend-core typecheck`
- [ ] `pnpm -F @getmunin/backend-core test -- src/common/audit/audit.interceptor.test.ts` (21 tests, 6 new for counter bump)
- [ ] Hit a non-MCP endpoint with an API key, confirm a row appears in `rate_limit_counters` with `bucket = 'api_calls_day'`
- [ ] Open `/v1/usage/summary` after a few requests and confirm `apiCalls.current` reflects the count

🤖 Generated with [Claude Code](https://claude.com/claude-code)