### PR TITLE
feat(backend-core): in-memory MCP burst guard, drop mcp_calls_minute bucket

### DIFF
--- a/.changeset/mcp-burst-in-memory.md
+++ b/.changeset/mcp-burst-in-memory.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Move MCP burst protection from `rate_limit_counters` to an in-memory token bucket per replica. `McpBurstGuard` enforces `MUNIN_MCP_BURST_PER_MIN` (default 60) per `(org_id || ip)` within a rolling minute window, throwing 429 on overflow. `RateLimitService.consume()` no longer bumps a `mcp_calls_minute` bucket; that bucket and its check are removed, along with `OrgLimits.perMinute` and the per-minute view in `usage()`. The daily cap is unchanged.
+
+Trade-off: multi-replica fleets no longer enforce a fleet-global per-minute cap — each pod independently allows up to `MUNIN_MCP_BURST_PER_MIN`. Adequate for runaway-agent protection (abusers don't load-balance themselves) and eliminates ~1440 rows/day/org of accumulating minute-bucket data.
+
+Breaking shape change: `/v1/usage` no longer returns a `minute` field. Dashboard and any consumer scripts that read it need to drop that key.

--- a/packages/backend-core/src/common/rate-limit/rate-limit.service.test.ts
+++ b/packages/backend-core/src/common/rate-limit/rate-limit.service.test.ts
@@ -27,8 +27,7 @@ const skipReason = TEST_URL
       .insert(schema.orgs)
       .values({
         name: 'Rate Test Org',
-        // Tight limits for fast tests.
-        settings: { rateLimits: { perMinute: 5, perDay: 10 } },
+        settings: { rateLimits: { perDay: 5 } },
       })
       .returning();
     orgId = org!.id;
@@ -61,16 +60,16 @@ const skipReason = TEST_URL
     });
   }
 
-  it('allows calls under the per-minute cap', async () => {
+  it('allows calls under the per-day cap', async () => {
     for (let i = 0; i < 5; i++) {
       await run(() => svc.consume());
     }
     const u = await run(() => svc.usage());
-    expect(u.minute.used).toBe(5);
-    expect(u.minute.limit).toBe(5);
+    expect(u.day.used).toBe(5);
+    expect(u.day.limit).toBe(5);
   });
 
-  it('throws RateLimitExceededError on the 6th call within the same minute', async () => {
+  it('throws RateLimitExceededError on the 6th call within the same day', async () => {
     for (let i = 0; i < 5; i++) {
       await run(() => svc.consume());
     }
@@ -100,7 +99,6 @@ const skipReason = TEST_URL
         };
         return withContext(ctx, () => svc.usage());
       });
-      expect(u.minute.limit).toBe(60);
       expect(u.day.limit).toBe(1000);
     } finally {
       await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
@@ -109,14 +107,14 @@ const skipReason = TEST_URL
   });
 
   it('record returns the post-bump count and never throws on limit', async () => {
-    const c1 = await run(() => svc.record('mcp_calls_minute'));
-    const c2 = await run(() => svc.record('mcp_calls_minute'));
+    const c1 = await run(() => svc.record('mcp_calls_day'));
+    const c2 = await run(() => svc.record('mcp_calls_day'));
     expect(c1).toBe(1);
     expect(c2).toBe(2);
 
-    for (let i = 0; i < 100; i++) await run(() => svc.record('mcp_calls_minute'));
+    for (let i = 0; i < 100; i++) await run(() => svc.record('mcp_calls_day'));
     const u = await run(() => svc.usage());
-    expect(u.minute.used).toBe(102);
+    expect(u.day.used).toBe(102);
   });
 
   it('different orgs have isolated counters', async () => {
@@ -124,14 +122,12 @@ const skipReason = TEST_URL
       .insert(schema.orgs)
       .values({
         name: 'Other Rate Org',
-        settings: { rateLimits: { perMinute: 5, perDay: 10 } },
+        settings: { rateLimits: { perDay: 5 } },
       })
       .returning();
     const otherActor = new ActorIdentity('admin_agent', 'agt_o', otherOrg!.id, ['*'], ['admin']);
     try {
-      // Consume 5 in `orgId` so it's at the cap.
       for (let i = 0; i < 5; i++) await run(() => svc.consume());
-      // The other org should still pass.
       const otherUsage = await appDb.transaction(async (tx) => {
         await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
         await tx.execute(sql`SELECT set_config('app.org_id', ${otherOrg!.id}, true)`);
@@ -145,7 +141,7 @@ const skipReason = TEST_URL
           return svc.usage();
         });
       });
-      expect(otherUsage.minute.used).toBe(1);
+      expect(otherUsage.day.used).toBe(1);
     } finally {
       await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
       await db.delete(schema.orgs).where(sql`id = ${otherOrg!.id}`);

--- a/packages/backend-core/src/common/rate-limit/rate-limit.service.ts
+++ b/packages/backend-core/src/common/rate-limit/rate-limit.service.ts
@@ -6,7 +6,7 @@ import { getCurrentContext } from '@getmunin/core';
 export class RateLimitExceededError extends Error {
   readonly code = 'rate_limited';
   constructor(
-    public readonly bucket: 'minute' | 'day',
+    public readonly bucket: 'day',
     public readonly limit: number,
     public readonly retryAfterSeconds: number,
   ) {
@@ -17,19 +17,16 @@ export class RateLimitExceededError extends Error {
 }
 
 interface OrgLimits {
-  perMinute: number;
   perDay: number;
 }
 
 const FREE_TIER_LIMITS: OrgLimits = {
-  perMinute: 60,
   perDay: 1_000,
 };
 
-type Granularity = 'minute' | 'day' | 'month';
+type Granularity = 'day' | 'month';
 
 const BUCKETS = {
-  mcp_calls_minute: 'minute',
   mcp_calls_day: 'day',
   api_calls_day: 'day',
   mcp_calls_month: 'month',
@@ -51,17 +48,11 @@ type BucketCountRow = {
  * Postgres-backed sliding-window counters keyed by `(org, bucket, window_start)`.
  * Each `record(bucket)` upserts the current window and returns the post-bump
  * count. Limit enforcement is the caller's responsibility — `consume()` packages
- * the MCP-tool-call recipe (record + check minute, record + check day).
+ * the MCP-tool-call recipe (record + check day). Per-minute burst protection
+ * lives in `McpBurstGuard` (in-memory, per replica).
  */
 @Injectable()
 export class RateLimitService {
-  /**
-   * Increment the bucket's counter for the current window and return the
-   * post-bump value. Pure record — never throws on limit; only DB errors.
-   *
-   * Must be called inside the request transaction; uses `getCurrentContext()`
-   * for both the org id and the db handle.
-   */
   async record(bucket: Bucket): Promise<number> {
     const ctx = getCurrentContext();
     const orgId = ctx.actor?.orgId;
@@ -70,30 +61,15 @@ export class RateLimitService {
     return this.bumpAndCount(orgId, bucket, windowStart);
   }
 
-  /**
-   * MCP tool-call gate: bump per-minute and per-day counters and throw
-   * `RateLimitExceededError` if either exceeds the org's tier limits.
-   */
   async consume(): Promise<void> {
     const ctx = getCurrentContext();
     const orgId = ctx.actor!.orgId;
     if (!orgId) return;
 
     const limits = await this.loadLimits(orgId);
-    const now = new Date();
-
-    const minuteCount = await this.record('mcp_calls_minute');
-    if (minuteCount > limits.perMinute) {
-      const minuteWindow = windowStartFor('minute', now);
-      throw new RateLimitExceededError(
-        'minute',
-        limits.perMinute,
-        Math.ceil((minuteWindow.getTime() + 60_000 - now.getTime()) / 1000),
-      );
-    }
-
     const dayCount = await this.record('mcp_calls_day');
     if (dayCount > limits.perDay) {
+      const now = new Date();
       const dayWindow = windowStartFor('day', now);
       throw new RateLimitExceededError(
         'day',
@@ -131,42 +107,30 @@ export class RateLimitService {
       .limit(1);
     const settings = (rows[0]?.settings ?? {}) as OrgSettings;
     return {
-      perMinute: settings.rateLimits?.perMinute ?? FREE_TIER_LIMITS.perMinute,
       perDay: settings.rateLimits?.perDay ?? FREE_TIER_LIMITS.perDay,
     };
   }
 
-  /**
-   * Read MCP usage for both windows without consuming. Used by the dashboard
-   * usage page.
-   */
   async usage(): Promise<{
-    minute: { used: number; limit: number; resetAt: string };
     day: { used: number; limit: number; resetAt: string };
   }> {
     const ctx = getCurrentContext();
     const orgId = ctx.actor!.orgId;
     const limits = await this.loadLimits(orgId);
     const now = new Date();
-    const minuteWindow = windowStartFor('minute', now);
     const dayWindow = windowStartFor('day', now);
 
     const rows = await ctx.db.execute<BucketCountRow>(sql`
       SELECT bucket, count::int AS count
       FROM rate_limit_counters
       WHERE org_id = ${orgId}
-        AND ((bucket = 'mcp_calls_minute' AND window_start = ${minuteWindow.toISOString()}::timestamptz)
-          OR (bucket = 'mcp_calls_day' AND window_start = ${dayWindow.toISOString()}::timestamptz))
+        AND bucket = 'mcp_calls_day'
+        AND window_start = ${dayWindow.toISOString()}::timestamptz
     `);
-    const byBucket = new Map(rows.map((r) => [r.bucket, r.count]));
+    const used = rows[0]?.count ?? 0;
     return {
-      minute: {
-        used: byBucket.get('mcp_calls_minute') ?? 0,
-        limit: limits.perMinute,
-        resetAt: new Date(minuteWindow.getTime() + 60_000).toISOString(),
-      },
       day: {
-        used: byBucket.get('mcp_calls_day') ?? 0,
+        used,
         limit: limits.perDay,
         resetAt: new Date(dayWindow.getTime() + 86_400_000).toISOString(),
       },
@@ -176,8 +140,6 @@ export class RateLimitService {
 
 function windowStartFor(granularity: Granularity, now: Date): Date {
   switch (granularity) {
-    case 'minute':
-      return new Date(Math.floor(now.getTime() / 60_000) * 60_000);
     case 'day':
       return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
     case 'month':

--- a/packages/backend-core/src/mcp/mcp-burst.guard.test.ts
+++ b/packages/backend-core/src/mcp/mcp-burst.guard.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type {
+  ContextType,
+  ExecutionContext,
+  Type,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import type { ResolvedCredential } from '@getmunin/core';
+import { McpBurstGuard } from './mcp-burst.guard.ts';
+
+type HttpArgumentsHost = ReturnType<ExecutionContext['switchToHttp']>;
+type RpcArgumentsHost = ReturnType<ExecutionContext['switchToRpc']>;
+type WsArgumentsHost = ReturnType<ExecutionContext['switchToWs']>;
+
+class MockExecutionContext implements ExecutionContext {
+  constructor(private readonly request: Partial<Request>) {}
+  switchToHttp(): HttpArgumentsHost {
+    const req = this.request;
+    return {
+      getRequest<T>(): T { return req as T; },
+      getResponse<T>(): T { return {} as T; },
+      getNext<T>(): T { return undefined as T; },
+    };
+  }
+  switchToRpc(): RpcArgumentsHost { throw new Error('not implemented'); }
+  switchToWs(): WsArgumentsHost { throw new Error('not implemented'); }
+  getType<TContext extends string = ContextType>(): TContext { return 'http' as TContext; }
+  getClass<T = unknown>(): Type<T> { throw new Error('not implemented'); }
+  getHandler(): (...args: unknown[]) => unknown { throw new Error('not implemented'); }
+  getArgs<T extends Array<unknown> = unknown[]>(): T { return [] as unknown[] as T; }
+  getArgByIndex<T = unknown>(_index: number): T { throw new Error('not implemented'); }
+}
+
+function makeRequest(orgId: string | null, ip = '10.0.0.1'): Partial<Request> {
+  const credential = orgId
+    ? {
+        actor: { orgId, type: 'admin_agent', id: 'agt_x', scopes: ['*'], audiences: ['admin'] },
+      }
+    : undefined;
+  return {
+    ip,
+    socket: { remoteAddress: ip } as Request['socket'],
+    credential,
+  } as Partial<Request> & { credential?: ResolvedCredential };
+}
+
+function makeContext(request: Partial<Request>): ExecutionContext {
+  return new MockExecutionContext(request);
+}
+
+describe('McpBurstGuard', () => {
+  const originalEnv = process.env.MUNIN_MCP_BURST_PER_MIN;
+
+  beforeEach(() => {
+    process.env.MUNIN_MCP_BURST_PER_MIN = '3';
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.MUNIN_MCP_BURST_PER_MIN;
+    else process.env.MUNIN_MCP_BURST_PER_MIN = originalEnv;
+  });
+
+  it('allows calls under the per-minute cap and rejects the (N+1)th', () => {
+    const guard = new McpBurstGuard();
+    const ctx = makeContext(makeRequest('org_a'));
+    expect(guard.canActivate(ctx)).toBe(true);
+    expect(guard.canActivate(ctx)).toBe(true);
+    expect(guard.canActivate(ctx)).toBe(true);
+    expect(() => guard.canActivate(ctx)).toThrow(/mcp_burst_limited/);
+  });
+
+  it('isolates orgs from each other', () => {
+    const guard = new McpBurstGuard();
+    const a = makeContext(makeRequest('org_a'));
+    const b = makeContext(makeRequest('org_b'));
+    for (let i = 0; i < 3; i++) expect(guard.canActivate(a)).toBe(true);
+    expect(() => guard.canActivate(a)).toThrow();
+    expect(guard.canActivate(b)).toBe(true);
+  });
+
+  it('falls back to IP-based key for anonymous traffic', () => {
+    const guard = new McpBurstGuard();
+    const same = makeContext(makeRequest(null, '203.0.113.5'));
+    const other = makeContext(makeRequest(null, '203.0.113.6'));
+    for (let i = 0; i < 3; i++) expect(guard.canActivate(same)).toBe(true);
+    expect(() => guard.canActivate(same)).toThrow();
+    expect(guard.canActivate(other)).toBe(true);
+  });
+
+  it('disables enforcement when MUNIN_MCP_BURST_PER_MIN=0', () => {
+    process.env.MUNIN_MCP_BURST_PER_MIN = '0';
+    const guard = new McpBurstGuard();
+    const ctx = makeContext(makeRequest('org_a'));
+    for (let i = 0; i < 100; i++) expect(guard.canActivate(ctx)).toBe(true);
+  });
+});

--- a/packages/backend-core/src/mcp/mcp-burst.guard.ts
+++ b/packages/backend-core/src/mcp/mcp-burst.guard.ts
@@ -1,0 +1,61 @@
+import { CanActivate, ExecutionContext, HttpException, Injectable } from '@nestjs/common';
+import type { Request } from 'express';
+import { parseEnvInt, type ResolvedCredential } from '@getmunin/core';
+
+interface Window {
+  count: number;
+  resetAt: number;
+}
+
+const WINDOW_MS = 60_000;
+
+/**
+ * Per-replica burst limiter for /mcp. Each pod keeps its own (org || ip) →
+ * (count, resetAt) map in memory; entries auto-expire at the end of their
+ * minute window. Multi-replica fleets don't enforce a global cap — each
+ * pod independently allows up to `MUNIN_MCP_BURST_PER_MIN` (default 60).
+ * Adequate for runaway-agent protection; deliberately not a billing gate.
+ */
+@Injectable()
+export class McpBurstGuard implements CanActivate {
+  private readonly windows = new Map<string, Window>();
+
+  canActivate(context: ExecutionContext): boolean {
+    const limit = parseEnvInt({ name: 'MUNIN_MCP_BURST_PER_MIN', default: 60 });
+    if (limit <= 0) return true;
+
+    const req = context.switchToHttp().getRequest<Request & { credential?: ResolvedCredential }>();
+    const orgId = req.credential?.actor.orgId;
+    const ip = req.ip ?? req.socket?.remoteAddress;
+    const key = orgId ? `org:${orgId}` : `ip:${ip ?? 'unknown'}`;
+
+    const now = Date.now();
+    const existing = this.windows.get(key);
+    if (!existing || existing.resetAt <= now) {
+      this.windows.set(key, { count: 1, resetAt: now + WINDOW_MS });
+      this.sweep(now);
+      return true;
+    }
+    if (existing.count >= limit) {
+      const retryAfter = Math.ceil((existing.resetAt - now) / 1000);
+      throw new HttpException(
+        {
+          statusCode: 429,
+          code: 'mcp_burst_limited',
+          message: `mcp_burst_limited: exceeded ${limit} MCP calls per minute on this replica. Retry in ${retryAfter}s.`,
+          retryAfter,
+        },
+        429,
+      );
+    }
+    existing.count += 1;
+    return true;
+  }
+
+  private sweep(now: number): void {
+    if (this.windows.size < 1024) return;
+    for (const [key, w] of this.windows) {
+      if (w.resetAt <= now) this.windows.delete(key);
+    }
+  }
+}

--- a/packages/backend-core/src/mcp/mcp.controller.ts
+++ b/packages/backend-core/src/mcp/mcp.controller.ts
@@ -18,6 +18,7 @@ import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 import { McpRegistryService } from './mcp.registry.ts';
 import { McpSkillRegistryService } from './mcp.skill-registry.service.ts';
+import { McpBurstGuard } from './mcp-burst.guard.ts';
 import { RateLimitService } from '../common/rate-limit/rate-limit.service.ts';
 import { QUOTAS_SERVICE, type QuotasService } from '../common/quotas/quotas.service.ts';
 import { deriveMcpAudience } from './mcp.audience.ts';
@@ -34,7 +35,7 @@ import { deriveMcpAudience } from './mcp.audience.ts';
  * SDK exposes one (currently a no-op for stateless mode).
  */
 @Controller('mcp')
-@UseGuards(AuthGuard)
+@UseGuards(AuthGuard, McpBurstGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 export class McpController {
   private readonly audit = new AuditLogger();

--- a/packages/backend-core/src/mcp/mcp.module.ts
+++ b/packages/backend-core/src/mcp/mcp.module.ts
@@ -3,12 +3,13 @@ import { DiscoveryModule } from '@nestjs/core';
 import { McpController } from './mcp.controller.ts';
 import { McpRegistryService } from './mcp.registry.ts';
 import { McpSkillRegistryService } from './mcp.skill-registry.service.ts';
+import { McpBurstGuard } from './mcp-burst.guard.ts';
 import { PingMcpTool } from './ping.tool.ts';
 
 @Module({
   imports: [DiscoveryModule],
   controllers: [McpController],
-  providers: [McpRegistryService, McpSkillRegistryService, PingMcpTool],
+  providers: [McpRegistryService, McpSkillRegistryService, McpBurstGuard, PingMcpTool],
   exports: [McpRegistryService, McpSkillRegistryService],
 })
 export class McpModule {}


### PR DESCRIPTION
## Summary

- New `McpBurstGuard` enforces `MUNIN_MCP_BURST_PER_MIN` (default 60) per `(org_id || ip)` in an in-memory map per replica.
- Applied to `McpController` via `@UseGuards(AuthGuard, McpBurstGuard)`.
- `RateLimitService.consume()` drops the per-minute bump+check; the `mcp_calls_minute` bucket and `OrgLimits.perMinute` are removed.
- `/v1/usage` no longer returns a `minute` field.

Stacked on top of #368 (call-quota unification). Auto-retargets to `main` once that lands.

## Trade-off

Multi-replica fleets no longer enforce a fleet-global per-minute cap — each pod independently allows up to the limit. Adequate for runaway-agent protection (one bad agent loops against one pod; a 60/min cap per pod still flatlines it). Eliminates ~1440 rows/day/org of accumulating minute-bucket data that nothing ever read except `usage()`.

## Breaking change

`/v1/usage` shape: the response previously returned `{ minute, day }`; now returns `{ day }`. Dashboard already consumes `/v1/usage/summary` (separate `UsageStatsController`) not `/v1/usage`, so no UI impact. Any external monitoring scripts hitting `/v1/usage` need to drop the `minute` field.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck`
- [x] `pnpm -F @getmunin/backend-core exec vitest run src/mcp/mcp-burst.guard.test.ts` (4 tests: under-cap, per-org isolation, IP fallback, disable via env=0)
- [x] `pnpm -F @getmunin/backend-core exec vitest run src/common/audit/audit.interceptor.test.ts` — unchanged, still 25/25
- [ ] After deploy: confirm 429 with `code: mcp_burst_limited` on a synthetic burst against `/mcp` from a single org, and that a second org is unaffected.
- [ ] Sanity-check: `SELECT bucket, count(*) FROM rate_limit_counters GROUP BY 1` no longer produces `mcp_calls_minute` rows for new traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)