### PR TITLE
refactor(backend-core): strip SaaS-flavored code from quotas surface

### DIFF
--- a/.changeset/untype-quota-callkind.md
+++ b/.changeset/untype-quota-callkind.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Strip SaaS-flavored code from `@getmunin/backend-core`'s quotas surface. The OSS module is now an abstract `QuotasService` (`assertCanAdd`, `recordCall`) plus a `DefaultQuotasService` that no-ops both. All tier numbers, the `MUNIN_QUOTAS_ENABLED` switch, the `FREE_TIER_QUOTAS` map, the `TABLE_FOR` row-count helpers, and the `cap` / `count` abstract methods are gone — those belong to whoever runs the SaaS, not to the OSS library.
+
+Concretely:
+
+- `QuotaCallKind` type removed (was `'mcp_tool' | 'api_request'` — cloud billing vocabulary). `recordCall(kind, key?)` now takes `kind: string`.
+- `cap()` and `count()` removed from the abstract — only `CloudQuotasService` used them, and it still has them as concrete methods on the subclass.
+- `DefaultQuotasService.assertCanAdd` is a no-op (previously executed row counts when `MUNIN_QUOTAS_ENABLED=true`).
+- `MUNIN_QUOTAS_ENABLED` env var no longer read; removed from `.env.example`.
+
+Coordinated cloud change: `@munin-cloud/quotas` must replace `import type { QuotaCallKind } from '@getmunin/backend-core'` with its existing local `CallKind` union from `@munin-cloud/plans` (or just `string`), and delete the now-pointless `_CallKindMatchesBackend` compile-time assertion. The existing `CloudQuotasService` row-count and tier logic continues to apply unchanged — it's just no longer a partial duplicate of code that was shipping in OSS.

--- a/.env.example
+++ b/.env.example
@@ -170,15 +170,6 @@ MUNIN_FEEDBACK_ENABLED=false
 # end-to-end testing). Defaults to Munin's production roadmap intake.
 # MUNIN_FEEDBACK_INTAKE_URL=https://feedback.getmunin.com/v1/public/feedback
 
-# --- Quotas (tier caps) -------------------------------------------------
-# Per-resource row caps (KB docs/spaces, CMS collections/entries/assets)
-# enforced at write time. Off by default so OSS self-hosters aren't capped
-# on their own hardware. Set to `true` in tiered/SaaS deployments. When
-# enabled, defaults come from FREE_TIER_QUOTAS in
-# packages/backend-core/src/common/quotas/quotas.service.ts; per-org
-# overrides live at `orgs.settings.quotas.<resource>`.
-MUNIN_QUOTAS_ENABLED=false
-
 # --- Curator scheduler (backend-side cron) ------------------------------
 # The backend enqueues curator sweep jobs on these cadences via
 # @nestjs/schedule. Standard cron expressions (minute hour dom mon dow).

--- a/packages/backend-core/src/common/audit/audit.interceptor.test.ts
+++ b/packages/backend-core/src/common/audit/audit.interceptor.test.ts
@@ -21,7 +21,6 @@ import { AuditInterceptor } from './audit.interceptor.ts';
 import { RateLimitService, type Bucket } from '../rate-limit/rate-limit.service.ts';
 import {
   QuotasService,
-  type QuotaCallKind,
   type QuotaResource,
 } from '../quotas/quotas.service.ts';
 
@@ -31,9 +30,9 @@ class MockRateLimitService extends RateLimitService {
 }
 
 class MockQuotasService extends QuotasService {
-  recordCallMock = vi.fn<(kind: QuotaCallKind, key?: string) => Promise<void>>().mockResolvedValue(undefined);
+  recordCallMock = vi.fn<(kind: string, key?: string) => Promise<void>>().mockResolvedValue(undefined);
   assertCanAdd(_resource: QuotaResource): Promise<void> { return Promise.resolve(); }
-  recordCall(kind: QuotaCallKind, key?: string): Promise<void> { return this.recordCallMock(kind, key); }
+  recordCall(kind: string, key?: string): Promise<void> { return this.recordCallMock(kind, key); }
   cap(_orgId: string, _resource: QuotaResource): Promise<number> { return Promise.resolve(Number.POSITIVE_INFINITY); }
   count(_resource: QuotaResource): Promise<number> { return Promise.resolve(0); }
 }
@@ -83,7 +82,7 @@ function makeActiveContext(actorType: ActorType = 'user'): RequestContext {
 }
 
 function makeInterceptor(
-  recordCallImpl: (kind: QuotaCallKind, key?: string) => Promise<void> = () => Promise.resolve(),
+  recordCallImpl: (kind: string, key?: string) => Promise<void> = () => Promise.resolve(),
 ): {
   interceptor: TestableAuditInterceptor;
   rateLimit: MockRateLimitService;

--- a/packages/backend-core/src/common/quotas/quotas.service.test.ts
+++ b/packages/backend-core/src/common/quotas/quotas.service.test.ts
@@ -1,131 +1,21 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
-import { createDb, runMigrations, schema } from '@getmunin/db';
-import { sql } from 'drizzle-orm';
-import { randomUUID } from 'node:crypto';
-import type { QuotasService } from './quotas.service.ts';
-import { DefaultQuotasService, QuotaExceededError } from './quotas.service.ts';
+import { describe, expect, it } from 'vitest';
+import { DefaultQuotasService } from './quotas.service.ts';
 
-const TEST_URL = process.env.TEST_DATABASE_URL;
-const skipReason = TEST_URL
-  ? null
-  : 'Set TEST_DATABASE_URL to a Postgres URL to run quotas tests.';
+describe('DefaultQuotasService', () => {
+  const svc = new DefaultQuotasService();
 
-(skipReason ? describe.skip : describe)('QuotasService', () => {
-  let db: ReturnType<typeof createDb>;
-  let appDb: ReturnType<typeof createDb>;
-  let svc: QuotasService;
-  let orgId: string;
-  let actor: ActorIdentity;
-
-  beforeAll(async () => {
-    process.env.MUNIN_QUOTAS_ENABLED = 'true';
-    await runMigrations(TEST_URL!);
-    db = createDb(TEST_URL!, { serviceRole: true });
-    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
-    appDb = createDb(appUrl);
-
-    const [org] = await db
-      .insert(schema.orgs)
-      .values({
-        name: 'Quota Test Org',
-        // Tight cap to make the test fast.
-        settings: { quotas: { kb_spaces: 2 } },
-      })
-      .returning();
-    orgId = org!.id;
-    actor = new ActorIdentity('admin_agent', 'agt_q', orgId, ['*'], ['admin']);
-    svc = new DefaultQuotasService();
+  it('assertCanAdd is a no-op for every resource', async () => {
+    await expect(svc.assertCanAdd('kb_documents')).resolves.toBeUndefined();
+    await expect(svc.assertCanAdd('kb_spaces')).resolves.toBeUndefined();
+    await expect(svc.assertCanAdd('cms_collections')).resolves.toBeUndefined();
+    await expect(svc.assertCanAdd('cms_entries')).resolves.toBeUndefined();
+    await expect(svc.assertCanAdd('cms_assets')).resolves.toBeUndefined();
+    await expect(svc.assertCanAdd('crm_contacts')).resolves.toBeUndefined();
   });
 
-  afterAll(async () => {
-    if (db) {
-      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
-      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
-    }
-  });
-
-  beforeEach(async () => {
-    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
-    await db.execute(sql`DELETE FROM kb_spaces WHERE org_id = ${orgId}`);
-  });
-
-  function run<T>(fn: () => Promise<T>): Promise<T> {
-    return appDb.transaction(async (tx) => {
-      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
-      await tx.execute(sql`SELECT set_config('app.org_id', ${orgId}, true)`);
-      const ctx: RequestContext = {
-        db: tx,
-        actor,
-        correlationId: randomUUID(),
-      };
-      return withContext(ctx, fn);
-    });
-  }
-
-  it('passes when under cap', async () => {
-    await expect(run(() => svc.assertCanAdd('kb_spaces'))).resolves.toBeUndefined();
-  });
-
-  it('throws QuotaExceededError when at cap', async () => {
-    await db.insert(schema.kbSpaces).values([
-      { orgId, name: 'A', slug: 'a' },
-      { orgId, name: 'B', slug: 'b' },
-    ]);
-    await expect(run(() => svc.assertCanAdd('kb_spaces'))).rejects.toThrow(QuotaExceededError);
-  });
-
-  it('throws QuotaExceededError on crm_contacts at cap', async () => {
-    await db
-      .update(schema.orgs)
-      .set({ settings: { quotas: { crm_contacts: 1 } } })
-      .where(sql`id = ${orgId}`);
-    try {
-      await db
-        .insert(schema.crmContacts)
-        .values({ orgId, name: 'A', email: 'a@example.com' });
-      await expect(run(() => svc.assertCanAdd('crm_contacts'))).rejects.toThrow(
-        QuotaExceededError,
-      );
-    } finally {
-      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
-      await db.delete(schema.crmContacts).where(sql`org_id = ${orgId}`);
-      await db.update(schema.orgs).set({ settings: { quotas: { kb_spaces: 2 } } }).where(sql`id = ${orgId}`);
-    }
-  });
-
-  it('recordCall is a no-op on the default impl', async () => {
-    await expect(run(() => svc.recordCall('mcp_tool', 'kb_search'))).resolves.toBeUndefined();
-    await expect(run(() => svc.recordCall('api_request', 'GET /v1/orgs'))).resolves.toBeUndefined();
-  });
-
-  it('falls back to free-tier defaults when settings.quotas is absent', async () => {
-    const [defaultOrg] = await db
-      .insert(schema.orgs)
-      .values({ name: 'Default Org' })
-      .returning();
-    const defaultActor = new ActorIdentity(
-      'admin_agent',
-      'agt_d',
-      defaultOrg!.id,
-      ['*'],
-      ['admin'],
-    );
-    try {
-      const cap = await appDb.transaction(async (tx) => {
-        await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
-        await tx.execute(sql`SELECT set_config('app.org_id', ${defaultOrg!.id}, true)`);
-        const ctx: RequestContext = {
-          db: tx,
-          actor: defaultActor,
-          correlationId: randomUUID(),
-        };
-        return withContext(ctx, () => svc.cap(defaultOrg!.id, 'kb_documents'));
-      });
-      expect(cap).toBe(10_000);
-    } finally {
-      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
-      await db.delete(schema.orgs).where(sql`id = ${defaultOrg!.id}`);
-    }
+  it('recordCall is a no-op for every kind', async () => {
+    await expect(svc.recordCall('mcp_tool', 'kb_search')).resolves.toBeUndefined();
+    await expect(svc.recordCall('api_request', 'GET /v1/orgs')).resolves.toBeUndefined();
+    await expect(svc.recordCall('arbitrary_downstream_kind')).resolves.toBeUndefined();
   });
 });

--- a/packages/backend-core/src/common/quotas/quotas.service.ts
+++ b/packages/backend-core/src/common/quotas/quotas.service.ts
@@ -1,7 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { schema } from '@getmunin/db';
-import { sql } from 'drizzle-orm';
-import { getCurrentContext, parseEnvBool } from '@getmunin/core';
 
 export const QUOTAS_SERVICE = Symbol('QUOTAS_SERVICE');
 
@@ -20,82 +17,17 @@ export type QuotaResource =
   | 'cms_assets'
   | 'crm_contacts';
 
-export type QuotaCallKind = 'mcp_tool' | 'api_request';
-
-const FREE_TIER_QUOTAS: Record<QuotaResource, number> = {
-  kb_documents: 10_000,
-  kb_spaces: 100,
-  cms_collections: 50,
-  cms_entries: 10_000,
-  cms_assets: 1_000,
-  crm_contacts: 1_000,
-};
-
-interface OrgSettings {
-  quotas?: Partial<Record<QuotaResource, number>>;
-}
-
-const TABLE_FOR: Record<QuotaResource, string> = {
-  kb_documents: 'kb_documents',
-  kb_spaces: 'kb_spaces',
-  cms_collections: 'cms_collections',
-  cms_entries: 'cms_entries',
-  cms_assets: 'cms_assets',
-  crm_contacts: 'crm_contacts',
-};
-
-function isEnabled(): boolean {
-  return parseEnvBool({ name: 'MUNIN_QUOTAS_ENABLED', default: false });
-}
-
 export abstract class QuotasService {
   abstract assertCanAdd(resource: QuotaResource): Promise<void>;
-  abstract recordCall(kind: QuotaCallKind, key?: string): Promise<void>;
-  abstract cap(orgId: string, resource: QuotaResource): Promise<number>;
-  abstract count(resource: QuotaResource): Promise<number>;
+  abstract recordCall(kind: string, key?: string): Promise<void>;
 }
 
-/**
- * Default row-count quota implementation. Opt-in via MUNIN_QUOTAS_ENABLED so
- * OSS self-hosters aren't capped on their own hardware. When enabled, the
- * count runs inside the request transaction so the count and the insert see
- * the same MVCC snapshot. `recordCall` is a no-op here — call-count quotas
- * require a counter table and live in the cloud override.
- */
 @Injectable()
 export class DefaultQuotasService extends QuotasService {
-  async assertCanAdd(resource: QuotaResource): Promise<void> {
-    if (!isEnabled()) return;
-    const ctx = getCurrentContext();
-    const orgId = ctx.actor!.orgId;
-    if (!orgId) return;
-    const cap = await this.cap(orgId, resource);
-    const used = await this.count(resource);
-    if (used >= cap) throw new QuotaExceededError(resource, cap);
-  }
-
-  recordCall(_kind: QuotaCallKind, _key?: string): Promise<void> {
+  assertCanAdd(_resource: QuotaResource): Promise<void> {
     return Promise.resolve();
   }
-
-  async cap(orgId: string, resource: QuotaResource): Promise<number> {
-    const ctx = getCurrentContext();
-    const rows = await ctx.db
-      .select({ settings: schema.orgs.settings })
-      .from(schema.orgs)
-      .where(sql`${schema.orgs.id} = ${orgId}`)
-      .limit(1);
-    const settings = (rows[0]?.settings ?? {}) as OrgSettings;
-    return settings.quotas?.[resource] ?? FREE_TIER_QUOTAS[resource];
-  }
-
-  async count(resource: QuotaResource): Promise<number> {
-    const ctx = getCurrentContext();
-    const orgId = ctx.actor!.orgId;
-    const table = TABLE_FOR[resource];
-    const rows = await ctx.db.execute<{ n: number } & Record<string, unknown>>(
-      sql`SELECT COUNT(*)::int AS n FROM ${sql.identifier(table)} WHERE org_id = ${orgId}`,
-    );
-    return rows[0]?.n ?? 0;
+  recordCall(_kind: string, _key?: string): Promise<void> {
+    return Promise.resolve();
   }
 }

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -126,7 +126,6 @@ export {
   DefaultQuotasService,
   QuotaExceededError,
   type QuotaResource,
-  type QuotaCallKind,
 } from './common/quotas/quotas.service.ts';
 export { WebhookModule } from './common/webhooks/webhook.module.ts';
 export { OAuthModule } from './oauth/oauth.module.ts';


### PR DESCRIPTION
## Summary

OSS shouldn't ship "your SaaS in a box." The `quotas` module today ships free-tier numbers, row-count helpers, a `MUNIN_QUOTAS_ENABLED` switch, and `cap`/`count` abstract methods that only cloud uses. The "OSS self-hoster opt-in" framing is thin — the values, the env comment ("Set to `true` in tiered/SaaS deployments"), and the FREE_TIER nomenclature all betray that this is cloud's free-tier surface.

After this PR, OSS keeps only the abstract extension point. Cloud's `CloudQuotasService` keeps its own implementation unchanged.

## What's removed from OSS

- `FREE_TIER_QUOTAS` map (cloud's free-tier numbers).
- `TABLE_FOR` row-count routing.
- `MUNIN_QUOTAS_ENABLED` env var + `.env.example` block.
- `cap()` and `count()` abstract methods (only `CloudQuotasService` used them; it still has them as concrete methods).
- `DefaultQuotasService` row-counting body — now a pure no-op.
- `QuotaCallKind` type (`'mcp_tool' | 'api_request'` — cloud billing vocabulary). `recordCall(kind, key?)` takes `kind: string`.

## What stays

- `QuotasService` abstract — the extension point.
- `DefaultQuotasService` — no-op default for OSS.
- `QuotaResource` type — these are OSS entity names (kb_documents, cms_entries, …), not cloud constructs.
- `QuotaExceededError` — useful for downstream overrides to throw.
- `assertCanAdd` and `recordCall` abstract methods — OSS code dispatches to them; cloud overrides.

## Coordinated cloud change

`@munin-cloud/quotas` must:
1. Replace `import type { QuotaCallKind } from '@getmunin/backend-core'` with the local `CallKind` union from `@munin-cloud/plans` (`'mcp_tool' | 'api_request'`).
2. Delete the now-pointless `_CallKindMatchesBackend` compile-time assertion in `policies.ts`.
3. Continue to override `assertCanAdd` and `recordCall` as today — the abstract contract is unchanged for those two methods.

Cloud's row-count enforcement, tier policies, and call-quota logic are unaffected (they all live in `CloudQuotasService`, not in OSS).

## Stacking

Stacked on top of #369 (in-memory MCP burst guard), which is stacked on #368 (call-quota unification). Merge order: #368 → #369 → this PR.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck`
- [x] `pnpm -F @getmunin/backend-core exec vitest run src/common/quotas/quotas.service.test.ts` — 2 tests confirming no-op behavior
- [x] `pnpm -F @getmunin/backend-core exec vitest run src/common/audit/audit.interceptor.test.ts src/mcp/mcp-burst.guard.test.ts` — 29 tests still pass
- [ ] After cloud PR ships: confirm `CloudQuotasService` continues to enforce row caps and call quotas (no behavior change there — just imports were swapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)