### PR TITLE
fix(backend-core): drop obsolete quota+rate tests, disable MCP burst in test env

### DIFF
--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -304,14 +304,12 @@ const skipReason = TEST_URL
     });
   }, 30_000);
 
-  it('rate limit: per-minute cap is enforced and the second call returns rate_limited', async () => {
-    // Fresh org with a 1-call-per-minute cap so the test can hit the limit deterministically.
-    const ts = Date.now();
+  it('rate limit: per-day cap is enforced and the second call returns rate_limited', async () => {
     const [rlOrg] = await db
       .insert(schema.orgs)
       .values({
         name: 'RL Org',
-        settings: { rateLimits: { perMinute: 1, perDay: 1000 } },
+        settings: { rateLimits: { perDay: 1 } },
       })
       .returning();
     const rlAdminKey = buildApiKey('admin');

--- a/packages/backend-core/src/modules/cms/cms.service.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.test.ts
@@ -17,7 +17,7 @@ import {
   CmsInvalidError,
 } from './cms.service.ts';
 import { EmbeddingProviderHolder } from '../kb/embedding.provider.ts';
-import { DefaultQuotasService, QuotaExceededError } from '../../common/quotas/quotas.service.ts';
+import { DefaultQuotasService } from '../../common/quotas/quotas.service.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
@@ -862,65 +862,9 @@ class StubStorage implements AssetStorage {
     });
   });
 
-  // ─── Quotas / RLS ────────────────────────────────────────────────────
+  // ─── RLS ─────────────────────────────────────────────────────────────
 
-  describe('quotas and RLS', () => {
-    let previousQuotasEnv: string | undefined;
-    beforeAll(() => {
-      previousQuotasEnv = process.env.MUNIN_QUOTAS_ENABLED;
-      process.env.MUNIN_QUOTAS_ENABLED = 'true';
-    });
-    afterAll(() => {
-      if (previousQuotasEnv === undefined) delete process.env.MUNIN_QUOTAS_ENABLED;
-      else process.env.MUNIN_QUOTAS_ENABLED = previousQuotasEnv;
-    });
-
-    it('createCollection respects org quota cap', async () => {
-      await db
-        .update(schema.orgs)
-        .set({ settings: { quotas: { cms_collections: 1 } } })
-        .where(sql`id = ${orgId}`);
-      try {
-        await run(() =>
-          svc.createCollection({ name: 'A', slug: 'a', fields: [{ name: 't', type: 'text' }] }),
-        );
-        await expect(
-          run(() =>
-            svc.createCollection({ name: 'B', slug: 'b', fields: [{ name: 't', type: 'text' }] }),
-          ),
-        ).rejects.toThrow(QuotaExceededError);
-      } finally {
-        await db.update(schema.orgs).set({ settings: {} }).where(sql`id = ${orgId}`);
-      }
-    });
-
-    it('createEntry respects org quota cap', async () => {
-      await ensureLocale('en');
-      const col = await run(() =>
-        svc.createCollection({
-          name: 'Q',
-          slug: 'q',
-          fields: [{ name: 'title', type: 'text', required: true }],
-        }),
-      );
-      await db
-        .update(schema.orgs)
-        .set({ settings: { quotas: { cms_entries: 1 } } })
-        .where(sql`id = ${orgId}`);
-      try {
-        await run(() =>
-          svc.createEntry({ collection: col.slug, slug: 'one', data: { title: 'one' } }),
-        );
-        await expect(
-          run(() =>
-            svc.createEntry({ collection: col.slug, slug: 'two', data: { title: 'two' } }),
-          ),
-        ).rejects.toThrow(QuotaExceededError);
-      } finally {
-        await db.update(schema.orgs).set({ settings: {} }).where(sql`id = ${orgId}`);
-      }
-    });
-
+  describe('RLS', () => {
     it('cross-org RLS isolation: another org cannot see this org\'s collections', async () => {
       const col = await run(() =>
         svc.createCollection({

--- a/packages/backend-core/src/modules/crm/crm.service.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.test.ts
@@ -76,31 +76,6 @@ const skipReason = TEST_URL
   // ─── Contacts ────────────────────────────────────────────────────────
 
   describe('contacts', () => {
-    it('createContact respects org quota cap and writes no row', async () => {
-      const previousEnv = process.env.MUNIN_QUOTAS_ENABLED;
-      process.env.MUNIN_QUOTAS_ENABLED = 'true';
-      await db
-        .update(schema.orgs)
-        .set({ settings: { quotas: { crm_contacts: 1 } } })
-        .where(sql`id = ${orgId}`);
-      try {
-        await run(() => svc.createContact({ name: 'first', email: 'first@example.com' }));
-        await expect(
-          run(() => svc.createContact({ name: 'second', email: 'second@example.com' })),
-        ).rejects.toThrow(/quota_exceeded/);
-        const rows = await db.execute<{ count: number }>(
-          sql`SELECT COUNT(*)::int AS count FROM crm_contacts WHERE org_id = ${orgId}`,
-        );
-        expect(rows[0]!.count).toBe(1);
-      } finally {
-        await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
-        await db.delete(schema.crmContacts).where(sql`org_id = ${orgId}`);
-        await db.update(schema.orgs).set({ settings: {} }).where(sql`id = ${orgId}`);
-        if (previousEnv === undefined) delete process.env.MUNIN_QUOTAS_ENABLED;
-        else process.env.MUNIN_QUOTAS_ENABLED = previousEnv;
-      }
-    });
-
     it('createContact persists with the requested fields', async () => {
       const c = await run(() =>
         svc.createContact({

--- a/packages/backend-core/src/modules/kb/kb.service.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.test.ts
@@ -11,7 +11,7 @@ import { sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { CURATION_INBOX_SLUG, KbService, KbConflictError, KbNotFoundError, KbInvalidError } from './kb.service.ts';
 import { EmbeddingProviderHolder } from './embedding.provider.ts';
-import { DefaultQuotasService, QuotaExceededError } from '../../common/quotas/quotas.service.ts';
+import { DefaultQuotasService } from '../../common/quotas/quotas.service.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
@@ -155,30 +155,6 @@ const skipReason = TEST_URL
     );
     expect(restored.version).toBe(3);
     expect(restored.body).toBe('Body v1');
-  });
-
-  it('createDocument throws QuotaExceededError at the org cap and writes no row', async () => {
-    const previous = process.env.MUNIN_QUOTAS_ENABLED;
-    process.env.MUNIN_QUOTAS_ENABLED = 'true';
-    await db
-      .update(schema.orgs)
-      .set({ settings: { quotas: { kb_documents: 1 } } })
-      .where(sql`id = ${orgId}`);
-    try {
-      const space = await run(() => svc.createSpace({ name: 'Q', slug: 'q' }));
-      await run(() => svc.createDocument({ spaceId: space.id, title: 'first', body: 'one' }));
-      await expect(
-        run(() => svc.createDocument({ spaceId: space.id, title: 'second', body: 'two' })),
-      ).rejects.toThrow(QuotaExceededError);
-      const rows = await db.execute<{ count: number }>(
-        sql`SELECT COUNT(*)::int AS count FROM kb_documents WHERE org_id = ${orgId}`,
-      );
-      expect(rows[0]!.count).toBe(1);
-    } finally {
-      await db.update(schema.orgs).set({ settings: {} }).where(sql`id = ${orgId}`);
-      if (previous === undefined) delete process.env.MUNIN_QUOTAS_ENABLED;
-      else process.env.MUNIN_QUOTAS_ENABLED = previous;
-    }
   });
 
   it('deletes with concurrency check', async () => {

--- a/packages/backend-core/test-env.ts
+++ b/packages/backend-core/test-env.ts
@@ -19,3 +19,5 @@ if (root) {
     process.loadEnvFile(envPath);
   }
 }
+
+process.env.MUNIN_MCP_BURST_PER_MIN ??= '0';

--- a/packages/backend-core/tsconfig.json
+++ b/packages/backend-core/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "@getmunin/tsconfig/nest.json",
   "compilerOptions": {
-    "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "test-env.ts", "vitest.config.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary

Cleanup PR after #370 (SaaS-strip from quotas) and #371 (in-memory MCP burst guard). The full integration suite was broken in two ways I missed in the earlier PRs:

1. **Obsolete tests** — `kb.service.test.ts`, `crm.service.test.ts`, `cms.service.test.ts` each drove `MUNIN_QUOTAS_ENABLED=true` and asserted `QuotaExceededError`. `DefaultQuotasService` no longer enforces row caps (cloud has its own coverage). The cases would fail on a clean DB. Removed.

2. **MCP integration rate-limit test** — set `rateLimits.perMinute: 1` on the org and expected `rate_limited`. `perMinute` is no longer enforced via `consume()`; the in-memory `McpBurstGuard` handles burst protection at the replica level. Swapped to `perDay: 1` to exercise the still-existing day cap with the same client-facing assertion.

3. **Burst guard tripping the integration suite** — the suite runs many MCP calls back-to-back from the same process, sharing the in-memory window. Defaulted `MUNIN_MCP_BURST_PER_MIN=0` in `test-env.ts` (the guard already treats `0` as "off"). Also widened `tsconfig.json`'s include to cover `test-env.ts` so the lint-staged pre-commit hook finds a TS project for it.

## Verification

- `pnpm -F @getmunin/backend-core typecheck` ✅
- `TEST_DATABASE_URL=… pnpm -F @getmunin/backend-core test` — **745/745 pass** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)