### PR TITLE
feat(backend-core): export RateLimitService + Bucket type

### DIFF
--- a/.changeset/export-rate-limit-service.md
+++ b/.changeset/export-rate-limit-service.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Export `RateLimitService`, `RateLimitExceededError`, and the `Bucket` type
+from the public surface so downstream backends (notably the cloud
+`QuotasService` override) can record into `rate_limit_counters` directly.

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -119,6 +119,11 @@ export { ConvModule } from './modules/conv/conv.module.ts';
 export { CrmModule } from './modules/crm/crm.module.ts';
 export { CmsModule } from './modules/cms/cms.module.ts';
 export { RateLimitModule } from './common/rate-limit/rate-limit.module.ts';
+export {
+  RateLimitService,
+  RateLimitExceededError,
+  type Bucket,
+} from './common/rate-limit/rate-limit.service.ts';
 export { QuotasModule } from './common/quotas/quotas.module.ts';
 export {
   QUOTAS_SERVICE,


### PR DESCRIPTION
## Summary
- Add named exports for `RateLimitService`, `RateLimitExceededError`, and the `Bucket` type from `@getmunin/backend-core`'s public surface.
- Unblocks the coordinated cloud-quotas rewire (org_call_counters → rate_limit_counters) that needs to inject `RateLimitService` and reference `Bucket` literal types.

## Why
`RateLimitModule` is `@Global()` and exports the service, but the class itself wasn't reachable from the package entry, and the `exports` map blocks deep imports. Without these exports, cloud can't follow through on the call-quota unification from #368.

## Test plan
- [ ] CI green (typecheck/lint/tests)
- [ ] After release, cloud bumps to the new version and the cloud-quotas PR compiles + tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)