### PR TITLE
feat(cms): cms_upload_asset_from_file via openai/fileParams

### DIFF
--- a/.changeset/cms-upload-asset-from-file.md
+++ b/.changeset/cms-upload-asset-from-file.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/mcp-toolkit': minor
+---
+
+Replace `cms_upload_asset_bytes` with `cms_upload_asset_from_file`, a ChatGPT-native upload path.
+
+The base64-bytes tool didn't work for any realistic image from ChatGPT workspace agents — JSON-encoded base64 blew past the tool-call token budget around 2–3 MB. The new tool declares `_meta["openai/fileParams"]: ["file"]` so ChatGPT hands the server a short-lived signed download URL for a file already in the conversation; the backend fetches it through the existing `safeFetch` + SSRF + 50 MB cap path. Accepts `image/*`, `video/*`, `audio/*`, and `application/pdf`; SVG rejected.
+
+The `uploadAssetBytes` service method is kept (the dashboard's `/v1/cms/drafts/:id/assets` REST endpoint still uses it); only the MCP tool was removed.
+
+Also: `@McpTool` now accepts an optional `_meta` bag that flows through to `tools/list` entries, so any module can attach OpenAI Apps-SDK metadata (or future MCP extensions) without changing the toolkit.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -69,7 +69,7 @@
   {
     "name": "cms_create_collection",
     "title": "CMS: Create collection",
-    "description": "Define a new collection. Fields is an array of { name, type, required?, options? } — see field types: text, rich_text, markdown, number, integer, boolean, date, datetime, select, multi_select, asset, reference, array, json.",
+    "description": "Define a new collection. Fields is an ORDERED array of { name, type, required?, options? } — field order is the render order in editor and public surfaces, so put fields in the sequence a human would read or fill them (e.g. lede asset → headline → excerpt → metadata → body → trailing/optional fields). See field types: text, rich_text, markdown, number, integer, boolean, date, datetime, select, multi_select, asset, reference, array, json.",
     "audiences": [
       "admin"
     ],
@@ -190,7 +190,7 @@
   {
     "name": "cms_update_collection",
     "title": "CMS: Update collection",
-    "description": "Patch a collection. Field migration is lossy: dropped or renamed fields stay in entries' `data` jsonb but stop being read by the projection layer.",
+    "description": "Patch a collection. When supplied, `fields` REPLACES the existing array — so include every field you want to keep, in the order they should render (the array order is the render order). Field migration is lossy: dropped or renamed fields stay in entries' `data` jsonb but stop being read by the projection layer.",
     "audiences": [
       "admin"
     ],
@@ -778,9 +778,9 @@
     }
   },
   {
-    "name": "cms_upload_asset_bytes",
-    "title": "CMS: Upload asset bytes",
-    "description": "Upload a small asset (≤2 MB after base64 decode) in one call by passing the file body as base64. Skips the request/complete handshake — the row is created in `uploaded:true` state. For larger files, use cms_request_asset_upload + cms_complete_asset_upload instead. SVG is rejected.",
+    "name": "cms_upload_asset_from_file",
+    "title": "CMS: Upload asset from a ChatGPT file",
+    "description": "Upload a file that's already in the ChatGPT conversation (e.g. a user-uploaded image or an image-gen output) as a CMS asset. ChatGPT mints a short-lived signed URL for the file and the server fetches it. Use this when your runtime can't PUT to a presigned URL — typical for ChatGPT workspace agents. Accepts image/*, video/*, audio/*, and application/pdf up to 50 MB. SVG is rejected.",
     "audiences": [
       "admin"
     ],
@@ -793,20 +793,38 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
+        "file": {
+          "type": "object",
+          "properties": {
+            "download_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "file_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "mime_type": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            },
+            "file_name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            }
+          },
+          "required": [
+            "download_url",
+            "file_id"
+          ],
+          "additionalProperties": false
+        },
         "name": {
           "type": "string",
           "minLength": 1,
           "maxLength": 255
-        },
-        "mime": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        },
-        "base64Body": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 2800000
         },
         "altText": {
           "type": "string",
@@ -821,9 +839,7 @@
         }
       },
       "required": [
-        "name",
-        "mime",
-        "base64Body"
+        "file"
       ],
       "additionalProperties": false
     }

--- a/packages/backend-core/src/modules/cms/cms.service.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.ts
@@ -694,6 +694,21 @@ export class CmsService {
     });
   }
 
+  async uploadAssetFromFile(input: {
+    file: { download_url: string; file_id: string; mime_type?: string; file_name?: string };
+    name?: string;
+    altText?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<AssetDto> {
+    return this.uploadAssetFromUrl({
+      sourceUrl: input.file.download_url,
+      name: input.name ?? input.file.file_name,
+      mime: input.file.mime_type,
+      altText: input.altText,
+      metadata: { ...(input.metadata ?? {}), openaiFileId: input.file.file_id },
+    });
+  }
+
   async uploadAssetFromUrl(input: {
     sourceUrl: string;
     name?: string;

--- a/packages/backend-core/src/modules/cms/cms.tools.ts
+++ b/packages/backend-core/src/modules/cms/cms.tools.ts
@@ -109,10 +109,14 @@ const RequestUploadInput = z.object({
 const CompleteUploadInput = z.object({ id: z.string() });
 const DeleteAssetInput = z.object({ id: z.string() });
 
-const UploadAssetBytesInput = z.object({
-  name: z.string().min(1).max(255),
-  mime: z.string().min(1).max(120),
-  base64Body: z.string().min(1).max(2_800_000),
+const UploadAssetFromFileInput = z.object({
+  file: z.object({
+    download_url: z.string().url(),
+    file_id: z.string().min(1),
+    mime_type: z.string().min(1).max(120).optional(),
+    file_name: z.string().min(1).max(255).optional(),
+  }),
+  name: z.string().min(1).max(255).optional(),
   altText: z.string().max(500).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
@@ -414,18 +418,19 @@ export class CmsAdminTools {
   }
 
   @McpTool({
-    name: 'cms_upload_asset_bytes',
-    title: 'CMS: Upload asset bytes',
+    name: 'cms_upload_asset_from_file',
+    title: 'CMS: Upload asset from a ChatGPT file',
     description:
-      'Upload a small asset (≤2 MB after base64 decode) in one call by passing the file body as base64. Skips the request/complete handshake — the row is created in `uploaded:true` state. For larger files, use cms_request_asset_upload + cms_complete_asset_upload instead. SVG is rejected.',
+      "Upload a file that's already in the ChatGPT conversation (e.g. a user-uploaded image or an image-gen output) as a CMS asset. ChatGPT mints a short-lived signed URL for the file and the server fetches it. Use this when your runtime can't PUT to a presigned URL — typical for ChatGPT workspace agents. Accepts image/*, video/*, audio/*, and application/pdf up to 50 MB. SVG is rejected.",
     audiences: ['admin'],
     scopes: ['cms:write'],
-    input: UploadAssetBytesInput,
+    input: UploadAssetFromFileInput,
     readOnlyHint: false,
     destructiveHint: false,
+    _meta: { 'openai/fileParams': ['file'] },
   })
-  uploadAssetBytes(args: z.infer<typeof UploadAssetBytesInput>) {
-    return this.cms.uploadAssetBytes(args);
+  uploadAssetFromFile(args: z.infer<typeof UploadAssetFromFileInput>) {
+    return this.cms.uploadAssetFromFile(args);
   }
 
   @McpTool({

--- a/packages/mcp-toolkit/src/decorator.ts
+++ b/packages/mcp-toolkit/src/decorator.ts
@@ -20,6 +20,7 @@ export interface McpToolMeta<TInput extends z.ZodObject = z.ZodObject> {
   title?: string;
   readOnlyHint?: boolean;
   destructiveHint?: boolean;
+  _meta?: Record<string, unknown>;
 }
 
 export const MCP_TOOL_META = Symbol.for('munin.mcp.tool.meta');

--- a/packages/mcp-toolkit/src/dispatch.ts
+++ b/packages/mcp-toolkit/src/dispatch.ts
@@ -26,6 +26,7 @@ export interface ToolListing {
     readOnlyHint: boolean;
     destructiveHint: boolean;
   };
+  _meta?: Record<string, unknown>;
 }
 
 export interface ToolCallResult {
@@ -56,6 +57,7 @@ export function listTools(ctx: DispatchContext): ToolListing[] {
       readOnlyHint: t.meta.readOnlyHint ?? false,
       destructiveHint: t.meta.destructiveHint ?? false,
     },
+    ...(t.meta._meta ? { _meta: t.meta._meta } : {}),
   }));
 }
 


### PR DESCRIPTION
## Summary

- Replace `cms_upload_asset_bytes` (base64-in-JSON) with `cms_upload_asset_from_file`, which uses ChatGPT's `_meta["openai/fileParams"]` to receive a short-lived signed URL for a file already in the conversation. The backend then fetches it through the existing `safeFetch` + SSRF + 50 MB cap path — same allowlist as `cms_upload_asset_from_url` (`image/*`, `video/*`, `audio/*`, `application/pdf`; SVG rejected).
- Extend `@McpTool` with an optional `_meta` passthrough, emitted in `tools/list` only when set. Lets future tools attach OpenAI Apps-SDK metadata (or other MCP extensions) without further toolkit changes.
- The base64-bytes path failed in practice for ChatGPT workspace agents: JSON-encoded image payloads truncated around 2–3 MB. Three upload paths remain — presigned PUT/POST (`cms_request_asset_upload` + `cms_complete_asset_upload`), public URL (`cms_upload_asset_from_url`), and ChatGPT file (`cms_upload_asset_from_file`).
- `uploadAssetBytes` service method retained — the dashboard's `/v1/cms/drafts/:id/assets` REST endpoint still uses it; only the MCP tool wrapper is removed.

## Test plan

- [ ] Call `cms_upload_asset_from_file` from a ChatGPT workspace agent with a file already in the conversation (user upload or image-gen output); confirm the asset row is created and the public URL serves the image.
- [ ] Confirm Claude / non-OpenAI MCP clients still see the tool listed (the `_meta` field is harmless — they ignore unknown keys).
- [ ] Confirm `cms_upload_asset_bytes` is gone from `tools/list` for admin agents.
- [ ] Dashboard draft upload (REST `/v1/cms/drafts/:id/assets`) still works — the underlying `uploadAssetBytes` service method is unchanged.
- [ ] SVG, oversized (>50 MB), and disallowed MIME (e.g. `text/html`) rejected as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)