### PR TITLE
feat(mcp): record args + capture exceptions on MCP tool errors

### DIFF
--- a/.changeset/mcp-audit-args-and-error-reporter.md
+++ b/.changeset/mcp-audit-args-and-error-reporter.md
@@ -2,6 +2,8 @@
 '@getmunin/backend-core': minor
 '@getmunin/mcp-toolkit': minor
 '@getmunin/core': minor
+'@getmunin/agent-host': patch
+'@getmunin/agent-runtime': patch
 ---
 
 MCP dispatch now records redacted `args` on every audit row — including the `denied`, `invalid_input`, `rate_limited`, and thrown-handler paths that previously dropped the args. The success path is unchanged. The `invalid_input` row also now carries the Zod error message in its `error` column instead of just the literal string `"invalid_input"`. Caller-controlled args on `unknown_tool` are still dropped (no schema available to redact against).
@@ -11,3 +13,5 @@ A new optional `captureException` hook on `createMcpServer` / `openInProcessMcpC
 `@getmunin/backend-core` exposes the wiring: a new `ErrorReporterModule` registers a `NoopErrorReporter` against the `ERROR_REPORTER` injection token. `McpController` injects it and forwards thrown handler errors. Hosts that want Sentry (or any other reporter) replace the provider for `ERROR_REPORTER` with their own `ErrorReporter` subclass — `apps/backend` does this with a `SentryErrorReporter` that uses `Sentry.withScope` to attach the tool / actor / args context.
 
 The `cms_upload_asset_from_url` / `cms_upload_asset_from_file` error path now walks the `Error.cause` chain when an outbound fetch fails, so the surfaced message includes the underlying error code (e.g. `ENOTFOUND`, `ECONNRESET`, `CERT_HAS_EXPIRED`) instead of undici's opaque `"fetch failed"`. The unwrapping helper lives in `@getmunin/core` as `describeError(err, maxDepth?)` so other callers of `safeFetch` (and anywhere else cause-chain visibility matters) can reuse it.
+
+`describeError` also replaces three sites that previously surfaced only `err.message`: the webhook delivery worker (`webhook_deliveries.error` — visible to customers via `webhooks_list_deliveries`), `@getmunin/agent-host`'s models fetcher, and `@getmunin/agent-runtime`'s web crawler. Each of those had its own local `describe(err)` helper that did the inferior version.

--- a/.changeset/mcp-audit-args-and-error-reporter.md
+++ b/.changeset/mcp-audit-args-and-error-reporter.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/mcp-toolkit': minor
+'@getmunin/core': minor
+---
+
+MCP dispatch now records redacted `args` on every audit row — including the `denied`, `invalid_input`, `rate_limited`, and thrown-handler paths that previously dropped the args. The success path is unchanged. The `invalid_input` row also now carries the Zod error message in its `error` column instead of just the literal string `"invalid_input"`. Caller-controlled args on `unknown_tool` are still dropped (no schema available to redact against).
+
+A new optional `captureException` hook on `createMcpServer` / `openInProcessMcpClient` receives any error thrown by a tool handler, along with the tool name, actor identity (type / id / orgId), and redacted args. `mcp-toolkit` remains observability-vendor agnostic.
+
+`@getmunin/backend-core` exposes the wiring: a new `ErrorReporterModule` registers a `NoopErrorReporter` against the `ERROR_REPORTER` injection token. `McpController` injects it and forwards thrown handler errors. Hosts that want Sentry (or any other reporter) replace the provider for `ERROR_REPORTER` with their own `ErrorReporter` subclass — `apps/backend` does this with a `SentryErrorReporter` that uses `Sentry.withScope` to attach the tool / actor / args context.
+
+The `cms_upload_asset_from_url` / `cms_upload_asset_from_file` error path now walks the `Error.cause` chain when an outbound fetch fails, so the surfaced message includes the underlying error code (e.g. `ENOTFOUND`, `ECONNRESET`, `CERT_HAS_EXPIRED`) instead of undici's opaque `"fetch failed"`. The unwrapping helper lives in `@getmunin/core` as `describeError(err, maxDepth?)` so other callers of `safeFetch` (and anywhere else cause-chain visibility matters) can reuse it.

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -5,11 +5,13 @@ import {
   BACKEND_BASE_CONTROLLERS,
   BACKEND_BASE_PROVIDERS,
   BACKEND_FEATURE_MODULES,
+  ERROR_REPORTER,
   FeedbackModule,
   isFeedbackEnabled,
 } from '@getmunin/backend-core';
 import { AgentHostModule, SingletonConfigRepository } from '@getmunin/agent-host';
 import { AuthModule } from './auth/auth.module.ts';
+import { SentryErrorReporter } from './sentry-error-reporter.ts';
 
 const FEEDBACK_MODULES = isFeedbackEnabled() ? [FeedbackModule] : [];
 
@@ -24,6 +26,10 @@ const FEEDBACK_MODULES = isFeedbackEnabled() ? [FeedbackModule] : [];
     ...FEEDBACK_MODULES,
   ],
   controllers: BACKEND_BASE_CONTROLLERS,
-  providers: [{ provide: APP_FILTER, useClass: SentryGlobalFilter }, ...BACKEND_BASE_PROVIDERS],
+  providers: [
+    { provide: APP_FILTER, useClass: SentryGlobalFilter },
+    { provide: ERROR_REPORTER, useClass: SentryErrorReporter },
+    ...BACKEND_BASE_PROVIDERS,
+  ],
 })
 export class AppModule {}

--- a/apps/backend/src/sentry-error-reporter.ts
+++ b/apps/backend/src/sentry-error-reporter.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+import { ErrorReporter, type ErrorReporterContext } from '@getmunin/backend-core';
+
+@Injectable()
+export class SentryErrorReporter extends ErrorReporter {
+  captureException(error: unknown, context?: ErrorReporterContext): void {
+    Sentry.withScope((scope) => {
+      if (context?.tool) scope.setTag('mcp.tool', context.tool);
+      if (context?.actor?.type) scope.setTag('mcp.actor_type', context.actor.type);
+      if (context?.actor?.orgId) scope.setTag('mcp.org_id', context.actor.orgId);
+      if (context?.actor?.id) scope.setUser({ id: context.actor.id });
+      if (context?.args) scope.setContext('mcp_args', context.args);
+      Sentry.captureException(toError(error));
+    });
+  }
+}
+
+function toError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  if (typeof value === 'string') return new Error(value);
+  try {
+    return new Error(JSON.stringify(value));
+  } catch {
+    return new Error(String(value));
+  }
+}

--- a/packages/agent-host/src/models.service.ts
+++ b/packages/agent-host/src/models.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { safeFetch } from '@getmunin/core';
+import { describeError, safeFetch } from '@getmunin/core';
 import { AGENT_CONFIG_REPOSITORY } from './injection-tokens.ts';
 import type { AgentConfigRepository } from './config.repository.ts';
 import { authHeaders } from './provider-auth.ts';
@@ -59,7 +59,7 @@ export class AgentModelsService {
         headers: authHeaders(baseUrl, apiKey),
       });
     } catch (err) {
-      this.logger.warn(`fetch ${url} failed: ${describe(err)}`);
+      this.logger.warn(`fetch ${url} failed: ${describeError(err)}`);
       return { supported: false, models: [], fetchedAt: new Date().toISOString() };
     }
     if (!res.ok) {
@@ -70,7 +70,7 @@ export class AgentModelsService {
     try {
       body = await res.json();
     } catch (err) {
-      this.logger.warn(`${url} returned non-JSON: ${describe(err)}`);
+      this.logger.warn(`${url} returned non-JSON: ${describeError(err)}`);
       return { supported: false, models: [], fetchedAt: new Date().toISOString() };
     }
     const models = parseOpenAiCompatModels(body);
@@ -132,6 +132,3 @@ function parsePerMillion(raw: unknown): number | null {
   return n * 1_000_000;
 }
 
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}

--- a/packages/agent-runtime/src/web-crawl.ts
+++ b/packages/agent-runtime/src/web-crawl.ts
@@ -1,4 +1,4 @@
-import { safeFetch } from '@getmunin/core';
+import { describeError, safeFetch } from '@getmunin/core';
 
 const USER_AGENT = 'MuninOnboardingBot/1.0 (+https://getmunin.com/bot)';
 const DEFAULT_MAX_PAGES = 25;
@@ -145,7 +145,7 @@ export class WebCrawler {
       try {
         fetched = await this.fetcher(target);
       } catch (err) {
-        const message = describe(err);
+        const message = describeError(err);
         const reason: SkipReason = /timeout|aborted/i.test(message) ? 'timeout' : 'fetch_failed';
         skipped.push({ url: target, reason, detail: message });
         return;
@@ -170,7 +170,7 @@ export class WebCrawler {
       try {
         extracted = await this.extractor(fetched.body, fetched.finalUrl);
       } catch (err) {
-        skipped.push({ url: target, reason: 'extract_failed', detail: describe(err) });
+        skipped.push({ url: target, reason: 'extract_failed', detail: describeError(err) });
         return;
       }
       if (!extracted) {
@@ -206,7 +206,7 @@ export class WebCrawler {
         return parseRobots(res.body);
       }
     } catch (err) {
-      console.debug(`[web-crawl] robots.txt fetch failed for ${origin}: ${describe(err)}`);
+      console.debug(`[web-crawl] robots.txt fetch failed for ${origin}: ${describeError(err)}`);
     }
     return parseRobots('');
   }
@@ -225,7 +225,7 @@ export class WebCrawler {
       }
       return out;
     } catch (err) {
-      console.debug(`[web-crawl] sitemap read failed for ${url}: ${describe(err)}`);
+      console.debug(`[web-crawl] sitemap read failed for ${url}: ${describeError(err)}`);
       return [];
     }
   }
@@ -248,7 +248,7 @@ export class WebCrawler {
         try {
           res = await this.fetcher(url);
         } catch (err) {
-          console.debug(`[web-crawl] bfs fetch failed for ${url}: ${describe(err)}`);
+          console.debug(`[web-crawl] bfs fetch failed for ${url}: ${describeError(err)}`);
           continue;
         }
         if (res.status >= 400 || !res.contentType.includes('html')) continue;
@@ -344,7 +344,7 @@ export function extractLinks(html: string, baseUrl: string): string[] {
     try {
       out.push(new URL(raw, baseUrl).toString());
     } catch (err) {
-      console.debug(`[web-crawl] malformed link "${raw}" in ${baseUrl}: ${describe(err)}`);
+      console.debug(`[web-crawl] malformed link "${raw}" in ${baseUrl}: ${describeError(err)}`);
     }
   }
   return out;
@@ -370,7 +370,7 @@ export function normalizeStartUrl(input: string): URL | null {
     if (u.pathname === '') u.pathname = '/';
     return u;
   } catch (err) {
-    console.debug(`[web-crawl] could not parse start url "${input}": ${describe(err)}`);
+    console.debug(`[web-crawl] could not parse start url "${input}": ${describeError(err)}`);
     return null;
   }
 }
@@ -388,7 +388,7 @@ export function normalizeCandidateUrl(raw: string, origin: string): string | nul
     return u.toString();
   } catch (err) {
     console.debug(
-      `[web-crawl] could not normalize candidate "${raw}" against ${origin}: ${describe(err)}`,
+      `[web-crawl] could not normalize candidate "${raw}" against ${origin}: ${describeError(err)}`,
     );
     return null;
   }
@@ -400,7 +400,7 @@ function sameOrigin(url: string, origin: string): boolean {
     const b = new URL(origin);
     return stripWww(a.host) === stripWww(b.host) && a.protocol === b.protocol;
   } catch (err) {
-    console.debug(`[web-crawl] sameOrigin parse failed for "${url}" vs "${origin}": ${describe(err)}`);
+    console.debug(`[web-crawl] sameOrigin parse failed for "${url}" vs "${origin}": ${describeError(err)}`);
     return false;
   }
 }
@@ -413,7 +413,7 @@ function pathOf(url: string): string | null {
   try {
     return new URL(url).pathname || '/';
   } catch (err) {
-    console.debug(`[web-crawl] pathOf parse failed for "${url}": ${describe(err)}`);
+    console.debug(`[web-crawl] pathOf parse failed for "${url}": ${describeError(err)}`);
     return null;
   }
 }
@@ -422,7 +422,7 @@ function safeHost(url: string): string | null {
   try {
     return new URL(url).host;
   } catch (err) {
-    console.debug(`[web-crawl] safeHost parse failed for "${url}": ${describe(err)}`);
+    console.debug(`[web-crawl] safeHost parse failed for "${url}": ${describeError(err)}`);
     return null;
   }
 }
@@ -457,7 +457,7 @@ function guessTitleFromUrl(url: string): string {
         .replace(/\b\w/g, (c) => c.toUpperCase()) || 'Home'
     );
   } catch (err) {
-    console.debug(`[web-crawl] guessTitleFromUrl failed for "${url}": ${describe(err)}`);
+    console.debug(`[web-crawl] guessTitleFromUrl failed for "${url}": ${describeError(err)}`);
     return 'Page';
   }
 }
@@ -496,9 +496,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
 
 const defaultFetcher: HtmlFetcher = async (url) => {
   const controller = new AbortController();
@@ -567,7 +564,7 @@ const defaultExtractor: Extractor = async (html, url) => {
     return { title: (result?.title ?? '').toString().trim(), markdown: md };
   } catch (err) {
     console.warn(
-      `[web-crawl] defuddle extraction failed for "${url}", falling back: ${describe(err)}`,
+      `[web-crawl] defuddle extraction failed for "${url}", falling back: ${describeError(err)}`,
     );
     return extractBasic(html);
   }
@@ -604,7 +601,7 @@ async function loadDefuddle(): Promise<DefuddleFn | null> {
     return defuddleCache;
   } catch (err) {
     console.warn(
-      `[web-crawl] defuddle module load failed, using basic extractor: ${describe(err)}`,
+      `[web-crawl] defuddle module load failed, using basic extractor: ${describeError(err)}`,
     );
     defuddleCache = null;
     return null;

--- a/packages/backend-core/src/app.module.ts
+++ b/packages/backend-core/src/app.module.ts
@@ -15,6 +15,7 @@ import { CmsModule } from './modules/cms/cms.module.ts';
 import { RateLimitModule } from './common/rate-limit/rate-limit.module.ts';
 import { PublicThrottleModule } from './common/rate-limit/public-throttle.module.ts';
 import { QuotasModule } from './common/quotas/quotas.module.ts';
+import { ErrorReporterModule } from './common/error-reporter/error-reporter.module.ts';
 import { MailModule } from './common/mail/mail.module.ts';
 import { WebhookModule } from './common/webhooks/webhook.module.ts';
 import { StorageModule } from './common/storage/storage.module.ts';
@@ -30,6 +31,7 @@ export const BACKEND_FEATURE_MODULES = [
   RateLimitModule,
   PublicThrottleModule,
   QuotasModule,
+  ErrorReporterModule,
   McpModule,
   ControlModule,
   KbModule,

--- a/packages/backend-core/src/common/error-reporter/error-reporter.module.ts
+++ b/packages/backend-core/src/common/error-reporter/error-reporter.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { ERROR_REPORTER, NoopErrorReporter } from './error-reporter.ts';
+
+@Global()
+@Module({
+  providers: [{ provide: ERROR_REPORTER, useClass: NoopErrorReporter }],
+  exports: [ERROR_REPORTER],
+})
+export class ErrorReporterModule {}

--- a/packages/backend-core/src/common/error-reporter/error-reporter.ts
+++ b/packages/backend-core/src/common/error-reporter/error-reporter.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+
+export const ERROR_REPORTER = Symbol('ERROR_REPORTER');
+
+export interface ErrorReporterContext {
+  tool?: string;
+  actor?: { type?: string | null; id?: string | null; orgId?: string | null } | null;
+  args?: Record<string, unknown> | null;
+}
+
+export abstract class ErrorReporter {
+  abstract captureException(error: unknown, context?: ErrorReporterContext): void;
+}
+
+@Injectable()
+export class NoopErrorReporter extends ErrorReporter {
+  captureException(_error: unknown, _context?: ErrorReporterContext): void {}
+}

--- a/packages/backend-core/src/common/webhooks/webhook.worker.ts
+++ b/packages/backend-core/src/common/webhooks/webhook.worker.ts
@@ -1,7 +1,13 @@
 import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
 import { and, eq, isNull, lt, lte } from 'drizzle-orm';
-import { parseEnvDisableFlag, parseEnvInt, safeFetch, WebhookDispatcher } from '@getmunin/core';
+import {
+  describeError,
+  parseEnvDisableFlag,
+  parseEnvInt,
+  safeFetch,
+  WebhookDispatcher,
+} from '@getmunin/core';
 import { DB } from '../db/db.module.ts';
 import { withSchedulerLock } from '../scheduler-lock/index.ts';
 
@@ -149,7 +155,7 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
       statusCode = res.status;
       if (!res.ok) error = `non-2xx: ${res.status}`;
     } catch (err) {
-      error = err instanceof Error ? err.message : String(err);
+      error = describeError(err);
     }
     const durationMs = Date.now() - start;
 

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -125,6 +125,13 @@ export {
   type Bucket,
 } from './common/rate-limit/rate-limit.service.ts';
 export { QuotasModule } from './common/quotas/quotas.module.ts';
+export { ErrorReporterModule } from './common/error-reporter/error-reporter.module.ts';
+export {
+  ERROR_REPORTER,
+  ErrorReporter,
+  NoopErrorReporter,
+  type ErrorReporterContext,
+} from './common/error-reporter/error-reporter.ts';
 export {
   QUOTAS_SERVICE,
   QuotasService,

--- a/packages/backend-core/src/mcp/mcp.controller.ts
+++ b/packages/backend-core/src/mcp/mcp.controller.ts
@@ -21,6 +21,10 @@ import { McpSkillRegistryService } from './mcp.skill-registry.service.ts';
 import { McpBurstGuard } from './mcp-burst.guard.ts';
 import { RateLimitService } from '../common/rate-limit/rate-limit.service.ts';
 import { QUOTAS_SERVICE, type QuotasService } from '../common/quotas/quotas.service.ts';
+import {
+  ERROR_REPORTER,
+  type ErrorReporter,
+} from '../common/error-reporter/error-reporter.ts';
 import { deriveMcpAudience } from './mcp.audience.ts';
 
 /**
@@ -45,6 +49,7 @@ export class McpController {
     @Inject(McpSkillRegistryService) private readonly skills: McpSkillRegistryService,
     @Inject(RateLimitService) private readonly rateLimit: RateLimitService,
     @Inject(QUOTAS_SERVICE) private readonly quotas: QuotasService,
+    @Inject(ERROR_REPORTER) private readonly errorReporter: ErrorReporter,
   ) {}
 
   @Post()
@@ -79,6 +84,7 @@ export class McpController {
       },
       skills: this.skills,
       instructions: this.skills.instructions(),
+      captureException: (error, context) => this.errorReporter.captureException(error, context),
     });
 
     const transport = new StreamableHTTPServerTransport({

--- a/packages/backend-core/src/modules/cms/cms.service.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.ts
@@ -9,6 +9,7 @@ import { schema } from '@getmunin/db';
 import { and, asc, desc, eq, sql, type SQL } from 'drizzle-orm';
 import {
   contentHash,
+  describeError,
   getCurrentContext,
   safeFetch,
   SsrfBlockedError,
@@ -724,7 +725,7 @@ export class CmsService {
       throw new CmsInvalidError(
         err instanceof SsrfBlockedError
           ? `sourceUrl blocked: ${err.message}`
-          : `fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+          : `fetch failed: ${describeError(err)}`,
       );
     });
     if (!res.ok) throw new CmsInvalidError(`fetch failed with status ${res.status}`);

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { describeError } from './errors.ts';
+
+describe('describeError', () => {
+  it('formats a plain error with its name and message', () => {
+    expect(describeError(new Error('boom'))).toBe('Error: boom');
+  });
+
+  it('includes the errno code when present', () => {
+    const err = Object.assign(new Error('getaddrinfo failed'), { code: 'ENOTFOUND' });
+    expect(describeError(err)).toBe('Error[ENOTFOUND]: getaddrinfo failed');
+  });
+
+  it('walks the cause chain and joins links', () => {
+    const inner = Object.assign(new Error('socket closed'), { code: 'ECONNRESET' });
+    const outer = new TypeError('fetch failed', { cause: inner });
+    expect(describeError(outer)).toBe(
+      'TypeError: fetch failed <- Error[ECONNRESET]: socket closed',
+    );
+  });
+
+  it('caps recursion depth', () => {
+    const a = new Error('a');
+    const b = new Error('b', { cause: a });
+    const c = new Error('c', { cause: b });
+    expect(describeError(c, 2)).toBe('Error: c <- Error: b');
+  });
+
+  it('handles non-Error causes', () => {
+    const outer = new Error('outer');
+    (outer as { cause?: unknown }).cause = 'bare string reason';
+    expect(describeError(outer)).toBe('Error: outer <- bare string reason');
+  });
+
+  it('handles undefined gracefully', () => {
+    expect(describeError(undefined)).toBe('');
+  });
+
+  it('JSON-stringifies object causes instead of [object Object]', () => {
+    const outer = new Error('outer');
+    (outer as { cause?: unknown }).cause = { code: 'E_WEIRD', detail: 'thing' };
+    expect(describeError(outer)).toBe('Error: outer <- {"code":"E_WEIRD","detail":"thing"}');
+  });
+});

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,36 @@
+/**
+ * Walk an `Error.cause` chain and produce a single-line description.
+ *
+ * Undici and other modern Node libraries throw a generic outer error
+ * (e.g. `TypeError: fetch failed`) and stash the real reason on `.cause`.
+ * This helper unwraps up to `maxDepth` levels and emits `Name[CODE]: msg`
+ * for each link, joined by ` <- `.
+ */
+export function describeError(err: unknown, maxDepth = 4): string {
+  const parts: string[] = [];
+  let cur: unknown = err;
+  for (let depth = 0; cur && depth < maxDepth; depth++) {
+    if (cur instanceof Error) {
+      const code = (cur as NodeJS.ErrnoException).code;
+      parts.push(code ? `${cur.name}[${code}]: ${cur.message}` : `${cur.name}: ${cur.message}`);
+      cur = (cur as { cause?: unknown }).cause;
+    } else {
+      parts.push(stringifyNonError(cur));
+      break;
+    }
+  }
+  return parts.join(' <- ');
+}
+
+function stringifyNonError(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return value.toString();
+  if (typeof value === 'bigint') return `${value.toString()}n`;
+  if (typeof value === 'symbol') return value.toString();
+  try {
+    return JSON.stringify(value) ?? '[unstringifiable]';
+  } catch {
+    return '[unstringifiable]';
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,8 @@ export {
   type SafeFetchOptions,
 } from './net/safe-fetch.ts';
 
+export { describeError } from './errors.ts';
+
 export {
   parseEnvBool,
   parseEnvCron,

--- a/packages/mcp-toolkit/src/dispatch.ts
+++ b/packages/mcp-toolkit/src/dispatch.ts
@@ -8,6 +8,17 @@ import type { McpToolRegistry } from './registry.ts';
 import { redactSensitive } from './sensitive.ts';
 import type { RegisteredSkill, SkillRegistry } from './skill-registry.ts';
 
+export interface CaptureExceptionContext {
+  tool?: string;
+  actor?: { type?: string | null; id?: string | null; orgId?: string | null } | null;
+  args?: Record<string, unknown> | null;
+}
+
+export type CaptureExceptionFn = (
+  error: unknown,
+  context?: CaptureExceptionContext,
+) => void;
+
 export interface DispatchContext {
   registry: McpToolRegistry;
   audience: Audience;
@@ -15,6 +26,7 @@ export interface DispatchContext {
   audit: AuditLogger;
   rateLimit?: (toolName: string) => Promise<void> | void;
   skills?: SkillRegistry;
+  captureException?: CaptureExceptionFn;
 }
 
 export interface ToolListing {
@@ -72,30 +84,54 @@ export async function callTool(
     return errorResult(`Unknown tool: ${name}`);
   }
 
+  const redactedRawArgs = safeRedact(tool.meta.input, args ?? {});
+
   if (!tool.meta.audiences.includes(ctx.audience)) {
-    await ctx.audit.record({ tool: tool.meta.name, result: 'denied', error: 'audience_mismatch' });
+    await ctx.audit.record({
+      tool: tool.meta.name,
+      args: redactedRawArgs,
+      result: 'denied',
+      error: 'audience_mismatch',
+    });
     return errorResult(`Tool ${tool.meta.name} is not available for this caller`);
   }
 
   for (const scope of tool.meta.scopes) {
     if (!ctx.actor.hasScope(scope)) {
-      await ctx.audit.record({ tool: tool.meta.name, result: 'denied', error: `missing_scope:${scope}` });
+      await ctx.audit.record({
+        tool: tool.meta.name,
+        args: redactedRawArgs,
+        result: 'denied',
+        error: `missing_scope:${scope}`,
+      });
       return errorResult(`Missing required scope: ${scope}`);
     }
   }
 
   const parseResult = tool.meta.input.safeParse(args ?? {});
   if (!parseResult.success) {
-    await ctx.audit.record({ tool: tool.meta.name, result: 'error', error: 'invalid_input' });
+    await ctx.audit.record({
+      tool: tool.meta.name,
+      args: redactedRawArgs,
+      result: 'error',
+      error: `invalid_input: ${parseResult.error.message}`,
+    });
     return errorResult(`Invalid input: ${parseResult.error.message}`);
   }
+
+  const redactedArgs = safeRedact(tool.meta.input, parseResult.data);
 
   if (ctx.rateLimit) {
     try {
       await ctx.rateLimit(tool.meta.name);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      await ctx.audit.record({ tool: tool.meta.name, result: 'denied', error: 'rate_limited' });
+      await ctx.audit.record({
+        tool: tool.meta.name,
+        args: redactedArgs,
+        result: 'denied',
+        error: 'rate_limited',
+      });
       return errorResult(message);
     }
   }
@@ -118,15 +154,21 @@ export async function callTool(
           : JSON.stringify(thrown);
     await ctx.audit.record({
       tool: tool.meta.name,
+      args: redactedArgs,
       result: 'error',
       error: message,
       durationMs: Date.now() - startedAt,
+    });
+    safeReportException(ctx.captureException, thrown, {
+      tool: tool.meta.name,
+      actor: { type: ctx.actor.type, id: ctx.actor.id, orgId: ctx.actor.orgId },
+      args: redactedArgs,
     });
     return errorResult(message);
   }
   await ctx.audit.record({
     tool: tool.meta.name,
-    args: redactSensitive(tool.meta.input, parseResult.data) as Record<string, unknown>,
+    args: redactedArgs,
     result: 'ok',
     durationMs: Date.now() - startedAt,
   });
@@ -172,4 +214,31 @@ function errorResult(message: string): ToolCallResult {
     isError: true,
     content: [{ type: 'text' as const, text: message }],
   };
+}
+
+function safeRedact(
+  schema: Parameters<typeof redactSensitive>[0],
+  value: unknown,
+): Record<string, unknown> | undefined {
+  try {
+    const out = redactSensitive(schema, value);
+    return out && typeof out === 'object' && !Array.isArray(out)
+      ? (out as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function safeReportException(
+  capture: CaptureExceptionFn | undefined,
+  error: unknown,
+  context: CaptureExceptionContext,
+): void {
+  if (!capture) return;
+  try {
+    capture(error, context);
+  } catch (reportErr) {
+    console.error('[mcp-toolkit] error reporter failed:', reportErr);
+  }
 }

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -4,6 +4,7 @@ import { ActorIdentity, RequestContextStore, type RequestContext } from '@getmun
 import { McpToolRegistry } from './registry.ts';
 import { SkillRegistry } from './skill-registry.ts';
 import { openInProcessMcpClient } from './in-process-client.ts';
+import type { CaptureExceptionContext, CaptureExceptionFn } from './dispatch.ts';
 
 const fakeAudit = { record: vi.fn(() => Promise.resolve()) };
 
@@ -51,6 +52,18 @@ function buildRegistry(): McpToolRegistry {
       input: z.object({}),
     },
     () => 'wrote',
+  );
+  r.register(
+    {
+      name: 'boom',
+      description: 'throws',
+      audiences: ['admin'],
+      scopes: [],
+      input: z.object({ note: z.string() }),
+    },
+    () => {
+      throw new Error('handler exploded');
+    },
   );
   return r;
 }
@@ -167,6 +180,65 @@ describe('openInProcessMcpClient', () => {
     expect(fakeAudit.record).toHaveBeenCalledWith(
       expect.objectContaining({ result: 'denied', error: 'missing_scope:kb:write' }),
     );
+  });
+
+  it('audits args (redacted) and forwards thrown handler errors to captureException', async () => {
+    fakeAudit.record.mockClear();
+    const captureException = vi.fn<CaptureExceptionFn>();
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+      captureException,
+    });
+    const out = await runInCtx(adminActor(), () => client.callTool('boom', { note: 'hi' }));
+    expect(out.isError).toBe(true);
+    expect(out.content[0]?.text).toBe('handler exploded');
+    expect(fakeAudit.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: 'boom',
+        result: 'error',
+        error: 'handler exploded',
+        args: { note: 'hi' },
+      }),
+    );
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const call = captureException.mock.calls[0];
+    expect(call).toBeDefined();
+    const thrown = call![0] as Error;
+    const ctx = call![1] as CaptureExceptionContext;
+    expect(thrown.message).toBe('handler exploded');
+    expect(ctx).toMatchObject({
+      tool: 'boom',
+      actor: { type: 'admin_agent', orgId: 'org_test' },
+      args: { note: 'hi' },
+    });
+  });
+
+  it('audits args on invalid_input and does not call captureException', async () => {
+    fakeAudit.record.mockClear();
+    const captureException = vi.fn<CaptureExceptionFn>();
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+      captureException,
+    });
+    const out = await runInCtx(adminActor(), () =>
+      client.callTool('echo', { msg: 42 }),
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content[0]?.text).toMatch(/Invalid input/);
+    expect(fakeAudit.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: 'echo',
+        result: 'error',
+        args: { msg: 42 },
+      }),
+    );
+    expect(captureException).not.toHaveBeenCalled();
   });
 
   it('readResource returns audience-filtered skill content', () => {

--- a/packages/mcp-toolkit/src/in-process-client.ts
+++ b/packages/mcp-toolkit/src/in-process-client.ts
@@ -6,6 +6,7 @@ import {
   listResources as dispatchListResources,
   listTools as dispatchListTools,
   readResource as dispatchReadResource,
+  type CaptureExceptionFn,
   type DispatchContext,
   type ResourceContent,
   type ResourceListing,
@@ -20,6 +21,7 @@ export interface OpenInProcessMcpClientOptions {
   audit: AuditLogger;
   rateLimit?: (toolName: string) => Promise<void> | void;
   skills?: SkillRegistry;
+  captureException?: CaptureExceptionFn;
 }
 
 export interface InProcessMcpClient {
@@ -37,6 +39,7 @@ export function openInProcessMcpClient(opts: OpenInProcessMcpClientOptions): InP
     audit: opts.audit,
     rateLimit: opts.rateLimit,
     skills: opts.skills,
+    captureException: opts.captureException,
   };
   return {
     listTools: () => Promise.resolve(dispatchListTools(ctx)),

--- a/packages/mcp-toolkit/src/index.ts
+++ b/packages/mcp-toolkit/src/index.ts
@@ -8,6 +8,8 @@ export {
   type OpenInProcessMcpClientOptions,
 } from './in-process-client.ts';
 export {
+  type CaptureExceptionContext,
+  type CaptureExceptionFn,
   type ResourceContent,
   type ResourceListing,
   type ToolCallResult,

--- a/packages/mcp-toolkit/src/server.ts
+++ b/packages/mcp-toolkit/src/server.ts
@@ -8,7 +8,14 @@ import {
 import type { AuditLogger, ActorIdentity, Audience } from '@getmunin/core';
 import type { McpToolRegistry } from './registry.ts';
 import type { SkillRegistry } from './skill-registry.ts';
-import { callTool, listResources, listTools, readResource, type DispatchContext } from './dispatch.ts';
+import {
+  callTool,
+  listResources,
+  listTools,
+  readResource,
+  type CaptureExceptionFn,
+  type DispatchContext,
+} from './dispatch.ts';
 
 export interface CreateMcpServerOptions {
   registry: McpToolRegistry;
@@ -19,6 +26,7 @@ export interface CreateMcpServerOptions {
   serverInfo?: { name: string; version: string };
   skills?: SkillRegistry;
   instructions?: string;
+  captureException?: CaptureExceptionFn;
 }
 
 export function createMcpServer(opts: CreateMcpServerOptions): Server {
@@ -30,6 +38,7 @@ export function createMcpServer(opts: CreateMcpServerOptions): Server {
     audit: opts.audit,
     rateLimit: opts.rateLimit,
     skills: opts.skills,
+    captureException: opts.captureException,
   };
 
   const server = new Server(info, {


### PR DESCRIPTION
## Summary

- MCP dispatch records redacted `args` on every error path (denied / invalid_input / rate_limited / handler-thrown), not just the success path. `invalid_input` rows also include the Zod failure detail. `unknown_tool` still drops args (no schema to redact against).
- New optional `captureException` hook on `createMcpServer` / `openInProcessMcpClient` fires on the handler-thrown path with tool + actor + redacted args. `mcp-toolkit` stays observability-vendor agnostic; `backend-core` defines an `ERROR_REPORTER` injection token + `NoopErrorReporter` default; `apps/backend` wires a `SentryErrorReporter` that uses `Sentry.withScope` for tags/user/context.
- `cms_upload_asset_from_url` / `cms_upload_asset_from_file` now unwrap `Error.cause` from undici failures via a new reusable `describeError()` helper in `@getmunin/core`, so the surfaced error contains the underlying errno (`ENOTFOUND`, `ECONNRESET`, `CERT_HAS_EXPIRED`, …) instead of just `"fetch failed"`.

Motivates from a `cms_upload_asset_from_file` failure where the audit log was empty of args and prod stdout had nothing to debug from. After this, the audit row and Sentry event together carry the OpenAI download_url, the actor, the tool, and the actual network failure code.

## Test plan

- [x] `pnpm -F @getmunin/mcp-toolkit test` — 42/42 (includes two new tests for thrown-handler + invalid_input paths)
- [x] `pnpm -F @getmunin/backend-core test` — 745/745
- [x] `pnpm -F @getmunin/core test` — new `describeError` tests cover plain errors, errno codes, cause-chain walking, depth cap, non-Error causes, object causes, and undefined input
- [x] `pnpm -F @getmunin/backend-core typecheck` and `pnpm -F @getmunin/backend typecheck` clean
- [ ] After deploy: trigger a failing `cms_upload_asset_from_file` call from ChatGPT and confirm (a) the Sentry issue carries `mcp.tool=cms_upload_asset_from_file`, the org id, and an `mcp_args` context block with the OpenAI download_url, and (b) the surfaced error string includes the underlying network errno via `describeError` instead of the bare `"fetch failed"`.

## Follow-up to consider

The CMS schema's `file.download_url` is not currently marked `sensitive(...)`. Audit rows and Sentry events for this tool will now carry the full short-lived OpenAI signed URL. That's exactly what we need for the immediate diagnosis, but once we know the failure mode it's worth wrapping `download_url` so we don't keep persisting credentials-in-URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)