### PR TITLE
feat(cms): replace cms_upload_asset_from_file with cms_upload_asset_from_base64

### DIFF
--- a/.changeset/cms-upload-asset-from-base64.md
+++ b/.changeset/cms-upload-asset-from-base64.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/backend-core': minor
+---
+
+CMS: drop `cms_upload_asset_from_file` (the `openai/fileParams`-based upload tool) and bring back the inline base64 path under a clearer name. The from-file tool didn't survive contact with ChatGPT's Apps SDK runtime — the `openai/fileParams` substitution only fires for files the user explicitly attached to the conversation, never for image-gen outputs that live in the sandbox's `/mnt/data`. ChatGPT's host clamps every such call client-side, so they never reach the server.
+
+The replacement is `cms_upload_asset_from_base64` (renamed from the previously-removed `cms_upload_asset_bytes`), with a tightened 100 KB decoded-size cap (down from 2 MB). The framing in the tool description is explicit about the use case: generated-in-conversation assets that need to land in the CMS without leaving the chat — compress to WebP/JPEG well under 100 KB first, then pass the bytes inline. Anything bigger should go through `cms_upload_asset_from_url`.
+
+Also reworded `cms_request_asset_upload`'s description to call out that it requires a client capable of issuing raw HTTP PUT/POST itself, with a forward pointer to the inline-base64 and from-URL tools for runtimes that don't have that primitive. This is a generic constraint, not a ChatGPT-specific carve-out.
+
+Service-side: the `uploadAssetFromFile` method is gone (had no other callers). `uploadAssetBytes` is renamed to `uploadAssetFromBase64` to match the new tool surface; the control-plane CMS drafts controller and the service tests are updated accordingly.

--- a/packages/backend-core/src/control/cms-drafts.controller.ts
+++ b/packages/backend-core/src/control/cms-drafts.controller.ts
@@ -107,7 +107,7 @@ export class CmsDraftsController {
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return translate(async () => {
       await this.cms.getEntry(id);
-      return this.cms.uploadAssetBytes(parsed.data);
+      return this.cms.uploadAssetFromBase64(parsed.data);
     });
   }
 

--- a/packages/backend-core/src/modules/cms/cms.service.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.test.ts
@@ -711,10 +711,10 @@ class StubStorage implements AssetStorage {
       );
     });
 
-    it('uploadAssetBytes writes bytes directly and persists an uploaded row', async () => {
+    it('uploadAssetFromBase64 writes bytes directly and persists an uploaded row', async () => {
       const body = Buffer.from('hello-world-binary');
       const asset = await run(() =>
-        svc.uploadAssetBytes({
+        svc.uploadAssetFromBase64({
           name: 'pic.png',
           mime: 'image/png',
           base64Body: body.toString('base64'),
@@ -728,31 +728,31 @@ class StubStorage implements AssetStorage {
       expect(write!.mime).toBe('image/png');
     });
 
-    it('uploadAssetBytes rejects empty body', async () => {
+    it('uploadAssetFromBase64 rejects empty body', async () => {
       await expect(
         run(() =>
-          svc.uploadAssetBytes({ name: 'pic.png', mime: 'image/png', base64Body: '' }),
+          svc.uploadAssetFromBase64({ name: 'pic.png', mime: 'image/png', base64Body: '' }),
         ),
       ).rejects.toThrow();
     });
 
-    it('uploadAssetBytes rejects >2MB decoded body', async () => {
-      const huge = Buffer.alloc(2 * 1024 * 1024 + 1, 1);
+    it('uploadAssetFromBase64 rejects >100KB decoded body', async () => {
+      const huge = Buffer.alloc(100 * 1024 + 1, 1);
       await expect(
         run(() =>
-          svc.uploadAssetBytes({
+          svc.uploadAssetFromBase64({
             name: 'big.bin',
             mime: 'application/octet-stream',
             base64Body: huge.toString('base64'),
           }),
         ),
-      ).rejects.toThrow(/exceeds 2MB/);
+      ).rejects.toThrow(/exceeds 100KB/);
     });
 
-    it('uploadAssetBytes rejects malformed base64', async () => {
+    it('uploadAssetFromBase64 rejects malformed base64', async () => {
       await expect(
         run(() =>
-          svc.uploadAssetBytes({
+          svc.uploadAssetFromBase64({
             name: 'pic.png',
             mime: 'image/png',
             base64Body: 'not!base64@@@',
@@ -761,16 +761,16 @@ class StubStorage implements AssetStorage {
       ).rejects.toThrow(/invalid characters/);
     });
 
-    it('uploadAssetBytes rejects SVG by extension and by mime', async () => {
+    it('uploadAssetFromBase64 rejects SVG by extension and by mime', async () => {
       const body = Buffer.from('<svg/>').toString('base64');
       await expect(
         run(() =>
-          svc.uploadAssetBytes({ name: 'logo.svg', mime: 'application/octet-stream', base64Body: body }),
+          svc.uploadAssetFromBase64({ name: 'logo.svg', mime: 'application/octet-stream', base64Body: body }),
         ),
       ).rejects.toThrow(/svg uploads are not allowed/);
       await expect(
         run(() =>
-          svc.uploadAssetBytes({ name: 'logo.png', mime: 'image/svg+xml', base64Body: body }),
+          svc.uploadAssetFromBase64({ name: 'logo.png', mime: 'image/svg+xml', base64Body: body }),
         ),
       ).rejects.toThrow(/svg uploads are not allowed/);
     });

--- a/packages/backend-core/src/modules/cms/cms.service.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.ts
@@ -678,7 +678,7 @@ export class CmsService {
     };
   }
 
-  async uploadAssetBytes(input: {
+  async uploadAssetFromBase64(input: {
     name: string;
     mime: string;
     base64Body: string;
@@ -692,21 +692,6 @@ export class CmsService {
       body,
       altText: input.altText,
       metadata: input.metadata,
-    });
-  }
-
-  async uploadAssetFromFile(input: {
-    file: { download_url: string; file_id: string; mime_type?: string; file_name?: string };
-    name?: string;
-    altText?: string;
-    metadata?: Record<string, unknown>;
-  }): Promise<AssetDto> {
-    return this.uploadAssetFromUrl({
-      sourceUrl: input.file.download_url,
-      name: input.name ?? input.file.file_name,
-      mime: input.file.mime_type,
-      altText: input.altText,
-      metadata: { ...(input.metadata ?? {}), openaiFileId: input.file.file_id },
     });
   }
 
@@ -1220,7 +1205,7 @@ function isSvgMime(mime: string): boolean {
   return normalized === 'image/svg+xml' || normalized === 'image/svg';
 }
 
-const UPLOAD_BYTES_MAX = 2 * 1024 * 1024;
+const UPLOAD_BYTES_MAX = 100 * 1024;
 
 function decodeAssetBody(base64Body: string): Buffer {
   let body: Buffer;
@@ -1234,7 +1219,7 @@ function decodeAssetBody(base64Body: string): Buffer {
   }
   if (body.length > UPLOAD_BYTES_MAX) {
     throw new CmsInvalidError(
-      'base64Body decoded size exceeds 2MB; use cms_request_asset_upload + cms_complete_asset_upload for larger files',
+      'base64Body decoded size exceeds 100KB; compress further (WebP/JPEG, smaller dimensions) or use cms_upload_asset_from_url with a public HTTPS URL',
     );
   }
   if (body.toString('base64').replace(/=+$/, '') !== base64Body.replace(/=+$/, '')) {

--- a/packages/backend-core/src/modules/cms/cms.tools.ts
+++ b/packages/backend-core/src/modules/cms/cms.tools.ts
@@ -109,14 +109,10 @@ const RequestUploadInput = z.object({
 const CompleteUploadInput = z.object({ id: z.string() });
 const DeleteAssetInput = z.object({ id: z.string() });
 
-const UploadAssetFromFileInput = z.object({
-  file: z.object({
-    download_url: z.string().url(),
-    file_id: z.string().min(1),
-    mime_type: z.string().min(1).max(120).optional(),
-    file_name: z.string().min(1).max(255).optional(),
-  }),
-  name: z.string().min(1).max(255).optional(),
+const UploadAssetFromBase64Input = z.object({
+  name: z.string().min(1).max(255),
+  mime: z.string().min(1).max(120),
+  base64Body: z.string().min(1),
   altText: z.string().max(500).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
@@ -406,7 +402,7 @@ export class CmsAdminTools {
     name: 'cms_request_asset_upload',
     title: 'CMS: Request asset upload URL',
     description:
-      'Mint a presigned upload for a new asset. The asset row is created in `uploaded:false` state. Look at `uploadMethod`: if `"PUT"`, send the file body as the raw PUT body to `uploadUrl`. If `"POST"`, send multipart/form-data to `uploadUrl` including every key/value in `uploadFields` followed by a `file` part (the binary body); the embedded policy enforces an exact `Content-Length` match. Then call `cms_complete_asset_upload` to verify and mark the row live. SVG uploads are rejected — SVG can carry inline scripts and is not safe to serve as an asset.',
+      'Mint a presigned upload for a new asset. Only usable from clients that can issue raw HTTP PUT/POST themselves. If your runtime has no client-side PUT primitive, this tool is not a fit — use `cms_upload_asset_from_base64` (small inline base64) or `cms_upload_asset_from_url` (public HTTPS URL) instead. Flow: the asset row is created in `uploaded:false` state. Look at `uploadMethod`: if `"PUT"`, send the file body as the raw PUT body to `uploadUrl`. If `"POST"`, send multipart/form-data to `uploadUrl` including every key/value in `uploadFields` followed by a `file` part; the embedded policy enforces an exact `Content-Length` match. Then call `cms_complete_asset_upload` to verify and mark the row live. SVG uploads are rejected — SVG can carry inline scripts and is not safe to serve as an asset.',
     audiences: ['admin'],
     scopes: ['cms:write'],
     input: RequestUploadInput,
@@ -418,19 +414,18 @@ export class CmsAdminTools {
   }
 
   @McpTool({
-    name: 'cms_upload_asset_from_file',
-    title: 'CMS: Upload asset from a ChatGPT file',
+    name: 'cms_upload_asset_from_base64',
+    title: 'CMS: Upload small asset inline (base64)',
     description:
-      "Upload a file that's already in the ChatGPT conversation (e.g. a user-uploaded image or an image-gen output) as a CMS asset. ChatGPT mints a short-lived signed URL for the file and the server fetches it. Use this when your runtime can't PUT to a presigned URL — typical for ChatGPT workspace agents. Accepts image/*, video/*, audio/*, and application/pdf up to 50 MB. SVG is rejected.",
+      'Upload a small asset inline as base64 (≤100 KB decoded). The right choice when you have generated the asset in this conversation (image-gen output, screenshot, plot) and need it in the CMS without leaving the chat: compress to WebP or JPEG well under 100 KB first, then pass the bytes here. SVG is rejected. For larger assets reachable over HTTPS use `cms_upload_asset_from_url`; for larger arbitrary files use `cms_request_asset_upload` from a client that can issue HTTP PUT.',
     audiences: ['admin'],
     scopes: ['cms:write'],
-    input: UploadAssetFromFileInput,
+    input: UploadAssetFromBase64Input,
     readOnlyHint: false,
     destructiveHint: false,
-    _meta: { 'openai/fileParams': ['file'] },
   })
-  uploadAssetFromFile(args: z.infer<typeof UploadAssetFromFileInput>) {
-    return this.cms.uploadAssetFromFile(args);
+  uploadAssetFromBase64(args: z.infer<typeof UploadAssetFromBase64Input>) {
+    return this.cms.uploadAssetFromBase64(args);
   }
 
   @McpTool({


### PR DESCRIPTION
## Summary

- Drops `cms_upload_asset_from_file` (the `openai/fileParams`-based upload tool). It never worked for ChatGPT's Apps SDK runtime in practice: image-gen outputs in `/mnt/data` aren't in the file library, so the host's substitution doesn't fire, and every call gets clamped client-side before reaching Munin (we verified this against prod audit logs and the OpenAI host's `INVALID_PARAMETERS` clamp output).
- Brings back the inline-base64 path under a clearer name: `cms_upload_asset_from_base64` (renamed from the previously-removed `cms_upload_asset_bytes`). Service method `uploadAssetBytes` → `uploadAssetFromBase64` to match.
- Tightens the decoded-size cap from 2 MB to **100 KB**. This is intentionally small: the base64 string sits in the LLM's context, so big inline uploads burn tokens fast. 100 KB comfortably covers compressed WebP/JPEG at 1024×1024 q70–80; anything bigger should go through `cms_upload_asset_from_url`.
- Reworded `cms_request_asset_upload`'s description to be generic about the runtime constraint ("only usable from clients that can issue raw HTTP PUT/POST themselves") instead of naming ChatGPT specifically, with a forward pointer to the inline-base64 and from-URL alternatives.

## Test plan

- [x] `pnpm -F @getmunin/backend-core test` — 745/745 (size-cap test updated to 100 KB)
- [x] `pnpm -F @getmunin/backend-core typecheck` clean
- [ ] In ChatGPT after deploy: ask the agent to generate a small image, compress to WebP <100 KB, and call `cms_upload_asset_from_base64`. Confirm the file lands in the CMS, the audit row carries the redacted args, and the over-size error message correctly redirects to `cms_upload_asset_from_url` if the bytes exceed the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)