### PR TITLE
fix(docs): restore list bullets and lighten code-block background

### DIFF
--- a/.changeset/docs-skill-code-bg-and-bullets.md
+++ b/.changeset/docs-skill-code-bg-and-bullets.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/docs-pages': patch
+---
+
+Restore list bullets inside `.docs .markdown` (Tailwind preflight in `apps/web` was zeroing out `list-style` on every `<ul>`/`<ol>`, leaving skill articles' list items as a mysteriously indented block with no marker). Now `disc` for unordered and `decimal` for ordered.
+
+Also moves inline `<code>` and `<pre>` backgrounds from `--docs-page` (the bone/beige page background) to `--docs-card` (paper white), so code reads distinctly against the article body in both light and dark mode.

--- a/packages/docs-pages/src/docs.css
+++ b/packages/docs-pages/src/docs.css
@@ -977,18 +977,24 @@
   margin: 0 0 18px;
   padding-left: 22px;
 }
+.docs .markdown ul {
+  list-style-type: disc;
+}
+.docs .markdown ol {
+  list-style-type: decimal;
+}
 .docs .markdown li {
   margin-bottom: 6px;
 }
 .docs .markdown code {
   font-family: var(--munin-mono);
   font-size: 0.92em;
-  background: var(--docs-page);
+  background: var(--docs-card);
   padding: 1px 5px;
   border: 1px solid var(--docs-rule);
 }
 .docs .markdown pre {
-  background: var(--docs-page);
+  background: var(--docs-card);
   border: 1px solid var(--docs-rule);
   padding: 14px 16px;
   overflow-x: auto;


### PR DESCRIPTION
## Summary

Two small fixes to skill articles (and anything else rendered through the docs shell):

- **List items had no markers.** Tailwind preflight in `apps/web` zeros out `list-style` on every `<ul>`/`<ol>`, and `.docs .markdown` wasn't re-enabling it. Lists showed indent but no `•` or `1.`, so readers saw an unexplained inset block. Now `disc` for unordered and `decimal` for ordered.
- **Code blocks blended into the page.** Inline `<code>` and `<pre>` were sitting on `--docs-page` (the bone/beige page background). Moved to `--docs-card` (paper white) for clear separation. The dark-mode `--docs-card` is `#14181e` vs `--docs-page`'s `#0b0e12`, so the contrast bump applies in both themes.

## Test plan

- [ ] Visit a skill article (e.g. `/docs/skills/cms/localize-entry`). Verify bullets render on the "Effect on entries" and "What NOT to do" lists, and that code blocks read distinctly against the page background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)