### PR TITLE
fix(oauth): add analytics:read and analytics:write to SUPPORTED_SCOPES

### DIFF
--- a/.changeset/oauth-supported-scopes-add-analytics.md
+++ b/.changeset/oauth-supported-scopes-add-analytics.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Add `analytics:read` and `analytics:write` to `SUPPORTED_SCOPES`. The analytics MCP tools (`analytics_create_tracker`, `analytics_list_trackers`, `analytics_top_subjects`, etc.) have been declaring those scopes in their `@McpTool` decorators since the module landed, but the OAuth supported-scopes registry never picked them up. That meant OAuth tokens could never carry the analytics scopes, so every external call (e.g. from a ChatGPT connector) hit *"Missing required scope: analytics:read"* at the dispatch guard — even though the tools showed up in `tools/list`. Internal `buildAdminAgentActor` callers were unaffected because they use the `*` wildcard.
+
+`SELF_SERVICE_SCOPES` (delegated end-user tokens) is intentionally not changed — analytics is admin surface, in the same bucket as `cms:write` / `outreach:write` / etc. that end-user tokens never see.

--- a/packages/backend-core/src/oauth/oauth.constants.ts
+++ b/packages/backend-core/src/oauth/oauth.constants.ts
@@ -15,6 +15,8 @@ export const SUPPORTED_SCOPES = [
   'cms:write',
   'outreach:read',
   'outreach:write',
+  'analytics:read',
+  'analytics:write',
 ] as const;
 
 export type SupportedScope = (typeof SUPPORTED_SCOPES)[number];


### PR DESCRIPTION
## Summary

Two-line fix: register `analytics:read` and `analytics:write` in `SUPPORTED_SCOPES`. The analytics MCP tools (`analytics_create_tracker`, `analytics_list_trackers`, `analytics_top_subjects`, `analytics_subject_engagement`, `analytics_zero_result_searches`, `analytics_update_tracker`, `analytics_revoke_tracker`) have been declaring those scopes since the module landed, but the OAuth registry never advertised them. Tokens couldn't carry them → external callers hit *"Missing required scope: analytics:read"* at dispatch even though the tools rendered in `tools/list`. Internal `buildAdminAgentActor` was fine because it carries the `*` wildcard.

Comparison with feedback tools (which work without explicit grant): feedback declares `scopes: []`, so the dispatch scope guard's loop runs zero times. Analytics follows the kb/conv/crm/cms/outreach pattern of a read/write split — same sensitivity as other business-data surfaces.

`SELF_SERVICE_SCOPES` is intentionally not changed. End-user delegated tokens have never had `cms:write` / `outreach:write` either; analytics is admin surface.

## Test plan

- [x] `pnpm -F @getmunin/backend-core test` — 745/745 (the existing `oauth-resource.controller.test.ts` references `SUPPORTED_SCOPES` symbolically, so it picks up the addition automatically)
- [x] `pnpm -F @getmunin/backend-core typecheck` clean
- [ ] After deploy: re-authorize the ChatGPT connector (existing tokens were granted before this fix, so they won't have the new scopes — fresh consent needed). Confirm `analytics_list_trackers` resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)