### PR TITLE
fix(mcp): align three tool titles with their function names

### DIFF
--- a/.changeset/mcp-tool-title-name-alignment.md
+++ b/.changeset/mcp-tool-title-name-alignment.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Align three MCP tool titles with their function names, so the display label tracks the operation the tool actually performs:
+
+- `cms_upload_asset_from_base64`: *"Upload small asset inline (base64)"* → *"Upload asset from base64"*. Matches the `from_url` / `from_base64` taxonomy and stops the title from making a separate size claim from what the description already documents.
+- `outreach_propose_initial`: *"Propose an initial draft"* → *"Propose initial"*. Drops the wording the function name doesn't carry.
+- `outreach_propose_reply`: *"Propose an reply draft"* → *"Propose reply"*. Same cleanup; also fixes the *"an reply"* grammar slip.
+
+No tool name / arguments / behavior changes.

--- a/packages/backend-core/src/modules/cms/cms.tools.ts
+++ b/packages/backend-core/src/modules/cms/cms.tools.ts
@@ -415,7 +415,7 @@ export class CmsAdminTools {
 
   @McpTool({
     name: 'cms_upload_asset_from_base64',
-    title: 'CMS: Upload small asset inline (base64)',
+    title: 'CMS: Upload asset from base64',
     description:
       'Upload a small asset inline as base64 (≤100 KB decoded). The right choice when you have generated the asset in this conversation (image-gen output, screenshot, plot) and need it in the CMS without leaving the chat: compress to WebP or JPEG well under 100 KB first, then pass the bytes here. SVG is rejected. For larger assets reachable over HTTPS use `cms_upload_asset_from_url`; for larger arbitrary files use `cms_request_asset_upload` from a client that can issue HTTP PUT.',
     audiences: ['admin'],

--- a/packages/backend-core/src/modules/outreach/outreach.tools.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.tools.ts
@@ -153,7 +153,7 @@ export class OutreachAdminTools {
 
   @McpTool({
     name: 'outreach_propose_initial',
-    title: 'Outreach: Propose an initial draft',
+    title: 'Outreach: Propose initial',
     description:
       'File one drafted initial outreach email per (campaign, contact) for human approval. Idempotent: re-proposing the same (campaign, contact, kind=initial) while a pending row exists throws — call `outreach_list_proposals` first to dedupe. Suppression and consent are re-checked at approve-time too; this tool refuses up-front if the contact is already suppressed.',
     audiences: ['admin'],
@@ -168,7 +168,7 @@ export class OutreachAdminTools {
 
   @McpTool({
     name: 'outreach_propose_reply',
-    title: 'Outreach: Propose an reply draft',
+    title: 'Outreach: Propose reply',
     description:
       "File a drafted reply to an inbound message on an outreach-originated conversation, for human approval. The conversation must have an `outreachCampaignId` set (it's an outreach conversation) and a CRM contact resolvable by email. Idempotent: re-proposing while a pending reply exists for the same conversation throws — the operator should approve or dismiss the existing one first. Reply approvals send via `conv_send_message` on the existing conversation; no unsubscribe footer is appended (replies thread inside the existing email chain that already carries the unsubscribe link).",
     audiences: ['admin'],


### PR DESCRIPTION
## Summary

Audit of every `@McpTool` `title` against its `name`. Three clear-cut misalignments where the title makes claims the function name doesn't, fixed here:

| name | before | after |
|---|---|---|
| `cms_upload_asset_from_base64` | `CMS: Upload small asset inline (base64)` | `CMS: Upload asset from base64` |
| `outreach_propose_initial` | `Outreach: Propose an initial draft` | `Outreach: Propose initial` |
| `outreach_propose_reply` | `Outreach: Propose an reply draft` (also: *"an reply"* grammar slip) | `Outreach: Propose reply` |

The size constraint for the base64 tool, and the "this drafts for human approval" framing for the outreach tools, both already live in the long `description` field. Titles now match the function-name taxonomy.

Other titles that *enrich* the name (`crm_find_contact` → "by email or phone", `feedback_list` → "List pending", all `get_*` → "Read X") are left alone — they're a deliberate, consistent convention across the codebase that adds disambiguation, not arbitrary divergence.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck` clean (no behavior changes).
- [ ] After release: confirm the three titles render correctly in the ChatGPT connector / dashboard listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)