### PR TITLE
feat(mcp): filter tools/list by scope as well as audience

### DIFF
--- a/.changeset/mcp-tools-list-filter-by-scope.md
+++ b/.changeset/mcp-tools-list-filter-by-scope.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/mcp-toolkit': minor
+'@getmunin/backend-core': patch
+---
+
+`tools/list` now intersects the caller's scopes with each tool's required `scopes`, in addition to the existing audience filter. Previously the list returned every audience-matched tool regardless of whether the caller actually held the scopes needed to invoke it — so a connector advertising `analytics:read` would happily list `analytics_*` tools to an OAuth caller whose token didn't carry that scope, and the model would only discover the mismatch by wasting a turn on a `"Missing required scope: ..."` error.
+
+After this change, `listTools` (and therefore the MCP `tools/list` response) only returns tools where every scope in `tool.meta.scopes` is held by the actor — including the existing `*` wildcard short-circuit, so internal `buildAdminAgentActor` callers are unaffected. Tools with `scopes: []` (like the feedback module) remain visible to everyone in the audience.
+
+`callTool` is unchanged — defense-in-depth scope check at dispatch time still fires if a caller invokes a hidden tool by name.

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -221,17 +221,19 @@ const skipReason = TEST_URL
     });
 
     await withClient(limitedKey, async (c) => {
-      // Tool is still listed — audience filtering is independent of scopes.
+      // listTools intersects both audience and scope: kb_search is listed
+      // (caller has kb:read) but kb_create_document is hidden (no kb:write).
       const { tools } = await c.listTools();
       const names = tools.map((t) => t.name);
       expect(names).toContain('kb_search');
-      expect(names).toContain('kb_create_document');
+      expect(names).not.toContain('kb_create_document');
 
       // kb_search works (kb:read).
       const search = await c.callTool({ name: 'kb_search', arguments: { query: 'anything' } });
       expect(JSON.stringify(search)).not.toMatch(/Missing required scope/);
 
-      // kb_create_document is denied with a scope error message.
+      // Defense in depth: even when invoked by name, kb_create_document is
+      // denied at dispatch with a scope error.
       const denied = await c.callTool({
         name: 'kb_create_document',
         arguments: {

--- a/packages/mcp-toolkit/src/dispatch.ts
+++ b/packages/mcp-toolkit/src/dispatch.ts
@@ -60,17 +60,20 @@ export interface ResourceContent {
 }
 
 export function listTools(ctx: DispatchContext): ToolListing[] {
-  return ctx.registry.list(ctx.audience).map((t) => ({
-    name: t.meta.name,
-    description: t.meta.description,
-    inputSchema: t.inputJsonSchema as Record<string, unknown>,
-    annotations: {
-      title: t.meta.title ?? t.meta.name,
-      readOnlyHint: t.meta.readOnlyHint ?? false,
-      destructiveHint: t.meta.destructiveHint ?? false,
-    },
-    ...(t.meta._meta ? { _meta: t.meta._meta } : {}),
-  }));
+  return ctx.registry
+    .list(ctx.audience)
+    .filter((t) => t.meta.scopes.every((s) => ctx.actor.hasScope(s)))
+    .map((t) => ({
+      name: t.meta.name,
+      description: t.meta.description,
+      inputSchema: t.inputJsonSchema as Record<string, unknown>,
+      annotations: {
+        title: t.meta.title ?? t.meta.name,
+        readOnlyHint: t.meta.readOnlyHint ?? false,
+        destructiveHint: t.meta.destructiveHint ?? false,
+      },
+      ...(t.meta._meta ? { _meta: t.meta._meta } : {}),
+    }));
 }
 
 export async function callTool(

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -182,6 +182,39 @@ describe('openInProcessMcpClient', () => {
     );
   });
 
+  it('listTools hides tools whose required scopes the actor lacks', async () => {
+    const scopedActor = new ActorIdentity(
+      'admin_agent',
+      'agent:scoped',
+      'org_test',
+      ['kb:read'],
+      ['admin'],
+    );
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: scopedActor,
+      audience: 'admin',
+      audit: fakeAudit,
+    });
+    const tools = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('echo');
+    expect(names).toContain('boom');
+    expect(names).not.toContain('kb_write');
+  });
+
+  it('listTools shows all audience-matched tools when actor has wildcard scope', async () => {
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+    });
+    const tools = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('kb_write');
+  });
+
   it('audits args (redacted) and forwards thrown handler errors to captureException', async () => {
     fakeAudit.record.mockClear();
     const captureException = vi.fn<CaptureExceptionFn>();


### PR DESCRIPTION
## Summary

`tools/list` now intersects the caller's scopes with each tool's required `scopes`, in addition to the existing audience filter.

Previously the list returned every audience-matched tool regardless of whether the caller actually held the scopes to invoke it. A connector advertising e.g. `analytics:*` would happily list `analytics_*` tools to an OAuth caller whose token didn't carry those scopes, and the model would only discover the mismatch by wasting a turn on `"Missing required scope: ..."`. That's exactly what surfaced this session with the analytics scopes (#382).

After this change:
- `listTools` (and therefore the wire `tools/list` response) only returns tools where every scope in `tool.meta.scopes` is held by the actor.
- The `*` wildcard short-circuit in `ActorIdentity.hasScope` still applies, so internal `buildAdminAgentActor` callers (agent-host, in-process MCP clients) are unaffected — they see everything.
- Tools with `scopes: []` (e.g. the entire feedback module) remain visible to everyone in the audience.
- `callTool`'s scope guard is unchanged — defense in depth: a caller invoking a hidden tool by name still gets a clean denial + audit row.

## Test plan

- [x] `pnpm -F @getmunin/mcp-toolkit test` — 44/44 (added two unit tests covering the filter behavior and the wildcard short-circuit)
- [x] `pnpm -F @getmunin/backend-core test` — 745/745 (updated the "scope gating" integration test to assert the new visibility behavior; defense-in-depth `callTool` denial assertion stays)
- [ ] After deploy: a connector token with only `kb:read` should see `kb_search` / `kb_get_document` but not `kb_create_document` / `kb_delete_document` in its `tools/list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)