### PR TITLE
feat(oauth): add resource_name and resource_logo_uri to PRM

### DIFF
--- a/.changeset/oauth-prm-resource-name-logo.md
+++ b/.changeset/oauth-prm-resource-name-logo.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Add `resource_name` and `resource_logo_uri` to the OAuth Protected Resource Metadata at `/.well-known/oauth-protected-resource`. Lets MCP clients (Claude.ai connector cards, etc.) display "Munin" plus an icon instead of a generic globe when the resource endpoint serves JSON-only responses.

--- a/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
@@ -19,6 +19,8 @@ describe('OAuthResourceController', () => {
     const meta = new OAuthResourceController().metadata();
     expect(meta).toEqual({
       resource: 'https://api.example.test/mcp',
+      resource_name: 'Munin',
+      resource_logo_uri: 'https://api.example.test/icon.png',
       authorization_servers: ['https://api.example.test'],
       scopes_supported: SUPPORTED_SCOPES,
       bearer_methods_supported: ['header'],

--- a/packages/backend-core/src/oauth/oauth-resource.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.ts
@@ -2,12 +2,15 @@ import { Get, Header } from '@nestjs/common';
 import { PublicController } from '../common/auth/auth.guard.ts';
 import {
   authorizationServerUrl,
+  mcpResourceOrigin,
   mcpResourceUrl,
   SUPPORTED_SCOPES,
 } from './oauth.constants.ts';
 
 interface ProtectedResourceMetadata {
   resource: string;
+  resource_name: string;
+  resource_logo_uri: string;
   authorization_servers: string[];
   scopes_supported: readonly string[];
   bearer_methods_supported: readonly string[];
@@ -23,6 +26,8 @@ export class OAuthResourceController {
   metadata(): ProtectedResourceMetadata {
     return {
       resource: mcpResourceUrl(),
+      resource_name: 'Munin',
+      resource_logo_uri: `${mcpResourceOrigin()}/icon.png`,
       authorization_servers: [authorizationServerUrl()],
       scopes_supported: SUPPORTED_SCOPES,
       bearer_methods_supported: ['header'],

--- a/packages/backend-core/src/oauth/oauth.constants.ts
+++ b/packages/backend-core/src/oauth/oauth.constants.ts
@@ -35,6 +35,10 @@ export function resourceMetadataUrl(): string {
   return `${authorizationServerUrl()}/.well-known/oauth-protected-resource`;
 }
 
+export function mcpResourceOrigin(): string {
+  return parsePublicUrl().origin;
+}
+
 export function mcpExternalHost(): string {
   return parsePublicUrl().hostname;
 }


### PR DESCRIPTION
## Summary
- Extend the OAuth Protected Resource Metadata response at `/.well-known/oauth-protected-resource` with two new fields:
  - `resource_name: "Munin"`
  - `resource_logo_uri: <mcp-origin>/icon.png`
- Adds a `mcpResourceOrigin()` helper next to the existing `mcpResourceUrl()`/`mcpExternalHost()` helpers, so the logo URL is derived from the same source of truth.
- The icon is already served by the backend at `/icon.png` and `/favicon.ico` — this change just advertises it in the metadata so JSON-only MCP clients can discover it.

## Why
Claude.ai's MCP connector UI (and similar clients) renders a generic globe icon for custom MCP servers because:
1. The resource endpoint (`/mcp`) serves JSON — no HTML, no `<link rel="icon">` to crawl.
2. The PRM endpoint previously had no `resource_name` or icon hint.

So even though `mcp.getmunin.com/favicon.ico` returns a valid icon (200 + `image/x-icon`), the client never asks for it. Advertising the icon in PRM is the canonical way to expose it for JSON-only resources.

## Test plan
- [x] `pnpm -F @getmunin/backend-core test` — both PRM unit tests and the conformance integration test green.
- [x] `pnpm -F @getmunin/backend-core typecheck` clean.
- [ ] After release + cloud bump, re-check the Claude.ai MCP card for `mcp.getmunin.com` — should display "Munin" + icon instead of the globe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)