### PR TITLE
feat(oauth): redesign consent page with SSR + favicon proxy + result panes

### DIFF
--- a/.changeset/oauth-consent-page-redesign.md
+++ b/.changeset/oauth-consent-page-redesign.md
@@ -1,0 +1,16 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+---
+
+OAuth consent page redesigned end-to-end. Three concrete changes:
+
+1. **Backend — enriched client lookup.** `GET /v1/oauth/clients/:id` now returns `{ client_id, name, uri, icon_url, redirect_uri_host, created_at }`. `name` falls back to a host-derived label when the client's DCR didn't include `client_name` (well-known hosts like `claude.ai`/`chatgpt.com`/`cursor.sh` get a branded label; anything else falls back to the bare host). `redirect_uri_host` is the host portion of the first registered redirect URI — the full URI stays off the wire.
+
+2. **Backend — favicon proxy.** New `GET /v1/oauth/clients/:id/icon` route. Server-side fetches `oauth_client.icon` if present, otherwise `https://<redirect_uri_host>/favicon.ico` using `safeFetch` (SSRF-guarded). Validates MIME (`image/*` only), caps response size, falls back to a generic SVG on any failure. Served from our origin with a 24h browser cache — keeps the user's IP off third-party hosts pre-authorization.
+
+3. **Frontend — SSR refactor + new layout.** The page is now an async server component (`apps/web/.../consent/page.tsx`) that fetches the enriched client info before render. The fixed CORS bug along the way: cookies are no longer sent on the lookup (closes the `Access-Control-Allow-Credentials` failure path that was leaving the page stuck on the raw `client_id`). New three-state machine (`new` / `granted` / `denied`) with intermediate result panes — instead of redirecting immediately on Authorize/Deny, the page shows a brief "Access granted/denied · Returning to claude.ai…" panel with spinner, then redirects. Layout matches the editorial design: serif headline that shifts copy per state, identity card with app icon, trust-timeline strip, grouped per-module permissions with `Read`/`Write` pills, reassurance block, and an actions footer.
+
+Also adds an `anonymous: true` opt-out on the `api()` helper for callers of `@PublicController` endpoints that shouldn't send the BetterAuth session cookie.
+
+i18n strings in `en.json` and `nb.json` updated to match the new copy; the keys are different from before (`title`, `lede`, `scopesLabel`, etc. reshaped — see the keys under `dashboard.oauthConsent`).

--- a/apps/web/app/[locale]/dashboard/oauth/consent/page.tsx
+++ b/apps/web/app/[locale]/dashboard/oauth/consent/page.tsx
@@ -1,1 +1,30 @@
-export { OAuthConsentPage as default } from '@getmunin/dashboard-pages';
+import { OAuthConsentPage, type OAuthClientInfo } from '@getmunin/dashboard-pages';
+
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+const API_URL = (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
+
+async function fetchClientInfo(clientId: string): Promise<OAuthClientInfo | null> {
+  if (!clientId) return null;
+  try {
+    const res = await fetch(`${API_URL}/v1/oauth/clients/${encodeURIComponent(clientId)}`, {
+      // anonymous lookup — no session cookies. Server-to-server, no CORS.
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as OAuthClientInfo;
+  } catch (err) {
+    console.warn('[oauth-consent] server-side client info lookup failed', err);
+    return null;
+  }
+}
+
+export default async function Page({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const raw = params.client_id;
+  const clientId = Array.isArray(raw) ? raw[0] ?? '' : raw ?? '';
+  const clientInfo = await fetchClientInfo(clientId);
+  return <OAuthConsentPage clientInfo={clientInfo} />;
+}

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -4114,6 +4114,30 @@
         "security": []
       }
     },
+    "/v1/oauth/clients/{clientId}/icon": {
+      "get": {
+        "operationId": "OAuthClientInfoController_icon",
+        "parameters": [
+          {
+            "name": "clientId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "OAuthClientInfo"
+        ],
+        "security": []
+      }
+    },
     "/v1/system/alerts": {
       "get": {
         "operationId": "SystemAlertsController_list",

--- a/packages/backend-core/src/oauth/oauth-client-info.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-client-info.controller.ts
@@ -4,9 +4,12 @@ import {
   Inject,
   NotFoundException,
   Param,
+  Res,
 } from '@nestjs/common';
+import type { Response } from 'express';
 import { eq } from 'drizzle-orm';
 import { schema, type Db } from '@getmunin/db';
+import { describeError, safeFetch, SsrfBlockedError } from '@getmunin/core';
 import { PublicController } from '../common/auth/auth.guard.ts';
 import { DB } from '../common/db/db.module.ts';
 
@@ -14,15 +17,39 @@ interface OAuthClientInfo {
   client_id: string;
   name: string | null;
   uri: string | null;
-  icon: string | null;
+  icon_url: string;
+  redirect_uri_host: string | null;
+  created_at: string;
 }
+
+const KNOWN_HOST_NAMES: Record<string, string> = {
+  'claude.ai': 'Claude',
+  'chatgpt.com': 'ChatGPT',
+  'openai.com': 'ChatGPT',
+  'cursor.sh': 'Cursor',
+  'cursor.com': 'Cursor',
+};
+
+const FAVICON_MIME_ALLOWLIST = new Set([
+  'image/x-icon',
+  'image/vnd.microsoft.icon',
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/svg+xml',
+  'image/webp',
+]);
+
+const FAVICON_MAX_BYTES = 256 * 1024;
+const FAVICON_BROWSER_TTL_SECONDS = 60 * 60 * 24;
 
 /**
  * Public lookup for the disclosure fields of a registered OAuth client.
  * The consent page renders the client's human-facing name + URL + logo
  * instead of the random RFC 7591 `client_id`. Strictly disclosure-only:
- * we never return `clientSecret`, `redirectUris`, or anything else the
- * caller could weaponize.
+ * we never return `clientSecret`, the full `redirectUris`, or anything
+ * else the caller could weaponize — only the host portion of the first
+ * redirect URI so the page can render "Returning to claude.ai/...".
  *
  * Anonymous on purpose — the consent page is rendered for any user
  * mid-authorization, before the OAuth flow has issued any credential.
@@ -34,13 +61,55 @@ export class OAuthClientInfoController {
   @Get(':clientId')
   @Header('cache-control', 'public, max-age=60')
   async lookup(@Param('clientId') clientId: string): Promise<OAuthClientInfo> {
+    const row = await this.loadRow(clientId);
+    const redirectHost = firstRedirectHost(row.redirectUris);
+    const name = row.name?.trim() ? row.name : deriveFallbackName(redirectHost);
+    return {
+      client_id: row.clientId,
+      name,
+      uri: row.uri ?? null,
+      icon_url: `/v1/oauth/clients/${encodeURIComponent(row.clientId)}/icon`,
+      redirect_uri_host: redirectHost,
+      created_at: row.createdAt.toISOString(),
+    };
+  }
+
+  @Get(':clientId/icon')
+  async icon(@Param('clientId') clientId: string, @Res() res: Response): Promise<void> {
+    const row = await this.loadRow(clientId);
+    const icon = await this.resolveIcon(row);
+    if (!icon) {
+      res
+        .status(200)
+        .setHeader('content-type', 'image/svg+xml')
+        .setHeader('cache-control', `public, max-age=${FAVICON_BROWSER_TTL_SECONDS}`)
+        .send(GENERIC_APP_ICON_SVG);
+      return;
+    }
+    res
+      .status(200)
+      .setHeader('content-type', icon.mime)
+      .setHeader('cache-control', `public, max-age=${FAVICON_BROWSER_TTL_SECONDS}`)
+      .send(icon.body);
+  }
+
+  private async loadRow(clientId: string): Promise<{
+    clientId: string;
+    name: string | null;
+    uri: string | null;
+    icon: string | null;
+    redirectUris: string[];
+    createdAt: Date;
+  }> {
     const rows = await this.db
       .select({
         clientId: schema.oauthClient.clientId,
         name: schema.oauthClient.name,
         uri: schema.oauthClient.uri,
         icon: schema.oauthClient.icon,
+        redirectUris: schema.oauthClient.redirectUris,
         disabled: schema.oauthClient.disabled,
+        createdAt: schema.oauthClient.createdAt,
       })
       .from(schema.oauthClient)
       .where(eq(schema.oauthClient.clientId, clientId))
@@ -48,10 +117,77 @@ export class OAuthClientInfoController {
     const row = rows[0];
     if (!row || row.disabled) throw new NotFoundException('oauth_client_not_found');
     return {
-      client_id: row.clientId,
+      clientId: row.clientId,
       name: row.name ?? null,
       uri: row.uri ?? null,
       icon: row.icon ?? null,
+      redirectUris: row.redirectUris ?? [],
+      createdAt: row.createdAt,
     };
   }
+
+  private async resolveIcon(row: {
+    icon: string | null;
+    redirectUris: string[];
+  }): Promise<{ body: Buffer; mime: string } | null> {
+    const fromUri = row.icon?.trim() ? row.icon.trim() : null;
+    if (fromUri) {
+      const fetched = await fetchImage(fromUri);
+      if (fetched) return fetched;
+    }
+    const host = firstRedirectHost(row.redirectUris);
+    if (!host) return null;
+    return fetchImage(`https://${host}/favicon.ico`);
+  }
 }
+
+function firstRedirectHost(redirectUris: string[] | null | undefined): string | null {
+  const first = redirectUris?.[0];
+  if (!first) return null;
+  try {
+    return new URL(first).hostname;
+  } catch {
+    return null;
+  }
+}
+
+function deriveFallbackName(host: string | null): string | null {
+  if (!host) return null;
+  const known = KNOWN_HOST_NAMES[host];
+  if (known) return known;
+  // strip leading www. and return the host so the user sees *something* identifiable
+  return host.replace(/^www\./, '');
+}
+
+async function fetchImage(url: string): Promise<{ body: Buffer; mime: string } | null> {
+  let res: Awaited<ReturnType<typeof safeFetch>>;
+  try {
+    res = await safeFetch(url, {
+      method: 'GET',
+      headers: { 'user-agent': 'Munin-Consent/1.0 (+https://getmunin.com)' },
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      console.warn(`[oauth-client-icon] ssrf blocked for ${url}: ${err.message}`);
+    } else {
+      console.warn(`[oauth-client-icon] fetch failed for ${url}: ${describeError(err)}`);
+    }
+    return null;
+  }
+  if (!res.ok) return null;
+  const rawMime = res.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() ?? '';
+  if (!FAVICON_MIME_ALLOWLIST.has(rawMime)) return null;
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.length === 0 || buf.length > FAVICON_MAX_BYTES) return null;
+  return { body: buf, mime: rawMime };
+}
+
+const GENERIC_APP_ICON_SVG = Buffer.from(
+  `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="12" fill="#1c1f24"/>
+  <path d="M20 22h24v4H20zM20 30h24v4H20zM20 38h16v4H20z" fill="#ffffff" opacity="0.9"/>
+</svg>`,
+  'utf8',
+);

--- a/packages/dashboard-pages/src/api.ts
+++ b/packages/dashboard-pages/src/api.ts
@@ -40,16 +40,23 @@ export class ApiError extends Error {
   }
 }
 
-export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const method = (init.method ?? 'GET').toUpperCase();
+export interface ApiOptions extends RequestInit {
+  /** Don't send the BetterAuth session cookie. For `@PublicController` endpoints
+   *  that would otherwise trip the credentials-mode CORS preflight check. */
+  anonymous?: boolean;
+}
+
+export async function api<T>(path: string, init: ApiOptions = {}): Promise<T> {
+  const { anonymous, ...rest } = init;
+  const method = (rest.method ?? 'GET').toUpperCase();
   let res: Response;
   try {
     res = await fetch(`${API_URL}${path}`, {
-      ...init,
-      credentials: 'include',
+      ...rest,
+      credentials: anonymous ? 'omit' : 'include',
       headers: {
         'Content-Type': 'application/json',
-        ...(init.headers ?? {}),
+        ...(rest.headers ?? {}),
       },
     });
   } catch (err) {

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -93,7 +93,11 @@ export { safeRedirect, resumeOauthAuthorizeUrl } from './auth/post-signin-redire
 export { AcceptInvitePage } from './pages/accept-invite';
 export { AccountPage, type AccountPageProps } from './pages/account';
 export { AiSettingsPage } from './pages/ai-settings';
-export { OAuthConsentPage } from './pages/oauth-consent';
+export {
+  OAuthConsentPage,
+  type OAuthClientInfo,
+  type OAuthConsentPageProps,
+} from './pages/oauth-consent';
 export { AgentSetupWizard } from './pages/agent-setup-wizard';
 export { AgentsPage } from './pages/agents';
 export { ApiKeysPage } from './pages/api-keys';

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -702,28 +702,78 @@
       }
     },
     "oauthConsent": {
+      "eyebrow": "OAuth 2.1 · authorization request",
       "title": "Authorize <client></client>?",
-      "lede": "An external application is asking for access to your Munin account. Review the requested permissions before deciding.",
-      "applicationLabel": "Application",
-      "scopesLabel": "Requested permissions",
-      "noScopes": "(no permissions requested)",
+      "lede": "<client></client> wants to connect to Munin and act through the MCP toolset on your behalf. Review what it can reach before you decide.",
+      "registered": "Registered {date}",
+      "trustFirst": "First time you're connecting <client></client> to this account. Nothing has been shared with it yet.",
+      "scopesLabel": "Requested access",
+      "scopesCount": "{modules, plural, =0 {0 modules} =1 {1 module} other {# modules}} · {scopes, plural, =0 {0 scopes} =1 {1 scope} other {# scopes}}",
       "noModuleScopes": "Sign-in only — no product permissions requested.",
-      "standardDisclosure": "Sign-in identity (openid, profile, email) and session refresh (offline_access) are also granted.",
       "modules": {
         "kb": "Knowledge Base",
         "conv": "Conversations",
         "crm": "Contacts",
         "cms": "Content",
-        "outreach": "Outreach"
+        "outreach": "Outreach",
+        "analytics": "Analytics"
+      },
+      "moduleDescriptions": {
+        "kb": {
+          "readWrite": "Read and edit your articles, spaces, and search.",
+          "read": "Read your articles, spaces, and search."
+        },
+        "conv": {
+          "readWrite": "Read threads and send messages on your behalf.",
+          "read": "Read conversation threads and messages."
+        },
+        "crm": {
+          "readWrite": "Read and modify contact records, deals, and segments.",
+          "read": "Read contact records, deals, and segments."
+        },
+        "cms": {
+          "readWrite": "Create, edit, and publish CMS content and schedules.",
+          "read": "Read CMS collections, entries, and assets."
+        },
+        "outreach": {
+          "readWrite": "Draft campaigns and send to consented contacts. Consent checks stay enforced.",
+          "read": "Read outreach campaigns and proposals."
+        },
+        "analytics": {
+          "readWrite": "Read analytics and manage tracker keys.",
+          "read": "Read analytics for content and search engagement."
+        }
       },
       "actions": {
         "read": "Read",
         "write": "Write"
       },
-      "authorize": "Authorize",
+      "reassurance": {
+        "lead": "Scoped, not god mode.",
+        "body": "<client></client> acts as <user></user> — it inherits your role and can't exceed it. It can't manage the team, billing, or API keys, or delete the org. Access lasts 90 days, auto-refreshed while in use, and you can revoke it anytime from <settings>Settings → Connected Apps</settings>."
+      },
+      "authorize": "Authorize access",
       "authorizing": "Authorizing…",
       "deny": "Deny",
       "denying": "Denying…",
+      "actingAs": "Authorizing as <user></user>",
+      "switchAccount": "Not you? Switch account",
+      "granted": {
+        "eyebrow": "Authorization granted",
+        "title": "Access <em>granted</em>.",
+        "sub": "<client></client> can now act in <strong>Munin</strong> within the scopes you approved. Sending you back to the app.",
+        "panelTitle": "<client></client> is connected.",
+        "panelBody": "An authorization code was issued and is being exchanged for a token. <client></client> now holds the scopes you approved for <strong>Munin</strong>, valid for 90 days and refreshed silently.",
+        "redirecting": "Returning to {host}…"
+      },
+      "denied": {
+        "eyebrow": "Authorization denied",
+        "title": "Access <em>denied</em>.",
+        "sub": "No token was issued. <client></client> can't reach anything in <strong>Munin</strong>. Returning you to the app.",
+        "panelTitle": "Nothing was shared.",
+        "panelBody": "You denied the request, so no token was issued. You can close this window or start over from <client></client>.",
+        "redirecting": "Returning to {host}…"
+      },
       "missingParams": "Missing OAuth request. Return to the application that started the authorization flow.",
       "errors": {
         "generic": "Something went wrong. Please try again."

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -702,28 +702,78 @@
       }
     },
     "oauthConsent": {
+      "eyebrow": "OAuth 2.1 · autoriseringsforespørsel",
       "title": "Gi <client></client> tilgang?",
-      "lede": "En ekstern applikasjon ber om tilgang til Munin-kontoen din. Gå gjennom forespurte tillatelser før du bestemmer deg.",
-      "applicationLabel": "Applikasjon",
-      "scopesLabel": "Forespurte tillatelser",
-      "noScopes": "(ingen tillatelser forespurt)",
+      "lede": "<client></client> vil koble seg til Munin og handle gjennom MCP-verktøyene på dine vegne. Se hva applikasjonen kan nå før du bestemmer deg.",
+      "registered": "Registrert {date}",
+      "trustFirst": "Første gang du kobler <client></client> til denne kontoen. Ingenting er delt med den enda.",
+      "scopesLabel": "Forespurt tilgang",
+      "scopesCount": "{modules, plural, =0 {0 moduler} =1 {1 modul} other {# moduler}} · {scopes, plural, =0 {0 omfang} =1 {1 omfang} other {# omfang}}",
       "noModuleScopes": "Bare innlogging — ingen produkttillatelser forespurt.",
-      "standardDisclosure": "Identitet ved innlogging (openid, profile, email) og fornyelse av økt (offline_access) gis også.",
       "modules": {
         "kb": "Kunnskapsbase",
         "conv": "Samtaler",
         "crm": "Kontakter",
         "cms": "Innhold",
-        "outreach": "Utgående"
+        "outreach": "Utgående",
+        "analytics": "Analyse"
+      },
+      "moduleDescriptions": {
+        "kb": {
+          "readWrite": "Les og rediger artikler, områder og søk.",
+          "read": "Les artikler, områder og søk."
+        },
+        "conv": {
+          "readWrite": "Les tråder og send meldinger på dine vegne.",
+          "read": "Les samtaletråder og meldinger."
+        },
+        "crm": {
+          "readWrite": "Les og endre kontakter, avtaler og segmenter.",
+          "read": "Les kontakter, avtaler og segmenter."
+        },
+        "cms": {
+          "readWrite": "Opprett, rediger og publiser CMS-innhold og planlegging.",
+          "read": "Les CMS-samlinger, oppføringer og ressurser."
+        },
+        "outreach": {
+          "readWrite": "Lag utkast til kampanjer og send til samtykkende kontakter. Samtykkesjekker er fortsatt aktive.",
+          "read": "Les utgående kampanjer og forslag."
+        },
+        "analytics": {
+          "readWrite": "Les analyse og administrer sporingsnøkler.",
+          "read": "Les analyse for innhold og søk."
+        }
       },
       "actions": {
         "read": "Lese",
         "write": "Skrive"
       },
+      "reassurance": {
+        "lead": "Avgrenset, ikke total tilgang.",
+        "body": "<client></client> opptrer som <user></user> — den arver din rolle og kan ikke gjøre mer enn deg. Den kan ikke styre teamet, fakturering eller API-nøkler, og kan heller ikke slette organisasjonen. Tilgangen varer i 90 dager og fornyes automatisk så lenge den brukes. Du kan trekke tilbake tilgangen når som helst fra <settings>Innstillinger → Tilkoblede apper</settings>."
+      },
       "authorize": "Gi tilgang",
       "authorizing": "Gir tilgang …",
       "deny": "Avslå",
       "denying": "Avslår …",
+      "actingAs": "Godkjenner som <user></user>",
+      "switchAccount": "Ikke deg? Bytt konto",
+      "granted": {
+        "eyebrow": "Tilgang gitt",
+        "title": "Tilgang <em>gitt</em>.",
+        "sub": "<client></client> kan nå handle i <strong>Munin</strong> innenfor de omfangene du godkjente. Sender deg tilbake til applikasjonen.",
+        "panelTitle": "<client></client> er tilkoblet.",
+        "panelBody": "En autorisasjonskode ble utstedt og byttes inn i et token. <client></client> har nå tilgangene du godkjente for <strong>Munin</strong>, gyldig i 90 dager og fornyet stille.",
+        "redirecting": "Returnerer til {host} …"
+      },
+      "denied": {
+        "eyebrow": "Tilgang avslått",
+        "title": "Tilgang <em>avslått</em>.",
+        "sub": "Ingen token ble utstedt. <client></client> får ikke tilgang til noe i <strong>Munin</strong>. Sender deg tilbake til applikasjonen.",
+        "panelTitle": "Ingenting ble delt.",
+        "panelBody": "Du avslo forespørselen, så ingen token ble utstedt. Du kan lukke dette vinduet eller starte på nytt fra <client></client>.",
+        "redirecting": "Returnerer til {host} …"
+      },
       "missingParams": "Mangler OAuth-forespørsel. Gå tilbake til applikasjonen som startet autoriseringen.",
       "errors": {
         "generic": "Noe gikk galt. Prøv igjen."

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -3,21 +3,29 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Button, Card, CardContent, Hero, PageSpinner } from '@getmunin/ui';
+import { PageSpinner } from '@getmunin/ui';
 import { authClient } from '../auth-client';
 import { api, ApiError } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 
-interface OAuthConsentResponse {
-  url?: string;
-  redirect_uri?: string;
-}
-
-interface OAuthClientInfo {
+export interface OAuthClientInfo {
   client_id: string;
   name: string | null;
   uri: string | null;
-  icon: string | null;
+  icon_url: string;
+  redirect_uri_host: string | null;
+  created_at: string;
+}
+
+export interface OAuthConsentPageProps {
+  /** Server-fetched client info. If `null`, the page falls back to client-side
+   *  rendering of the raw `client_id` (e.g. when the lookup failed). */
+  clientInfo: OAuthClientInfo | null;
+}
+
+interface OAuthConsentResponse {
+  url?: string;
+  redirect_uri?: string;
 }
 
 const HIDDEN_SCOPES = new Set([
@@ -30,7 +38,7 @@ const HIDDEN_SCOPES = new Set([
   'mcp:self_service',
 ]);
 
-const MODULE_ORDER = ['kb', 'conv', 'crm', 'cms', 'outreach'] as const;
+const MODULE_ORDER = ['kb', 'conv', 'crm', 'cms', 'outreach', 'analytics'] as const;
 type ModuleKey = (typeof MODULE_ORDER)[number];
 
 interface ModuleScopes {
@@ -58,13 +66,17 @@ function groupScopes(scopes: string[]): ModuleScopes[] {
   return MODULE_ORDER.filter((m) => map.has(m)).map((m) => map.get(m)!);
 }
 
-export function OAuthConsentPage() {
+type FlowState = 'new' | 'granted' | 'denied';
+
+const REDIRECT_DELAY_MS = 1200;
+
+export function OAuthConsentPage({ clientInfo }: OAuthConsentPageProps) {
   const t = useTranslations('dashboard.oauthConsent');
   const translate = useTranslateError();
   const search = useSearchParams();
   const { data: session, isPending } = authClient.useSession();
 
-  const clientId = search?.get('client_id') ?? '';
+  const clientId = search?.get('client_id') ?? clientInfo?.client_id ?? '';
   const scopeRaw = search?.get('scope') ?? '';
   const oauthQuery = useMemo(() => {
     if (typeof window === 'undefined') return '';
@@ -76,8 +88,12 @@ export function OAuthConsentPage() {
     [scopeRaw],
   );
   const groupedScopes = useMemo(() => groupScopes(scopes), [scopes]);
+  const totalScopeCount = useMemo(
+    () => groupedScopes.reduce((n, g) => n + (g.read ? 1 : 0) + (g.write ? 1 : 0), 0),
+    [groupedScopes],
+  );
 
-  const [clientInfo, setClientInfo] = useState<OAuthClientInfo | null>(null);
+  const [flow, setFlow] = useState<FlowState>('new');
   const [busy, setBusy] = useState<'allow' | 'deny' | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -88,37 +104,23 @@ export function OAuthConsentPage() {
     }
   }, [isPending, session]);
 
-  useEffect(() => {
-    if (!clientId) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const info = await api<OAuthClientInfo>(`/v1/oauth/clients/${encodeURIComponent(clientId)}`);
-        if (!cancelled) setClientInfo(info);
-      } catch {
-        // 404 or other failure — fall back to displaying the client_id verbatim.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [clientId]);
-
   if (isPending || !session) {
     return <PageSpinner className="min-h-screen bg-bone dark:bg-background" />;
   }
 
   if (!clientId || !oauthQuery) {
     return (
-      <div className="flex min-h-screen items-center justify-center px-6">
-        <Card className="max-w-md">
-          <CardContent className="py-6 text-sm text-destructive">{t('missingParams')}</CardContent>
-        </Card>
+      <div className="flex min-h-screen items-center justify-center bg-bone px-6 dark:bg-background">
+        <div className="max-w-md border border-ink bg-paper p-6 text-sm text-destructive dark:bg-card">
+          {t('missingParams')}
+        </div>
       </div>
     );
   }
 
   const displayName = clientInfo?.name?.trim() ? clientInfo.name : clientId;
+  const userName = session.user?.name?.trim() || session.user?.email || '';
+  const redirectHost = clientInfo?.redirect_uri_host ?? '';
 
   async function submit(accept: boolean) {
     setBusy(accept ? 'allow' : 'deny');
@@ -129,8 +131,10 @@ export function OAuthConsentPage() {
         body: JSON.stringify({ accept, oauth_query: oauthQuery }),
       });
       const target = resp?.url ?? resp?.redirect_uri;
-      if (target) window.location.assign(target);
-      else window.history.back();
+      setFlow(accept ? 'granted' : 'denied');
+      if (target) {
+        window.setTimeout(() => window.location.assign(target), REDIRECT_DELAY_MS);
+      }
     } catch (err) {
       if (err instanceof ApiError) setError(translate(err) || err.message);
       else setError(t('errors.generic'));
@@ -140,79 +144,425 @@ export function OAuthConsentPage() {
 
   return (
     <div className="min-h-screen bg-bone dark:bg-background">
-      <main className="mx-auto max-w-xl px-6 py-16">
-        <Hero
-          title={
-            <>
-              {t.rich('title', {
-                client: () => <em>{displayName}</em>,
-              })}
-            </>
-          }
-          lede={t('lede')}
+      <main className="mx-auto flex w-full max-w-[720px] flex-col px-6 py-12 sm:py-16">
+        <EditorialHeader
+          flow={flow}
+          clientName={displayName}
         />
 
-        <Card className="mt-8">
-          <CardContent className="space-y-5 py-6">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                {t('applicationLabel')}
-              </p>
-              <p className="mt-1 text-sm">
-                {clientInfo?.name?.trim() ? clientInfo.name : <span className="font-mono">{clientId}</span>}
-              </p>
-              {clientInfo?.uri && (
-                <p className="mt-0.5 text-xs text-muted-foreground">
-                  <a className="underline" href={clientInfo.uri} target="_blank" rel="noreferrer">
-                    {clientInfo.uri}
-                  </a>
-                </p>
-              )}
-            </div>
-
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                {t('scopesLabel')}
-              </p>
-              {groupedScopes.length === 0 ? (
-                <p className="mt-1 text-sm text-muted-foreground">{t('noModuleScopes')}</p>
-              ) : (
-                <ul className="mt-2 space-y-2">
-                  {groupedScopes.map(({ module, read, write }) => (
-                    <li key={module} className="text-sm">
-                      <span className="font-medium">{t(`modules.${module}`)}</span>
-                      <span className="ml-2 text-muted-foreground">
-                        {[read ? t('actions.read') : null, write ? t('actions.write') : null]
-                          .filter(Boolean)
-                          .join(' · ')}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-
-            {error && (
-              <p className="text-sm text-destructive" role="alert">
-                {error}
-              </p>
-            )}
-
-            <div className="flex gap-3 pt-2">
-              <Button onClick={() => void submit(true)} disabled={busy !== null}>
-                {busy === 'allow' ? t('authorizing') : t('authorize')}
-              </Button>
-              <Button
-                variant="outline"
-                onClick={() => void submit(false)}
-                disabled={busy !== null}
-              >
-                {busy === 'deny' ? t('denying') : t('deny')}
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        <section className="mt-8 border border-ink bg-paper dark:bg-card">
+          {flow === 'new' ? (
+            <RequestPane
+              clientInfo={clientInfo}
+              clientId={clientId}
+              displayName={displayName}
+              userName={userName}
+              groupedScopes={groupedScopes}
+              totalScopeCount={totalScopeCount}
+              busy={busy}
+              error={error}
+              onSubmit={(accept) => void submit(accept)}
+            />
+          ) : (
+            <ResultPane
+              flow={flow}
+              displayName={displayName}
+              redirectHost={redirectHost}
+            />
+          )}
+        </section>
       </main>
     </div>
   );
+}
+
+// ─── editorial header ────────────────────────────────────────────────
+
+interface EditorialHeaderProps {
+  flow: FlowState;
+  clientName: string;
+}
+
+function EditorialHeader({ flow, clientName }: EditorialHeaderProps) {
+  const t = useTranslations('dashboard.oauthConsent');
+  if (flow === 'granted') {
+    return (
+      <header className="mb-6">
+        <div className="mb-4 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-mute">
+          <span className="text-cobalt">✓</span>
+          <span>{t('granted.eyebrow')}</span>
+        </div>
+        <h1 className="font-serif text-[clamp(46px,6.6vw,72px)] font-normal leading-[0.98] tracking-[-0.02em]">
+          {t.rich('granted.title', { em: (chunks) => <em className="not-italic text-cobalt italic">{chunks}</em> })}
+        </h1>
+        <p className="mt-4 max-w-[54ch] text-base leading-relaxed text-ink-soft">
+          {t.rich('granted.sub', {
+            client: () => <em className="not-italic font-medium text-ink italic">{clientName}</em>,
+            strong: (chunks) => <strong className="font-medium text-ink">{chunks}</strong>,
+          })}
+        </p>
+      </header>
+    );
+  }
+  if (flow === 'denied') {
+    return (
+      <header className="mb-6">
+        <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-mute">
+          {t('denied.eyebrow')}
+        </div>
+        <h1 className="font-serif text-[clamp(46px,6.6vw,72px)] font-normal leading-[0.98] tracking-[-0.02em]">
+          {t.rich('denied.title', { em: (chunks) => <em className="not-italic text-ink italic">{chunks}</em> })}
+        </h1>
+        <p className="mt-4 max-w-[54ch] text-base leading-relaxed text-ink-soft">
+          {t.rich('denied.sub', {
+            client: () => <em className="not-italic font-medium text-ink italic">{clientName}</em>,
+            strong: (chunks) => <strong className="font-medium text-ink">{chunks}</strong>,
+          })}
+        </p>
+      </header>
+    );
+  }
+  return (
+    <header className="mb-6">
+      <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-mute">
+        {t('eyebrow')}
+      </div>
+      <h1 className="font-serif text-[clamp(46px,6.6vw,72px)] font-normal leading-[0.98] tracking-[-0.02em]">
+        {t.rich('title', { client: () => <em className="not-italic text-cobalt italic">{clientName}</em> })}
+      </h1>
+      <p className="mt-4 max-w-[54ch] text-base leading-relaxed text-ink-soft">
+        {t.rich('lede', {
+          client: () => <em className="not-italic font-medium text-ink italic">{clientName}</em>,
+        })}
+      </p>
+    </header>
+  );
+}
+
+// ─── request pane (the `new` state) ─────────────────────────────────
+
+interface RequestPaneProps {
+  clientInfo: OAuthClientInfo | null;
+  clientId: string;
+  displayName: string;
+  userName: string;
+  groupedScopes: ModuleScopes[];
+  totalScopeCount: number;
+  busy: 'allow' | 'deny' | null;
+  error: string | null;
+  onSubmit: (accept: boolean) => void;
+}
+
+function RequestPane({
+  clientInfo,
+  clientId,
+  displayName,
+  userName,
+  groupedScopes,
+  totalScopeCount,
+  busy,
+  error,
+  onSubmit,
+}: RequestPaneProps) {
+  const t = useTranslations('dashboard.oauthConsent');
+  return (
+    <>
+      <IdentityCard clientInfo={clientInfo} clientId={clientId} displayName={displayName} />
+      <TrustTimeline clientName={displayName} />
+
+      <div className="px-7 pt-2 pb-1">
+        <div className="flex items-baseline justify-between py-4">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-mute">
+            {t('scopesLabel')}
+          </span>
+          <span className="font-mono text-[11px] text-ink-soft">
+            {t('scopesCount', { modules: groupedScopes.length, scopes: totalScopeCount })}
+          </span>
+        </div>
+
+        {groupedScopes.length === 0 ? (
+          <p className="pb-4 text-sm text-ink-soft">{t('noModuleScopes')}</p>
+        ) : (
+          <ul className="border-t border-rule-soft">
+            {groupedScopes.map((g) => (
+              <PermissionRow key={g.module} group={g} />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ReassuranceBlock displayName={displayName} userName={userName} />
+
+      {error && (
+        <p className="px-7 pb-3 text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+
+      <ActionsFooter
+        userName={userName}
+        busy={busy}
+        onAuthorize={() => onSubmit(true)}
+        onDeny={() => onSubmit(false)}
+      />
+    </>
+  );
+}
+
+// ─── identity card ──────────────────────────────────────────────────
+
+interface IdentityCardProps {
+  clientInfo: OAuthClientInfo | null;
+  clientId: string;
+  displayName: string;
+}
+
+function IdentityCard({ clientInfo, clientId, displayName }: IdentityCardProps) {
+  const t = useTranslations('dashboard.oauthConsent');
+  const firstChar = (clientInfo?.name?.trim() ?? clientId).slice(0, 1).toUpperCase();
+  const registeredLabel = formatRegistered(clientInfo?.created_at);
+  return (
+    <div className="flex items-start gap-4 border-b border-rule-soft px-7 py-5">
+      <div className="flex h-[50px] w-[50px] shrink-0 items-center justify-center overflow-hidden rounded-xl border border-ink bg-ink font-serif text-[28px] leading-none text-paper">
+        {clientInfo?.icon_url ? (
+          <img
+            src={clientInfo.icon_url}
+            alt=""
+            className="h-full w-full object-cover"
+            onError={(e) => {
+              (e.currentTarget).style.display = 'none';
+            }}
+          />
+        ) : (
+          <span>{firstChar}</span>
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-serif text-[26px] leading-tight tracking-[-0.01em]">
+            {displayName}
+          </span>
+        </div>
+        {registeredLabel && (
+          <div className="mt-1.5 font-mono text-[11px] tracking-[0.02em] text-ink-mute">
+            {t('registered', { date: registeredLabel })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatRegistered(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
+}
+
+// ─── trust timeline ─────────────────────────────────────────────────
+
+function TrustTimeline({ clientName }: { clientName: string }) {
+  const t = useTranslations('dashboard.oauthConsent');
+  return (
+    <div className="flex items-start gap-3 border-b border-rule-soft bg-paper px-7 py-3 text-[13px] leading-snug text-ink-soft dark:bg-card">
+      <span className="mt-0.5 text-ink-mute">
+        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="9" />
+          <path d="M12 8v4l3 2" />
+        </svg>
+      </span>
+      <span>
+        {t.rich('trustFirst', {
+          client: () => <strong className="font-semibold text-ink">{clientName}</strong>,
+        })}
+      </span>
+    </div>
+  );
+}
+
+// ─── permission row ─────────────────────────────────────────────────
+
+function PermissionRow({ group }: { group: ModuleScopes }) {
+  const t = useTranslations('dashboard.oauthConsent');
+  const descKey = group.write
+    ? `moduleDescriptions.${group.module}.readWrite`
+    : `moduleDescriptions.${group.module}.read`;
+  return (
+    <li className="grid grid-cols-[1fr_auto] items-center gap-x-4 border-t border-rule-soft py-3.5 first:border-t-0">
+      <div className="min-w-0">
+        <div className="text-[15px] font-semibold text-ink">{t(`modules.${group.module}`)}</div>
+        <div className="mt-1 text-[13px] leading-snug text-ink-soft">
+          {t(descKey)}
+        </div>
+      </div>
+      <div className="inline-flex shrink-0 items-center gap-1.5">
+        {group.read && <ScopePill kind="read" label={t('actions.read')} />}
+        {group.write && <ScopePill kind="write" label={t('actions.write')} />}
+      </div>
+    </li>
+  );
+}
+
+function ScopePill({ kind, label }: { kind: 'read' | 'write'; label: string }) {
+  const cls =
+    kind === 'write'
+      ? 'border-cobalt text-cobalt bg-cobalt/5'
+      : 'border-rule-soft text-ink-soft';
+  return (
+    <span
+      className={`whitespace-nowrap rounded-full border px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.1em] ${cls}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ─── reassurance ────────────────────────────────────────────────────
+
+function ReassuranceBlock({ displayName, userName }: { displayName: string; userName: string }) {
+  const t = useTranslations('dashboard.oauthConsent');
+  return (
+    <div className="mx-7 my-3 border border-rule-soft bg-paper-deep px-4 py-3.5 text-[12.5px] leading-relaxed text-ink-soft">
+      <b className="font-semibold text-ink">{t('reassurance.lead')}</b>{' '}
+      {t.rich('reassurance.body', {
+        client: () => <b className="font-semibold text-ink">{displayName}</b>,
+        user: () => <b className="font-semibold text-ink">{userName || '…'}</b>,
+        settings: (chunks) => (
+          <a className="text-cobalt no-underline hover:underline" href="/dashboard/settings/connected-apps">
+            {chunks}
+          </a>
+        ),
+      })}
+    </div>
+  );
+}
+
+// ─── actions ────────────────────────────────────────────────────────
+
+interface ActionsFooterProps {
+  userName: string;
+  busy: 'allow' | 'deny' | null;
+  onAuthorize: () => void;
+  onDeny: () => void;
+}
+
+function ActionsFooter({ userName, busy, onAuthorize, onDeny }: ActionsFooterProps) {
+  const t = useTranslations('dashboard.oauthConsent');
+  return (
+    <div className="flex flex-wrap items-center gap-3 border-t border-rule-soft px-7 py-5">
+      <button
+        type="button"
+        onClick={onAuthorize}
+        disabled={busy !== null}
+        className="inline-flex h-11 items-center justify-center gap-2 border border-ink bg-ink px-6 font-sans text-[15px] font-medium text-paper transition hover:bg-cobalt hover:border-cobalt disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {busy === 'allow' ? t('authorizing') : t('authorize')}
+        {busy !== 'allow' && (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M5 12h14M13 5l7 7-7 7" />
+          </svg>
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={onDeny}
+        disabled={busy !== null}
+        className="inline-flex h-11 items-center justify-center border border-ink bg-transparent px-6 font-sans text-[15px] font-medium text-ink transition hover:bg-ink hover:text-paper disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {busy === 'deny' ? t('denying') : t('deny')}
+      </button>
+      <div className="ml-auto text-right text-[12px] leading-snug text-ink-mute">
+        {t.rich('actingAs', {
+          user: () => <span>{userName || '…'}</span>,
+        })}
+        <br />
+        <a href="/login" className="text-cobalt no-underline hover:underline">
+          {t('switchAccount')}
+        </a>
+      </div>
+    </div>
+  );
+}
+
+// ─── result pane (granted / denied) ─────────────────────────────────
+
+function ResultPane({
+  flow,
+  displayName,
+  redirectHost,
+}: {
+  flow: 'granted' | 'denied';
+  displayName: string;
+  redirectHost: string;
+}) {
+  const t = useTranslations('dashboard.oauthConsent');
+  const isGranted = flow === 'granted';
+  return (
+    <div className="flex flex-col gap-4 px-7 py-8">
+      <div
+        className={`inline-flex h-11 w-11 items-center justify-center rounded-full border ${
+          isGranted
+            ? 'border-cobalt/40 bg-cobalt/10 text-cobalt-deep'
+            : 'border-rule-soft bg-paper-deep text-ink-soft'
+        }`}
+      >
+        {isGranted ? (
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 12.5l5 5 11-11" />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M6 6l12 12M18 6 6 18" />
+          </svg>
+        )}
+      </div>
+      <div className="font-serif text-[24px] tracking-[-0.01em]">
+        {isGranted
+          ? t.rich('granted.panelTitle', { client: () => <em className="not-italic italic">{displayName}</em> })
+          : t('denied.panelTitle')}
+      </div>
+      <div className="max-w-[52ch] text-sm leading-relaxed text-ink-soft">
+        {isGranted
+          ? t.rich('granted.panelBody', {
+              client: () => <em className="not-italic font-medium text-ink italic">{displayName}</em>,
+              strong: (chunks) => <strong className="font-medium text-ink">{chunks}</strong>,
+            })
+          : t.rich('denied.panelBody', {
+              client: () => <em className="not-italic font-medium text-ink italic">{displayName}</em>,
+            })}
+      </div>
+      {redirectHost && (
+        <div className="mt-1 flex items-center gap-2.5 font-mono text-[11px] tracking-[0.04em] text-ink-mute">
+          <Spinner />
+          <span>
+            {isGranted
+              ? t('granted.redirecting', { host: redirectHost })
+              : t('denied.redirecting', { host: redirectHost })}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Spinner() {
+  return (
+    <span
+      className="inline-block h-3 w-3 rounded-full border-[1.5px] border-ink-mute border-t-transparent"
+      style={{ animation: 'munin-consent-spin 0.9s linear infinite' }}
+    />
+  );
+}
+
+// ─── inline keyframes (kept local so we don't bloat global CSS) ─────
+
+if (typeof document !== 'undefined') {
+  const id = 'munin-consent-spin-keyframes';
+  if (!document.getElementById(id)) {
+    const style = document.createElement('style');
+    style.id = id;
+    style.textContent = '@keyframes munin-consent-spin{to{transform:rotate(360deg)}}';
+    document.head.appendChild(style);
+  }
 }

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -162,6 +162,13 @@ export function OAuthConsentPage({ clientInfo }: OAuthConsentPageProps) {
               busy={busy}
               error={error}
               onSubmit={(accept) => void submit(accept)}
+              onSwitchAccount={() => {
+                void (async () => {
+                  const next = encodeURIComponent(window.location.href);
+                  await authClient.signOut();
+                  window.location.assign(`/login?next=${next}`);
+                })();
+              }}
             />
           ) : (
             <ResultPane
@@ -251,6 +258,7 @@ interface RequestPaneProps {
   busy: 'allow' | 'deny' | null;
   error: string | null;
   onSubmit: (accept: boolean) => void;
+  onSwitchAccount: () => void;
 }
 
 function RequestPane({
@@ -263,6 +271,7 @@ function RequestPane({
   busy,
   error,
   onSubmit,
+  onSwitchAccount,
 }: RequestPaneProps) {
   const t = useTranslations('dashboard.oauthConsent');
   return (
@@ -304,6 +313,7 @@ function RequestPane({
         busy={busy}
         onAuthorize={() => onSubmit(true)}
         onDeny={() => onSubmit(false)}
+        onSwitchAccount={onSwitchAccount}
       />
     </>
   );
@@ -322,7 +332,11 @@ function IdentityCard({ clientInfo, clientId, displayName }: IdentityCardProps) 
   const firstChar = (clientInfo?.name?.trim() ?? clientId).slice(0, 1).toUpperCase();
   const registeredLabel = formatRegistered(clientInfo?.created_at);
   return (
-    <div className="flex items-start gap-4 border-b border-rule-soft px-7 py-5">
+    <div
+      className={`flex gap-4 border-b border-rule-soft px-7 py-5 ${
+        registeredLabel ? 'items-start' : 'items-center'
+      }`}
+    >
       <div className="flex h-[50px] w-[50px] shrink-0 items-center justify-center overflow-hidden rounded-xl border border-ink bg-ink font-serif text-[28px] leading-none text-paper">
         {clientInfo?.icon_url ? (
           <img
@@ -365,8 +379,8 @@ function formatRegistered(iso: string | undefined): string | null {
 function TrustTimeline({ clientName }: { clientName: string }) {
   const t = useTranslations('dashboard.oauthConsent');
   return (
-    <div className="flex items-start gap-3 border-b border-rule-soft bg-paper px-7 py-3 text-[13px] leading-snug text-ink-soft dark:bg-card">
-      <span className="mt-0.5 text-ink-mute">
+    <div className="flex items-center gap-3 border-b border-rule-soft bg-paper px-7 py-3 text-[13px] leading-snug text-ink-soft dark:bg-card">
+      <span className="text-ink-mute">
         <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <circle cx="12" cy="12" r="9" />
           <path d="M12 8v4l3 2" />
@@ -445,9 +459,10 @@ interface ActionsFooterProps {
   busy: 'allow' | 'deny' | null;
   onAuthorize: () => void;
   onDeny: () => void;
+  onSwitchAccount: () => void;
 }
 
-function ActionsFooter({ userName, busy, onAuthorize, onDeny }: ActionsFooterProps) {
+function ActionsFooter({ userName, busy, onAuthorize, onDeny, onSwitchAccount }: ActionsFooterProps) {
   const t = useTranslations('dashboard.oauthConsent');
   return (
     <div className="flex flex-wrap items-center gap-3 border-t border-rule-soft px-7 py-5">
@@ -477,9 +492,14 @@ function ActionsFooter({ userName, busy, onAuthorize, onDeny }: ActionsFooterPro
           user: () => <span>{userName || '…'}</span>,
         })}
         <br />
-        <a href="/login" className="text-cobalt no-underline hover:underline">
+        <button
+          type="button"
+          onClick={onSwitchAccount}
+          disabled={busy !== null}
+          className="text-cobalt no-underline hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+        >
           {t('switchAccount')}
-        </a>
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Closes the consent-page-shows-raw-client-id bug and lands the redesigned layout in one pass.

### Backend

1. **`GET /v1/oauth/clients/:id` enriched.** Returns `{ client_id, name, uri, icon_url, redirect_uri_host, created_at }`.
   - `name` gets a host-derived fallback when the client's DCR didn't include `client_name`. Well-known hosts (`claude.ai`/`chatgpt.com`/`cursor.sh`/etc.) get a branded label; everything else falls back to the bare host. Replaces the previous behavior of leaking the random 32-char `client_id` to the UI.
   - `redirect_uri_host` exposes only the host portion of the first registered redirect URI — full URI stays off the wire (used for the "Returning to claude.ai…" message in the result panes).
   - `created_at` powers the "Registered Month YYYY" line under the app name.
2. **`GET /v1/oauth/clients/:id/icon` — favicon proxy.** Server-side fetches `oauth_client.icon` if the DCR provided one, otherwise `https://<redirect_uri_host>/favicon.ico` via SSRF-guarded `safeFetch`. Validates `image/*` content-type, caps response size at 256 KB, falls back to a generic SVG on any failure. Served from our origin with a 24h browser cache — keeps the user's IP off third-party hosts pre-authorization. Verified that `claude.ai/favicon.ico` returns a real multi-resolution .ico straight away.

### Frontend

3. **SSR refactor.** The consent route in `apps/web` is now an async server component that fetches the enriched client info before render. This:
   - **Fixes the CORS bug.** The browser was calling `/v1/oauth/clients/:id` with `credentials: 'include'` (the `api()` default), and the backend correctly refused to set `Access-Control-Allow-Credentials: true` for an anonymous endpoint. The fetch threw, the page caught silently, and the user saw the raw `client_id` in the editorial title. Server-side fetch makes the CORS path moot.
   - **Eliminates the flash.** First paint shows the correct name + logo.
4. **New three-state machine.** `new` → `granted` / `denied`, with intermediate result panes that show "Access granted · Returning to claude.ai…" with a spinner for ~1.2s before the redirect. Replaces the previous "click → immediate `location.assign()`" pattern. Same OAuth flow underneath; just a less jarring transition.
5. **New layout** matching the editorial design: serif headline that shifts copy per state, identity card with proxied app icon + month-precision "Registered" line, trust-timeline strip, grouped per-module permissions with `Read`/`Write` pills, reassurance block, and an actions footer with "Authorizing as Ola Nordmann" + switch-account link.

### Misc

- New `anonymous: true` opt-out on the `api()` helper for any other client-side caller of `@PublicController` endpoints — same credentials-mode CORS story.
- i18n strings in `en.json` and `nb.json` updated end-to-end. The keys reshaped (`title`, `lede`, `scopesLabel`, per-state copy, etc.) — see the `dashboard.oauthConsent` block.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck` clean
- [x] `pnpm -F @getmunin/dashboard-pages typecheck` clean
- [x] `pnpm -F @getmunin/web typecheck` clean
- [x] `pnpm -F @getmunin/backend-core test` — 745/745
- [ ] After deploy: open the consent page in prod for a real DCR'd client. Confirm the title shows the app name (not `client_id`), the icon renders (from `/v1/oauth/clients/<id>/icon`), the per-module permissions list looks right, and Authorize/Deny show the intermediate result pane before redirect.

## Follow-ups intentionally out of scope

- Per-permission expandable tool lists (the design has a collapsible "tool examples" detail; not wired here — needs a static module→example-tools mapping from the registry).
- First-time vs returning copy variants for the trust-timeline strip (would need an `oauth_consent` history lookup; currently shows the first-time copy unconditionally).
- Multi-org context in the topbar (the design shows a Munin selector that doesn't apply to single-tenant OSS today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
