### PR TITLE
chore(db): drop legacy oauth_clients table

### DIFF
--- a/.changeset/drop-legacy-oauth-clients-table.md
+++ b/.changeset/drop-legacy-oauth-clients-table.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/db': minor
+'@getmunin/backend-core': patch
+---
+
+Drop the legacy `oauth_clients` (plural) table and its dormant FK column `tokens.oauth_client_id`.
+
+`oauth_clients` predates the BetterAuth OAuth provider plugin we adopted in migration 0017/0018. Since then the real OAuth client model has lived in `oauth_client` (singular) — that's the table the consent page reads from, the table DCR writes into, and the table FK'd by `oauth_access_token` / `oauth_refresh_token` / `oauth_consent`. The legacy `oauth_clients` was kept around because `tokens.oauth_client_id` had an FK pointing at it, but nothing has ever written either side: BetterAuth uses its own table, and `tokens.oauth_client_id` has only ever held NULL.
+
+Both `oauth_clients` and `tokens.oauth_client_id` were verified empty in dev and prod before the drop. The new migration `0037_drop_legacy_oauth_clients.sql` drops the FK, the column, the index, and the table; `src/sql/rls.sql` loses the matching RLS block; `schema.ts` loses the `oauthClients` export and the `oauthClientId` field on `tokens`.
+
+No application-level changes — nothing referenced the dropped column or table.

--- a/packages/db/drizzle/0037_drop_legacy_oauth_clients.sql
+++ b/packages/db/drizzle/0037_drop_legacy_oauth_clients.sql
@@ -1,0 +1,17 @@
+-- Drop the legacy `oauth_clients` table and its dormant FK from `tokens`.
+--
+-- Historical context: we shipped our own minimal OAuth client model in
+-- `oauth_clients` (migration 0000) before adopting `@better-auth/oauth-provider`
+-- in 0017/0018, which insists on owning its own table (`oauth_client`,
+-- singular). The legacy table was kept around because `tokens` had a FK
+-- pointing at it, but nothing actually writes either side: BetterAuth uses
+-- `oauth_client`, and `tokens.oauth_client_id` has only ever held NULL.
+--
+-- Both `oauth_clients` and `tokens.oauth_client_id` are confirmed empty in
+-- dev and prod at the time of this migration.
+
+ALTER TABLE "tokens" DROP CONSTRAINT IF EXISTS "tokens_oauth_client_id_oauth_clients_id_fk";
+ALTER TABLE "tokens" DROP COLUMN IF EXISTS "oauth_client_id";
+
+DROP INDEX IF EXISTS "oauth_clients_org_idx";
+DROP TABLE IF EXISTS "oauth_clients";

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1780700000000,
       "tag": "0036_analytics_trackers",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1780753800000,
+      "tag": "0037_drop_legacy_oauth_clients",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -260,27 +260,10 @@ export const agents = pgTable(
 );
 
 // ───────────────────────────── OAuth (MCP spec) ──────────────────────
-// Dynamically-registered OAuth clients (per the MCP OAuth 2.1 flow).
-export const oauthClients = pgTable(
-  'oauth_clients',
-  {
-    id: id('oac'),
-    orgId: text('org_id').references(() => orgs.id, { onDelete: 'cascade' }),
-    clientId: text('client_id').notNull().unique(),
-    clientSecretHash: text('client_secret_hash'),
-    name: text('name').notNull(),
-    redirectUris: jsonb('redirect_uris').$type<string[]>().notNull().default([]),
-    grantTypes: jsonb('grant_types').$type<string[]>().notNull().default([]),
-    scopes: jsonb('scopes').$type<string[]>().notNull().default([]),
-    metadata: jsonb('metadata').$type<Record<string, unknown>>().notNull().default({}),
-    createdAt,
-    updatedAt,
-  },
-  (t) => ({
-    orgIdx: index('oauth_clients_org_idx').on(t.orgId),
-  }),
-);
-
+// BetterAuth's `@better-auth/oauth-provider` plugin owns the OAuth client
+// model. The plugin runs unmodified and writes into the table below; we
+// mirror its expected fields verbatim. Renaming any column requires a
+// corresponding `schema:` mapping in the plugin config.
 export const oauthClient = pgTable(
   'oauth_client',
   {
@@ -403,7 +386,6 @@ export const tokens = pgTable(
     audiences: jsonb('audiences').$type<('admin' | 'self_service')[]>().notNull().default([]),
     userId: text('user_id').references(() => users.id, { onDelete: 'cascade' }),
     agentId: text('agent_id').references(() => agents.id, { onDelete: 'cascade' }),
-    oauthClientId: text('oauth_client_id').references(() => oauthClients.id, { onDelete: 'cascade' }),
     endUserId: text('end_user_id').references(() => endUsers.id, { onDelete: 'cascade' }),
     expiresAt: timestamp('expires_at', { withTimezone: true }),
     revokedAt: timestamp('revoked_at', { withTimezone: true }),
@@ -1811,7 +1793,6 @@ export const allTables = {
   orgInvitations,
   endUsers,
   agents,
-  oauthClients,
   oauthClient,
   oauthAccessToken,
   oauthRefreshToken,

--- a/packages/db/src/sql/rls.sql
+++ b/packages/db/src/sql/rls.sql
@@ -88,17 +88,6 @@ CREATE POLICY tenant_isolation ON assistants
   USING (app_bypass_rls() OR org_id = app_org_id())
   WITH CHECK (app_bypass_rls() OR org_id = app_org_id());
 
--- ───────────────────────── oauth_clients ───────────────────────────────────
--- oauth_clients can be either org-scoped (after consent links them) or
--- nullable-org (during pre-consent registration). Allow null org reads
--- only with bypass; otherwise require match.
-ALTER TABLE oauth_clients ENABLE ROW LEVEL SECURITY;
-ALTER TABLE oauth_clients FORCE ROW LEVEL SECURITY;
-DROP POLICY IF EXISTS tenant_isolation ON oauth_clients;
-CREATE POLICY tenant_isolation ON oauth_clients
-  USING (app_bypass_rls() OR (org_id IS NOT NULL AND org_id = app_org_id()))
-  WITH CHECK (app_bypass_rls() OR (org_id IS NOT NULL AND org_id = app_org_id()));
-
 -- ───────────────────────── tokens ──────────────────────────────────────────
 -- Tokens carry both org_id and (sometimes) end_user_id. End-user agents can
 -- only see their own token row.


### PR DESCRIPTION
## Summary

`oauth_clients` (plural) is the original OAuth client model we wrote ourselves before adopting `@better-auth/oauth-provider` in migrations 0017/0018. Since then the real client model has lived in **`oauth_client`** (singular):

| Table | Who writes to it | Used today? |
|---|---|---|
| `oauth_client` (singular, BetterAuth) | The DCR + authorize flow plugin | ✅ all prod rows live here |
| `oauth_clients` (plural, legacy) | Nothing | ❌ empty in dev *and* prod |

The only remaining reference to `oauth_clients` was a dormant FK column `tokens.oauth_client_id`, which has only ever held NULL — no writer ever populated it, and no reader ever filtered on it.

## The drop

- New migration `0037_drop_legacy_oauth_clients.sql`: drops the FK, the column, the index, and the table.
- `packages/db/src/sql/rls.sql`: removes the matching RLS block (would otherwise fail on the next migrate run after the table is gone).
- `packages/db/src/schema.ts`: removes the `oauthClients` export and the `oauthClientId` field on `tokens`.
- `packages/db/drizzle/meta/_journal.json`: registers the new migration.

## Verification

- Both `oauth_clients` and `tokens.oauth_client_id` were verified empty in dev and prod before drafting.
- Test DB migrated cleanly; backend-core integration test suite (745/745) passes against the migrated schema.
- `pnpm -F @getmunin/db typecheck` clean.
- `pnpm -F @getmunin/backend-core typecheck` clean.
- Workspace-wide grep: no references to `schema.oauthClients` or `oauthClientId` outside the lines being deleted.

## Test plan

- [x] Local migration applied; consent flow still works (uses `oauth_client` singular).
- [ ] After deploy: ensure prod migration applies without surprises (the table being dropped is empty, so this should be instant).
- [ ] Spot-check: prod consent page still resolves DCR'd clients (Claude / ChatGPT rows are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)