### PR TITLE
feat(agent-host): enforce tenant-isolation RLS on multi-tenant agent_config/agent_health

### DIFF
--- a/.changeset/agent-host-multi-tenant-rls.md
+++ b/.changeset/agent-host-multi-tenant-rls.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/agent-host': patch
+---
+
+Add tenant-isolation RLS policies to `agent_config` and `agent_health` when they're built in **multi-tenant** mode (one row per org). Closes a defense-in-depth gap: in the multi-tenant variant, `id` references `orgs(id)` so each row holds an org's encrypted LLM provider API key, provider URL, and agent settings, but the table had no RLS policy. An app-DB query with the wrong `app.org_id` GUC could read another tenant's row (the encryption envelope still protects the key value itself, but everything else leaked).
+
+The new policy uses the same `tenant_isolation` template as the rest of the schema: `id = app_org_id()` with an `app_bypass_rls()` short-circuit. `app_org_id()` / `app_bypass_rls()` are the helpers installed by `@getmunin/db`'s `rls.sql`, which `runMigrations` always applies before the agent-host DDL runs in cloud.
+
+`AGENT_HOST_SINGLETON_DDL` and `AGENT_HEALTH_SINGLETON_DDL` (the OSS one-row variants) are **intentionally untouched** — RLS on a one-row, no-org-GUC table would just lock out the singleton fetch.
+
+DDL is idempotent (`ALTER TABLE … ENABLE`, `DROP POLICY IF EXISTS`, `CREATE POLICY`) so re-applying on every cloud boot is safe.

--- a/packages/agent-host/src/agent-health.schema.ts
+++ b/packages/agent-host/src/agent-health.schema.ts
@@ -39,4 +39,14 @@ export const AGENT_HEALTH_MULTI_TENANT_DDL = sql`
 
   ALTER TABLE agent_health DROP COLUMN IF EXISTS last_provider_error_code;
   ALTER TABLE agent_health DROP COLUMN IF EXISTS last_provider_error_message;
+
+  -- Tenant isolation. \`id\` IS the org id (PK references orgs(id)), so the
+  -- policy matches the GUC directly. Multi-tenant only — the OSS singleton
+  -- variant doesn't set app.org_id.
+  ALTER TABLE agent_health ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE agent_health FORCE ROW LEVEL SECURITY;
+  DROP POLICY IF EXISTS tenant_isolation ON agent_health;
+  CREATE POLICY tenant_isolation ON agent_health
+    USING (app_bypass_rls() OR id = app_org_id())
+    WITH CHECK (app_bypass_rls() OR id = app_org_id());
 `;

--- a/packages/agent-host/src/schema.ts
+++ b/packages/agent-host/src/schema.ts
@@ -108,4 +108,14 @@ export const AGENT_HOST_MULTI_TENANT_DDL = sql`
 
   CREATE INDEX IF NOT EXISTS agent_config_provisioned_idx
     ON agent_config(id) WHERE provider_api_key_ct IS NOT NULL;
+
+  -- Tenant isolation. \`id\` IS the org id on this table (PK references orgs(id)),
+  -- so the policy can match the GUC directly. Multi-tenant only — the OSS
+  -- singleton variant is one row and doesn't set app.org_id.
+  ALTER TABLE agent_config ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE agent_config FORCE ROW LEVEL SECURITY;
+  DROP POLICY IF EXISTS tenant_isolation ON agent_config;
+  CREATE POLICY tenant_isolation ON agent_config
+    USING (app_bypass_rls() OR id = app_org_id())
+    WITH CHECK (app_bypass_rls() OR id = app_org_id());
 `;


### PR DESCRIPTION
## Summary

Closes a defense-in-depth gap surfaced during today's RLS audit: in the multi-tenant cloud variant, both `agent_config` and `agent_health` have `id REFERENCES orgs(id)` (one row per tenant), but **neither table had an RLS policy**. Every other org-scoped table in the schema has one. The OSS singleton variants are intentionally not affected.

### What was at risk

- **`agent_config`** — per-tenant row holds the encrypted LLM provider API key (`provider_api_key_ct`), provider base URL, model selection, debounce settings, history caps. With the wrong `app.org_id` GUC, an app-DB query could read another tenant's row. The pgcrypto envelope still protects the key *value*, but everything else (provider URL, model choice, timing) leaks, and we lose the defense-in-depth posture.
- **`agent_health`** — per-tenant `last_error_at` / `last_ok_at` timestamps. Lower sensitivity, but still org data.

### Fix

Add the same `tenant_isolation` template the rest of the schema uses, on the multi-tenant DDLs only:

```sql
ALTER TABLE agent_config ENABLE ROW LEVEL SECURITY;
ALTER TABLE agent_config FORCE ROW LEVEL SECURITY;
DROP POLICY IF EXISTS tenant_isolation ON agent_config;
CREATE POLICY tenant_isolation ON agent_config
  USING (app_bypass_rls() OR id = app_org_id())
  WITH CHECK (app_bypass_rls() OR id = app_org_id());
```

`id` *is* the org id on these tables, so the policy matches the GUC directly. `app_bypass_rls()` / `app_org_id()` are the helpers `@getmunin/db`'s `rls.sql` installs before the agent-host DDL runs in cloud (`munin-cloud/apps/backend-cloud/src/migrate.ts:85-88`). DDL is idempotent — `DROP POLICY IF EXISTS` + `CREATE POLICY`, plus `ENABLE/FORCE RLS` are no-ops on re-run.

### Why not the OSS singleton DDLs

Those tables have one row, `id = 'singleton'`, and no `app.org_id` GUC is set when the agent-host service reads them. Applying RLS would lock out the singleton fetch with no security benefit (one row).

## Test plan

- [x] `pnpm -F @getmunin/agent-host typecheck` clean
- [x] `pnpm -F @getmunin/agent-host test` — 40/40
- [x] OSS migrations against the test DB succeed (the OSS path doesn't apply these DDLs at all, just the singleton variant from `apps/backend` boot).
- [ ] **Cloud deploy verification**: after the next `agent-host` bump in `munin-cloud`, confirm via `\d+ agent_config` and `\d+ agent_health` in cloud DB that RLS is enabled + forced, and that `tenant_isolation` policy exists with the expected `USING` clause. Confirm the agent-host runner still reads/writes correctly (it runs in a service context with `app.org_id` set per-org via `runWithServiceContext`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)