### PR TITLE
fix(oauth): return absolute icon_url so cross-origin web can fetch it

### DIFF
--- a/.changeset/oauth-consent-icon-absolute-url.md
+++ b/.changeset/oauth-consent-icon-absolute-url.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+`GET /v1/oauth/clients/:id` now returns `icon_url` as an absolute URL (e.g. `https://api.example.com/v1/oauth/clients/<id>/icon`) instead of a same-origin relative path. The consent page renders the icon via an `<img>` tag on the *web* origin, so when the API and web are on different origins (any deployment where backend ≠ web, including the standard cloud `api.getmunin.com` / `app.getmunin.com` split), the browser was requesting the icon from the wrong origin and falling back to the placeholder square. The base URL is taken from `authorizationServerUrl()` — the same env (`NEXT_PUBLIC_AUTH_URL` / `NEXT_PUBLIC_MCP_URL`) that drives every other public OAuth URL — so single-process OSS deployments where backend and web share an origin still render correctly.

--- a/packages/backend-core/src/oauth/oauth-client-info.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-client-info.controller.ts
@@ -12,6 +12,7 @@ import { schema, type Db } from '@getmunin/db';
 import { describeError, safeFetch, SsrfBlockedError } from '@getmunin/core';
 import { PublicController } from '../common/auth/auth.guard.ts';
 import { DB } from '../common/db/db.module.ts';
+import { authorizationServerUrl } from './oauth.constants.ts';
 
 interface OAuthClientInfo {
   client_id: string;
@@ -68,7 +69,7 @@ export class OAuthClientInfoController {
       client_id: row.clientId,
       name,
       uri: row.uri ?? null,
-      icon_url: `/v1/oauth/clients/${encodeURIComponent(row.clientId)}/icon`,
+      icon_url: `${authorizationServerUrl()}/v1/oauth/clients/${encodeURIComponent(row.clientId)}/icon`,
       redirect_uri_host: redirectHost,
       created_at: row.createdAt.toISOString(),
     };


### PR DESCRIPTION
## Summary
- `GET /v1/oauth/clients/:id` was returning `icon_url` as the relative path `/v1/oauth/clients/<id>/icon`. Whenever the consent page lives on a different origin from the API (cloud's `app.getmunin.com` vs `api.getmunin.com`, OSS local dev with web on `:3000` and backend on `:3001`, …), the browser `<img>` request landed on the web origin and 404'd — the identity card fell back to the placeholder square.
- Prefix `icon_url` with `authorizationServerUrl()` so the response carries an absolute URL. Single-process OSS deployments where backend and web share an origin still resolve correctly.

This was already patched in cloud by rewriting the relative URL in the SSR wrapper (`getmunin/munin-cloud#222`). This PR moves the fix to the right layer so the dashboard-pages component doesn't need to know about origins; once this ships and cloud bumps to the new release, the wrapper-side rewrite becomes a no-op.

## Test plan
- [ ] CI green
- [ ] After release + cloud bump: verify identity card shows the client favicon on `app.getmunin.com`
- [ ] OSS local dev (`pnpm dev`): same check at `localhost:3000/.../oauth/consent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)