### PR TITLE
fix(oauth): consent identity card polish + agents-settings link

### DIFF
--- a/.changeset/oauth-consent-icon-and-settings-link.md
+++ b/.changeset/oauth-consent-icon-and-settings-link.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+OAuth consent identity card polish: the icon container now has a white background with the favicon inset (h-9 w-9 inside the 50×50 frame) so vendor logos sit on a neutral surface with breathing room, instead of bleeding to the dark edge. Tightened the gap between the client name and the "Registered …" line. Reassurance footer now links to **Settings → Agents** (`/dashboard/settings/agents`) — the actual revocation surface — instead of the stale "Connected Apps" label and path.

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -750,7 +750,7 @@
       },
       "reassurance": {
         "lead": "Scoped, not god mode.",
-        "body": "<client></client> acts as <user></user> — it inherits your role and can't exceed it. It can't manage the team, billing, or API keys, or delete the org. Access lasts 90 days, auto-refreshed while in use, and you can revoke it anytime from <settings>Settings → Connected Apps</settings>."
+        "body": "<client></client> acts as <user></user> — it inherits your role and can't exceed it. It can't manage the team, billing, or API keys, or delete the org. Access lasts 90 days, auto-refreshed while in use, and you can revoke it anytime from <settings>Settings → Agents</settings>."
       },
       "authorize": "Authorize access",
       "authorizing": "Authorizing…",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -750,7 +750,7 @@
       },
       "reassurance": {
         "lead": "Avgrenset, ikke total tilgang.",
-        "body": "<client></client> opptrer som <user></user> — den arver din rolle og kan ikke gjøre mer enn deg. Den kan ikke styre teamet, fakturering eller API-nøkler, og kan heller ikke slette organisasjonen. Tilgangen varer i 90 dager og fornyes automatisk så lenge den brukes. Du kan trekke tilbake tilgangen når som helst fra <settings>Innstillinger → Tilkoblede apper</settings>."
+        "body": "<client></client> opptrer som <user></user> — den arver din rolle og kan ikke gjøre mer enn deg. Den kan ikke styre teamet, fakturering eller API-nøkler, og kan heller ikke slette organisasjonen. Tilgangen varer i 90 dager og fornyes automatisk så lenge den brukes. Du kan trekke tilbake tilgangen når som helst fra <settings>Innstillinger → Agenter</settings>."
       },
       "authorize": "Gi tilgang",
       "authorizing": "Gir tilgang …",

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -337,12 +337,12 @@ function IdentityCard({ clientInfo, clientId, displayName }: IdentityCardProps) 
         registeredLabel ? 'items-start' : 'items-center'
       }`}
     >
-      <div className="flex h-[50px] w-[50px] shrink-0 items-center justify-center overflow-hidden rounded-xl border border-ink bg-ink font-serif text-[28px] leading-none text-paper">
+      <div className="flex h-[50px] w-[50px] shrink-0 items-center justify-center overflow-hidden rounded-xl border border-ink bg-white font-serif text-[28px] leading-none text-ink">
         {clientInfo?.icon_url ? (
           <img
             src={clientInfo.icon_url}
             alt=""
-            className="h-full w-full object-cover"
+            className="h-9 w-9 object-contain"
             onError={(e) => {
               (e.currentTarget).style.display = 'none';
             }}
@@ -358,7 +358,7 @@ function IdentityCard({ clientInfo, clientId, displayName }: IdentityCardProps) 
           </span>
         </div>
         {registeredLabel && (
-          <div className="mt-1.5 font-mono text-[11px] tracking-[0.02em] text-ink-mute">
+          <div className="font-mono text-[11px] tracking-[0.02em] text-ink-mute">
             {t('registered', { date: registeredLabel })}
           </div>
         )}
@@ -443,7 +443,7 @@ function ReassuranceBlock({ displayName, userName }: { displayName: string; user
         client: () => <b className="font-semibold text-ink">{displayName}</b>,
         user: () => <b className="font-semibold text-ink">{userName || '…'}</b>,
         settings: (chunks) => (
-          <a className="text-cobalt no-underline hover:underline" href="/dashboard/settings/connected-apps">
+          <a className="text-cobalt no-underline hover:underline" href="/dashboard/settings/agents">
             {chunks}
           </a>
         ),


### PR DESCRIPTION
## Summary
- Icon container: switch to white background with the favicon inset (`h-9 w-9` inside the 50×50 frame). Vendor logos that ship with their own dark backdrop (Claude's mark, etc.) now sit on a neutral surface with breathing room around them, instead of bleeding to the dark container edge.
- Tighten the gap between the client name ("Claude") and the "Registered June 2026" caption.
- Reassurance footer now links to **Settings → Agents** (`/dashboard/settings/agents`) — the actual revocation surface — instead of the stale "Connected Apps" copy and path.

en.json + nb.json copy updated to match.

## Test plan
- [ ] CI green
- [ ] Manual: load `/dashboard/oauth/consent?client_id=...` with a registered client whose favicon resolves; verify identity card has white-bg icon, image is smaller than the container, "Claude" and "Registered …" sit close, and the footer link points at `/dashboard/settings/agents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)