### PR TITLE
chore(release): bring analytics-tracker into the fixed group

### DIFF
--- a/.changeset/analytics-tracker-fixed-group.md
+++ b/.changeset/analytics-tracker-fixed-group.md
@@ -1,0 +1,8 @@
+---
+'@getmunin/analytics-tracker': patch
+---
+
+Tidy up the changesets configuration to cover every workspace package:
+
+- Add `@getmunin/analytics-tracker` to the `fixed` group so it bumps in lockstep with the rest of the publishable `@getmunin/*` suite. The package was introduced at `4.33.0` and never re-versioned, leaving downstream consumers unable to pin `^4.x` against the same range as `@getmunin/backend-core`. `apps/analytics-tracker/package.json` is manually aligned to `4.40.1` so this release moves the group together.
+- Add `@getmunin/widget-voice` to the `ignore` list. It's `private: true` and already excluded from publishing, but every other private package in the workspace is explicitly ignored — adding it here keeps the config consistent and prevents accidental version-bump noise.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,11 +2,11 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core", "@getmunin/agent-runtime", "@getmunin/agent-host", "@getmunin/docs-pages", "@getmunin/chat-widget", "@getmunin/emails"]],
+  "fixed": [["@getmunin/core", "@getmunin/db", "@getmunin/types", "@getmunin/sdk", "@getmunin/mcp-toolkit", "@getmunin/ui", "@getmunin/dashboard-pages", "@getmunin/backend-core", "@getmunin/agent-runtime", "@getmunin/agent-host", "@getmunin/docs-pages", "@getmunin/chat-widget", "@getmunin/analytics-tracker", "@getmunin/emails"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@getmunin/backend", "@getmunin/web", "@getmunin/eslint-config", "@getmunin/tsconfig"]
+  "ignore": ["@getmunin/backend", "@getmunin/web", "@getmunin/widget-voice", "@getmunin/eslint-config", "@getmunin/tsconfig"]
 }
 

--- a/apps/analytics-tracker/package.json
+++ b/apps/analytics-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmunin/analytics-tracker",
-  "version": "4.33.0",
+  "version": "4.40.1",
   "license": "MIT",
   "description": "Drop-in browser analytics tracker for self-hosted Munin. Built as a single content-hashed IIFE bundle and served by the Munin backend.",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Add `@getmunin/analytics-tracker` to the changesets `fixed` group so it bumps in lockstep with the rest of the publishable `@getmunin/*` suite — it was introduced at `4.33.0` (PR #360) and never re-versioned, so downstream consumers can't pin `^4.x` the way they can for `@getmunin/backend-core`.
- Manually align `apps/analytics-tracker/package.json` from `4.33.0` → `4.40.1` (current group baseline) so the next release moves the full group together. `pnpm changeset status` confirms the included patch changeset bumps every fixed-group member together.
- Add `@getmunin/widget-voice` to the `ignore` list for consistency with the other private workspace packages (`backend`, `web`, `eslint-config`, `tsconfig`). It's already `private: true` so this is belt-and-braces, but keeps the config self-describing.

After this lands and the next changesets release PR (likely `4.40.2`) merges, downstream consumers — e.g. `munin-cloud`'s `backend-cloud` — can finally use `"@getmunin/analytics-tracker": "^4.40.1"` instead of the version-skewed `4.33.0` exact pin.

## Test plan
- [x] `pnpm changeset status` shows analytics-tracker bundled with the rest of the fixed group at patch
- [ ] CI green (lint, typecheck, tests)
- [ ] After merge, the auto-generated `chore: release` PR bumps `apps/analytics-tracker/package.json` to the same version as the rest of the group
- [ ] Once the release publishes, `pnpm info @getmunin/analytics-tracker versions` returns the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)