### PR TITLE
fix(analytics): coerce aggregate timestamp to Date in tool serialization

### DIFF
--- a/.changeset/analytics-tool-date-coercion.md
+++ b/.changeset/analytics-tool-date-coercion.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Fix `analytics_subject_engagement` and `analytics_zero_result_searches` crashing with `r.last_view_at.toISOString is not a function` (and the analogous `last_seen_at` error) when the query returns any row.
+
+Both tools use raw SQL via `ctx.db.execute(sql\`…\`)` to compute aggregate timestamps (`MAX(created_at)`). That path bypasses Drizzle's column type-mapping, so postgres-js returns the value as an ISO string rather than a `Date`. The tools then called `.toISOString()` on the string and threw. `analytics_subject_engagement` was unusable on real data; `analytics_zero_result_searches` was latent (only happened when at least one zero-result search had been recorded).
+
+Fix is two-line per tool: coerce with `new Date(...)` before serialising. The widened TS type (`Date | string`) reflects what the driver actually returns. Integration test covers the read-side path now so this doesn't regress.

--- a/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
+++ b/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
@@ -145,6 +145,29 @@ const skipReason = TEST_URL
     expect(beaconRow[0]?.subjectType).toBe('page');
     expect(beaconRow[0]?.metadata).toMatchObject({ variant: 'b' });
 
+    // Exercise the read-side tools too. They use raw `db.execute(sql\`…\`)`
+    // which returns aggregate timestamp columns as strings, not Date — a
+    // previous version of these tools crashed with
+    // `r.last_view_at.toISOString is not a function` on real data.
+    const engagement = await withClient(adminKey, async (c) =>
+      parseToolResult<{
+        views: number;
+        visitors: number;
+        avgDwellMs: number | null;
+        avgReadDepth: number | null;
+        lastViewAt: string | null;
+      }>(
+        await c.callTool({
+          name: 'analytics_subject_engagement',
+          arguments: { subjectType: 'page', subjectId: 'pricing', sinceDays: 1 },
+        }),
+      ),
+    );
+    expect(engagement.views).toBeGreaterThan(0);
+    expect(engagement.avgDwellMs).toBe(8000);
+    expect(engagement.avgReadDepth).toBe(60);
+    expect(engagement.lastViewAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
     const badKey = 'mn_track_invalid_xxx';
     const beforeBad = await countTrackerEvents(db, orgId);
     const bad = await fetch(`${baseUrl}/v1/a/t/${badKey}.gif?s=pricing`);

--- a/packages/backend-core/src/modules/analytics/analytics.tools.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.tools.ts
@@ -272,7 +272,10 @@ export class AnalyticsAdminTools {
       visitors: number;
       avg_dwell_ms: number | null;
       avg_read_depth: number | null;
-      last_view_at: Date | null;
+      // postgres-js returns aggregate timestamp columns as ISO strings when
+      // reached via raw `db.execute(sql\`…\`)`. Coerce via `new Date(...)`
+      // below — it accepts both strings and Date objects.
+      last_view_at: Date | string | null;
     }>(sql`
       SELECT COUNT(*)::int AS views,
              COUNT(DISTINCT visitor_id)::int AS visitors,
@@ -291,7 +294,7 @@ export class AnalyticsAdminTools {
       visitors: r.visitors,
       avgDwellMs: r.avg_dwell_ms !== null ? Math.round(Number(r.avg_dwell_ms)) : null,
       avgReadDepth: r.avg_read_depth !== null ? Math.round(Number(r.avg_read_depth)) : null,
-      lastViewAt: r.last_view_at ? r.last_view_at.toISOString() : null,
+      lastViewAt: r.last_view_at ? new Date(r.last_view_at).toISOString() : null,
     };
   }
 
@@ -327,7 +330,9 @@ export class AnalyticsAdminTools {
     const rows = await ctx.db.execute<{
       query: string;
       occurrences: number;
-      last_seen_at: Date;
+      // See `analytics_subject_engagement` — raw `db.execute` returns
+      // aggregate timestamp columns as ISO strings; coerce below.
+      last_seen_at: Date | string;
     }>(sql`
       SELECT query,
              COUNT(*)::int AS occurrences,
@@ -341,7 +346,7 @@ export class AnalyticsAdminTools {
     return rows.map((r) => ({
       query: r.query,
       occurrences: r.occurrences,
-      lastSeenAt: r.last_seen_at.toISOString(),
+      lastSeenAt: new Date(r.last_seen_at).toISOString(),
     }));
   }
 


### PR DESCRIPTION
## Summary
\`analytics_subject_engagement\` crashes with \`r.last_view_at.toISOString is not a function\` on any non-empty result. \`analytics_zero_result_searches\` has the same latent bug on \`r.last_seen_at\` — it just hasn't tripped yet because no zero-result searches have been recorded.

Both tools use raw SQL via \`ctx.db.execute(sql\`…\`)\` to compute \`MAX(created_at)\`. That path bypasses Drizzle's column type-mapping, so postgres-js returns the value as an ISO string rather than a \`Date\`. The tools then called \`.toISOString()\` on the string and threw.

Fix is two-line per tool: coerce with \`new Date(...)\` before serialising (works whether the value is already a Date or an ISO string). Widened the TS type (\`Date | string\`) so the next reader doesn't write the same code again.

Integration test now exercises the read-side path via \`analytics_subject_engagement\` right after the beacon ingest, so this regression is caught.

## Test plan
- [x] \`pnpm -F @getmunin/backend-core typecheck\`
- [ ] CI: \`analytics-tracker.integration.test.ts\` — new assertions on \`engagement.views\`, \`avgDwellMs\`, \`avgReadDepth\`, \`lastViewAt\` matching ISO format

🤖 Generated with [Claude Code](https://claude.com/claude-code)