### PR TITLE
fix(analytics): accept JSON null in tracker beacon optional fields

### DIFF
--- a/.changeset/beacon-schema-accept-null.md
+++ b/.changeset/beacon-schema-accept-null.md
@@ -1,0 +1,15 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Fix tracker beacons being silently dropped when the payload contains JSON `null` for optional fields.
+
+The `BeaconBodySchema` in `analytics-tracker.controller.ts` declared every optional field as `z.string().optional()` (or the numeric equivalent), which Zod treats as `string | undefined` — JSON `null` fails validation. The controller then `return`s on `safeParse → !success` without logging, so the event is silently dropped.
+
+The deployed `@getmunin/analytics-tracker` bundle sends `null` (not `undefined`) for at least:
+- `referrer` — on direct navigation (`document.referrer === ''` → bundle normalizes to `null`)
+- `visitorId` — when `localStorage` throws or returns `null` (private windows, embedded WebViews, locked-down enterprise browsers)
+
+So real traffic from refreshes, bookmarks, direct URL bar entries, and a chunk of mobile/private-mode visits has been disappearing since the schema was tightened in #362.
+
+Fix: make every optional field `.nullable().optional()`. The downstream `recordView` already accepts `null | undefined` interchangeably (uses `??`), so no service-side changes needed. Integration test now sends an all-null payload and asserts the row lands.

--- a/packages/backend-core/src/control/analytics-tracker.controller.ts
+++ b/packages/backend-core/src/control/analytics-tracker.controller.ts
@@ -33,12 +33,6 @@ const PixelQuerySchema = z.object({
   v: z.string().min(1).max(64).optional(),
 });
 
-// All optional fields are `.nullable()` because the deployed tracker
-// bundle sends JSON `null` (not `undefined`) for fields it doesn't have
-// — most commonly `referrer` on direct navigations and `visitorId` when
-// localStorage is unavailable (private windows, embedded WebViews). A
-// pure `.optional()` schema rejects `null`, which silently drops the
-// whole payload via `safeParse → !success → return` in the controller.
 const NullableString = (max: number) => z.string().max(max).nullable().optional();
 const NullableInt = (min: number, max: number) =>
   z.number().int().min(min).max(max).nullable().optional();

--- a/packages/backend-core/src/control/analytics-tracker.controller.ts
+++ b/packages/backend-core/src/control/analytics-tracker.controller.ts
@@ -33,24 +33,35 @@ const PixelQuerySchema = z.object({
   v: z.string().min(1).max(64).optional(),
 });
 
+// All optional fields are `.nullable()` because the deployed tracker
+// bundle sends JSON `null` (not `undefined`) for fields it doesn't have
+// — most commonly `referrer` on direct navigations and `visitorId` when
+// localStorage is unavailable (private windows, embedded WebViews). A
+// pure `.optional()` schema rejects `null`, which silently drops the
+// whole payload via `safeParse → !success → return` in the controller.
+const NullableString = (max: number) => z.string().max(max).nullable().optional();
+const NullableInt = (min: number, max: number) =>
+  z.number().int().min(min).max(max).nullable().optional();
+
 const BeaconBodySchema = z.object({
   key: z.string(),
-  subjectType: z.string().min(1).max(32).optional(),
+  subjectType: z.string().min(1).max(32).nullable().optional(),
   subjectId: z.string().min(1).max(512),
-  path: z.string().max(512).optional(),
-  referrer: z.string().max(512).optional(),
-  visitorId: z.string().max(64).optional(),
-  locale: z.string().max(16).optional(),
-  dwellMs: z.number().int().min(0).optional(),
-  readDepth: z.number().int().min(0).max(100).optional(),
+  path: NullableString(512),
+  referrer: NullableString(512),
+  visitorId: NullableString(64),
+  locale: NullableString(16),
+  dwellMs: z.number().int().min(0).nullable().optional(),
+  readDepth: NullableInt(0, 100),
   utm: z
     .object({
-      source: z.string().max(128).optional(),
-      medium: z.string().max(128).optional(),
-      campaign: z.string().max(128).optional(),
+      source: NullableString(128),
+      medium: NullableString(128),
+      campaign: NullableString(128),
     })
+    .nullable()
     .optional(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 
 interface ResolvedTracker {

--- a/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
+++ b/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
@@ -149,6 +149,33 @@ const skipReason = TEST_URL
     // config degrades gracefully (rather than crashing the ingest path).
     expect(beaconRow[0]?.country).toBeNull();
 
+    // The deployed tracker bundle sends JSON `null` (not `undefined`) for
+    // fields it doesn't have — most commonly `referrer` on a direct
+    // navigation and `visitorId` when localStorage is blocked. An
+    // overly-strict `.optional()` (without `.nullable()`) would silently
+    // drop these via safeParse failure, so a real chunk of traffic would
+    // never land. Cover that here.
+    const beforeNullPayload = await countTrackerEvents(db, orgId);
+    const nullPayload = await fetch(`${baseUrl}/v1/a/t`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain;charset=UTF-8' },
+      body: JSON.stringify({
+        key: minted.trackerKey,
+        subjectType: 'page',
+        subjectId: 'direct-nav',
+        path: '/direct-nav',
+        referrer: null,
+        visitorId: null,
+        locale: null,
+        dwellMs: null,
+        readDepth: null,
+        utm: null,
+        metadata: null,
+      }),
+    });
+    expect(nullPayload.status).toBe(204);
+    await waitFor(async () => (await countTrackerEvents(db, orgId)) > beforeNullPayload);
+
     // Exercise the read-side tools too. They use raw `db.execute(sql\`…\`)`
     // which returns aggregate timestamp columns as strings, not Date — a
     // previous version of these tools crashed with

--- a/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
+++ b/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
@@ -149,12 +149,6 @@ const skipReason = TEST_URL
     // config degrades gracefully (rather than crashing the ingest path).
     expect(beaconRow[0]?.country).toBeNull();
 
-    // The deployed tracker bundle sends JSON `null` (not `undefined`) for
-    // fields it doesn't have — most commonly `referrer` on a direct
-    // navigation and `visitorId` when localStorage is blocked. An
-    // overly-strict `.optional()` (without `.nullable()`) would silently
-    // drop these via safeParse failure, so a real chunk of traffic would
-    // never land. Cover that here.
     const beforeNullPayload = await countTrackerEvents(db, orgId);
     const nullPayload = await fetch(`${baseUrl}/v1/a/t`, {
       method: 'POST',

--- a/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
+++ b/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
@@ -94,11 +94,6 @@ const skipReason = TEST_URL
     });
     expect(minted.trackerKey).toMatch(/^mn_track_[A-Za-z0-9_-]+$/);
 
-    // The `/tracker.js` route is wired by bootstrap-app.ts (mirroring
-    // `/widget.js`) and reads `public/tracker/manifest.json`. In tests
-    // we don't run the prebuild copy, so it 503s — that's exercised by
-    // the bootstrap-app middleware unit tests instead.
-
     const beforePixel = await countTrackerEvents(db, orgId);
     const pixel = await fetch(
       `${baseUrl}/v1/a/t/${minted.trackerKey}.gif?s=pricing&t=page&v=visitor-1`,
@@ -114,8 +109,6 @@ const skipReason = TEST_URL
     expect(await countTrackerEvents(db, orgId)).toBe(beforePixel + 1);
 
     const beforeBeacon = await countTrackerEvents(db, orgId);
-    // Match the deployed tracker bundle: it uses `text/plain` so
-    // navigator.sendBeacon doesn't trigger a CORS preflight.
     const beacon = await fetch(`${baseUrl}/v1/a/t`, {
       method: 'POST',
       headers: { 'content-type': 'text/plain;charset=UTF-8' },
@@ -144,9 +137,6 @@ const skipReason = TEST_URL
     expect(beaconRow[0]?.utmSource).toBe('reddit');
     expect(beaconRow[0]?.subjectType).toBe('page');
     expect(beaconRow[0]?.metadata).toMatchObject({ variant: 'b' });
-    // No MUNIN_GEOIP_DB_PATH in the test env → GeoIpService no-ops and the
-    // column stays NULL. This proves the column exists and that missing
-    // config degrades gracefully (rather than crashing the ingest path).
     expect(beaconRow[0]?.country).toBeNull();
 
     const beforeNullPayload = await countTrackerEvents(db, orgId);
@@ -170,10 +160,6 @@ const skipReason = TEST_URL
     expect(nullPayload.status).toBe(204);
     await waitFor(async () => (await countTrackerEvents(db, orgId)) > beforeNullPayload);
 
-    // Exercise the read-side tools too. They use raw `db.execute(sql\`…\`)`
-    // which returns aggregate timestamp columns as strings, not Date — a
-    // previous version of these tools crashed with
-    // `r.last_view_at.toISOString is not a function` on real data.
     const engagement = await withClient(adminKey, async (c) =>
       parseToolResult<{
         views: number;


### PR DESCRIPTION
## Summary
Tracker beacons sending JSON `null` for optional fields are silently dropped — the controller returns `204` (because `@HttpCode(204)` applies to every code path, including the early-return on `safeParse → !success`), but no row lands in `analytics_view_events`.

This has been broken since #362 tightened the schema. The bundle sends `null` (not `undefined`) for at least:
- `referrer` — on direct navigation, refresh after a Referrer-Policy strip, etc.
- `visitorId` — when `localStorage` is unavailable (private windows, embedded WebViews, locked-down enterprise browsers)

So a meaningful slice of real traffic has been disappearing for weeks. Symptom report: `www.getmunin.com/en/` refresh produces a visible `POST /v1/a/t 204` in DevTools, but no row in `analytics_top_subjects`.

## Fix
Every optional field on `BeaconBodySchema` gets `.nullable()`. `recordView` already accepts `null | undefined` interchangeably (uses `??`), so no service-side changes.

Two small refactors: extracted `NullableString(max)` / `NullableInt(min, max)` helpers because the schema was already repetitive and got worse with the addition.

## Test plan
- [x] `pnpm -F @getmunin/backend-core typecheck`
- [ ] Integration test (added in this PR) sends an all-null payload and asserts the row count increases
- [ ] After deploy: refresh `www.getmunin.com/en/`, `analytics_top_subjects` count for `/en/` increments

## Follow-up not in this PR
The controller silently swallows validation failures (returns 204 with no log). Worth adding a `logger.warn('beacon.validation_failed', { error: parsed.error.message })` so this kind of bug is observable in backend logs next time. Keeping it out of this changeset to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)