### PR TITLE
chore(analytics): log warn on tracker ingest validation failures

### DIFF
--- a/.changeset/beacon-validation-observability.md
+++ b/.changeset/beacon-validation-observability.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+`AnalyticsTrackerController` now logs a `warn` line when a pixel query or beacon body fails Zod validation. Previously both ingest paths silently returned (pixel → 200 GIF, beacon → 204) on validation failure, which hid schema-vs-bundle mismatches: clients saw "success" while no row landed. The fix in #406 was discovered exactly this way — having backend logs surface these from the start would have caught it weeks earlier. Log messages are `pixel.validation_failed: <reason>` and `beacon.validation_failed: <reason>`.

--- a/packages/backend-core/src/control/analytics-tracker.controller.ts
+++ b/packages/backend-core/src/control/analytics-tracker.controller.ts
@@ -4,6 +4,7 @@ import {
   HttpCode,
   Headers,
   Inject,
+  Logger,
   Param,
   Post,
   Query,
@@ -62,6 +63,8 @@ interface ResolvedTracker {
 
 @PublicController('v1/a', { throttle: true })
 export class AnalyticsTrackerController {
+  private readonly logger = new Logger(AnalyticsTrackerController.name);
+
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
@@ -81,7 +84,12 @@ export class AnalyticsTrackerController {
     sendPixel(res);
     if (looksLikeBot(userAgent)) return;
     const parsed = PixelQuerySchema.safeParse(rawQuery);
-    if (!parsed.success) return;
+    if (!parsed.success) {
+      // Pixel always returns 200 (1x1 GIF) regardless of validity — log
+      // so a misconfigured embed doesn't disappear into the void.
+      this.logger.warn(`pixel.validation_failed: ${parsed.error.message}`);
+      return;
+    }
     const { s: subjectId, t: subjectType, v: visitorId } = parsed.data;
     const tracker = await this.resolveTrackerKey(key);
     if (!tracker) return;
@@ -110,7 +118,14 @@ export class AnalyticsTrackerController {
   ): Promise<void> {
     if (looksLikeBot(userAgent)) return;
     const parsed = BeaconBodySchema.safeParse(rawBody);
-    if (!parsed.success) return;
+    if (!parsed.success) {
+      // The route always returns 204 (per @HttpCode), so without this log
+      // a schema mismatch between the deployed bundle and the server is
+      // invisible — the client sees "success", no row lands. If you see
+      // this in logs, either fix the schema or the bundle.
+      this.logger.warn(`beacon.validation_failed: ${parsed.error.message}`);
+      return;
+    }
     const body = parsed.data;
     const tracker = await this.resolveTrackerKey(body.key);
     if (!tracker) return;

--- a/packages/backend-core/src/control/analytics-tracker.controller.ts
+++ b/packages/backend-core/src/control/analytics-tracker.controller.ts
@@ -85,8 +85,6 @@ export class AnalyticsTrackerController {
     if (looksLikeBot(userAgent)) return;
     const parsed = PixelQuerySchema.safeParse(rawQuery);
     if (!parsed.success) {
-      // Pixel always returns 200 (1x1 GIF) regardless of validity — log
-      // so a misconfigured embed doesn't disappear into the void.
       this.logger.warn(`pixel.validation_failed: ${parsed.error.message}`);
       return;
     }
@@ -119,10 +117,6 @@ export class AnalyticsTrackerController {
     if (looksLikeBot(userAgent)) return;
     const parsed = BeaconBodySchema.safeParse(rawBody);
     if (!parsed.success) {
-      // The route always returns 204 (per @HttpCode), so without this log
-      // a schema mismatch between the deployed bundle and the server is
-      // invisible — the client sees "success", no row lands. If you see
-      // this in logs, either fix the schema or the bundle.
       this.logger.warn(`beacon.validation_failed: ${parsed.error.message}`);
       return;
     }


### PR DESCRIPTION
## Summary
Follow-up to #406. Both tracker ingest paths (pixel + beacon) silently returned on Zod validation failure — pixel handed back the 1×1 GIF with status 200, beacon returned 204 via \`@HttpCode\`. Clients saw "success" while no row landed. That's exactly how #406 escaped detection for weeks.

Add a one-liner at each early-return:

  this.logger.warn(\`beacon.validation_failed: \${parsed.error.message}\`);
  this.logger.warn(\`pixel.validation_failed: \${parsed.error.message}\`);

Tracker endpoints stay quiet about the 200/204 HTTP status (no client-side error metric noise — the original ergonomic choice), but operators now have a server-side breadcrumb when the deployed bundle and the schema drift apart.

## Test plan
- [x] \`pnpm -F @getmunin/backend-core typecheck\`
- [ ] CI passes (no new tests needed — log lines are not a behavioral contract worth pinning).
- [ ] After deploy, intentionally POST an invalid body to \`/v1/a/t\` and confirm \`beacon.validation_failed: …\` in backend logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)