### PR TITLE
fix(agent-host): correct default OpenRouter base URL

### DIFF
--- a/.changeset/fix-openrouter-default-base-url.md
+++ b/.changeset/fix-openrouter-default-base-url.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/agent-host': patch
+'@getmunin/dashboard-pages': patch
+---
+
+Fix the default OpenRouter provider base URL — was `https://openrouter.ai/v1`, should be `https://openrouter.ai/api/v1`.
+
+`PerOrgConfigRepository` materialized new `agent_config` rows with the wrong host, so hitting `/models` returned OpenRouter's marketing HTML page and `AgentModelsService` choked when parsing it. Same typo in the dashboard's `PROVIDER_PRESETS` and in two `shouldEnablePromptCache` test fixtures.
+
+Existing rows already persisted with the wrong URL are backfilled by an idempotent `UPDATE` inside `AGENT_HOST_MULTI_TENANT_DDL` (multi-tenant only — the OSS singleton DDL defaults to Anthropic).

--- a/packages/agent-host/src/per-org-config.repository.ts
+++ b/packages/agent-host/src/per-org-config.repository.ts
@@ -9,7 +9,7 @@ import type {
 } from './config.repository.ts';
 
 const DEFAULT_FAST_MODEL = 'anthropic/claude-haiku-4.5';
-const DEFAULT_PROVIDER_BASE_URL = 'https://openrouter.ai/v1';
+const DEFAULT_PROVIDER_BASE_URL = 'https://openrouter.ai/api/v1';
 
 @Injectable()
 export class PerOrgConfigRepository implements AgentConfigRepository {

--- a/packages/agent-host/src/schema.ts
+++ b/packages/agent-host/src/schema.ts
@@ -97,6 +97,10 @@ export const AGENT_HOST_MULTI_TENANT_DDL = sql`
 
   ALTER TABLE agent_config ADD COLUMN IF NOT EXISTS smart_model text;
 
+  UPDATE agent_config
+    SET provider_base_url = 'https://openrouter.ai/api/v1'
+    WHERE provider_base_url = 'https://openrouter.ai/v1';
+
   DROP INDEX IF EXISTS agent_config_enabled_idx;
 
   ALTER TABLE agent_config DROP COLUMN IF EXISTS enabled;

--- a/packages/agent-runtime/src/providers/openai-compatible.test.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.test.ts
@@ -113,7 +113,7 @@ describe('shouldEnablePromptCache', () => {
   it('auto-enables for OpenRouter with anthropic/* model', () => {
     expect(
       shouldEnablePromptCache({
-        provider: { baseUrl: 'https://openrouter.ai/v1' },
+        provider: { baseUrl: 'https://openrouter.ai/api/v1' },
         model: 'anthropic/claude-haiku-4.5',
       }),
     ).toBe(true);
@@ -122,7 +122,7 @@ describe('shouldEnablePromptCache', () => {
   it('does not auto-enable for OpenRouter with non-anthropic model', () => {
     expect(
       shouldEnablePromptCache({
-        provider: { baseUrl: 'https://openrouter.ai/v1' },
+        provider: { baseUrl: 'https://openrouter.ai/api/v1' },
         model: 'openai/gpt-4o-mini',
       }),
     ).toBe(false);

--- a/packages/dashboard-pages/src/components/agent-config/types.ts
+++ b/packages/dashboard-pages/src/components/agent-config/types.ts
@@ -29,7 +29,7 @@ export interface UpsertBody {
 }
 
 export const PROVIDER_PRESETS = [
-  { id: 'openrouter', name: 'OpenRouter', url: 'https://openrouter.ai/v1' },
+  { id: 'openrouter', name: 'OpenRouter', url: 'https://openrouter.ai/api/v1' },
   { id: 'anthropic', name: 'Anthropic', url: 'https://api.anthropic.com/v1' },
   { id: 'openai', name: 'OpenAI', url: 'https://api.openai.com/v1' },
   { id: 'custom', name: 'Custom', url: '' },


### PR DESCRIPTION
## Summary

- `PerOrgConfigRepository` materialized new `agent_config` rows with `https://openrouter.ai/v1`, but OpenRouter's actual API is hosted at `https://openrouter.ai/api/v1`. Hitting `/v1/models` returns the marketing HTML page, which `AgentModelsService` then chokes on while parsing — manifesting as `OpenRouter non-JSON … <!DOCTYPE` errors.
- Fixes the same typo in the dashboard's `PROVIDER_PRESETS` and two `shouldEnablePromptCache` test fixtures in `@getmunin/agent-runtime` (the prompt-cache regex matched `openrouter.ai` either way, so the fixtures were lying but passing).
- Adds an idempotent `UPDATE` to `AGENT_HOST_MULTI_TENANT_DDL` that backfills any already-persisted row stuck on the wrong URL. The OSS singleton DDL defaults to Anthropic so it's unaffected.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm -F @getmunin/agent-runtime test` green (fixtures updated)
- [x] `pnpm -F @getmunin/agent-host test` green
- [ ] On next backend boot in multi-tenant mode, confirm rows previously stuck on `https://openrouter.ai/v1` flip to `https://openrouter.ai/api/v1` via the DDL backfill
- [ ] Confirm `AgentModelsService` returns the OpenRouter `/models` payload for a fresh org (no manual override needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)