### PR TITLE
fix(auth): land email verification on the web app, not the API host

### DIFF
--- a/.changeset/email-verification-callback-url.md
+++ b/.changeset/email-verification-callback-url.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Send the email verification callback to the web app's `/verify-email` page instead of leaving it relative to the API host (where it 404'd).

--- a/apps/backend/src/auth/auth.config.callback-url.test.ts
+++ b/apps/backend/src/auth/auth.config.callback-url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { ensureAbsoluteCallbackUrl } from './auth.config.ts';
+
+describe('ensureAbsoluteCallbackUrl', () => {
+  const verifyUrl = 'https://api.getmunin.com/auth/verify-email?token=abc&callbackURL=%2F';
+
+  it('rewrites a relative callbackURL against webBaseUrl', () => {
+    const result = ensureAbsoluteCallbackUrl(verifyUrl, 'https://app.getmunin.com');
+    const callback = new URL(result).searchParams.get('callbackURL');
+    expect(callback).toBe('https://app.getmunin.com/');
+  });
+
+  it('rewrites a relative path callbackURL against webBaseUrl', () => {
+    const url = 'https://api.getmunin.com/auth/verify-email?token=abc&callbackURL=%2Fdashboard';
+    const result = ensureAbsoluteCallbackUrl(url, 'https://app.getmunin.com');
+    const callback = new URL(result).searchParams.get('callbackURL');
+    expect(callback).toBe('https://app.getmunin.com/dashboard');
+  });
+
+  it('leaves an already-absolute callbackURL untouched', () => {
+    const absolute = 'https://app.getmunin.com/welcome';
+    const url = `https://api.getmunin.com/auth/verify-email?token=abc&callbackURL=${encodeURIComponent(absolute)}`;
+    const result = ensureAbsoluteCallbackUrl(url, 'https://app.getmunin.com');
+    expect(new URL(result).searchParams.get('callbackURL')).toBe(absolute);
+  });
+
+  it('returns the original url when webBaseUrl is missing', () => {
+    expect(ensureAbsoluteCallbackUrl(verifyUrl, undefined)).toBe(verifyUrl);
+  });
+
+  it('returns the original url when there is no callbackURL param', () => {
+    const url = 'https://api.getmunin.com/auth/verify-email?token=abc';
+    expect(ensureAbsoluteCallbackUrl(url, 'https://app.getmunin.com')).toBe(url);
+  });
+
+  it('returns the original url when input is not a valid URL', () => {
+    expect(ensureAbsoluteCallbackUrl('not a url', 'https://app.getmunin.com')).toBe('not a url');
+  });
+});

--- a/apps/backend/src/auth/auth.config.ts
+++ b/apps/backend/src/auth/auth.config.ts
@@ -55,7 +55,8 @@ export function createMuninAuth({
       : undefined,
     sendVerificationEmail: mailer
       ? async ({ user, url }) => {
-          const tpl = await renderVerifyEmail({ url });
+          const finalUrl = ensureAbsoluteCallbackUrl(url, webBaseUrl);
+          const tpl = await renderVerifyEmail({ url: finalUrl });
           await mailer.send({ to: user.email, subject: tpl.subject, text: tpl.text, html: tpl.html });
         }
       : undefined,
@@ -146,6 +147,20 @@ async function ensureSingletonOrgMembershipFor(
       .insert(schema.orgMembers)
       .values({ orgId: orgRow!.id, userId: user.id, role, isDefault: true });
   });
+}
+
+export function ensureAbsoluteCallbackUrl(verificationUrl: string, webBaseUrl?: string): string {
+  if (!webBaseUrl) return verificationUrl;
+  try {
+    const url = new URL(verificationUrl);
+    const callback = url.searchParams.get('callbackURL');
+    if (!callback) return verificationUrl;
+    if (/^https?:\/\//i.test(callback)) return verificationUrl;
+    url.searchParams.set('callbackURL', new URL(callback, webBaseUrl).toString());
+    return url.toString();
+  } catch {
+    return verificationUrl;
+  }
 }
 
 export function readAllowedEmailDomainsFromEnv(): string[] {

--- a/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
@@ -81,7 +81,12 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
     setSubmitting(true);
     setError(null);
     try {
-      const result = await authClient.signUp.email({ email, password, name });
+      const result = await authClient.signUp.email({
+        email,
+        password,
+        name,
+        callbackURL: absoluteCallbackUrl('/verify-email'),
+      });
       if (result.error) {
         setError(translateError(result.error) || t('failed'));
         setSubmitting(false);


### PR DESCRIPTION
## Summary
- Signup didn't pass a `callbackURL`, so BetterAuth defaulted to `/` and the post-verification redirect landed on `api.getmunin.com/` (no route → 404). Signup now targets the existing `/verify-email` page.
- Added a server-side backstop in `auth.config.ts` that rewrites any relative `callbackURL` in the verification email against `webBaseUrl`, so future entry points can't repeat the bug.

## Test plan
- [x] Unit tests for `ensureAbsoluteCallbackUrl` (6 passing).
- [ ] Sign up in prod with a fresh email, confirm the verification link lands on `app.getmunin.com/verify-email` (success state).
- [ ] Verify `MUNIN_WEB_URL` is set in the cloud backend env — the server-side rewrite no-ops without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)