### PR TITLE
feat(dashboard): OAuth-aware onboarding completion

### DIFF
--- a/.changeset/oauth-setup-continue.md
+++ b/.changeset/oauth-setup-continue.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Onboarding wizard: drop the "Customize chatbot" / "Tweak settings" buttons from the lift-off card; keep only "Go to dashboard" + "Back". When the user arrived through an OAuth authorize flow (e.g. signing up via an MCP client), preserve OAuth params through the signup → setup chain and replace "Go to dashboard" with a "Continue" button that lands on the OAuth consent page.

--- a/packages/dashboard-pages/src/auth/post-signin-redirect.ts
+++ b/packages/dashboard-pages/src/auth/post-signin-redirect.ts
@@ -16,3 +16,12 @@ export function resumeOauthAuthorizeUrl(params: URLSearchParams): string | null 
   if (!/^https?:\/\//.test(apiBase)) return null;
   return `${apiBase}/auth/oauth2/authorize?${params.toString()}`;
 }
+
+export function hasOauthAuthorizeParams(params: URLSearchParams): boolean {
+  return params.get('response_type') === 'code' && !!params.get('client_id');
+}
+
+export function oauthParamString(params: URLSearchParams): string {
+  if (!hasOauthAuthorizeParams(params)) return '';
+  return params.toString();
+}

--- a/packages/dashboard-pages/src/auth/use-dashboard-gate.ts
+++ b/packages/dashboard-pages/src/auth/use-dashboard-gate.ts
@@ -29,7 +29,8 @@ export function useDashboardGate(): { ready: boolean; role: OrgRole | null } {
     if (exempt) return;
     if (roleLoading || configLoading || membershipLoading) return;
     if (setupIncomplete && isOwnerOrAdmin(role)) {
-      router.push('/setup');
+      const search = typeof window !== 'undefined' ? window.location.search : '';
+      router.push(search ? `/setup${search}` : '/setup');
     }
   }, [
     isPending,

--- a/packages/dashboard-pages/src/auth/use-setup-gate.ts
+++ b/packages/dashboard-pages/src/auth/use-setup-gate.ts
@@ -1,13 +1,16 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useRouter } from '../i18n-navigation';
 import { authClient } from '../auth-client';
 import { useActiveMembership } from './use-active-role';
 import { useAgentConfigStatus } from './use-agent-config-status';
+import { hasOauthAuthorizeParams } from './post-signin-redirect';
 
 export function useSetupGate(): { ready: boolean } {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: session, isPending } = authClient.useSession();
   const { configured, loading: configLoading } = useAgentConfigStatus();
   const { membership, loading: membershipLoading } = useActiveMembership();
@@ -24,9 +27,13 @@ export function useSetupGate(): { ready: boolean } {
     }
     if (configLoading || membershipLoading) return;
     if (setupComplete) {
-      router.push('/dashboard');
+      if (searchParams && hasOauthAuthorizeParams(searchParams)) {
+        router.push(`/dashboard/oauth/consent?${searchParams.toString()}`);
+      } else {
+        router.push('/dashboard');
+      }
     }
-  }, [isPending, session, configLoading, membershipLoading, setupComplete, router]);
+  }, [isPending, session, configLoading, membershipLoading, setupComplete, router, searchParams]);
 
   const ready =
     !isPending &&

--- a/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
@@ -6,7 +6,12 @@ import { useTranslations } from 'next-intl';
 import { authClient } from '../../auth-client';
 import { Link, useRouter } from '../../i18n-navigation';
 import { useTranslateError } from '../../i18n/translate-error';
-import { absoluteCallbackUrl, safeRedirect, resumeOauthAuthorizeUrl } from '../../auth/post-signin-redirect';
+import {
+  absoluteCallbackUrl,
+  safeRedirect,
+  resumeOauthAuthorizeUrl,
+  hasOauthAuthorizeParams,
+} from '../../auth/post-signin-redirect';
 import {
   AuthShell,
   AuthHeading,
@@ -42,9 +47,11 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
   const params = useSearchParams();
   const redirectRaw = params.get('redirect');
   const redirectTo = safeRedirect(redirectRaw);
-  const signupHref = redirectRaw
-    ? `/signup?redirect=${encodeURIComponent(redirectRaw)}`
-    : '/signup';
+  const signupHref = hasOauthAuthorizeParams(params)
+    ? `/signup?${params.toString()}`
+    : redirectRaw
+      ? `/signup?redirect=${encodeURIComponent(redirectRaw)}`
+      : '/signup';
   const { refetch } = authClient.useSession();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
@@ -7,7 +7,11 @@ import { api, ApiError } from '../../api';
 import { authClient } from '../../auth-client';
 import { Link, useRouter } from '../../i18n-navigation';
 import { useTranslateError } from '../../i18n/translate-error';
-import { absoluteCallbackUrl, safeRedirect, resumeOauthAuthorizeUrl } from '../../auth/post-signin-redirect';
+import {
+  absoluteCallbackUrl,
+  safeRedirect,
+  hasOauthAuthorizeParams,
+} from '../../auth/post-signin-redirect';
 import {
   AuthShell,
   AuthHeading,
@@ -88,9 +92,8 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
         return;
       }
       await refetch();
-      const oauthResume = resumeOauthAuthorizeUrl(params);
-      if (oauthResume) {
-        window.location.assign(oauthResume);
+      if (hasOauthAuthorizeParams(params)) {
+        router.push(`/setup?${params.toString()}`);
         return;
       }
       router.push(redirectTo);
@@ -100,9 +103,11 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
     }
   }
 
-  const signInHref = redirectRaw
-    ? `/login?redirect=${encodeURIComponent(redirectRaw)}`
-    : '/login';
+  const signInHref = hasOauthAuthorizeParams(params)
+    ? `/login?${params.toString()}`
+    : redirectRaw
+      ? `/login?redirect=${encodeURIComponent(redirectRaw)}`
+      : '/login';
 
   return (
     <AuthShell

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1033,8 +1033,7 @@
       },
       "cta": {
         "goToDashboard": "Go to dashboard",
-        "customizeChatbot": "Customize chatbot",
-        "tweakSettings": "Tweak settings"
+        "continue": "Continue"
       }
     },
     "saved": "Saved.",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1033,8 +1033,7 @@
       },
       "cta": {
         "goToDashboard": "Gå til dashbord",
-        "customizeChatbot": "Tilpass chatbot",
-        "tweakSettings": "Endre innstillinger"
+        "continue": "Fortsett"
       }
     },
     "saved": "Lagret.",

--- a/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Link } from '../i18n-navigation';
 import { useTranslations } from 'next-intl';
 import { Button, Card, CardContent, Hero } from '@getmunin/ui';
@@ -10,6 +11,7 @@ import { OrgNameCard } from '../components/agent-config/org-name-card';
 import { ProviderCard } from '../components/agent-config/provider-card';
 import { ModelsCard } from '../components/agent-config/models-card';
 import { WebsiteImportCard } from '../components/agent-config/website-import-card';
+import { hasOauthAuthorizeParams } from '../auth/post-signin-redirect';
 import type { AgentConfigDto } from '../components/agent-config/types';
 import { api } from '../api';
 
@@ -150,6 +152,12 @@ interface ReadyCardProps {
 function ReadyCard({ config, importJobId, onBack }: ReadyCardProps) {
   const t = useTranslations('agentSetup');
   const tCommon = useTranslations('common');
+  const searchParams = useSearchParams();
+  const oauthContinueHref = useMemo(() => {
+    if (!searchParams) return null;
+    if (!hasOauthAuthorizeParams(searchParams)) return null;
+    return `/dashboard/oauth/consent?${searchParams.toString()}`;
+  }, [searchParams]);
 
   const lines: string[] = [
     t('wizard.checklist.provider', { url: shortHost(config.providerBaseUrl) }),
@@ -176,21 +184,15 @@ function ReadyCard({ config, importJobId, onBack }: ReadyCardProps) {
         </ul>
         {importJobId && <WebsiteImportStatus jobId={importJobId} />}
         <div className="flex flex-wrap items-center gap-3 pt-2">
-          <Button render={<Link href="/dashboard" />}>
-            {t('wizard.cta.goToDashboard')}
-          </Button>
-          <Button
-            variant="outline"
-            render={<Link href="/dashboard/settings/ai" />}
-          >
-            {t('wizard.cta.customizeChatbot')}
-          </Button>
-          <Button
-            variant="outline"
-            render={<Link href="/dashboard/settings/ai" />}
-          >
-            {t('wizard.cta.tweakSettings')}
-          </Button>
+          {oauthContinueHref ? (
+            <Button render={<Link href={oauthContinueHref} />}>
+              {t('wizard.cta.continue')}
+            </Button>
+          ) : (
+            <Button render={<Link href="/dashboard" />}>
+              {t('wizard.cta.goToDashboard')}
+            </Button>
+          )}
           <Button variant="ghost" onClick={onBack}>
             {tCommon('back')}
           </Button>


### PR DESCRIPTION
## Summary

- When a new user signs up via an OAuth authorize flow (e.g. an MCP client like Lovable), preserve OAuth params through the signup → setup chain so the lift-off card can offer a **Continue** button into the consent screen.
- Trim the lift-off card to a single primary action — drop "Customize chatbot" and "Tweak settings", keep "Go to dashboard" + "Back" (or "Continue" + "Back" in OAuth flows).

### What changed

- `auth/post-signin-redirect.ts` — new `hasOauthAuthorizeParams()` helper.
- `auth-shell/{login,signup}-form.tsx` — `signupHref`/`signInHref` now preserve OAuth params (`response_type`, `client_id`, …) when crossing between forms.
- `signup-form.tsx` — after signup with OAuth params, route to `/setup?<oauth>` (new users always need org setup before consent) instead of jumping straight to backend authorize.
- `use-dashboard-gate.ts` — when redirecting to `/setup`, preserve current `window.location.search`.
- `use-setup-gate.ts` — when setup is already complete and OAuth params are in the URL, push to `/dashboard/oauth/consent?<oauth>` instead of `/dashboard`.
- `agent-setup-wizard.tsx` `ReadyCard` — when `client_id`+`response_type=code` are in the URL, show **Continue** → `/dashboard/oauth/consent?<oauth>` instead of "Go to dashboard". Otherwise just "Go to dashboard" + "Back".

## Test plan

- [ ] Trigger MCP OAuth from a client (Lovable / mcp-inspector) against a fresh signup → onboarding completes → lift-off shows **Continue** → lands on consent page with correct client + scopes.
- [ ] Regular email signup (no OAuth params) → lift-off shows **Go to dashboard** + **Back** only.
- [ ] Existing user signs in with OAuth params → goes through backend authorize → consent as before (unchanged path).
- [ ] OAuth-flow user kicked from `/dashboard` while setup incomplete → arrives at `/setup` with params preserved.
- [ ] Norwegian locale renders **Fortsett**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)