### PR TITLE
chore(test): retry once on flaky vitest runs against shared infra

### DIFF
--- a/apps/backend/eslint.config.mjs
+++ b/apps/backend/eslint.config.mjs
@@ -3,6 +3,6 @@ import base from '@getmunin/eslint-config';
 export default [
   ...base,
   {
-    ignores: ['scripts/**/*.mjs', 'eslint.config.mjs'],
+    ignores: ['scripts/**/*.mjs', 'eslint.config.mjs', 'vitest.config.ts'],
   },
 ];

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -28,5 +28,6 @@ export default defineConfig({
   ],
   test: {
     fileParallelism: false,
+    retry: 1,
   },
 });

--- a/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
+++ b/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
@@ -450,7 +450,7 @@ async function countTrackerEvents(
   return r[0]?.n ?? 0;
 }
 
-async function waitFor(check: () => Promise<boolean>, timeoutMs = 8000): Promise<void> {
+async function waitFor(check: () => Promise<boolean>, timeoutMs = 15_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await check()) return;

--- a/packages/backend-core/vitest.config.ts
+++ b/packages/backend-core/vitest.config.ts
@@ -28,5 +28,6 @@ export default defineConfig({
   test: {
     fileParallelism: false,
     testTimeout: 30_000,
+    retry: 1,
   },
 });

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*", "drizzle.config.ts"],
+  "include": ["src/**/*", "drizzle.config.ts", "test-env.ts", "vitest.config.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
   test: {
     fileParallelism: false,
     testTimeout: 30_000,
+    retry: 1,
   },
 });


### PR DESCRIPTION
## Summary

CI on #414 hit a `waitFor` timeout in `analytics-tracker.integration.test.ts:273`. Root cause: the tracker pixel endpoint writes the HTTP response before the DB insert completes, and the test polls for the row to appear. Under CI load the 8s poll window lost the race.

This PR raises the floor against that whole class of flake:

- Enable `test.retry: 1` for vitest configs whose suites touch shared infra: `packages/backend-core`, `apps/backend`, `packages/db`. Unit-only configs (`apps/web`, `apps/chat-widget`, `packages/core`) keep `retry: 0` so real regressions there still fail loudly on the first run.
- Bump the analytics tracker test's own `waitFor` default from 8s → 15s so a single CI hiccup usually doesn't even need the retry.
- Drive-by: `packages/db/tsconfig.json` now includes `test-env.ts` + `vitest.config.ts` (matches `packages/backend-core`) so eslint can parse them. `apps/backend/eslint.config.mjs` ignores its root `vitest.config.ts` (its tsconfig rootDir is `./src` so the root-level file isn't in the project).

No changeset — test-infrastructure only, no API or behavior surface.

### Tradeoff

Retries can mask intermittent real bugs that pass on the second try. Vitest does report retried passes distinctly in the output, so they're greppable. With `retry: 1` and the timeout bump, most CI flake should resolve on the first run; a single retry is the safety net.

## Test plan

- [ ] CI passes on this PR.
- [ ] Trigger an artificial flake locally (e.g. set the waitFor timeout back to 100ms) and confirm vitest reports the retry rather than silently passing.
- [ ] Unit-only packages (`apps/web`, `packages/core`) still fail on first attempt for genuine errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)