### PR TITLE
fix(dashboard): wrap AgentSetupWizard ReadyCard in Suspense

### DIFF
--- a/.changeset/wizard-suspense.md
+++ b/.changeset/wizard-suspense.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Fix prerender failure in consumer apps that statically render `/setup`.
+
+`AgentSetupWizard`'s `ReadyCard` calls `useSearchParams()` to detect a resumed OAuth-authorize flow. In Next.js 16, that hook bails out of SSG and requires a `<Suspense>` boundary; without one, consumers that prerender the wizard page fail their build with `useSearchParams() should be wrapped in a suspense boundary`.
+
+The OSS test app (`apps/web`) hides this by setting `export const dynamic = 'force-dynamic'` in `[locale]/layout.tsx`, so it never exercises the SSG path. Consumer apps that don't opt out of static rendering hit the failure as soon as they upgrade to the version where `useSearchParams` was introduced.
+
+Wrap the `ReadyCard` instance in a `<Suspense fallback={null}>` so the wizard works regardless of the consumer's static/dynamic configuration.

--- a/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Link } from '../i18n-navigation';
 import { useTranslations } from 'next-intl';
@@ -136,7 +136,9 @@ export function AgentSetupWizard() {
         )}
 
         {step === 5 && (
-          <ReadyCard config={config} importJobId={importJobId} onBack={() => setStep(4)} />
+          <Suspense fallback={null}>
+            <ReadyCard config={config} importJobId={importJobId} onBack={() => setStep(4)} />
+          </Suspense>
         )}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- `ReadyCard` (the final step of `AgentSetupWizard`) calls `useSearchParams()` to detect a resumed OAuth-authorize flow. In Next.js 16 that hook bails out of SSG and requires a `<Suspense>` boundary; without one, consumer apps that statically prerender `/setup` fail their build with `useSearchParams() should be wrapped in a suspense boundary`.
- Wraps the `ReadyCard` instance in `<Suspense fallback={null}>` so the wizard works regardless of whether the consumer opts out of static rendering.
- Adds a patch changeset for `@getmunin/dashboard-pages`.

## Why this wasn't caught
`apps/web` (the OSS test app) sets `export const dynamic = 'force-dynamic'` in `[locale]/layout.tsx`, so none of its pages get statically prerendered and the missing Suspense never trips the build. Consumer apps that don't opt out (e.g. `munin-cloud/apps/web-cloud`) hit the failure immediately after upgrading to the version that introduced `useSearchParams` (4.43.0, via #416).

If we want OSS CI to catch this class of issue in the future, the simplest move is to drop the `force-dynamic` on `apps/web/[locale]/layout.tsx` — that would have surfaced this in the build step that runs on every PR. Left out of this PR; happy to do it as a follow-up.

## Test plan
- [x] `pnpm --filter '@getmunin/dashboard-pages...' typecheck` clean
- [ ] After release, re-bump `@getmunin/* → 4.43.x` in `munin-cloud` and confirm `next build` of `apps/web-cloud` prerenders `/en/setup` without the Suspense error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)