### PR TITLE
fix(dashboard): read window.location.search lazily in useSetupGate

### DIFF
--- a/.changeset/setup-gate-no-search-params-hook.md
+++ b/.changeset/setup-gate-no-search-params-hook.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Fix prerender failure on `/setup` (round 2).
+
+`useSetupGate` called `useSearchParams()` at the top level to detect a resumed OAuth-authorize flow. Even though consumers render the gate via a one-line `'use client'` page, that hook still triggers Next.js's SSG bailout — the wrapped `<Suspense>` around the wizard's `ReadyCard` (from 4.43.1) doesn't help because the gate runs before the wizard mounts.
+
+Since the params are only read inside a `useEffect` (for navigation side effects), there's no need to subscribe to a reactive hook. Read `window.location.search` lazily inside the effect instead, removing the SSG bailout from the gate entirely.

--- a/packages/dashboard-pages/src/auth/use-setup-gate.ts
+++ b/packages/dashboard-pages/src/auth/use-setup-gate.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { useRouter } from '../i18n-navigation';
 import { authClient } from '../auth-client';
 import { useActiveMembership } from './use-active-role';
@@ -10,7 +9,6 @@ import { hasOauthAuthorizeParams } from './post-signin-redirect';
 
 export function useSetupGate(): { ready: boolean } {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { data: session, isPending } = authClient.useSession();
   const { configured, loading: configLoading } = useAgentConfigStatus();
   const { membership, loading: membershipLoading } = useActiveMembership();
@@ -27,13 +25,14 @@ export function useSetupGate(): { ready: boolean } {
     }
     if (configLoading || membershipLoading) return;
     if (setupComplete) {
-      if (searchParams && hasOauthAuthorizeParams(searchParams)) {
-        router.push(`/dashboard/oauth/consent?${searchParams.toString()}`);
+      const params = new URLSearchParams(window.location.search);
+      if (hasOauthAuthorizeParams(params)) {
+        router.push(`/dashboard/oauth/consent?${params.toString()}`);
       } else {
         router.push('/dashboard');
       }
     }
-  }, [isPending, session, configLoading, membershipLoading, setupComplete, router, searchParams]);
+  }, [isPending, session, configLoading, membershipLoading, setupComplete, router]);
 
   const ready =
     !isPending &&


### PR DESCRIPTION
## Summary
Follow-up to #421. The wizard-side `<Suspense>` wrap from 4.43.1 only helps subtrees inside `AgentSetupWizard`. The `useSetupGate` hook is called by the consumer's `/setup` page **before** the wizard mounts — its own `useSearchParams()` still triggers Next.js's SSG bailout, so consumer builds that prerender `/setup` keep failing with the same error.

`useSetupGate` only needs the search params inside a `useEffect` (to decide between `/dashboard` and `/dashboard/oauth/consent?…` after setup completes). There's no reason to subscribe to the reactive hook — read `window.location.search` lazily inside the effect instead. That removes the SSG bailout from the gate entirely, with no behavior change.

## Why this wasn't caught (again)
Same reason as #421: `apps/web/[locale]/layout.tsx` opts out of static rendering with `force-dynamic`, so the OSS test app never exercises the SSG path that real consumers take. Tracked separately — would be worth removing that opt-out so OSS CI catches this class of regression.

## Test plan
- [x] `pnpm --filter '@getmunin/dashboard-pages...' typecheck` clean
- [ ] After release, re-bump `@getmunin/* → 4.43.2` in `munin-cloud` and confirm `next build` of `apps/web-cloud` prerenders `/en/setup` without the Suspense error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)