### PR TITLE
feat(analytics): rotate-key action for tracker keys

### DIFF
--- a/.changeset/tracker-rotate-key.md
+++ b/.changeset/tracker-rotate-key.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Add tracker key rotation for analytics trackers.
+
+Settings → Channels has long exposed a "Rotate key" action that revokes the active `mn_widget_*` key and mints a fresh one. Settings → Analytics trackers had no equivalent — only the identity-verification secret could be rotated, leaving operators stuck with `analytics_revoke_tracker` + `analytics_create_tracker` (which loses the tracker's name and config) if a `mn_track_*` key leaked.
+
+Adds the missing symmetric action:
+
+- New `analytics_rotate_tracker_key` MCP tool that revokes the tracker's active `mn_track_*` keys and mints a fresh one.
+- New `POST /v1/analytics/trackers/:id/rotate-key` endpoint.
+- Dashboard now shows "Rotate tracker key" above "Rotate identity secret" on each tracker row, with a one-time copy dialog matching the channels flow.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -150,6 +150,32 @@
     }
   },
   {
+    "name": "analytics_rotate_tracker_key",
+    "title": "Analytics: Rotate tracker key",
+    "description": "Revoke any active `mn_track_*` keys bound to this tracker and mint a fresh one. Returns the new plaintext key once; update any page that embeds the old key. Pages still embedding the old key will silently stop recording views once revocation lands.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "analytics:write"
+    ],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "trackerId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "trackerId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "analytics_top_subjects",
     "title": "Analytics: Top subjects by view count",
     "description": "List the most-viewed subjects (CMS entries, landing pages, etc.) over a recent window. Use this to see what content is actually getting traffic. Filter by `subjectType` to scope to one surface (e.g. `cms_entry`). Pass `endUserId` or `contactId` to restrict the ranking to one identified visitor — useful for \"what has this lead been reading?\".",

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -1556,6 +1556,37 @@
         ]
       }
     },
+    "/v1/analytics/trackers/{id}/rotate-key": {
+      "post": {
+        "operationId": "AnalyticsTrackersController_rotateKey",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AnalyticsTrackers"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/analytics/trackers/{id}/revoke": {
       "post": {
         "operationId": "AnalyticsTrackersController_revoke",

--- a/packages/backend-core/src/control/analytics-trackers.controller.ts
+++ b/packages/backend-core/src/control/analytics-trackers.controller.ts
@@ -63,6 +63,14 @@ export class AnalyticsTrackersController {
     return this.tools.rotateIdentitySecret({ trackerId: id });
   }
 
+  @Post(':id/rotate-key')
+  @HttpCode(200)
+  async rotateKey(
+    @Param('id') id: string,
+  ): Promise<Awaited<ReturnType<AnalyticsAdminTools['rotateTrackerKey']>>> {
+    return this.tools.rotateTrackerKey({ trackerId: id });
+  }
+
   @Post(':id/revoke')
   @HttpCode(200)
   async revoke(

--- a/packages/backend-core/src/modules/analytics/analytics.tools.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.tools.ts
@@ -32,6 +32,10 @@ const RotateIdentitySecretInput = z.object({
   trackerId: z.string(),
 });
 
+const RotateTrackerKeyInput = z.object({
+  trackerId: z.string(),
+});
+
 const ContactJourneyInput = z.object({
   contactId: z.string().optional(),
   endUserId: z.string().optional(),
@@ -59,6 +63,12 @@ interface CreateTrackerResult extends TrackerSummary {
 interface RotateIdentitySecretResult {
   trackerId: string;
   identityVerificationSecret: string;
+}
+
+interface RotateTrackerKeyResult {
+  trackerId: string;
+  trackerKey: string;
+  keyPrefix: string;
 }
 
 @Injectable()
@@ -258,6 +268,64 @@ export class AnalyticsAdminTools {
       .returning({ id: schema.analyticsTrackers.id });
     if (!updated) throw new NotFoundException(`tracker ${args.trackerId} not found`);
     return { trackerId: updated.id, identityVerificationSecret };
+  }
+
+  @McpTool({
+    name: 'analytics_rotate_tracker_key',
+    title: 'Analytics: Rotate tracker key',
+    description:
+      'Revoke any active `mn_track_*` keys bound to this tracker and mint a fresh one. Returns the new plaintext key once; update any page that embeds the old key. Pages still embedding the old key will silently stop recording views once revocation lands.',
+    audiences: ['admin'],
+    scopes: ['analytics:write'],
+    input: RotateTrackerKeyInput,
+    readOnlyHint: false,
+    destructiveHint: true,
+  })
+  async rotateTrackerKey(
+    args: z.infer<typeof RotateTrackerKeyInput>,
+  ): Promise<RotateTrackerKeyResult> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const tracker = await ctx.db
+      .select({ id: schema.analyticsTrackers.id, name: schema.analyticsTrackers.name })
+      .from(schema.analyticsTrackers)
+      .where(
+        and(
+          eq(schema.analyticsTrackers.id, args.trackerId),
+          eq(schema.analyticsTrackers.orgId, actor.orgId),
+        ),
+      )
+      .limit(1);
+    if (!tracker[0]) throw new NotFoundException(`tracker ${args.trackerId} not found`);
+
+    await ctx.db
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(
+          eq(schema.apiKeys.trackerId, args.trackerId),
+          eq(schema.apiKeys.orgId, actor.orgId),
+          eq(schema.apiKeys.type, 'track'),
+          isNull(schema.apiKeys.revokedAt),
+        ),
+      );
+
+    const rawKey = buildApiKey('track');
+    const [key] = await ctx.db
+      .insert(schema.apiKeys)
+      .values({
+        orgId: actor.orgId,
+        type: 'track',
+        name: tracker[0].name,
+        keyHash: hashSecret(rawKey),
+        keyPrefix: keyPrefix(rawKey),
+        scopes: ['analytics:track:write'],
+        audiences: ['public'],
+        trackerId: args.trackerId,
+        createdByUserId: actor.userId ?? null,
+      })
+      .returning();
+    return { trackerId: args.trackerId, trackerKey: rawKey, keyPrefix: key!.keyPrefix };
   }
 
   @McpTool({

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -686,6 +686,11 @@
       "keyLabelIdentitySecret": "Identity verification secret",
       "identitySecretHint": "Keep this on your server. Use it to compute data-user-hash for verified visitors. Never expose it in the browser.",
       "anyOrigin": "any origin",
+      "rotateKey": "Rotate tracker key",
+      "rotateKeyConfirmTitle": "Rotate tracker key?",
+      "rotateKeyConfirm": "Rotate the tracker key for {name}. The old mn_track_* key will be revoked; pages still embedding it will silently stop recording views.",
+      "rotatedKeyTitle": "Tracker key rotated — copy it now",
+      "rotatedKeyDescription": "New tracker key for {name}. Update every page that embeds the old key.",
       "rotateIdentity": "Rotate identity secret",
       "rotateIdentityConfirmTitle": "Rotate identity secret?",
       "rotateIdentityConfirm": "Rotate the identity secret for {name}. Previously-issued user hashes will stop verifying immediately.",
@@ -713,6 +718,7 @@
         "load": "Could not load trackers.",
         "create": "Could not create tracker.",
         "rotate": "Could not rotate identity secret.",
+        "rotateKey": "Could not rotate tracker key.",
         "revoke": "Could not revoke tracker."
       }
     },

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -686,6 +686,11 @@
       "keyLabelIdentitySecret": "Identitetshemmelighet",
       "identitySecretHint": "Hold denne på server-siden. Bruk den til å beregne data-user-hash for verifiserte besøkende. Aldri eksponer i nettleseren.",
       "anyOrigin": "alle opphav",
+      "rotateKey": "Roter sporenøkkel",
+      "rotateKeyConfirmTitle": "Roter sporenøkkel?",
+      "rotateKeyConfirm": "Roter sporenøkkelen for {name}. Den gamle mn_track_*-nøkkelen blir tilbakekalt; sider som fortsatt bruker den slutter å registrere visninger uten varsel.",
+      "rotatedKeyTitle": "Sporenøkkel rotert — kopier den nå",
+      "rotatedKeyDescription": "Ny sporenøkkel for {name}. Oppdater alle sider som bruker den gamle nøkkelen.",
       "rotateIdentity": "Roter identitetshemmelighet",
       "rotateIdentityConfirmTitle": "Roter identitetshemmelighet?",
       "rotateIdentityConfirm": "Roter identitetshemmeligheten for {name}. Tidligere utstedte hasher slutter å verifisere umiddelbart.",
@@ -713,6 +718,7 @@
         "load": "Kunne ikke laste sporere.",
         "create": "Kunne ikke opprette sporer.",
         "rotate": "Kunne ikke rotere identitetshemmelighet.",
+        "rotateKey": "Kunne ikke rotere sporenøkkel.",
         "revoke": "Kunne ikke tilbakekalle sporer."
       }
     },

--- a/packages/dashboard-pages/src/pages/trackers.tsx
+++ b/packages/dashboard-pages/src/pages/trackers.tsx
@@ -59,6 +59,12 @@ interface RotatedIdentity {
   identityVerificationSecret: string;
 }
 
+interface RotatedKey {
+  trackerId: string;
+  name: string;
+  trackerKey: string;
+}
+
 const KEY_DISPLAY_TIMEOUT_MS = 1500;
 
 function toSaveErrorDetail(
@@ -90,6 +96,7 @@ export function TrackersPage() {
   const [trackers, setTrackers] = useState<TrackerSummary[] | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [rotatedIdentity, setRotatedIdentity] = useState<RotatedIdentity | null>(null);
+  const [rotatedKey, setRotatedKey] = useState<RotatedKey | null>(null);
   const [embedFor, setEmbedFor] = useState<TrackerSummary | null>(null);
 
   const load = useCallback(async () => {
@@ -103,6 +110,31 @@ export function TrackersPage() {
   useEffect(() => {
     void tryLoad();
   }, [tryLoad]);
+
+  async function rotateKey(tracker: TrackerSummary) {
+    const ok = await confirm({
+      title: t('rotateKeyConfirmTitle'),
+      message: t('rotateKeyConfirm', { name: tracker.name }),
+      confirmLabel: t('rotateKey'),
+      cancelLabel: tCommon('cancel'),
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      const result = await api<{ trackerKey: string }>(
+        `/v1/analytics/trackers/${tracker.id}/rotate-key`,
+        { method: 'POST' },
+      );
+      setRotatedKey({
+        trackerId: tracker.id,
+        name: tracker.name,
+        trackerKey: result.trackerKey,
+      });
+      await tryLoad();
+    } catch (err) {
+      notify.error(translate(err) || t('errors.rotateKey'));
+    }
+  }
 
   async function rotateIdentity(tracker: TrackerSummary) {
     const ok = await confirm({
@@ -178,6 +210,10 @@ export function TrackersPage() {
         />
       )}
 
+      {rotatedKey && (
+        <RotatedKeyDialog rotated={rotatedKey} onClose={() => setRotatedKey(null)} />
+      )}
+
       {embedFor && (
         <EmbedSnippetDialog tracker={embedFor} onClose={() => setEmbedFor(null)} />
       )}
@@ -208,6 +244,9 @@ export function TrackersPage() {
                 key={tr.id}
                 tracker={tr}
                 onShowEmbed={() => setEmbedFor(tr)}
+                onRotateKey={() => {
+                  void rotateKey(tr);
+                }}
                 onRotateIdentity={() => {
                   void rotateIdentity(tr);
                 }}
@@ -226,11 +265,13 @@ export function TrackersPage() {
 function TrackerRow({
   tracker,
   onShowEmbed,
+  onRotateKey,
   onRotateIdentity,
   onRevoke,
 }: {
   tracker: TrackerSummary;
   onShowEmbed: () => void;
+  onRotateKey: () => void;
   onRotateIdentity: () => void;
   onRevoke: () => void;
 }) {
@@ -264,13 +305,16 @@ function TrackerRow({
                 <Button
                   variant="outline"
                   size="icon-sm"
-                  aria-label={t('rotateIdentity')}
+                  aria-label={t('rotateKey')}
                 />
               }
             >
               <MoreHorizontal className="size-3.5" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onRotateKey}>
+                {t('rotateKey')}
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={onRotateIdentity}>
                 {t('rotateIdentity')}
               </DropdownMenuItem>
@@ -496,6 +540,37 @@ function RotatedIdentityDialog({
             value={rotated.identityVerificationSecret}
             hint={t('identitySecretHint')}
           />
+        </div>
+        <DialogFooter className={dialogFooterClass}>
+          <Button variant="accent" className={dialogButtonClass} onClick={onClose}>
+            {tCommon('gotIt')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RotatedKeyDialog({
+  rotated,
+  onClose,
+}: {
+  rotated: RotatedKey;
+  onClose: () => void;
+}) {
+  const t = useTranslations('dashboard.trackers');
+  const tCommon = useTranslations('common');
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('rotatedKeyTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('rotatedKeyDescription', { name: rotated.name })}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-2">
+          <CopyableSecret label={t('keyLabelTracker')} value={rotated.trackerKey} />
         </div>
         <DialogFooter className={dialogFooterClass}>
           <Button variant="accent" className={dialogButtonClass} onClick={onClose}>


### PR DESCRIPTION
## Summary

- Adds `analytics_rotate_tracker_key` MCP tool + `POST /v1/analytics/trackers/:id/rotate-key` endpoint, mirroring the existing `conv_widget_rotate_key` flow: revokes any active `mn_track_*` keys bound to the tracker and mints a fresh one.
- Adds "Rotate tracker key" to the tracker row dropdown in Settings → Analytics trackers, with a one-time copy dialog that matches the channels UX. Settings → Channels has had this for widget keys; trackers only exposed identity-secret rotation.
- Regenerates `openapi.json` + `mcp-tools.json` fixtures so the new tool/endpoint show up in the public catalog.

## Test plan

- [ ] Dashboard → Settings → Analytics trackers: dropdown shows "Rotate tracker key" above "Rotate identity secret"; confirming opens a one-time dialog with the new `mn_track_*` value.
- [ ] Embed snippet on a test page continues to record views with the new key.
- [ ] Old key returns 401/silently-drops after rotation lands (per `api_keys.revokedAt`).
- [ ] `analytics_rotate_tracker_key` callable via MCP with `analytics:write` scope; fails for trackers in other orgs (RLS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)