### PR TITLE
fix(dashboard): route incomplete-setup users through onboarding before OAuth consent

### DIFF
--- a/.changeset/oauth-consent-setup-gate.md
+++ b/.changeset/oauth-consent-setup-gate.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/dashboard-pages': minor
+---
+
+Route incomplete-setup users through onboarding before the OAuth consent page.
+
+If an owner/admin with an unconfigured org (no provider API key, or empty org name) hit the OAuth authorize flow — e.g. adding the Munin MCP to an AI agent — they landed directly on `/dashboard/oauth/consent` and could grant access before completing onboarding. New accounts created during the OAuth flow already get routed through `/setup?<oauth_params>` from the signup form, then back to consent once `useSetupGate` clears; existing accounts with incomplete orgs skipped that step entirely because the consent page is exempted from `useDashboardGate`.
+
+Adds a server-side gate (`redirectIfSetupIncomplete`) used by `apps/web/app/[locale]/dashboard/oauth/consent/page.tsx`. The Server Component forwards the session cookie to `/v1/agent-config` and `/v1/me/memberships`, and when setup is incomplete for an owner/admin it `redirect()`s to `/setup?<oauth_params>` before any consent HTML is sent. Once setup completes, `useSetupGate` already routes back to `/dashboard/oauth/consent?<oauth_params>`, so the consent UI shows on the next pass.

--- a/apps/web/app/[locale]/dashboard/oauth/consent/page.tsx
+++ b/apps/web/app/[locale]/dashboard/oauth/consent/page.tsx
@@ -1,6 +1,8 @@
 import { OAuthConsentPage, type OAuthClientInfo } from '@getmunin/dashboard-pages';
+import { redirectIfSetupIncomplete } from '@getmunin/dashboard-pages/server';
 
 interface PageProps {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
@@ -21,9 +23,10 @@ async function fetchClientInfo(clientId: string): Promise<OAuthClientInfo | null
   }
 }
 
-export default async function Page({ searchParams }: PageProps) {
-  const params = await searchParams;
-  const raw = params.client_id;
+export default async function Page({ params, searchParams }: PageProps) {
+  const [{ locale }, sp] = await Promise.all([params, searchParams]);
+  await redirectIfSetupIncomplete({ locale, searchParams: sp });
+  const raw = sp.client_id;
   const clientId = Array.isArray(raw) ? raw[0] ?? '' : raw ?? '';
   const clientInfo = await fetchClientInfo(clientId);
   return <OAuthConsentPage clientInfo={clientInfo} />;

--- a/packages/dashboard-pages/src/auth/server-session.ts
+++ b/packages/dashboard-pages/src/auth/server-session.ts
@@ -5,6 +5,34 @@ import { safeRedirect } from './post-signin-redirect';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
+type OrgRole = 'owner' | 'admin' | 'member';
+
+interface MembershipDto {
+  orgId: string;
+  name: string;
+  slug: string;
+  role: string;
+  isDefault: boolean;
+}
+
+interface AgentConfigStatusDto {
+  providerApiKeySet: boolean;
+}
+
+async function fetchWithCookies<T>(path: string, cookieHeader: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${API_URL}${path}`, {
+      headers: { cookie: cookieHeader },
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn('[server-session] fetch failed', path, err);
+    return null;
+  }
+}
+
 export interface ServerSession {
   user: { id: string; email?: string | null } & Record<string, unknown>;
   session: { id: string } & Record<string, unknown>;
@@ -37,4 +65,48 @@ export async function redirectIfAuthenticated(opts: {
   if (!session) return;
   const raw = Array.isArray(opts.redirectParam) ? opts.redirectParam[0] : opts.redirectParam;
   redirect({ href: safeRedirect(raw ?? null), locale: opts.locale });
+}
+
+export async function redirectIfSetupIncomplete(opts: {
+  locale: string;
+  searchParams: Record<string, string | string[] | undefined>;
+}): Promise<void> {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+  if (!cookieHeader) return;
+
+  const [config, memberships] = await Promise.all([
+    fetchWithCookies<AgentConfigStatusDto>('/v1/agent-config', cookieHeader),
+    fetchWithCookies<MembershipDto[]>('/v1/me/memberships', cookieHeader),
+  ]);
+  if (!config || !memberships) return;
+
+  const active = memberships.find((m) => m.isDefault) ?? memberships[0] ?? null;
+  if (!active) return;
+  const role = isOrgRole(active.role) ? active.role : null;
+  if (role !== 'owner' && role !== 'admin') return;
+
+  const orgNamed = active.name.trim().length > 0;
+  const setupIncomplete = !config.providerApiKeySet || !orgNamed;
+  if (!setupIncomplete) return;
+
+  const query = serializeSearchParams(opts.searchParams);
+  redirect({ href: query ? `/setup?${query}` : '/setup', locale: opts.locale });
+}
+
+function serializeSearchParams(sp: Record<string, string | string[] | undefined>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(sp)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(key, item);
+    } else {
+      params.append(key, value);
+    }
+  }
+  return params.toString();
+}
+
+function isOrgRole(value: string): value is OrgRole {
+  return value === 'owner' || value === 'admin' || value === 'member';
 }

--- a/packages/dashboard-pages/src/server.ts
+++ b/packages/dashboard-pages/src/server.ts
@@ -1,5 +1,6 @@
 export {
   getServerSession,
   redirectIfAuthenticated,
+  redirectIfSetupIncomplete,
   type ServerSession,
 } from './auth/server-session';


### PR DESCRIPTION
## Summary

- Existing owner/admin users with an org that hadn't completed onboarding (no provider API key, or empty org name) could land directly on `/dashboard/oauth/consent` when adding the Munin MCP to an AI agent, and grant access before finishing setup. The consent page is exempt from `useDashboardGate`, and the consent component itself only gated on session.
- New accounts created during the OAuth flow already get routed through `/setup?<oauth_params>` from `signup-form`, then back to consent when `useSetupGate` clears. This change restores parity for the existing-account case.
- Adds a server-side `redirectIfSetupIncomplete` helper (forwards the session cookie to `/v1/agent-config` + `/v1/me/memberships`) called from the consent page's Server Component, so the redirect happens before any HTML hits the browser — no client-side spinner flash.

## Test plan

- [ ] Sign in as an owner of an org with no provider API key set, then visit `/dashboard/oauth/consent?response_type=code&client_id=…` directly: should be redirected to `/setup?response_type=code&client_id=…`.
- [ ] Complete onboarding from there → `useSetupGate` routes back to `/dashboard/oauth/consent?<params>` and the consent UI renders.
- [ ] Sign in as a member (non-owner/admin) of an org with incomplete setup: stays on consent (no setup redirect — members can't fix it anyway).
- [ ] Sign in as an owner of a fully-configured org: consent renders normally, no redirect.
- [ ] New-account OAuth flow (no account yet) still routes signup → /setup → consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)