### PR TITLE
Make Munin's frontend-integration playbook actually discoverable + close allowlist write-side gap

### DIFF
--- a/.changeset/allowlist-write-side-check.md
+++ b/.changeset/allowlist-write-side-check.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Refuse to mint or update widget channels and analytics trackers with an empty origin allowlist when the corresponding `MUNIN_*_REQUIRE_ALLOWLIST` env is on.
+
+Previously the env flag was only consulted at request time deep in `enforceOriginAllowlist`, so an admin (or agent) could mint a key with an empty allowlist, see the dashboard render it as "any origin", and only discover at the first browser request that every origin gets a 403. The dashboard's "any origin" pill was particularly misleading on backends with the flag on — it meant "blocks everything" but read as "permissive".
+
+`conv_widget_create_channel`, `conv_widget_update_channel`, `analytics_create_tracker`, and `analytics_update_tracker` now reject empty `originAllowlist` / `allowedOrigins` with `BadRequestException('origin_allowlist_required: …')` when the env flag is on. Update tools only check when the caller is actively changing the list (passing `undefined` to leave it as-is still works, so existing channels aren't retroactively broken — they're just blocked at the request edge as before until someone explicitly fixes them).

--- a/.changeset/featured-skills-playbooks.md
+++ b/.changeset/featured-skills-playbooks.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Pin playbooks to the top of the MCP "Frequently relevant" skills list, and point scaffolding tools at the frontend-integration playbook.
+
+Coding-agent platforms (Lovable, Bolt, v0, Replit, Cursor) routinely scaffold a frontend against Munin without reading `skill://playbooks/frontend-integration`, then re-discover the same gotchas (CMS CORS, embed paths, host probing). The skill exists and is registered, but two things hid it: (1) the MCP server-instructions `Frequently relevant` block picked the first 6 admin skills alphabetically by URI, which is all `analytics/*` and `cms/*` — playbooks sit at position 28+; (2) agents that skip `resources/list` and read only tool descriptions never see a pointer.
+
+- `mcp.skill-registry.service.ts` now pins all `skill://playbooks/*` first, then fills the remainder alphabetically, and bumps the cap from 6 to 8 so non-playbook skills still appear.
+- `conv_widget_create_channel`, `analytics_create_tracker`, and `cms_list_collections` descriptions now reference `skill://playbooks/frontend-integration` so agents that skip resource discovery still get nudged.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -24,7 +24,7 @@
   {
     "name": "analytics_create_tracker",
     "title": "Analytics: Create tracker key",
-    "description": "Create a tracker and mint a public `mn_track_*` API key bound to it. The key is safe to embed in `<script>` tags or mobile clients — it can only write page-view events scoped to your org, never read them. `allowedOrigins` is an optional list of full origins (`https://example.com`) the tracker will accept; when empty, any origin is accepted (set `MUNIN_TRACKER_REQUIRE_ALLOWLIST=1` to fail-closed instead). Returns the plaintext key once; store it where it needs to be embedded.",
+    "description": "Create a tracker and mint a public `mn_track_*` API key bound to it. The key is safe to embed in `<script>` tags or mobile clients — it can only write page-view events scoped to your org, never read them. `allowedOrigins` is an optional list of full origins (`https://example.com`) the tracker will accept; when empty, any origin is accepted (set `MUNIN_TRACKER_REQUIRE_ALLOWLIST=1` to fail-closed instead). Returns the plaintext key once; store it where it needs to be embedded. Scaffolding a frontend from Lovable/Bolt/v0/Replit/Cursor? Read `skill://playbooks/frontend-integration` first — it covers the tracker + widget + CMS wiring end-to-end.",
     "audiences": [
       "admin"
     ],
@@ -556,7 +556,7 @@
   {
     "name": "cms_list_collections",
     "title": "CMS: List collections",
-    "description": "List CMS collections (content types) defined for your org.",
+    "description": "List CMS collections (content types) defined for your org. Scaffolding a frontend from Lovable/Bolt/v0/Replit/Cursor and need to render CMS content? Read `skill://playbooks/frontend-integration` — the delivery API is anonymous and intentionally has no CORS, so the fetch must run server-side.",
     "audiences": [
       "admin"
     ],
@@ -2761,7 +2761,7 @@
   {
     "name": "conv_widget_create_channel",
     "title": "Conv: Create chat-widget channel",
-    "description": "Create a chat-widget channel and mint a widget API key (`mn_widget_*`) bound to it. Returns the plaintext key once; store it server-side and pass it as `Authorization: Bearer` when calling POST /v1/widget/messages from the external agent.",
+    "description": "Create a chat-widget channel and mint a widget API key (`mn_widget_*`) bound to it. Returns the plaintext key once; store it server-side and pass it as `Authorization: Bearer` when calling POST /v1/widget/messages from the external agent. Scaffolding a frontend from Lovable/Bolt/v0/Replit/Cursor? Read `skill://playbooks/frontend-integration` first — it covers the widget + tracker + CMS wiring end-to-end.",
     "audiences": [
       "admin"
     ],

--- a/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
+++ b/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
@@ -27,7 +27,9 @@ export class McpSkillRegistryService extends SkillRegistry implements OnModuleIn
 }
 
 function buildInstructions(adminSkills: ReadonlyArray<{ uri: string; name: string }>): string {
-  const featured = adminSkills.slice(0, 6);
+  const playbooks = adminSkills.filter((s) => s.uri.startsWith('skill://playbooks/'));
+  const rest = adminSkills.filter((s) => !s.uri.startsWith('skill://playbooks/'));
+  const featured = [...playbooks, ...rest].slice(0, 8);
   const lines = [
     'Munin: agent-native business apps. You have ~80 tools across these modules:',
     '  • Knowledge Base (kb_*)        — articles, search, versions',

--- a/packages/backend-core/src/modules/analytics/analytics.tools.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.tools.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
 import { schema } from '@getmunin/db';
@@ -10,6 +10,19 @@ import {
   keyPrefix,
   randomToken,
 } from '@getmunin/core';
+
+function requireTrackerAllowlist(): boolean {
+  const raw = process.env.MUNIN_TRACKER_REQUIRE_ALLOWLIST?.trim().toLowerCase();
+  return raw === '1' || raw === 'true';
+}
+
+function assertTrackerAllowlistPopulated(allowedOrigins: readonly string[]): void {
+  if (allowedOrigins.length === 0 && requireTrackerAllowlist()) {
+    throw new BadRequestException(
+      'allowed_origins_required: this deployment requires at least one entry in `allowedOrigins` (full origin like `https://app.example.com`). Add the production and any preview origins before saving.',
+    );
+  }
+}
 
 const CreateTrackerInput = z.object({
   name: z.string().min(1).max(120),
@@ -77,6 +90,7 @@ export class AnalyticsAdminTools {
   async createTracker(args: z.infer<typeof CreateTrackerInput>): Promise<CreateTrackerResult> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
+    assertTrackerAllowlistPopulated(args.allowedOrigins ?? []);
     const identityVerificationSecret = randomToken(32);
     const [tracker] = await ctx.db
       .insert(schema.analyticsTrackers)
@@ -191,7 +205,10 @@ export class AnalyticsAdminTools {
       updatedAt: new Date(),
     };
     if (args.name !== undefined) patch.name = args.name;
-    if (args.allowedOrigins !== undefined) patch.allowedOrigins = args.allowedOrigins;
+    if (args.allowedOrigins !== undefined) {
+      assertTrackerAllowlistPopulated(args.allowedOrigins);
+      patch.allowedOrigins = args.allowedOrigins;
+    }
     if (args.requireVerifiedIdentity !== undefined)
       patch.requireVerifiedIdentity = args.requireVerifiedIdentity;
     const [updated] = await ctx.db

--- a/packages/backend-core/src/modules/analytics/analytics.tools.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.tools.ts
@@ -67,7 +67,7 @@ export class AnalyticsAdminTools {
     name: 'analytics_create_tracker',
     title: 'Analytics: Create tracker key',
     description:
-      'Create a tracker and mint a public `mn_track_*` API key bound to it. The key is safe to embed in `<script>` tags or mobile clients — it can only write page-view events scoped to your org, never read them. `allowedOrigins` is an optional list of full origins (`https://example.com`) the tracker will accept; when empty, any origin is accepted (set `MUNIN_TRACKER_REQUIRE_ALLOWLIST=1` to fail-closed instead). Returns the plaintext key once; store it where it needs to be embedded.',
+      'Create a tracker and mint a public `mn_track_*` API key bound to it. The key is safe to embed in `<script>` tags or mobile clients — it can only write page-view events scoped to your org, never read them. `allowedOrigins` is an optional list of full origins (`https://example.com`) the tracker will accept; when empty, any origin is accepted (set `MUNIN_TRACKER_REQUIRE_ALLOWLIST=1` to fail-closed instead). Returns the plaintext key once; store it where it needs to be embedded. Scaffolding a frontend from Lovable/Bolt/v0/Replit/Cursor? Read `skill://playbooks/frontend-integration` first — it covers the tracker + widget + CMS wiring end-to-end.',
     audiences: ['admin'],
     scopes: ['analytics:write'],
     input: CreateTrackerInput,

--- a/packages/backend-core/src/modules/cms/cms.tools.ts
+++ b/packages/backend-core/src/modules/cms/cms.tools.ts
@@ -166,7 +166,8 @@ export class CmsAdminTools {
   @McpTool({
     name: 'cms_list_collections',
     title: 'CMS: List collections',
-    description: 'List CMS collections (content types) defined for your org.',
+    description:
+      'List CMS collections (content types) defined for your org. Scaffolding a frontend from Lovable/Bolt/v0/Replit/Cursor and need to render CMS content? Read `skill://playbooks/frontend-integration` — the delivery API is anonymous and intentionally has no CORS, so the fetch must run server-side.',
     audiences: ['admin'],
     scopes: ['cms:read'],
     input: EmptyInput,

--- a/packages/backend-core/src/modules/conv/widget/widget.tools.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.tools.ts
@@ -60,7 +60,7 @@ export class WidgetAdminTools {
     name: 'conv_widget_create_channel',
     title: 'Conv: Create chat-widget channel',
     description:
-      'Create a chat-widget channel and mint a widget API key (`mn_widget_*`) bound to it. Returns the plaintext key once; store it server-side and pass it as `Authorization: Bearer` when calling POST /v1/widget/messages from the external agent.',
+      'Create a chat-widget channel and mint a widget API key (`mn_widget_*`) bound to it. Returns the plaintext key once; store it server-side and pass it as `Authorization: Bearer` when calling POST /v1/widget/messages from the external agent. Scaffolding a frontend from Lovable/Bolt/v0/Replit/Cursor? Read `skill://playbooks/frontend-integration` first — it covers the widget + tracker + CMS wiring end-to-end.',
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: CreateInput,

--- a/packages/backend-core/src/modules/conv/widget/widget.tools.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.tools.ts
@@ -1,10 +1,23 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
 import { schema } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
 import { buildApiKey, getCurrentContext, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
 import { WidgetChannelConfig } from './widget.types.ts';
+
+function requireWidgetAllowlist(): boolean {
+  const raw = process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST?.trim().toLowerCase();
+  return raw === '1' || raw === 'true';
+}
+
+function assertAllowlistPopulated(originAllowlist: readonly string[]): void {
+  if (originAllowlist.length === 0 && requireWidgetAllowlist()) {
+    throw new BadRequestException(
+      'origin_allowlist_required: this deployment requires at least one entry in `originAllowlist` (full origin like `https://app.example.com`). Add the production and any preview origins before saving.',
+    );
+  }
+}
 
 const CreateInput = z.object({
   name: z.string().min(1).max(120),
@@ -70,6 +83,8 @@ export class WidgetAdminTools {
   async createChannel(args: z.infer<typeof CreateInput>): Promise<CreateResult> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
+
+    assertAllowlistPopulated(args.originAllowlist);
 
     const identityVerificationSecret = randomToken(32);
     const config = WidgetChannelConfig.parse({
@@ -142,6 +157,10 @@ export class WidgetAdminTools {
     const existing = rows[0];
     if (!existing) throw new NotFoundException(`channel ${args.channelId} not found`);
     const prev = WidgetChannelConfig.parse(existing.config);
+
+    if (args.originAllowlist !== undefined) {
+      assertAllowlistPopulated(args.originAllowlist);
+    }
 
     const next = WidgetChannelConfig.parse({
       provider: 'widget',


### PR DESCRIPTION
## Summary

Two related fixes that came out of watching Lovable's coding agent scaffold a SpaceX fan-club site against Munin and miss the `skill://playbooks/frontend-integration` skill that exists specifically for this:

- **Pin playbooks in the MCP "Frequently relevant" featured list.** Previously sliced the first 6 admin skills alphabetically — all `analytics/*` and `cms/*`, never any playbook. Now all `skill://playbooks/*` get pinned first; cap raised from 6 → 8 so non-playbook skills still appear. Also added a one-line pointer to `skill://playbooks/frontend-integration` in `conv_widget_create_channel`, `analytics_create_tracker`, and `cms_list_collections` descriptions for agents that skip `resources/list` entirely.
- **Refuse empty origin allowlists at write time when `MUNIN_*_REQUIRE_ALLOWLIST` is on.** Previously the env flag was only consulted at request time deep in `enforceOriginAllowlist`. An admin or agent could mint a key with an empty list, the dashboard would render "any origin", and the first browser request would 403 — after the embed snippet had already shipped. `conv_widget_create_channel`, `conv_widget_update_channel`, `analytics_create_tracker`, and `analytics_update_tracker` now reject empty lists with a clear `BadRequestException`. Update tools only check when the caller is actively changing the list, so existing channels aren't retroactively rejected for unrelated edits.

## Test plan

- [x] `pnpm -F @getmunin/backend-core typecheck`
- [x] `pnpm -F @getmunin/backend-core test` — 752 pass; existing `MUNIN_TRACKER_REQUIRE_ALLOWLIST=1` integration test still passes (creates tracker before flipping the env)
- [x] `pnpm -F @getmunin/backend-core docs:generate` — `mcp-tools.json` regenerated for the description changes
- [ ] Manual: spin up a fresh tenant via Lovable/Bolt/v0/Cursor and confirm the agent reads `skill://playbooks/frontend-integration` early
- [ ] Manual: with `MUNIN_WIDGET_REQUIRE_ALLOWLIST=1` set, confirm `conv_widget_create_channel` with an empty `originAllowlist` fails with `origin_allowlist_required` instead of minting a doomed key

🤖 Generated with [Claude Code](https://claude.com/claude-code)