### PR TITLE
feat(auth): per-environment session cookie prefix via MUNIN_AUTH_COOKIE_PREFIX

### DIFF
--- a/.changeset/spotty-cookies-differ.md
+++ b/.changeset/spotty-cookies-differ.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Add `MUNIN_AUTH_COOKIE_PREFIX` (and a `cookiePrefix` option on `createMuninAuthCore`) to namespace BetterAuth session cookies per environment. Set a distinct prefix on deployments that share a registrable domain (e.g. apex prod + dev subdomain) so the prod apex-domain cookie no longer shadows the dev session cookie under the same name and breaks sign-in. The auth guard, realtime gateway, and invitation-accept cookie parsers all derive their accepted cookie names from the same prefix.

--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,11 @@ MUNIN_ENCRYPTION_KEY=replace-me-with-strong-random-key
 # Comma-separated origins permitted to call /auth (CSRF/CORS). Defaults to
 # localhost:3000 for dev. Set this to your dashboard URL in production.
 MUNIN_AUTH_TRUSTED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+# Session cookie name prefix; defaults to better-auth's own ("better-auth").
+# Set a distinct value per environment when environments share a registrable
+# domain (e.g. getmunin.com prod + dev.getmunin.com dev) — otherwise the
+# prod apex-domain cookie shadows the dev one and sign-in breaks.
+# MUNIN_AUTH_COOKIE_PREFIX=munin-dev
 
 # --- Signup gating -----------------------------------------------------
 # Munin is single-tenant: the first user to sign up becomes the admin of

--- a/packages/backend-core/src/auth/auth-cookies.test.ts
+++ b/packages/backend-core/src/auth/auth-cookies.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { authCookiePrefix, sessionCookieNames } from './auth-cookies.ts';
+
+describe('auth cookie prefix', () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env.MUNIN_AUTH_COOKIE_PREFIX;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.MUNIN_AUTH_COOKIE_PREFIX;
+    else process.env.MUNIN_AUTH_COOKIE_PREFIX = original;
+  });
+
+  it('defaults to better-auth', () => {
+    delete process.env.MUNIN_AUTH_COOKIE_PREFIX;
+    expect(authCookiePrefix()).toBe('better-auth');
+    expect(sessionCookieNames()).toEqual([
+      'better-auth.session_token',
+      '__Secure-better-auth.session_token',
+    ]);
+  });
+
+  it('uses MUNIN_AUTH_COOKIE_PREFIX when set', () => {
+    process.env.MUNIN_AUTH_COOKIE_PREFIX = 'munin-dev';
+    expect(sessionCookieNames()).toEqual([
+      'munin-dev.session_token',
+      '__Secure-munin-dev.session_token',
+    ]);
+  });
+
+  it('falls back to the default for blank values', () => {
+    process.env.MUNIN_AUTH_COOKIE_PREFIX = '  ';
+    expect(authCookiePrefix()).toBe('better-auth');
+  });
+});

--- a/packages/backend-core/src/auth/auth-cookies.ts
+++ b/packages/backend-core/src/auth/auth-cookies.ts
@@ -1,0 +1,10 @@
+const DEFAULT_COOKIE_PREFIX = 'better-auth';
+
+export function authCookiePrefix(): string {
+  return process.env.MUNIN_AUTH_COOKIE_PREFIX?.trim() || DEFAULT_COOKIE_PREFIX;
+}
+
+export function sessionCookieNames(): string[] {
+  const prefix = authCookiePrefix();
+  return [`${prefix}.session_token`, `__Secure-${prefix}.session_token`];
+}

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -7,6 +7,7 @@ import {
   SUPPORTED_SCOPES as MUNIN_SUPPORTED_SCOPES,
   mcpResourceUrl,
 } from '../oauth/oauth.constants.ts';
+import { authCookiePrefix } from './auth-cookies.ts';
 
 type BetterAuthInstance = ReturnType<typeof betterAuth>;
 
@@ -57,6 +58,9 @@ export interface MuninAuthCoreOptions {
   };
 
   crossSubDomainCookies?: { domain: string };
+
+  /** Defaults to MUNIN_AUTH_COOKIE_PREFIX, falling back to better-auth's default. */
+  cookiePrefix?: string;
 
   rateLimit?: BetterAuthOptions['rateLimit'];
 
@@ -137,6 +141,7 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
     trustedOrigins: origins,
     advanced: {
       useSecureCookies: dashboardUrl.startsWith('https://'),
+      cookiePrefix: opts.cookiePrefix ?? authCookiePrefix(),
       ...(opts.crossSubDomainCookies
         ? {
             crossSubDomainCookies: {

--- a/packages/backend-core/src/common/auth/auth.guard.test.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.test.ts
@@ -70,6 +70,45 @@ describe('AuthGuard cookie fallback', () => {
   });
 });
 
+describe('AuthGuard cookie prefix (MUNIN_AUTH_COOKIE_PREFIX)', () => {
+  let originalPrefix: string | undefined;
+
+  beforeEach(() => {
+    originalPrefix = process.env.MUNIN_AUTH_COOKIE_PREFIX;
+    process.env.MUNIN_AUTH_COOKIE_PREFIX = 'munin-dev';
+  });
+  afterEach(() => {
+    if (originalPrefix === undefined) delete process.env.MUNIN_AUTH_COOKIE_PREFIX;
+    else process.env.MUNIN_AUTH_COOKIE_PREFIX = originalPrefix;
+  });
+
+  it('accepts the prefixed session cookie', async () => {
+    const resolveSessionToken = vi.fn().mockResolvedValue({ actor: { type: 'user' } });
+    const guard = makeGuard({ resolveSessionToken });
+    const ctx = makeContext({
+      headers: { cookie: '__Secure-munin-dev.session_token=raw.signature' },
+      url: '/v1/kb/spaces',
+      path: '/v1/kb/spaces',
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(resolveSessionToken).toHaveBeenCalledWith('raw');
+  });
+
+  it('ignores a default-named cookie from another environment', async () => {
+    const resolveSessionToken = vi.fn().mockResolvedValue({ actor: { type: 'user' } });
+    const guard = makeGuard({ resolveSessionToken });
+    const ctx = makeContext({
+      headers: {
+        cookie: `${SESSION_COOKIE}; __Secure-munin-dev.session_token=devraw.signature`,
+      },
+      url: '/v1/kb/spaces',
+      path: '/v1/kb/spaces',
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(resolveSessionToken).toHaveBeenCalledWith('devraw');
+  });
+});
+
 describe('AuthGuard audience binding', () => {
   let originalMcp: string | undefined;
 

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -16,6 +16,7 @@ import type { Db } from '@getmunin/db';
 import { DB } from '../db/db.module.ts';
 import { Reflector } from '@nestjs/core';
 import { mcpResourceUrl, resourceMetadataUrl } from '../../oauth/oauth.constants.ts';
+import { sessionCookieNames } from '../../auth/auth-cookies.ts';
 
 /**
  * Decorator used on routes that should be reachable without auth
@@ -168,15 +169,14 @@ function maybeSetMcpResourceMetadataHeader(
   );
 }
 
-const SESSION_COOKIE_NAMES = ['better-auth.session_token', '__Secure-better-auth.session_token'];
-
 function readSessionCookie(cookieHeader: string | undefined): string | null {
   if (!cookieHeader) return null;
+  const names = sessionCookieNames();
   for (const part of cookieHeader.split(';')) {
     const eq = part.indexOf('=');
     if (eq < 0) continue;
     const name = part.slice(0, eq).trim();
-    if (!SESSION_COOKIE_NAMES.includes(name)) continue;
+    if (!names.includes(name)) continue;
     const raw = decodeURIComponent(part.slice(eq + 1).trim());
     // BetterAuth signs session tokens as `<token>.<signature>`. Both halves
     // are stored in the cookie; we only need the token portion to look up

--- a/packages/backend-core/src/control/accept-invitation.controller.ts
+++ b/packages/backend-core/src/control/accept-invitation.controller.ts
@@ -16,6 +16,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { AllowAnonymous } from '../common/auth/auth.guard.ts';
+import { sessionCookieNames } from '../auth/auth-cookies.ts';
 import { z } from 'zod';
 import { CredentialResolver } from '@getmunin/core';
 import type { Db } from '@getmunin/db';
@@ -90,15 +91,14 @@ export class AcceptInvitationController {
   }
 }
 
-const SESSION_COOKIE_NAMES = ['better-auth.session_token', '__Secure-better-auth.session_token'];
-
 function readSessionCookie(cookieHeader: string | undefined): string | null {
   if (!cookieHeader) return null;
+  const names = sessionCookieNames();
   for (const part of cookieHeader.split(';')) {
     const eq = part.indexOf('=');
     if (eq < 0) continue;
     const name = part.slice(0, eq).trim();
-    if (!SESSION_COOKIE_NAMES.includes(name)) continue;
+    if (!names.includes(name)) continue;
     const raw = decodeURIComponent(part.slice(eq + 1).trim());
     const dot = raw.indexOf('.');
     return dot >= 0 ? raw.slice(0, dot) : raw;

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -52,6 +52,7 @@ export {
   type SignupBeforeUser,
   type DeleteUserConfig,
 } from './auth/auth-factory.ts';
+export { authCookiePrefix, sessionCookieNames } from './auth/auth-cookies.ts';
 
 export {
   AuthGuard,

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -28,6 +28,7 @@ import {
   ADDITIONAL_CREDENTIAL_RESOLVERS,
   type AdditionalCredentialResolver,
 } from '../common/auth/auth.guard.ts';
+import { sessionCookieNames } from '../auth/auth-cookies.ts';
 import { DbListenerService, type EventRow } from './db-listener.service.ts';
 import { RealtimeEventBus, type AgentTypingBusEvent } from './realtime-event-bus.ts';
 import {
@@ -781,11 +782,6 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   }
 }
 
-const SESSION_COOKIE_NAMES = [
-  'better-auth.session_token',
-  '__Secure-better-auth.session_token',
-];
-
 function readHeader(req: IncomingMessage, name: string): string | undefined {
   const headers = req.headers as Record<string, string | string[] | undefined>;
   const raw = headers[name];
@@ -815,11 +811,12 @@ export function readBearerSubprotocol(value: string | undefined): string | null 
 
 function readSessionCookie(cookieHeader: string | undefined): string | null {
   if (!cookieHeader) return null;
+  const names = sessionCookieNames();
   for (const part of cookieHeader.split(';')) {
     const eq = part.indexOf('=');
     if (eq < 0) continue;
     const name = part.slice(0, eq).trim();
-    if (!SESSION_COOKIE_NAMES.includes(name)) continue;
+    if (!names.includes(name)) continue;
     const raw = decodeURIComponent(part.slice(eq + 1).trim());
     const dot = raw.indexOf('.');
     return dot >= 0 ? raw.slice(0, dot) : raw;


### PR DESCRIPTION
## Problem

Cloud prod sets its BetterAuth session cookie on the apex domain (`.getmunin.com`), so browsers also send it to `dev.getmunin.com`. Both environments use the identical default cookie name (`__Secure-better-auth.session_token`), and with two same-named cookies in the header, whichever was created first wins — after a prod login, dev frequently reads the prod token, fails validation, and dev sign-in breaks.

## Fix

Namespace the session cookie per environment so the names never collide:

- New `authCookiePrefix()` / `sessionCookieNames()` helpers read `MUNIN_AUTH_COOKIE_PREFIX` (default `better-auth`, so existing deployments are unaffected).
- `createMuninAuthCore` passes the prefix to BetterAuth via `advanced.cookiePrefix`, with an explicit `cookiePrefix` option as override.
- The three places that parsed hardcoded cookie names (auth guard, realtime gateway, invitation accept) now derive them from the same helper, so cookie writes and reads can't drift.

## Rollout

Cloud follow-up (separate repo): set `MUNIN_AUTH_COOKIE_PREFIX=munin-dev` on the dev environment only, once this backend-core version is picked up. Prod stays on the default name, so prod sessions survive; dev users get logged out once when the cookie name changes.

## Testing

- New unit tests for the helper and for guard behavior with a custom prefix (including ignoring a default-named cookie from another environment).
- `pnpm typecheck` green across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)