### PR TITLE
fix(dashboard): surface server 4xx messages in SaveErrorStage

### DIFF
--- a/.changeset/clear-badger-flies.md
+++ b/.changeset/clear-badger-flies.md
@@ -4,4 +4,4 @@
 
 Surface the backend's 4xx error message in the dashboard's `SaveErrorStage` instead of always rendering the generic "couldn't reach the server" copy. The shared dialog was discarding `ApiError.message` even when the server returned an actionable validation error. `SaveErrorDetail` now carries an optional `message`, and the channel and tracker save flows populate it from the parsed server body for 4xx responses (5xx and network errors keep the original "try again" copy).
 
-Also stops the widget channel create form from POSTing with an empty origin allowlist when the deployment requires one. Set `NEXT_PUBLIC_MUNIN_WIDGET_REQUIRE_ALLOWLIST=1` on the dashboard to mirror the existing backend `MUNIN_WIDGET_REQUIRE_ALLOWLIST` and the form will show an inline "at least one origin required" error before submit.
+Also stops the widget channel create form from POSTing with an empty origin allowlist when the deployment requires one. Set `NEXT_PUBLIC_WIDGET_REQUIRE_ALLOWLIST=1` on the dashboard to mirror the existing backend `MUNIN_WIDGET_REQUIRE_ALLOWLIST` and the form will show an inline "at least one origin required" error before submit.

--- a/.changeset/clear-badger-flies.md
+++ b/.changeset/clear-badger-flies.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Surface the backend's 4xx error message in the dashboard's `SaveErrorStage` instead of always rendering the generic "couldn't reach the server" copy. The shared dialog was discarding `ApiError.message` even when the server returned an actionable validation error. `SaveErrorDetail` now carries an optional `message`, and the channel and tracker save flows populate it from the parsed server body for 4xx responses (5xx and network errors keep the original "try again" copy).
+
+Also stops the widget channel create form from POSTing with an empty origin allowlist when the deployment requires one. Set `NEXT_PUBLIC_MUNIN_WIDGET_REQUIRE_ALLOWLIST=1` on the dashboard to mirror the existing backend `MUNIN_WIDGET_REQUIRE_ALLOWLIST` and the form will show an inline "at least one origin required" error before submit.

--- a/packages/dashboard-pages/src/components/save-error-stage.tsx
+++ b/packages/dashboard-pages/src/components/save-error-stage.tsx
@@ -16,6 +16,7 @@ export interface SaveErrorDetail {
   method: string;
   status: string;
   requestId: string | null;
+  message?: string;
 }
 
 export interface SaveErrorStageProps {
@@ -47,7 +48,9 @@ export function SaveErrorStage({
       </DialogHeader>
 
       <div className="border-[0.5px] border-cobalt/40 dark:border-cobalt-soft/40 bg-paper-deep dark:bg-secondary p-5 space-y-4">
-        <p className="text-sm leading-relaxed text-ink dark:text-foreground">{t('body')}</p>
+        <p className="text-sm leading-relaxed text-ink dark:text-foreground">
+          {detail.message ?? t('body')}
+        </p>
         <hr className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark" aria-hidden />
         <dl className="grid grid-cols-[90px_1fr] gap-x-3 gap-y-2 font-mono text-[12px]">
           {detail.requestId && (

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -440,6 +440,7 @@
       "originsLabel": "Origin allowlist",
       "originsHint": "Comma- or whitespace-separated origins (full URLs with scheme + host) that may load the widget. Leave empty to allow any origin.",
       "originsInvalid": "Not a valid URL: {invalid}. Each origin must include the scheme + host, e.g. https://example.com.",
+      "originsRequired": "At least one origin is required. Add the production origin (and any preview origins) before saving — e.g. https://example.com.",
       "createWidget": "Create widget channel",
       "createdTitle": "Channel created — copy these secrets now",
       "createdDescription": "Two values for {name}. We store both server-side; the widget key is shown only once on creation, the identity secret only on creation and rotation.",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -440,6 +440,7 @@
       "originsLabel": "Liste over godkjente opprinnelser",
       "originsHint": "Komma- eller mellomroms-separert liste over opprinnelser (full URL med scheme + host) som kan laste widgeten. Tom for å tillate alle opprinnelser.",
       "originsInvalid": "Ikke en gyldig URL: {invalid}. Hver opprinnelse må inkludere scheme + vert, f.eks. https://example.com.",
+      "originsRequired": "Minst én opprinnelse er påkrevd. Legg til produksjons-opprinnelsen (og eventuelle preview-opprinnelser) før du lagrer — f.eks. https://example.com.",
       "createWidget": "Opprett widget-kanal",
       "createdTitle": "Kanal opprettet — kopier disse hemmelighetene nå",
       "createdDescription": "To verdier for {name}. Begge lagres server-side; widget-nøkkelen vises kun én gang ved opprettelse, identitets-hemmeligheten kun ved opprettelse og rotasjon.",

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -1055,7 +1055,7 @@ function zodIssuesToFieldErrors(
 }
 
 function widgetAllowlistRequired(): boolean {
-  const raw = process.env.NEXT_PUBLIC_MUNIN_WIDGET_REQUIRE_ALLOWLIST?.trim().toLowerCase();
+  const raw = process.env.NEXT_PUBLIC_WIDGET_REQUIRE_ALLOWLIST?.trim().toLowerCase();
   return raw === '1' || raw === 'true';
 }
 

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -889,6 +889,10 @@ function CreateWidgetDialog({
       .split(/[\s,]+/)
       .map((s) => s.trim())
       .filter(Boolean);
+    if (widgetAllowlistRequired() && allowlist.length === 0) {
+      setOriginsError(t('originsRequired'));
+      return;
+    }
     const parsed = CreateWidgetBody.safeParse({
       name: name.trim(),
       originAllowlist: allowlist,
@@ -1050,6 +1054,11 @@ function zodIssuesToFieldErrors(
   return errors;
 }
 
+function widgetAllowlistRequired(): boolean {
+  const raw = process.env.NEXT_PUBLIC_MUNIN_WIDGET_REQUIRE_ALLOWLIST?.trim().toLowerCase();
+  return raw === '1' || raw === 'true';
+}
+
 function toSaveErrorDetail(
   err: unknown,
   _message: string,
@@ -1061,6 +1070,7 @@ function toSaveErrorDetail(
       method: err.method,
       status: `${err.status} · ${err.statusText}`,
       requestId: err.requestId,
+      message: err.status >= 400 && err.status < 500 ? err.message : undefined,
     };
   }
   return {

--- a/packages/dashboard-pages/src/pages/trackers.tsx
+++ b/packages/dashboard-pages/src/pages/trackers.tsx
@@ -78,6 +78,7 @@ function toSaveErrorDetail(
       method: err.method,
       status: `${err.status} · ${err.statusText}`,
       requestId: err.requestId,
+      message: err.status >= 400 && err.status < 500 ? err.message : undefined,
     };
   }
   return {


### PR DESCRIPTION
## Summary

- `SaveErrorStage` was rendering the hardcoded "Munin couldn't reach the server" copy for every save failure — including 4xx responses with an actionable validation message (e.g. `origin_allowlist_required` from the cloud widget validator). `SaveErrorDetail` now carries an optional `message`; `toSaveErrorDetail` populates it from `ApiError.message` on 4xx for both the channel and tracker save flows, and the dialog renders it. 5xx and network errors keep the original "try again" copy.
- The widget channel create form also short-circuits with an inline `originsRequired` error when `NEXT_PUBLIC_WIDGET_REQUIRE_ALLOWLIST=1` is set on the dashboard and the allowlist is empty, mirroring the existing backend `MUNIN_WIDGET_REQUIRE_ALLOWLIST`. Self-hosted users are unaffected by default.

## Deploy note

Cloud needs `NEXT_PUBLIC_WIDGET_REQUIRE_ALLOWLIST=1` on `apps/web` to enable the client-side gate. Without it, the server still enforces — and now the dashboard surfaces the real error message inline instead of "couldn't reach the server".

## Test plan

- [ ] In a dev shell with `MUNIN_WIDGET_REQUIRE_ALLOWLIST=1` on the backend and `NEXT_PUBLIC_WIDGET_REQUIRE_ALLOWLIST=1` on the web, open *Channels → Add chat widget* with an empty origin allowlist and confirm the inline "at least one origin required" error blocks submit.
- [ ] Unset `NEXT_PUBLIC_WIDGET_REQUIRE_ALLOWLIST` on the web only and submit with empty allowlist; confirm the SaveErrorStage now shows the server's `origin_allowlist_required: …` message instead of the generic copy.
- [ ] Trigger an unrelated 5xx or kill the backend mid-submit; confirm the dialog still shows the original "Munin couldn't reach the server" body.
- [ ] Confirm tracker create with an invalid allowed-origins value still shows the existing inline error and that any 4xx from the tracker endpoint now surfaces the server message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)