### PR TITLE
Generic, registry-driven channel admin (replaces per-vendor voice/SMS tools)

### DIFF
--- a/.changeset/generic-channel-admin.md
+++ b/.changeset/generic-channel-admin.md
@@ -1,0 +1,10 @@
+---
+"@getmunin/backend-core": minor
+---
+
+Replace per-vendor voice/SMS channel admin MCP tools with a generic, registry-driven surface that scales as vendors are added.
+
+- New `ChannelAdminProvider` contract: each configurable voice/SMS vendor registers one provider (config schema + capabilities + configure/test/call/sendTest), dispatched by `ChannelAdminService`.
+- Generic MCP tools replace the per-vendor ones: `conv_list_channel_vendors` (discovery — lists each vendor's config fields), `conv_channel_configure`, `conv_channel_test`, `conv_voice_call`, `conv_channel_send_test`. Removed `conv_{vapi,threll}_configure/test_channel/call_initiate` and `conv_{twilio,messagebird}_sms_configure/test_channel/send_test` (and `conv_voice_call_initiate`).
+- Generic `/v1/conversations/channels` control-plane endpoints (`GET /vendors`, `POST /`, `POST /:id/{test,call,send-test}`); the existing per-vendor endpoints are retained for the dashboard.
+- Adding a voice/SMS vendor now means registering one provider — no new tools, endpoints, or types. Email and the chat widget keep their bespoke tools.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -2372,473 +2372,6 @@
     }
   },
   {
-    "name": "conv_messagebird_sms_configure",
-    "title": "Conv: Configure MessageBird SMS channel",
-    "description": "Create or update a MessageBird SMS channel. Pass `channelId` to update; omit to create. The plaintext `accessKey` and `signingKey` are encrypted before storage and returned redacted. On update, omit either secret to keep the existing one.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "description": "Pass an existing channel id to update; omit to create a new channel.",
-          "type": "string"
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        },
-        "accessKey": {
-          "description": "MessageBird live or test Access Key (used to authorize outbound SMS). Required on create. On update, omit to keep the existing value.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256
-        },
-        "signingKey": {
-          "description": "MessageBird signing key (used to verify the JWT on incoming webhooks). Required on create. On update, omit to keep the existing value.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256
-        },
-        "originator": {
-          "description": "Sender ID — either an E.164 number registered with your MessageBird account or an alphanumeric ≤ 11 chars. Required on create.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 32
-        }
-      },
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_messagebird_sms_test_channel",
-    "title": "Conv: Test MessageBird SMS channel credentials",
-    "description": "Verify a MessageBird channel's stored Access Key by fetching the account balance. Returns `{ ok: true, balance }` on success.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": null,
-    "readOnly": true,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "channelId"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_messagebird_sms_send_test",
-    "title": "Conv: Send a real test SMS via MessageBird",
-    "description": "Send a real SMS through this channel's MessageBird account. Useful for end-to-end deliverability checks.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "type": "string"
-        },
-        "to": {
-          "type": "string",
-          "minLength": 2,
-          "maxLength": 32,
-          "description": "E.164 destination number."
-        },
-        "body": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 1600
-        }
-      },
-      "required": [
-        "channelId",
-        "to"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_twilio_sms_configure",
-    "title": "Conv: Configure Twilio SMS channel",
-    "description": "Create or update a Twilio SMS channel. Pass `channelId` to update an existing channel; omit to create one. The plaintext `authToken` is encrypted before storage and is returned redacted. On update, omit `authToken` to keep the existing one. Either `fromNumber` (E.164) or `messagingServiceSid` is required.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "description": "Pass an existing channel id to update; omit to create a new channel.",
-          "type": "string"
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        },
-        "accountSid": {
-          "description": "Twilio Account SID — starts with \"AC\". Required on create.",
-          "type": "string",
-          "minLength": 2,
-          "maxLength": 64
-        },
-        "authToken": {
-          "description": "Twilio Auth Token (plaintext). Required on create. On update, omit to keep the existing token, or pass a new value to rotate.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256
-        },
-        "fromNumber": {
-          "description": "E.164-formatted Twilio number to send from. Either this or messagingServiceSid is required.",
-          "type": "string",
-          "minLength": 2,
-          "maxLength": 32
-        },
-        "messagingServiceSid": {
-          "description": "Twilio Messaging Service SID (starts with \"MG\"). Alternative to fromNumber.",
-          "type": "string",
-          "minLength": 2,
-          "maxLength": 64
-        }
-      },
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_twilio_sms_test_channel",
-    "title": "Conv: Test Twilio SMS channel credentials",
-    "description": "Verify a Twilio SMS channel's stored Account SID + Auth Token by fetching the account record from Twilio. Returns `{ ok: true, friendlyName, status }` on success.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": null,
-    "readOnly": true,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "channelId"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_twilio_sms_send_test",
-    "title": "Conv: Send a real test SMS",
-    "description": "Send a real SMS through this channel's Twilio account. The recipient must be a number Twilio is permitted to reach (verified caller ID on trial accounts). Useful for end-to-end deliverability checks.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "type": "string"
-        },
-        "to": {
-          "type": "string",
-          "minLength": 2,
-          "maxLength": 32,
-          "description": "E.164 destination number."
-        },
-        "body": {
-          "default": "Munin test message — outbound SMS is working.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 1600
-        }
-      },
-      "required": [
-        "channelId",
-        "to"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_vapi_configure",
-    "title": "Conv: Configure Vapi voice channel",
-    "description": "Create or update a Vapi voice channel. Pass `channelId` to update; omit to create. The plaintext `apiKey` and `webhookSecret` are encrypted before storage and returned redacted. The assistant + phone number must already exist in Vapi — paste their IDs here.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "description": "Pass an existing channel id to update; omit to create a new channel.",
-          "type": "string"
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        },
-        "apiKey": {
-          "description": "Vapi API key. Required on create. On update, omit to keep the existing value.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256
-        },
-        "webhookSecret": {
-          "description": "Shared secret used to authenticate inbound webhooks from Vapi. In the Vapi dashboard go to the assistant's Advanced → Webhook Server → HTTP Headers and add header `X-Webhook-Secret` with this value. Required on create.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256
-        },
-        "assistantId": {
-          "description": "Vapi assistant ID. Create the assistant in the Vapi dashboard or via their API, then paste its ID here.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 128
-        },
-        "phoneNumberId": {
-          "description": "Vapi phone number ID. Only required if you want to place or receive PSTN phone calls — leave blank for WebRTC/browser-only voice. Either import a Twilio number into Vapi or buy one from Vapi, then paste the ID here.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 128
-        },
-        "publicKey": {
-          "description": "Vapi public key — safe to expose to the browser. Required if you want the chat widget to start in-browser voice sessions; not needed for phone-only setups. Find it in the Vapi dashboard under your assistant.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256
-        }
-      },
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_vapi_test_channel",
-    "title": "Conv: Test Vapi voice channel credentials",
-    "description": "Verify a Vapi channel's stored API key and assistant by fetching the assistant from Vapi. Returns `{ ok: true, assistant }` on success.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": null,
-    "readOnly": true,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "channelId"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_voice_call_initiate",
-    "title": "Conv: Place an outbound voice call",
-    "description": "Initiate an outbound voice call through this channel. The Vapi assistant will run the conversation. Returns the Vapi call id and status.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "type": "string"
-        },
-        "to": {
-          "type": "string",
-          "maxLength": 32,
-          "pattern": "^\\+[1-9]\\d{4,18}$"
-        },
-        "customerName": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        }
-      },
-      "required": [
-        "channelId",
-        "to"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_threll_configure",
-    "title": "Conv: Configure Threll voice channel",
-    "description": "Create or update a Threll voice channel. Pass `channelId` to update; omit to create. The plaintext `apiKey` and `webhookSecret` are encrypted before storage and returned redacted. The worker must already exist in Threll — paste its account and worker IDs here.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "description": "Pass an existing channel id to update; omit to create a new channel.",
-          "type": "string"
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        },
-        "apiKey": {
-          "description": "Threll API key (Settings → Developer). Sent as the `x-api-key` header. Required on create.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256
-        },
-        "webhookSecret": {
-          "description": "Shared HMAC signing secret. Use the same value here and as the `signingSecret` of the Threll webhook subscription that points at this channel’s webhook URL. Munin verifies the `X-Threll-Signature` HMAC with it and reuses it to sign tool-call deliveries. Required on create.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256
-        },
-        "accountId": {
-          "description": "Threll account ID (shown alongside your API key). Required on create.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 128
-        },
-        "workerId": {
-          "description": "Threll worker ID that handles calls on this channel. Required on create.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 128
-        }
-      },
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_threll_test_channel",
-    "title": "Conv: Test Threll voice channel credentials",
-    "description": "Verify a Threll channel's stored API key and worker by fetching the worker from Threll. Returns `{ ok: true, worker }` on success.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": null,
-    "readOnly": true,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "channelId"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "conv_threll_call_initiate",
-    "title": "Conv: Place an outbound Threll voice call",
-    "description": "Initiate an outbound voice call through this Threll channel. The worker runs the conversation. Returns the Threll call id and status.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "channelId": {
-          "type": "string"
-        },
-        "to": {
-          "type": "string",
-          "maxLength": 32,
-          "pattern": "^\\+[1-9]\\d{4,18}$"
-        },
-        "customerName": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        }
-      },
-      "required": [
-        "channelId",
-        "to"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
     "name": "conv_request_phone_call_for_my_conversation",
     "title": "Conv: Place a phone call to the user in this conversation",
     "description": "Place an outbound phone call to the contact in this conversation. Use this only when the user has asked to be called — e.g. \"can you call me?\". The call goes to the phone number already on file for this conversation's contact; you cannot specify an arbitrary number. The org must have an active Vapi voice channel configured. After requesting the call, tell the user briefly that a call is on the way and stop replying — the rest of the conversation happens on the phone.",
@@ -2872,7 +2405,7 @@
   {
     "name": "conv_voice_call_contact",
     "title": "Conv: Place a voice call to this conversation's contact",
-    "description": "Place an outbound voice call to the contact attached to a conversation. Resolves the phone number from the conversation's contact. If your org has more than one active Vapi voice channel, pass `channelId` to pick one; with a single channel the call falls back to it. For arbitrary destinations, use `conv_voice_call_initiate` instead.",
+    "description": "Place an outbound voice call to the contact attached to a conversation. Resolves the phone number from the conversation's contact. If your org has more than one active voice channel, pass `channelId` to pick one; with a single channel the call falls back to it. For arbitrary destinations, use `conv_voice_call` instead.",
     "audiences": [
       "admin"
     ],
@@ -3039,6 +2572,173 @@
       },
       "required": [
         "channelId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "conv_list_channel_vendors",
+    "title": "Conv: List configurable channel vendors",
+    "description": "List the voice/SMS channel vendors you can configure, with each vendor’s `kind`, capabilities (call/sendTest), and config fields (name, required, secret, description). Use this to discover what to pass to conv_channel_configure.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "conv:read"
+    ],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "conv_channel_configure",
+    "title": "Conv: Configure a voice/SMS channel",
+    "description": "Create or update a voice or SMS channel for any supported vendor. Pass `vendor` + a vendor-specific `config` object (see conv_list_channel_vendors). Pass `channelId` to update; omit to create. Plaintext secrets in `config` are encrypted before storage and returned redacted.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "conv:write"
+    ],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40,
+          "description": "Channel vendor, e.g. \"vapi\", \"threll\", \"twilio\", \"messagebird\". Call conv_list_channel_vendors for the full list and each vendor’s config fields."
+        },
+        "channelId": {
+          "description": "Pass an existing channel id to update; omit to create a new channel.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Channel display name. Required on create.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "config": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {},
+          "description": "Vendor-specific configuration object. The exact fields (and which are secret) come from conv_list_channel_vendors. Plaintext secrets are encrypted before storage and returned redacted."
+        }
+      },
+      "required": [
+        "vendor",
+        "config"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "conv_channel_test",
+    "title": "Conv: Test a channel’s stored credentials",
+    "description": "Verify a channel’s stored credentials with its vendor (no message sent). The result shape is vendor-specific.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "conv:write"
+    ],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "channelId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "channelId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "conv_voice_call",
+    "title": "Conv: Place an outbound voice call",
+    "description": "Place an outbound voice call through a voice channel (any vendor). The channel’s configured assistant/worker runs the conversation.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "conv:write"
+    ],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "channelId": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string",
+          "maxLength": 32,
+          "pattern": "^\\+[1-9]\\d{4,18}$"
+        },
+        "customerName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        }
+      },
+      "required": [
+        "channelId",
+        "to"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "conv_channel_send_test",
+    "title": "Conv: Send a real test message",
+    "description": "Send a real test message (e.g. SMS) through a channel that supports it, addressed to `to`. Useful for end-to-end deliverability checks.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "conv:write"
+    ],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "channelId": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 64
+        },
+        "body": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1600
+        }
+      },
+      "required": [
+        "channelId",
+        "to"
       ],
       "additionalProperties": false
     }

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -1942,10 +1942,145 @@
         "security": []
       }
     },
+    "/v1/conversations/channels/vendors": {
+      "get": {
+        "operationId": "ConvChannelsController_listVendors",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ConvChannels"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/conversations/channels": {
+      "post": {
+        "operationId": "ConvChannelsController_configureChannel",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ConvChannels"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      },
       "get": {
         "operationId": "ConvChannelsController_list",
         "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ConvChannels"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/conversations/channels/{id}/test": {
+      "post": {
+        "operationId": "ConvChannelsController_testChannel",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ConvChannels"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/conversations/channels/{id}/call": {
+      "post": {
+        "operationId": "ConvChannelsController_callChannel",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ConvChannels"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/conversations/channels/{id}/send-test": {
+      "post": {
+        "operationId": "ConvChannelsController_sendTestChannel",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": ""

--- a/packages/backend-core/src/control/conv-channels.controller.ts
+++ b/packages/backend-core/src/control/conv-channels.controller.ts
@@ -24,6 +24,7 @@ import { TwilioSmsAdminTools } from '../modules/conv/twilio/twilio-sms.tools.ts'
 import { MessageBirdSmsAdminTools } from '../modules/conv/messagebird/messagebird-sms.tools.ts';
 import { VapiAdminTools } from '../modules/conv/vapi/vapi.tools.ts';
 import { ThrellAdminTools } from '../modules/conv/threll/threll.tools.ts';
+import { ChannelAdminService } from '../modules/conv/channels/channel-admin.service.ts';
 import {
   CreateWidgetBody,
   UpdateWidgetBody,
@@ -37,6 +38,9 @@ import {
   VapiCallInitiateBody,
   ConfigureThrellBody,
   ThrellCallInitiateBody,
+  ConfigureChannelBody,
+  ChannelVoiceCallBody,
+  ChannelSendTestBody,
 } from '@getmunin/types';
 
 interface ChannelListResponse {
@@ -56,7 +60,43 @@ export class ConvChannelsController {
     private readonly messageBirdSmsTools: MessageBirdSmsAdminTools,
     private readonly vapiTools: VapiAdminTools,
     private readonly threllTools: ThrellAdminTools,
+    private readonly channelAdmin: ChannelAdminService,
   ) {}
+
+  @Get('vendors')
+  listVendors(): ReturnType<ChannelAdminService['listVendors']> {
+    return this.channelAdmin.listVendors();
+  }
+
+  @Post()
+  @HttpCode(200)
+  async configureChannel(@Body() body: unknown): Promise<Awaited<ReturnType<ChannelAdminService['configure']>>> {
+    const parsed = ConfigureChannelBody.safeParse(body ?? {});
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return this.channelAdmin.configure(parsed.data);
+  }
+
+  @Post(':id/test')
+  @HttpCode(200)
+  async testChannel(@Param('id') id: string): Promise<unknown> {
+    return this.channelAdmin.test(id);
+  }
+
+  @Post(':id/call')
+  @HttpCode(200)
+  async callChannel(@Param('id') id: string, @Body() body: unknown): Promise<unknown> {
+    const parsed = ChannelVoiceCallBody.safeParse(body ?? {});
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return this.channelAdmin.call({ channelId: id, to: parsed.data.to, customerName: parsed.data.customerName });
+  }
+
+  @Post(':id/send-test')
+  @HttpCode(200)
+  async sendTestChannel(@Param('id') id: string, @Body() body: unknown): Promise<unknown> {
+    const parsed = ChannelSendTestBody.safeParse(body ?? {});
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return this.channelAdmin.sendTest({ channelId: id, to: parsed.data.to, body: parsed.data.body });
+  }
 
   @Get()
   async list(): Promise<ChannelListResponse> {

--- a/packages/backend-core/src/modules/conv/channels/channel-admin.service.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-admin.service.ts
@@ -1,0 +1,101 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import { getCurrentContext } from '@getmunin/core';
+import { schema } from '@getmunin/db';
+import {
+  CHANNEL_ADMIN_PROVIDERS,
+  type ChannelAdminDto,
+  type ChannelAdminProvider,
+} from './channel-admin.ts';
+
+@Injectable()
+export class ChannelAdminService {
+  private readonly byVendor = new Map<string, ChannelAdminProvider>();
+
+  constructor(@Inject(CHANNEL_ADMIN_PROVIDERS) providers: ChannelAdminProvider[]) {
+    for (const provider of providers) {
+      if (this.byVendor.has(provider.vendor)) {
+        throw new Error(`duplicate ChannelAdminProvider for vendor '${provider.vendor}'`);
+      }
+      this.byVendor.set(provider.vendor, provider);
+    }
+  }
+
+  listVendors() {
+    return [...this.byVendor.values()].map((p) => ({
+      vendor: p.vendor,
+      kind: p.kind,
+      displayName: p.displayName,
+      capabilities: p.capabilities,
+      configFields: p.configFields,
+    }));
+  }
+
+  async configure(input: {
+    vendor: string;
+    channelId?: string;
+    name?: string;
+    config: Record<string, unknown>;
+  }): Promise<ChannelAdminDto> {
+    const provider = this.requireVendor(input.vendor);
+    const parsed = provider.configInput.safeParse(input.config);
+    if (!parsed.success) {
+      throw new BadRequestException(`invalid config for ${input.vendor}: ${parsed.error.message}`);
+    }
+    return provider.configure({
+      channelId: input.channelId,
+      name: input.name,
+      config: parsed.data,
+    });
+  }
+
+  async test(channelId: string): Promise<unknown> {
+    return this.providerForChannel(channelId).then((p) => p.test(channelId));
+  }
+
+  async call(input: { channelId: string; to: string; customerName?: string }): Promise<unknown> {
+    const provider = await this.providerForChannel(input.channelId);
+    if (!provider.call) {
+      throw new BadRequestException(`channel vendor '${provider.vendor}' does not support voice calls`);
+    }
+    return provider.call(input);
+  }
+
+  async sendTest(input: { channelId: string; to: string; body?: string }): Promise<unknown> {
+    const provider = await this.providerForChannel(input.channelId);
+    if (!provider.sendTest) {
+      throw new BadRequestException(`channel vendor '${provider.vendor}' does not support test sends`);
+    }
+    return provider.sendTest(input);
+  }
+
+  private requireVendor(vendor: string): ChannelAdminProvider {
+    const provider = this.byVendor.get(vendor);
+    if (!provider) {
+      throw new BadRequestException(
+        `unknown channel vendor '${vendor}'. Call conv_list_channel_vendors to see the available vendors.`,
+      );
+    }
+    return provider;
+  }
+
+  private async providerForChannel(channelId: string): Promise<ChannelAdminProvider> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db
+      .select({ vendor: schema.convChannels.vendor })
+      .from(schema.convChannels)
+      .where(
+        and(eq(schema.convChannels.id, channelId), eq(schema.convChannels.orgId, actor.orgId)),
+      )
+      .limit(1);
+    const row = rows[0];
+    if (!row) throw new NotFoundException(`channel ${channelId} not found`);
+    return this.requireVendor(row.vendor);
+  }
+}

--- a/packages/backend-core/src/modules/conv/channels/channel-admin.tools.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-admin.tools.ts
@@ -1,0 +1,133 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpTool } from '@getmunin/mcp-toolkit';
+import { sensitive } from '@getmunin/types';
+import { ChannelAdminService } from './channel-admin.service.ts';
+import type { ChannelAdminDto } from './channel-admin.ts';
+
+const E164 = /^\+[1-9]\d{4,18}$/;
+
+const ConfigureInput = z.object({
+  vendor: z
+    .string()
+    .min(1)
+    .max(40)
+    .describe('Channel vendor, e.g. "vapi", "threll", "twilio", "messagebird". Call conv_list_channel_vendors for the full list and each vendor’s config fields.'),
+  channelId: z
+    .string()
+    .optional()
+    .describe('Pass an existing channel id to update; omit to create a new channel.'),
+  name: z.string().min(1).max(120).optional().describe('Channel display name. Required on create.'),
+  config: sensitive(
+    z
+      .record(z.string(), z.unknown())
+      .describe(
+        'Vendor-specific configuration object. The exact fields (and which are secret) come from conv_list_channel_vendors. Plaintext secrets are encrypted before storage and returned redacted.',
+      ),
+  ),
+});
+
+const TestInput = z.object({ channelId: z.string() });
+
+const VoiceCallInput = z.object({
+  channelId: z.string(),
+  to: z.string().regex(E164, 'must be E.164').max(32),
+  customerName: z.string().min(1).max(120).optional(),
+});
+
+const SendTestInput = z.object({
+  channelId: z.string(),
+  to: z.string().min(2).max(64),
+  body: z.string().min(1).max(1600).optional(),
+});
+
+const ListVendorsInput = z.object({});
+
+@Injectable()
+export class ChannelAdminTools {
+  constructor(@Inject(ChannelAdminService) private readonly svc: ChannelAdminService) {}
+
+  @McpTool({
+    name: 'conv_list_channel_vendors',
+    title: 'Conv: List configurable channel vendors',
+    description:
+      'List the voice/SMS channel vendors you can configure, with each vendor’s `kind`, capabilities (call/sendTest), and config fields (name, required, secret, description). Use this to discover what to pass to conv_channel_configure.',
+    audiences: ['admin'],
+    scopes: ['conv:read'],
+    input: ListVendorsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  listVendors(_args: z.infer<typeof ListVendorsInput>) {
+    return { vendors: this.svc.listVendors() };
+  }
+
+  @McpTool({
+    name: 'conv_channel_configure',
+    title: 'Conv: Configure a voice/SMS channel',
+    description:
+      'Create or update a voice or SMS channel for any supported vendor. Pass `vendor` + a vendor-specific `config` object (see conv_list_channel_vendors). Pass `channelId` to update; omit to create. Plaintext secrets in `config` are encrypted before storage and returned redacted.',
+    audiences: ['admin'],
+    scopes: ['conv:write'],
+    input: ConfigureInput,
+    readOnlyHint: false,
+    destructiveHint: true,
+  })
+  configure(args: z.infer<typeof ConfigureInput>): Promise<ChannelAdminDto> {
+    return this.svc.configure({
+      vendor: args.vendor,
+      channelId: args.channelId,
+      name: args.name,
+      config: args.config,
+    });
+  }
+
+  @McpTool({
+    name: 'conv_channel_test',
+    title: 'Conv: Test a channel’s stored credentials',
+    description:
+      'Verify a channel’s stored credentials with its vendor (no message sent). The result shape is vendor-specific.',
+    audiences: ['admin'],
+    scopes: ['conv:write'],
+    input: TestInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  test(args: z.infer<typeof TestInput>): Promise<unknown> {
+    return this.svc.test(args.channelId);
+  }
+
+  @McpTool({
+    name: 'conv_voice_call',
+    title: 'Conv: Place an outbound voice call',
+    description:
+      'Place an outbound voice call through a voice channel (any vendor). The channel’s configured assistant/worker runs the conversation.',
+    audiences: ['admin'],
+    scopes: ['conv:write'],
+    input: VoiceCallInput,
+    readOnlyHint: false,
+    destructiveHint: true,
+  })
+  voiceCall(args: z.infer<typeof VoiceCallInput>): Promise<unknown> {
+    return this.svc.call({
+      channelId: args.channelId,
+      to: args.to,
+      customerName: args.customerName,
+    });
+  }
+
+  @McpTool({
+    name: 'conv_channel_send_test',
+    title: 'Conv: Send a real test message',
+    description:
+      'Send a real test message (e.g. SMS) through a channel that supports it, addressed to `to`. Useful for end-to-end deliverability checks.',
+    audiences: ['admin'],
+    scopes: ['conv:write'],
+    input: SendTestInput,
+    readOnlyHint: false,
+    destructiveHint: true,
+  })
+  sendTest(args: z.infer<typeof SendTestInput>): Promise<unknown> {
+    return this.svc.sendTest({ channelId: args.channelId, to: args.to, body: args.body });
+  }
+}

--- a/packages/backend-core/src/modules/conv/channels/channel-admin.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-admin.ts
@@ -1,0 +1,62 @@
+import { isSensitiveSchema } from '@getmunin/types';
+import type { z } from 'zod';
+
+/**
+ * Vendor-agnostic admin surface for configurable channels.
+ *
+ * Each configurable vendor registers a `ChannelAdminProvider` (under the
+ * `CHANNEL_ADMIN_PROVIDERS` multi-token); the generic `conv_channel_*` MCP
+ * tools and `/v1/conversations/channels` endpoints dispatch to it by vendor.
+ * Adding a voice/SMS vendor means registering one provider — no new tools,
+ * endpoints, or types.
+ */
+export type ChannelAdminKind = 'voice' | 'sms';
+
+export interface ChannelConfigFieldInfo {
+  name: string;
+  required: boolean;
+  secret: boolean;
+  description?: string;
+}
+
+export interface ChannelAdminDto {
+  id: string;
+  name: string;
+  type: string;
+  vendor: string;
+  active: boolean;
+  config: unknown;
+}
+
+export interface ConfigureChannelInput {
+  channelId?: string;
+  name?: string;
+  config: unknown;
+}
+
+export interface ChannelAdminProvider {
+  readonly kind: ChannelAdminKind;
+  readonly vendor: string;
+  readonly displayName: string;
+  /** Validates the `config` blob (no channelId/name). */
+  readonly configInput: z.ZodType;
+  /** Field metadata derived from `configInput`, for discovery. */
+  readonly configFields: ChannelConfigFieldInfo[];
+  readonly capabilities: { call: boolean; sendTest: boolean };
+  configure(input: ConfigureChannelInput): Promise<ChannelAdminDto>;
+  test(channelId: string): Promise<unknown>;
+  call?(input: { channelId: string; to: string; customerName?: string }): Promise<unknown>;
+  sendTest?(input: { channelId: string; to: string; body?: string }): Promise<unknown>;
+}
+
+export const CHANNEL_ADMIN_PROVIDERS = Symbol('CHANNEL_ADMIN_PROVIDERS');
+
+export function describeConfigFields(schema: z.ZodType): ChannelConfigFieldInfo[] {
+  const shape = (schema as z.ZodObject<z.ZodRawShape>).shape as Record<string, z.ZodType>;
+  return Object.entries(shape).map(([name, field]) => ({
+    name,
+    required: !field.isOptional(),
+    secret: isSensitiveSchema(field),
+    description: field.description,
+  }));
+}

--- a/packages/backend-core/src/modules/conv/conv.module.ts
+++ b/packages/backend-core/src/modules/conv/conv.module.ts
@@ -11,6 +11,16 @@ import { EmailService } from './email/email.service.ts';
 import { EmailAdminTools } from './email/email.tools.ts';
 import { EmailAdapter } from './email/email-adapter.ts';
 import { CHANNEL_ADAPTERS } from './channels/adapter.ts';
+import {
+  CHANNEL_ADMIN_PROVIDERS,
+  type ChannelAdminProvider,
+} from './channels/channel-admin.ts';
+import { ChannelAdminService } from './channels/channel-admin.service.ts';
+import { ChannelAdminTools } from './channels/channel-admin.tools.ts';
+import { VapiAdminProvider } from './vapi/vapi-admin.provider.ts';
+import { ThrellAdminProvider } from './threll/threll-admin.provider.ts';
+import { TwilioSmsAdminProvider } from './twilio/twilio-sms-admin.provider.ts';
+import { MessageBirdSmsAdminProvider } from './messagebird/messagebird-sms-admin.provider.ts';
 import { ChannelIngestService } from './channels/channel-ingest.service.ts';
 import { ChannelWebhookController } from './channels/channel-webhook.controller.ts';
 import { InboundPollWorker } from './channels/inbound-poll.worker.ts';
@@ -102,6 +112,27 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
         WidgetAdapter,
       ],
     },
+    VapiAdminProvider,
+    ThrellAdminProvider,
+    TwilioSmsAdminProvider,
+    MessageBirdSmsAdminProvider,
+    ChannelAdminService,
+    ChannelAdminTools,
+    {
+      provide: CHANNEL_ADMIN_PROVIDERS,
+      useFactory: (
+        vapi: VapiAdminProvider,
+        threll: ThrellAdminProvider,
+        twilioSms: TwilioSmsAdminProvider,
+        messageBirdSms: MessageBirdSmsAdminProvider,
+      ): ChannelAdminProvider[] => [vapi, threll, twilioSms, messageBirdSms],
+      inject: [
+        VapiAdminProvider,
+        ThrellAdminProvider,
+        TwilioSmsAdminProvider,
+        MessageBirdSmsAdminProvider,
+      ],
+    },
   ],
   exports: [
     ConvService,
@@ -125,6 +156,8 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
     ThrellService,
     ThrellAdapter,
     ThrellAdminTools,
+    ChannelAdminService,
+    ChannelAdminTools,
     VoiceCallbackService,
     VoiceCallbackTools,
     WidgetAdapter,

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-admin.provider.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { describeConfigFields } from '../channels/channel-admin.ts';
+import type {
+  ChannelAdminDto,
+  ChannelAdminProvider,
+  ConfigureChannelInput,
+} from '../channels/channel-admin.ts';
+import { ConfigureInput, MessageBirdSmsAdminTools } from './messagebird-sms.tools.ts';
+
+const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
+
+@Injectable()
+export class MessageBirdSmsAdminProvider implements ChannelAdminProvider {
+  readonly kind = 'sms' as const;
+  readonly vendor = 'messagebird';
+  readonly displayName = 'MessageBird SMS';
+  readonly configInput = ConfigSchema;
+  readonly configFields = describeConfigFields(ConfigSchema);
+  readonly capabilities = { call: false, sendTest: true };
+
+  constructor(@Inject(MessageBirdSmsAdminTools) private readonly tools: MessageBirdSmsAdminTools) {}
+
+  configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
+    const config = ConfigSchema.parse(input.config);
+    return this.tools.configure({ channelId: input.channelId, name: input.name, ...config });
+  }
+
+  test(channelId: string) {
+    return this.tools.testChannel({ channelId });
+  }
+
+  sendTest(input: { channelId: string; to: string; body?: string }) {
+    return this.tools.sendTest(input);
+  }
+}

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.tools.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.tools.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
-import { McpTool } from '@getmunin/mcp-toolkit';
 import { sensitive } from '@getmunin/types';
 import { schema } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
@@ -12,7 +11,7 @@ import {
   type MessageBirdSmsChannelDto,
 } from './messagebird-sms.service.ts';
 
-const ConfigureInput = z.object({
+export const ConfigureInput = z.object({
   channelId: z
     .string()
     .optional()
@@ -48,14 +47,6 @@ const ConfigureInput = z.object({
     ),
 });
 
-const TestInput = z.object({ channelId: z.string() });
-
-const SendTestInput = z.object({
-  channelId: z.string(),
-  to: z.string().min(2).max(32).describe('E.164 destination number.'),
-  body: z.string().min(1).max(1600).optional(),
-});
-
 @Injectable()
 export class MessageBirdSmsAdminTools {
   constructor(
@@ -63,17 +54,6 @@ export class MessageBirdSmsAdminTools {
     @Inject(MessageBirdClientService) private readonly client: MessageBirdClientService,
   ) {}
 
-  @McpTool({
-    name: 'conv_messagebird_sms_configure',
-    title: 'Conv: Configure MessageBird SMS channel',
-    description:
-      'Create or update a MessageBird SMS channel. Pass `channelId` to update; omit to create. The plaintext `accessKey` and `signingKey` are encrypted before storage and returned redacted. On update, omit either secret to keep the existing one.',
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: ConfigureInput,
-    readOnlyHint: false,
-    destructiveHint: true,
-  })
   async configure(args: z.infer<typeof ConfigureInput>): Promise<MessageBirdSmsChannelDto> {
     if (args.channelId) {
       return this.svc.updateChannel({
@@ -100,18 +80,7 @@ export class MessageBirdSmsAdminTools {
     });
   }
 
-  @McpTool({
-    name: 'conv_messagebird_sms_test_channel',
-    title: 'Conv: Test MessageBird SMS channel credentials',
-    description:
-      "Verify a MessageBird channel's stored Access Key by fetching the account balance. Returns `{ ok: true, balance }` on success.",
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: TestInput,
-    readOnlyHint: true,
-    destructiveHint: false,
-  })
-  async testChannel(args: z.infer<typeof TestInput>): Promise<
+  async testChannel(args: { channelId: string }): Promise<
     { ok: true; balance: unknown } | { ok: false; error: string }
   > {
     const channel = await this.loadChannel(args.channelId);
@@ -120,19 +89,8 @@ export class MessageBirdSmsAdminTools {
     return this.client.verifyAccessKey(accessKey);
   }
 
-  @McpTool({
-    name: 'conv_messagebird_sms_send_test',
-    title: 'Conv: Send a real test SMS via MessageBird',
-    description:
-      "Send a real SMS through this channel's MessageBird account. Useful for end-to-end deliverability checks.",
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: SendTestInput,
-    readOnlyHint: false,
-    destructiveHint: true,
-  })
   async sendTest(
-    args: z.infer<typeof SendTestInput>,
+    args: { channelId: string; to: string; body?: string },
   ): Promise<{ delivered: true; id: string; status: string }> {
     const channel = await this.loadChannel(args.channelId);
     const config = jsonbToStored(channel.config);

--- a/packages/backend-core/src/modules/conv/threll/threll-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-admin.provider.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { describeConfigFields } from '../channels/channel-admin.ts';
+import type {
+  ChannelAdminDto,
+  ChannelAdminProvider,
+  ConfigureChannelInput,
+} from '../channels/channel-admin.ts';
+import { ConfigureInput, ThrellAdminTools } from './threll.tools.ts';
+
+const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
+
+@Injectable()
+export class ThrellAdminProvider implements ChannelAdminProvider {
+  readonly kind = 'voice' as const;
+  readonly vendor = 'threll';
+  readonly displayName = 'Threll';
+  readonly configInput = ConfigSchema;
+  readonly configFields = describeConfigFields(ConfigSchema);
+  readonly capabilities = { call: true, sendTest: false };
+
+  constructor(@Inject(ThrellAdminTools) private readonly tools: ThrellAdminTools) {}
+
+  configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
+    const config = ConfigSchema.parse(input.config);
+    return this.tools.configure({ channelId: input.channelId, name: input.name, ...config });
+  }
+
+  test(channelId: string) {
+    return this.tools.testChannel({ channelId });
+  }
+
+  call(input: { channelId: string; to: string; customerName?: string }) {
+    return this.tools.callInitiate(input);
+  }
+}

--- a/packages/backend-core/src/modules/conv/threll/threll.tools.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll.tools.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
-import { McpTool } from '@getmunin/mcp-toolkit';
 import { sensitive } from '@getmunin/types';
 import { schema } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
@@ -8,9 +7,7 @@ import { getCurrentContext } from '@getmunin/core';
 import { ThrellClientService } from './threll-client.service.ts';
 import { ThrellService, jsonbToStored, type ThrellChannelDto } from './threll.service.ts';
 
-const E164 = /^\+[1-9]\d{4,18}$/;
-
-const ConfigureInput = z.object({
+export const ConfigureInput = z.object({
   channelId: z
     .string()
     .optional()
@@ -50,14 +47,6 @@ const ConfigureInput = z.object({
     .describe('Threll worker ID that handles calls on this channel. Required on create.'),
 });
 
-const TestInput = z.object({ channelId: z.string() });
-
-const CallInitiateInput = z.object({
-  channelId: z.string(),
-  to: z.string().regex(E164, 'must be E.164').max(32),
-  customerName: z.string().min(1).max(120).optional(),
-});
-
 @Injectable()
 export class ThrellAdminTools {
   constructor(
@@ -65,17 +54,6 @@ export class ThrellAdminTools {
     @Inject(ThrellClientService) private readonly client: ThrellClientService,
   ) {}
 
-  @McpTool({
-    name: 'conv_threll_configure',
-    title: 'Conv: Configure Threll voice channel',
-    description:
-      'Create or update a Threll voice channel. Pass `channelId` to update; omit to create. The plaintext `apiKey` and `webhookSecret` are encrypted before storage and returned redacted. The worker must already exist in Threll — paste its account and worker IDs here.',
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: ConfigureInput,
-    readOnlyHint: false,
-    destructiveHint: true,
-  })
   async configure(args: z.infer<typeof ConfigureInput>): Promise<ThrellChannelDto> {
     if (args.channelId) {
       return this.svc.updateChannel({
@@ -105,19 +83,8 @@ export class ThrellAdminTools {
     });
   }
 
-  @McpTool({
-    name: 'conv_threll_test_channel',
-    title: 'Conv: Test Threll voice channel credentials',
-    description:
-      "Verify a Threll channel's stored API key and worker by fetching the worker from Threll. Returns `{ ok: true, worker }` on success.",
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: TestInput,
-    readOnlyHint: true,
-    destructiveHint: false,
-  })
   async testChannel(
-    args: z.infer<typeof TestInput>,
+    args: { channelId: string },
   ): Promise<
     { ok: true; worker: { id: string; name: string | null } } | { ok: false; error: string }
   > {
@@ -131,19 +98,8 @@ export class ThrellAdminTools {
     });
   }
 
-  @McpTool({
-    name: 'conv_threll_call_initiate',
-    title: 'Conv: Place an outbound Threll voice call',
-    description:
-      'Initiate an outbound voice call through this Threll channel. The worker runs the conversation. Returns the Threll call id and status.',
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: CallInitiateInput,
-    readOnlyHint: false,
-    destructiveHint: true,
-  })
   async callInitiate(
-    args: z.infer<typeof CallInitiateInput>,
+    args: { channelId: string; to: string; customerName?: string },
   ): Promise<{ initiated: true; callId: string; status: string }> {
     const channel = await this.loadChannel(args.channelId);
     const config = jsonbToStored(channel.config);

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms-admin.provider.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { describeConfigFields } from '../channels/channel-admin.ts';
+import type {
+  ChannelAdminDto,
+  ChannelAdminProvider,
+  ConfigureChannelInput,
+} from '../channels/channel-admin.ts';
+import { ConfigureInput, TwilioSmsAdminTools } from './twilio-sms.tools.ts';
+
+const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
+
+@Injectable()
+export class TwilioSmsAdminProvider implements ChannelAdminProvider {
+  readonly kind = 'sms' as const;
+  readonly vendor = 'twilio';
+  readonly displayName = 'Twilio SMS';
+  readonly configInput = ConfigSchema;
+  readonly configFields = describeConfigFields(ConfigSchema);
+  readonly capabilities = { call: false, sendTest: true };
+
+  constructor(@Inject(TwilioSmsAdminTools) private readonly tools: TwilioSmsAdminTools) {}
+
+  configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
+    const config = ConfigSchema.parse(input.config);
+    return this.tools.configure({ channelId: input.channelId, name: input.name, ...config });
+  }
+
+  test(channelId: string) {
+    return this.tools.testChannel({ channelId });
+  }
+
+  sendTest(input: { channelId: string; to: string; body?: string }) {
+    return this.tools.sendTest(input);
+  }
+}

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms.tools.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms.tools.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
-import { McpTool } from '@getmunin/mcp-toolkit';
 import { sensitive } from '@getmunin/types';
 import { schema, type Db } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
@@ -13,7 +12,7 @@ import {
   type TwilioSmsChannelDto,
 } from './twilio-sms.service.ts';
 
-const ConfigureInput = z.object({
+export const ConfigureInput = z.object({
   channelId: z
     .string()
     .optional()
@@ -49,19 +48,6 @@ const ConfigureInput = z.object({
     .describe('Twilio Messaging Service SID (starts with "MG"). Alternative to fromNumber.'),
 });
 
-const TestInput = z.object({ channelId: z.string() });
-
-const SendTestInput = z.object({
-  channelId: z.string(),
-  to: z.string().min(2).max(32).describe('E.164 destination number.'),
-  body: z
-    .string()
-    .min(1)
-    .max(1600)
-    .default('Munin test message — outbound SMS is working.')
-    .optional(),
-});
-
 @Injectable()
 export class TwilioSmsAdminTools {
   constructor(
@@ -70,17 +56,6 @@ export class TwilioSmsAdminTools {
     @Inject(DB) private readonly db: Db,
   ) {}
 
-  @McpTool({
-    name: 'conv_twilio_sms_configure',
-    title: 'Conv: Configure Twilio SMS channel',
-    description:
-      'Create or update a Twilio SMS channel. Pass `channelId` to update an existing channel; omit to create one. The plaintext `authToken` is encrypted before storage and is returned redacted. On update, omit `authToken` to keep the existing one. Either `fromNumber` (E.164) or `messagingServiceSid` is required.',
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: ConfigureInput,
-    readOnlyHint: false,
-    destructiveHint: true,
-  })
   async configure(args: z.infer<typeof ConfigureInput>): Promise<TwilioSmsChannelDto> {
     if (args.channelId) {
       return this.svc.updateChannel({
@@ -111,19 +86,8 @@ export class TwilioSmsAdminTools {
     });
   }
 
-  @McpTool({
-    name: 'conv_twilio_sms_test_channel',
-    title: 'Conv: Test Twilio SMS channel credentials',
-    description:
-      "Verify a Twilio SMS channel's stored Account SID + Auth Token by fetching the account record from Twilio. Returns `{ ok: true, friendlyName, status }` on success.",
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: TestInput,
-    readOnlyHint: true,
-    destructiveHint: false,
-  })
   async testChannel(
-    args: z.infer<typeof TestInput>,
+    args: { channelId: string },
   ): Promise<
     | { ok: true; friendlyName: string; status: string }
     | { ok: false; error: string }
@@ -134,19 +98,8 @@ export class TwilioSmsAdminTools {
     return this.client.verifyCredentials({ accountSid: config.accountSid, authToken });
   }
 
-  @McpTool({
-    name: 'conv_twilio_sms_send_test',
-    title: 'Conv: Send a real test SMS',
-    description:
-      "Send a real SMS through this channel's Twilio account. The recipient must be a number Twilio is permitted to reach (verified caller ID on trial accounts). Useful for end-to-end deliverability checks.",
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: SendTestInput,
-    readOnlyHint: false,
-    destructiveHint: true,
-  })
   async sendTest(
-    args: z.infer<typeof SendTestInput>,
+    args: { channelId: string; to: string; body?: string },
   ): Promise<{ delivered: true; sid: string; status: string }> {
     const channel = await this.loadChannel(args.channelId);
     const config = jsonbToStored(channel.config);

--- a/packages/backend-core/src/modules/conv/vapi/vapi-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-admin.provider.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { describeConfigFields } from '../channels/channel-admin.ts';
+import type {
+  ChannelAdminDto,
+  ChannelAdminProvider,
+  ConfigureChannelInput,
+} from '../channels/channel-admin.ts';
+import { ConfigureInput, VapiAdminTools } from './vapi.tools.ts';
+
+const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
+
+@Injectable()
+export class VapiAdminProvider implements ChannelAdminProvider {
+  readonly kind = 'voice' as const;
+  readonly vendor = 'vapi';
+  readonly displayName = 'Vapi';
+  readonly configInput = ConfigSchema;
+  readonly configFields = describeConfigFields(ConfigSchema);
+  readonly capabilities = { call: true, sendTest: false };
+
+  constructor(@Inject(VapiAdminTools) private readonly tools: VapiAdminTools) {}
+
+  configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
+    const config = ConfigSchema.parse(input.config);
+    return this.tools.configure({ channelId: input.channelId, name: input.name, ...config });
+  }
+
+  test(channelId: string) {
+    return this.tools.testChannel({ channelId });
+  }
+
+  call(input: { channelId: string; to: string; customerName?: string }) {
+    return this.tools.callInitiate(input);
+  }
+}

--- a/packages/backend-core/src/modules/conv/vapi/vapi.tools.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi.tools.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { z } from 'zod';
-import { McpTool } from '@getmunin/mcp-toolkit';
 import { sensitive } from '@getmunin/types';
 import { schema } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
@@ -12,9 +11,7 @@ import {
   type VapiChannelDto,
 } from './vapi.service.ts';
 
-const E164 = /^\+[1-9]\d{4,18}$/;
-
-const ConfigureInput = z.object({
+export const ConfigureInput = z.object({
   channelId: z
     .string()
     .optional()
@@ -58,14 +55,6 @@ const ConfigureInput = z.object({
     .describe('Vapi public key — safe to expose to the browser. Required if you want the chat widget to start in-browser voice sessions; not needed for phone-only setups. Find it in the Vapi dashboard under your assistant.'),
 });
 
-const TestInput = z.object({ channelId: z.string() });
-
-const CallInitiateInput = z.object({
-  channelId: z.string(),
-  to: z.string().regex(E164, 'must be E.164').max(32),
-  customerName: z.string().min(1).max(120).optional(),
-});
-
 @Injectable()
 export class VapiAdminTools {
   constructor(
@@ -73,17 +62,6 @@ export class VapiAdminTools {
     @Inject(VapiClientService) private readonly client: VapiClientService,
   ) {}
 
-  @McpTool({
-    name: 'conv_vapi_configure',
-    title: 'Conv: Configure Vapi voice channel',
-    description:
-      'Create or update a Vapi voice channel. Pass `channelId` to update; omit to create. The plaintext `apiKey` and `webhookSecret` are encrypted before storage and returned redacted. The assistant + phone number must already exist in Vapi — paste their IDs here.',
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: ConfigureInput,
-    readOnlyHint: false,
-    destructiveHint: true,
-  })
   async configure(args: z.infer<typeof ConfigureInput>): Promise<VapiChannelDto> {
     if (args.channelId) {
       return this.svc.updateChannel({
@@ -114,19 +92,8 @@ export class VapiAdminTools {
     });
   }
 
-  @McpTool({
-    name: 'conv_vapi_test_channel',
-    title: 'Conv: Test Vapi voice channel credentials',
-    description:
-      "Verify a Vapi channel's stored API key and assistant by fetching the assistant from Vapi. Returns `{ ok: true, assistant }` on success.",
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: TestInput,
-    readOnlyHint: true,
-    destructiveHint: false,
-  })
   async testChannel(
-    args: z.infer<typeof TestInput>,
+    args: { channelId: string },
   ): Promise<
     { ok: true; assistant: { id: string; name: string | null } } | { ok: false; error: string }
   > {
@@ -136,19 +103,8 @@ export class VapiAdminTools {
     return this.client.fetchAssistant({ apiKey, assistantId: config.assistantId });
   }
 
-  @McpTool({
-    name: 'conv_voice_call_initiate',
-    title: 'Conv: Place an outbound voice call',
-    description:
-      'Initiate an outbound voice call through this channel. The Vapi assistant will run the conversation. Returns the Vapi call id and status.',
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: CallInitiateInput,
-    readOnlyHint: false,
-    destructiveHint: true,
-  })
   async callInitiate(
-    args: z.infer<typeof CallInitiateInput>,
+    args: { channelId: string; to: string; customerName?: string },
   ): Promise<{ initiated: true; callId: string; status: string }> {
     const channel = await this.loadChannel(args.channelId);
     const config = jsonbToStored(channel.config);

--- a/packages/backend-core/src/modules/conv/voice-callback.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/voice-callback.integration.test.ts
@@ -228,9 +228,9 @@ const skipReason = TEST_URL
       const { tools } = await c.listTools();
       const names = tools.map((t) => t.name);
       expect(names).toContain('conv_request_phone_call_for_my_conversation');
-      expect(names).not.toContain('conv_voice_call_initiate');
+      expect(names).not.toContain('conv_voice_call');
       expect(names).not.toContain('conv_voice_call_contact');
-      expect(names).not.toContain('conv_vapi_configure');
+      expect(names).not.toContain('conv_channel_configure');
     });
   });
 
@@ -238,7 +238,7 @@ const skipReason = TEST_URL
     await withClient(adminKey, async (c) => {
       const { tools } = await c.listTools();
       const names = tools.map((t) => t.name);
-      expect(names).toContain('conv_voice_call_initiate');
+      expect(names).toContain('conv_voice_call');
       expect(names).toContain('conv_voice_call_contact');
     });
   });

--- a/packages/backend-core/src/modules/conv/voice-callback.tools.ts
+++ b/packages/backend-core/src/modules/conv/voice-callback.tools.ts
@@ -33,7 +33,7 @@ export class VoiceCallbackTools {
     name: 'conv_voice_call_contact',
     title: "Conv: Place a voice call to this conversation's contact",
     description:
-      "Place an outbound voice call to the contact attached to a conversation. Resolves the phone number from the conversation's contact. If your org has more than one active Vapi voice channel, pass `channelId` to pick one; with a single channel the call falls back to it. For arbitrary destinations, use `conv_voice_call_initiate` instead.",
+      "Place an outbound voice call to the contact attached to a conversation. Resolves the phone number from the conversation's contact. If your org has more than one active voice channel, pass `channelId` to pick one; with a single channel the call falls back to it. For arbitrary destinations, use `conv_voice_call` instead.",
     audiences: ['admin'],
     scopes: ['conv:write'],
     input: CallbackInput,

--- a/packages/types/src/channels.ts
+++ b/packages/types/src/channels.ts
@@ -203,3 +203,26 @@ export const ThrellCallInitiateBody = z.object({
 });
 
 export type ThrellCallInitiateBodyT = z.infer<typeof ThrellCallInitiateBody>;
+
+export const ConfigureChannelBody = z.object({
+  vendor: z.string().min(1).max(40),
+  channelId: z.string().optional(),
+  name: z.string().min(1).max(120).optional(),
+  config: z.record(z.string(), z.unknown()),
+});
+
+export type ConfigureChannelBodyT = z.infer<typeof ConfigureChannelBody>;
+
+export const ChannelVoiceCallBody = z.object({
+  to: z.string().regex(E164, 'must be E.164').max(32),
+  customerName: z.string().min(1).max(120).optional(),
+});
+
+export type ChannelVoiceCallBodyT = z.infer<typeof ChannelVoiceCallBody>;
+
+export const ChannelSendTestBody = z.object({
+  to: z.string().min(2).max(64),
+  body: z.string().min(1).max(1600).optional(),
+});
+
+export type ChannelSendTestBodyT = z.infer<typeof ChannelSendTestBody>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,6 +33,12 @@ export {
   type ConfigureThrellBodyT,
   ThrellCallInitiateBody,
   type ThrellCallInitiateBodyT,
+  ConfigureChannelBody,
+  type ConfigureChannelBodyT,
+  ChannelVoiceCallBody,
+  type ChannelVoiceCallBodyT,
+  ChannelSendTestBody,
+  type ChannelSendTestBodyT,
 } from './channels.ts';
 export {
   CreateTrackerBody,


### PR DESCRIPTION
## Summary

Replaces the per-vendor voice/SMS channel admin MCP tools with a registry-driven surface, so adding a vendor is one provider — no new tools/endpoints/types. Follow-up to the Threll voice channel (#437, merged).

- `ChannelAdminProvider` contract + `ChannelAdminService` dispatch by vendor.
- 5 generic MCP tools replace 12 per-vendor ones: `conv_list_channel_vendors` (discovery), `conv_channel_configure`, `conv_channel_test`, `conv_voice_call`, `conv_channel_send_test`.
- Generic `/v1` endpoints (`GET /vendors`, `POST /`, `POST /:id/{test,call,send-test}`); per-vendor endpoints retained so the dashboard is unchanged.
- Vendor `*AdminTools` keep their methods (used by providers + per-vendor `/v1`) but no longer register MCP tools; providers reuse their `ConfigureInput` schemas. Email + chat widget keep their bespoke tools.

Tool catalog 145 → 138, flat going forward. typecheck 29/29, lint 29/29, build 14/14; fixtures regenerated; changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)