### PR TITLE
chore: log previously swallowed errors in widget and dashboard paths

### DIFF
--- a/.changeset/log-swallowed-errors.md
+++ b/.changeset/log-swallowed-errors.md
@@ -1,0 +1,6 @@
+---
+"@getmunin/chat-widget": patch
+"@getmunin/dashboard-pages": patch
+---
+
+Log previously swallowed errors in widget realtime, dashboard, and voice session paths. Empty `catch {}` blocks now emit `console.warn` for socket lifecycle/fetch failures and `console.debug` for listener-loop exceptions so issues surface during debugging instead of disappearing.

--- a/apps/chat-widget/src/realtime.ts
+++ b/apps/chat-widget/src/realtime.ts
@@ -135,8 +135,8 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
     for (const l of stateListeners) {
       try {
         l(next);
-      } catch {
-        // listener errors must never break the client
+      } catch (err) {
+        console.debug('[munin-widget] state listener threw:', err);
       }
     }
   }
@@ -193,8 +193,8 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
             sessionId,
           }),
         );
-      } catch {
-        // socket might have transitioned; let close handler reconnect
+      } catch (err) {
+        console.warn('[munin-widget] subscribe send failed:', err);
       }
     });
     socket.addEventListener('message', (event) => {
@@ -209,16 +209,16 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
         for (const l of eventListeners) {
           try {
             l(msg as IncomingEvent);
-          } catch {
-            // continue
+          } catch (err) {
+            console.debug('[munin-widget] event listener threw:', err);
           }
         }
       } else if (msg.type === 'typing') {
         for (const l of typingListeners) {
           try {
             l(msg as IncomingTyping);
-          } catch {
-            // continue
+          } catch (err) {
+            console.debug('[munin-widget] typing listener threw:', err);
           }
         }
       }
@@ -252,8 +252,8 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
       if (ws && ws.readyState !== WS.CLOSED) {
         try {
           ws.close();
-        } catch {
-          // ignore
+        } catch (err) {
+          console.warn('[munin-widget] socket close failed:', err);
         }
       }
       setState('closed');
@@ -268,8 +268,8 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
       if (ws && ws.readyState !== WS.CLOSED) {
         try {
           ws.close();
-        } catch {
-          // ignore
+        } catch (err) {
+          console.warn('[munin-widget] socket close failed during reconnect:', err);
         }
         ws = null;
       }
@@ -299,8 +299,8 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
             isTyping,
           }),
         );
-      } catch {
-        // socket might be mid-close; ignore
+      } catch (err) {
+        console.warn('[munin-widget] typing send failed:', err);
       }
     },
     sendRead(messageIds) {

--- a/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
@@ -48,8 +48,8 @@ export function RecentConversationsSection({
           `/v1/conversations?limit=${FETCH_LIMIT}`,
         );
         setItems(page.items);
-      } catch {
-        // hide silently on fetch errors
+      } catch (err) {
+        console.warn('[dashboard] recent conversations fetch failed:', err);
       }
     })();
   }, []);

--- a/packages/widget-voice/src/vendors/vapi.ts
+++ b/packages/widget-voice/src/vendors/vapi.ts
@@ -139,8 +139,8 @@ export class VapiVoiceSession implements VoiceSession {
     for (const listener of this.listeners) {
       try {
         listener(event);
-      } catch {
-        // Listener errors are swallowed to keep the session loop running.
+      } catch (err) {
+        console.debug('[munin-voice] vapi listener threw:', err);
       }
     }
   }

--- a/packages/widget-voice/src/webrtc-session.ts
+++ b/packages/widget-voice/src/webrtc-session.ts
@@ -90,8 +90,8 @@ export class WebRtcVoiceSession implements VoiceSession {
   end(): Promise<void> {
     try {
       this.channel.close();
-    } catch {
-      // ignore channel close errors
+    } catch (err) {
+      console.warn('[munin-voice] channel close failed:', err);
     }
     if (this.localStream) {
       for (const track of this.localStream.getTracks()) track.stop();
@@ -181,8 +181,8 @@ export class WebRtcVoiceSession implements VoiceSession {
     for (const listener of this.listeners) {
       try {
         listener(event);
-      } catch {
-        // listener errors are swallowed to keep the session loop running
+      } catch (err) {
+        console.debug('[munin-voice] session listener threw:', err);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replace empty `catch {}` blocks in `apps/chat-widget/src/realtime.ts`, `packages/widget-voice/src/{webrtc-session,vendors/vapi}.ts`, and `packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx` with real log calls.
- `console.warn` for one-off socket lifecycle, channel close, typing-send, and dashboard-fetch failures; `console.debug` for hot-loop listener exceptions so per-message errors don't spam.
- No behavior change — previously these failures vanished without a trace.

## Test plan
- [ ] `pnpm typecheck` (already green locally for the three affected packages)
- [ ] Manually verify the chat widget reconnect path still works; no new errors during normal open/close

🤖 Generated with [Claude Code](https://claude.com/claude-code)