### PR TITLE
fix(dashboard): align agent recipes with the docs recipe guides

### DIFF
--- a/.changeset/align-dashboard-recipes.md
+++ b/.changeset/align-dashboard-recipes.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Align the dashboard "agent recipes" starter list with the recipe guides shipped in `@getmunin/docs-pages`. The panel had drifted: it still listed **Content Marketer** (renamed to Conversation Distiller), **CRM Deduper**, and **KB Curator** (both dropped — the built-in curator now runs `skill://crm/clean-contact-data` and `skill://kb/review-content` automatically), and their "view prompt" links pointed at guide slugs that no longer exist (404).
+
+Replaces those with current recipes (Lead Research, Lead Scoring, Conversation Distiller) alongside the still-valid Bug Triage, Renewal Watch, and SDR — keeping the list at 6, every `id` now resolving to a real `recipe-*` guide, and tool chips using current MCP tool names.

--- a/packages/dashboard-pages/src/data/recipes.ts
+++ b/packages/dashboard-pages/src/data/recipes.ts
@@ -10,6 +10,28 @@ export interface Recipe {
 
 export const RECIPES: Recipe[] = [
   {
+    id: 'lead-research',
+    name: 'Lead Research',
+    summary:
+      'When a contact lands, scrapes their company site and fills role, seniority, and industry on the CRM record.',
+    cadence: 'event-driven',
+    tools: ['crm_get_contact', 'crm_update_contact', 'crm_set_ai_summary'],
+  },
+  {
+    id: 'lead-scoring',
+    name: 'Lead Scoring',
+    summary:
+      'Ranks a segment by fit and intent using enrichment data, conversation tone, and recent activity.',
+    cadence: 'weekly',
+    tools: [
+      'crm_list_contacts_in_segment',
+      'crm_get_contact',
+      'crm_list_activities',
+      'conv_search_messages',
+      'crm_set_ai_summary',
+    ],
+  },
+  {
     id: 'bug-triage',
     name: 'Bug Triage',
     summary:
@@ -23,65 +45,37 @@ export const RECIPES: Recipe[] = [
     ],
   },
   {
-    id: 'content-marketer',
-    name: 'Content Marketer',
-    summary: 'Mines conversations for FAQs and drafts CMS entries that answer them.',
+    id: 'conversation-distiller',
+    name: 'Conversation Distiller',
+    summary:
+      'Reads recent conversations for recurring themes — questions, complaints, feature asks — and drafts a CMS entry for each.',
     cadence: 'weekly',
-    tools: [
-      'conv_search_messages',
-      'kb_search',
-      'cms_list_collections',
-      'cms_create_entry',
-      'cms_publish_entry',
-    ],
+    tools: ['conv_list_conversations', 'conv_search_messages', 'kb_search', 'cms_create_entry'],
   },
   {
-    id: 'crm-deduper',
-    name: 'CRM Deduper',
-    summary: 'Finds duplicate contacts, files structured merge proposals for review.',
+    id: 'renewal-watch',
+    name: 'Renewal Watch',
+    summary:
+      'Surfaces deals approaching renewal, scores account health, and drafts account-management outreach for review.',
     cadence: 'daily',
     tools: [
-      'crm_list_contacts',
-      'crm_search_contacts',
-      'crm_propose_merge',
-      'crm_list_merge_proposals',
-    ],
-  },
-  {
-    id: 'kb-curator',
-    name: 'KB Curator',
-    summary: 'Watches conversations for KB gaps, drafts new articles, queues them for review.',
-    cadence: 'daily',
-    tools: [
-      'conv_search_messages',
-      'conv_list_conversations',
-      'kb_search',
-      'kb_propose_curation_candidate',
-      'kb_publish_curation_candidate',
+      'crm_list_deals',
+      'crm_get_contact',
+      'crm_set_ai_summary',
+      'outreach_propose_initial',
     ],
   },
   {
     id: 'sdr',
     name: 'SDR',
-    summary: 'Builds outbound campaigns from a brief, drafts personalised opener emails for review.',
+    summary:
+      'Takes a campaign brief, targets a CRM segment, and queues personalised opener emails for human approval.',
     cadence: 'on-demand',
     tools: [
       'crm_list_segments',
       'crm_list_contacts_in_segment',
       'crm_get_contact',
       'outreach_create_campaign',
-      'outreach_propose_initial',
-    ],
-  },
-  {
-    id: 'renewal-watch',
-    name: 'Renewal Watch',
-    summary: 'Watches deals for upcoming renewals and drafts outreach when contracts approach end.',
-    cadence: 'daily',
-    tools: [
-      'crm_list_deals',
-      'crm_get_contact',
-      'crm_set_ai_summary',
       'outreach_propose_initial',
     ],
   },


### PR DESCRIPTION
## What

The dashboard "agent recipes" starter panel (`get-started.tsx`, driven by `data/recipes.ts`) had drifted from the recipe guides shipped in `@getmunin/docs-pages`.

| Before | After | Why |
|---|---|---|
| Bug Triage | Bug Triage | kept (valid) |
| Content Marketer | **Conversation Distiller** | renamed recipe |
| CRM Deduper | **Lead Research** | CRM Deduper dropped — curator auto-runs `skill://crm/clean-contact-data` |
| KB Curator | **Lead Scoring** | KB Curator dropped — curator auto-runs `skill://kb/review-content` |
| SDR | SDR | kept (valid) |
| Renewal Watch | Renewal Watch | kept (valid) |

Still **6** recipes (per the existing cap). Each `id` now resolves to a real `recipe-*` guide — the stale ids (`content-marketer`, `crm-deduper`, `kb-curator`) produced **404 "view prompt" links** since the component links to `/guides/recipe-${id}`. Tool chips updated to current MCP tool names.

The 8 docs recipes are Lead Research, Lead Scoring, Bug Triage, Conversation Distiller, Renewal Watch, Win-Back, Event Follow-up, SDR. To keep the cap at 6, **Win-Back** and **Event Follow-up** (the two most niche outreach recipes) are left out of the dashboard panel — easy to swap if you'd prefer a different 6.

## Verification

- `pnpm -F @getmunin/dashboard-pages typecheck` — clean
- Confirmed all 6 ids map to existing `packages/docs-pages/src/guides/recipe-*` dirs
- Confirmed every referenced tool exists as a current `@McpTool` name

🤖 Generated with [Claude Code](https://claude.com/claude-code)