### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,13 @@ jobs:
       MUNIN_CMS_SCHEDULE_WORKER_DISABLED: '1'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -131,11 +131,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -154,11 +154,11 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -173,7 +173,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('apps/web/package.json', 'pnpm-lock.yaml') }}
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload trace artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-traces
           path: apps/web/test-results/


### PR DESCRIPTION
## What

GitHub forces Node 20 JS actions onto Node 24 from **2026-06-16** (the warning surfaced during the 4.47.0 release runs). Bumps each pinned action in `ci.yml` to its first Node 24 major:

| Action | Before → After |
|---|---|
| actions/checkout | v4 → v5 |
| actions/setup-node | v4 → v5 |
| pnpm/action-setup | v4 → v5 |
| actions/cache | v4 → v5 |
| actions/upload-artifact | v4 → v6 |

Each target verified to ship `runs.using: node24`; `with:` inputs unchanged across these majors. Mirrors the same bump just landed in munin-cloud (#240). `ci.yml` is the only workflow in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)