### PR TITLE
fix(dashboard): align usage-KPI sparklines

### DIFF
--- a/.changeset/misaligned-sparklines.md
+++ b/.changeset/misaligned-sparklines.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Fix misaligned usage-KPI sparklines on the dashboard. Three causes were making the four cards' sparklines sit at inconsistent vertical positions:
+
+- **Stroke clipping** — the polyline mapped values to the full `0–22` viewBox height, so the 1.2px stroke was sliced in half at peaks and troughs. Values now inset into a `2–20` band so the line never touches the edges.
+- **Floating flat lines** — a constant series (`max === min`) no longer floats at an arbitrary height; it rests on the baseline like every other card's minimum.
+- **Collapsing delta row** — a tile with no comparison (e.g. API calls, whose previous period is 0) rendered an empty space that HTML collapsed to zero height, shifting its sparkline up by one line. The placeholder is now a non-breaking space so the row keeps its height.

--- a/packages/dashboard-pages/src/components/dashboard/spark.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/spark.tsx
@@ -14,10 +14,13 @@ export function Spark({ values, className, tone = 'accent' }: SparkProps) {
   const min = Math.min(...values);
   const w = 200;
   const h = 22;
+  const pad = 2;
+  const range = max - min;
   const points = values
     .map((v, i) => {
       const x = (i / (values.length - 1)) * w;
-      const y = h - ((v - min) / Math.max(1, max - min)) * h;
+      const t = range === 0 ? 0 : (v - min) / range;
+      const y = h - pad - t * (h - 2 * pad);
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(' ');

--- a/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
@@ -101,7 +101,7 @@ function Kpi({ label, value, previous, spark, format, lowerIsBetter, tone = 'acc
             : 'font-mono text-[10px] text-ink-mute'
         }
       >
-        {delta?.label ?? ' '}
+        {delta?.label ?? ' '}
       </div>
       <Spark className="mt-2" values={spark} tone={tone} />
     </div>


### PR DESCRIPTION
## Problem

The four usage cards in **Bruk · denne måneden** (`UsageKpis`) rendered sparklines at inconsistent vertical positions, so the cards looked misaligned next to each other.

Three independent causes:

1. **Stroke clipping** — `Spark` mapped values to the full `0–22` viewBox height. The 1.2px polyline is centered on its coordinate, so peaks (`y=0`) and troughs (`y=22`) were sliced in half by the SVG edge.
2. **Floating flat lines** — a constant series (`max === min`) had no defined position and floated at an arbitrary height instead of sitting on the baseline like every other card's minimum.
3. **Collapsing delta row** — a tile with no comparison (e.g. **API-kall**, whose previous period is `0`, so `formatDelta` returns `null`) fell back to a plain space `' '`. HTML collapses whitespace-only block content to zero height, dropping the ~14px the other cards' "vs. forrige" line occupies — which shifted that card's sparkline up by one line.

## Fix

- **`spark.tsx`** — inset values into a `2–20` band (`pad = 2`) so the stroke never touches the edges; rest a constant series on the baseline (`t = 0`) instead of floating it.
- **`usage-kpis.tsx`** — use a non-breaking space for the empty-delta fallback so the row keeps its height regardless of whether a comparison is shown.

## Notes

The blank comparison on API-kall itself is **not** a bug — its `api_calls_day` counter (`rate_limit_counters`) went live on Jun 4 (#366) with no backfill, so the previous-period window is genuinely `0`, tripping the `previous === 0` guard. That self-heals once the prior month is fully covered by the counter. The other tiles read durable tables (`conv_conversations`, `audit_log`) or an already-populated counter (`mcp_calls_day`), so they're unaffected. This PR only addresses the layout/rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)