### PR TITLE
feat(mcp): expose skills/playbooks via skills_list and skills_read tools

### DIFF
--- a/.changeset/skills-tools-fallback.md
+++ b/.changeset/skills-tools-fallback.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/mcp-toolkit": minor
+---
+
+Expose skills and playbooks through `skills_list` / `skills_read` MCP tools in addition to the existing `resources/list` / `resources/read` surface. Coding-agent MCP clients (Lovable, Bolt, Cursor, …) that implement only tools and ignore server resources could not discover `skill://` playbooks; the new tools give them the same content and URIs. The tools appear in `tools/list` only when at least one skill is visible to the caller's audience, respect the same audience gating as resources, and are also listed in the public tool catalog (`/v1/public/mcp-tools`). Both surfaces derive from a single `SKILL_TOOLS` descriptor so they cannot drift.

--- a/packages/backend-core/src/control/public-mcp-tools.controller.test.ts
+++ b/packages/backend-core/src/control/public-mcp-tools.controller.test.ts
@@ -83,12 +83,37 @@ describe('PublicMcpToolsController', () => {
     if (app) await app.close();
   });
 
-  it('GET /v1/public/mcp-tools lists every registered tool', async () => {
+  it('GET /v1/public/mcp-tools lists every registered tool plus the skill tools', async () => {
     const res = await fetch(`${baseUrl}/v1/public/mcp-tools`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as Array<{ name: string }>;
     const names = body.map((t) => t.name).sort();
-    expect(names).toEqual(['conv_reply', 'crm_delete_person', 'kb_search']);
+    expect(names).toEqual([
+      'conv_reply',
+      'crm_delete_person',
+      'kb_search',
+      'skills_list',
+      'skills_read',
+    ]);
+  });
+
+  it('exposes the synthetic skill tools with read-only metadata and a schema', async () => {
+    const list = (await (await fetch(`${baseUrl}/v1/public/mcp-tools`)).json()) as Array<
+      Record<string, unknown>
+    >;
+    const read = list.find((t) => t.name === 'skills_read')!;
+    expect(read).toMatchObject({
+      name: 'skills_read',
+      audiences: ['admin', 'self_service'],
+      scopes: [],
+      readOnly: true,
+      danger: null,
+    });
+
+    const detail = (await (
+      await fetch(`${baseUrl}/v1/public/mcp-tools/skills_read`)
+    ).json()) as Record<string, unknown>;
+    expect((detail.inputSchema as { properties?: object }).properties).toHaveProperty('uri');
   });
 
   it('list response carries audiences, scopes, and danger derived from hints', async () => {

--- a/packages/backend-core/src/control/public-mcp-tools.controller.ts
+++ b/packages/backend-core/src/control/public-mcp-tools.controller.ts
@@ -1,7 +1,12 @@
 import { Get, Inject, NotFoundException, Param } from '@nestjs/common';
 import { PublicController } from '../common/auth/auth.guard.ts';
 import { McpRegistryService } from '../mcp/mcp.registry.ts';
-import type { RegisteredMcpTool } from '@getmunin/mcp-toolkit';
+import {
+  SKILL_TOOLS,
+  getSkillToolDescriptor,
+  type RegisteredMcpTool,
+  type SkillToolDescriptor,
+} from '@getmunin/mcp-toolkit';
 
 interface PublicMcpToolListItem {
   name: string;
@@ -23,31 +28,44 @@ export class PublicMcpToolsController {
 
   @Get()
   list(): PublicMcpToolListItem[] {
-    return this.registry.list().map(toListItem);
+    return [...this.registry.list().map(toListItem), ...SKILL_TOOLS.map(skillToListItem)];
   }
 
   @Get(':name')
   read(@Param('name') name: string): PublicMcpToolDetail {
+    const skill = getSkillToolDescriptor(name);
+    if (skill) return { ...skillToListItem(skill), inputSchema: skill.inputSchema };
     const tool = this.registry.get(name);
     if (!tool) throw new NotFoundException(`MCP tool ${name} not found`);
     return { ...toListItem(tool), inputSchema: tool.inputJsonSchema };
   }
 }
 
+function dangerOf(readOnlyHint?: boolean, destructiveHint?: boolean): PublicMcpToolListItem['danger'] {
+  return destructiveHint ? 'destructive' : readOnlyHint ? null : 'writes';
+}
+
 function toListItem(tool: RegisteredMcpTool): PublicMcpToolListItem {
   const { meta } = tool;
-  const danger: PublicMcpToolListItem['danger'] = meta.destructiveHint
-    ? 'destructive'
-    : meta.readOnlyHint
-      ? null
-      : 'writes';
   return {
     name: meta.name,
     title: meta.title,
     description: meta.description,
     audiences: meta.audiences,
     scopes: meta.scopes,
-    danger,
+    danger: dangerOf(meta.readOnlyHint, meta.destructiveHint),
     readOnly: meta.readOnlyHint === true,
+  };
+}
+
+function skillToListItem(tool: SkillToolDescriptor): PublicMcpToolListItem {
+  return {
+    name: tool.name,
+    title: tool.title,
+    description: tool.description,
+    audiences: tool.audiences,
+    scopes: tool.scopes,
+    danger: dangerOf(tool.readOnlyHint, tool.destructiveHint),
+    readOnly: tool.readOnlyHint,
   };
 }

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -192,6 +192,33 @@ const skipReason = TEST_URL
     });
   });
 
+  it('exposes skills via the skills_list / skills_read tools for resource-blind clients', async () => {
+    await withClient(adminKey, async (c) => {
+      const { tools } = await c.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('skills_list');
+      expect(names).toContain('skills_read');
+
+      const listed = await c.callTool({ name: 'skills_list', arguments: {} });
+      const listText =
+        Array.isArray(listed.content) && listed.content[0] && 'text' in listed.content[0]
+          ? (listed.content[0] as { text: string }).text
+          : '';
+      const uris = (JSON.parse(listText) as Array<{ uri: string }>).map((s) => s.uri);
+      expect(uris).toContain('skill://playbooks/frontend-integration');
+
+      const read = await c.callTool({
+        name: 'skills_read',
+        arguments: { uri: 'skill://playbooks/frontend-integration' },
+      });
+      const readText =
+        Array.isArray(read.content) && read.content[0] && 'text' in read.content[0]
+          ? (read.content[0] as { text: string }).text
+          : '';
+      expect(readText).toContain('Frontend integration');
+    });
+  });
+
   it('end-user agent does not see admin-only skills', async () => {
     await withClient(endUserToken, async (c) => {
       const { resources } = await c.listResources();

--- a/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
+++ b/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
@@ -41,6 +41,8 @@ function buildInstructions(adminSkills: ReadonlyArray<{ uri: string; name: strin
     '',
     'Multi-step workflows have detailed skills. Call `resources/list` to discover',
     'them (URIs use the `skill://` scheme), then `resources/read` to fetch one.',
+    'If your client does not expose MCP resources, use the `skills_list` and',
+    '`skills_read` tools instead — same content, same URIs.',
     'Cross-module workflows live under `skill://playbooks/*`.',
   ];
   if (featured.length > 0) {

--- a/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
+++ b/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
@@ -111,7 +111,7 @@ const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
     it('every tool name follows the <module>_<verb> convention or is a known utility', async () => {
       const tools = await admin.listTools();
       const KNOWN_PREFIXES = Object.values(EXPECTED_BY_MODULE);
-      const UTILITY_TOOLS = new Set(['ping']);
+      const UTILITY_TOOLS = new Set(['ping', 'skills_list', 'skills_read']);
       for (const t of tools) {
         if (UTILITY_TOOLS.has(t.name)) continue;
         const matchesAny = KNOWN_PREFIXES.some((re) => re.test(t.name));

--- a/packages/mcp-toolkit/src/dispatch.ts
+++ b/packages/mcp-toolkit/src/dispatch.ts
@@ -7,6 +7,7 @@ import {
 import type { McpToolRegistry } from './registry.ts';
 import { redactSensitive } from './sensitive.ts';
 import type { RegisteredSkill, SkillRegistry } from './skill-registry.ts';
+import { SKILLS_LIST_TOOL, SKILLS_READ_TOOL, SKILL_TOOLS } from './skill-tools.ts';
 
 export interface CaptureExceptionContext {
   tool?: string;
@@ -59,8 +60,21 @@ export interface ResourceContent {
   text: string;
 }
 
+function skillToolListings(): ToolListing[] {
+  return SKILL_TOOLS.map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+    annotations: {
+      title: t.title,
+      readOnlyHint: t.readOnlyHint,
+      destructiveHint: t.destructiveHint,
+    },
+  }));
+}
+
 export function listTools(ctx: DispatchContext): ToolListing[] {
-  return ctx.registry
+  const tools = ctx.registry
     .list(ctx.audience)
     .filter((t) => t.meta.scopes.every((s) => ctx.actor.hasScope(s)))
     .map((t) => ({
@@ -74,6 +88,10 @@ export function listTools(ctx: DispatchContext): ToolListing[] {
       },
       ...(t.meta._meta ? { _meta: t.meta._meta } : {}),
     }));
+  if (listResources(ctx).length > 0) {
+    tools.push(...skillToolListings());
+  }
+  return tools;
 }
 
 export async function callTool(
@@ -81,6 +99,10 @@ export async function callTool(
   name: string,
   args: Record<string, unknown> | undefined,
 ): Promise<ToolCallResult> {
+  if (name === SKILLS_LIST_TOOL || name === SKILLS_READ_TOOL) {
+    return callSkillTool(ctx, name, args);
+  }
+
   const tool = ctx.registry.get(name);
   if (!tool) {
     await ctx.audit.record({ tool: name, result: 'denied', error: 'unknown_tool' });
@@ -183,6 +205,55 @@ export async function callTool(
       },
     ],
   };
+}
+
+async function callSkillTool(
+  ctx: DispatchContext,
+  name: string,
+  args: Record<string, unknown> | undefined,
+): Promise<ToolCallResult> {
+  if (!ctx.skills) {
+    await ctx.audit.record({ tool: name, result: 'denied', error: 'unknown_tool' });
+    return errorResult(`Unknown tool: ${name}`);
+  }
+
+  if (name === SKILLS_LIST_TOOL) {
+    const payload = listResources(ctx).map((r) => ({
+      uri: r.uri,
+      name: r.name,
+      description: r.description,
+    }));
+    await ctx.audit.record({ tool: name, result: 'ok' });
+    return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
+  }
+
+  const uri = typeof args?.uri === 'string' ? args.uri : undefined;
+  if (!uri) {
+    await ctx.audit.record({
+      tool: name,
+      args: { uri: args?.uri ?? null },
+      result: 'error',
+      error: 'invalid_input: "uri" is required',
+    });
+    return errorResult('Invalid input: "uri" (string) is required');
+  }
+
+  const skill = ctx.skills.get(uri);
+  if (!skill || !skill.uri.startsWith('skill://')) {
+    await ctx.audit.record({ tool: name, args: { uri }, result: 'denied', error: 'unknown_skill' });
+    return errorResult(`Unknown skill: ${uri}`);
+  }
+  if (!skill.audiences.includes(ctx.audience)) {
+    await ctx.audit.record({
+      tool: name,
+      args: { uri },
+      result: 'denied',
+      error: 'audience_mismatch',
+    });
+    return errorResult(`Skill ${uri} is not available for this caller`);
+  }
+  await ctx.audit.record({ tool: name, args: { uri }, result: 'ok' });
+  return { content: [{ type: 'text' as const, text: skill.content }] };
 }
 
 export function listResources(ctx: DispatchContext): ResourceListing[] {

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -274,6 +274,116 @@ describe('openInProcessMcpClient', () => {
     expect(captureException).not.toHaveBeenCalled();
   });
 
+  function skillsRegistry(): SkillRegistry {
+    const skills = new SkillRegistry();
+    skills.register({
+      uri: 'skill://playbooks/frontend-integration',
+      name: 'Frontend integration',
+      description: 'Wire a frontend to a Munin tenant',
+      audiences: ['admin'],
+      mimeType: 'text/markdown',
+      content: '# Frontend integration\nbody',
+      public: true,
+    });
+    skills.register({
+      uri: 'skill://kb/self-help',
+      name: 'Self help',
+      description: 'End-user guide',
+      audiences: ['self_service'],
+      mimeType: 'text/markdown',
+      content: '# self',
+      public: true,
+    });
+    return skills;
+  }
+
+  it('exposes skills_list and skills_read tools when skills are present', async () => {
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+      skills: skillsRegistry(),
+    });
+    const names = (await client.listTools()).map((t) => t.name);
+    expect(names).toContain('skills_list');
+    expect(names).toContain('skills_read');
+  });
+
+  it('does not expose skill tools when no skills are visible to the audience', async () => {
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+    });
+    const names = (await client.listTools()).map((t) => t.name);
+    expect(names).not.toContain('skills_list');
+    expect(names).not.toContain('skills_read');
+  });
+
+  it('skills_list returns audience-filtered skill URIs', async () => {
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+      skills: skillsRegistry(),
+    });
+    const out = await runInCtx(adminActor(), () => client.callTool('skills_list', {}));
+    expect(out.isError).toBeUndefined();
+    const listed = JSON.parse(out.content[0]!.text) as Array<{ uri: string }>;
+    const uris = listed.map((s) => s.uri);
+    expect(uris).toContain('skill://playbooks/frontend-integration');
+    expect(uris).not.toContain('skill://kb/self-help');
+  });
+
+  it('skills_read returns the skill markdown by URI', async () => {
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+      skills: skillsRegistry(),
+    });
+    const out = await runInCtx(adminActor(), () =>
+      client.callTool('skills_read', { uri: 'skill://playbooks/frontend-integration' }),
+    );
+    expect(out.isError).toBeUndefined();
+    expect(out.content[0]!.text).toContain('# Frontend integration');
+  });
+
+  it('skills_read denies a skill outside the caller audience', async () => {
+    fakeAudit.record.mockClear();
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+      skills: skillsRegistry(),
+    });
+    const out = await runInCtx(adminActor(), () =>
+      client.callTool('skills_read', { uri: 'skill://kb/self-help' }),
+    );
+    expect(out.isError).toBe(true);
+    expect(fakeAudit.record).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: 'skills_read', result: 'denied', error: 'audience_mismatch' }),
+    );
+  });
+
+  it('skills_read errors on a missing uri argument', async () => {
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+      skills: skillsRegistry(),
+    });
+    const out = await runInCtx(adminActor(), () => client.callTool('skills_read', {}));
+    expect(out.isError).toBe(true);
+    expect(out.content[0]!.text).toMatch(/uri/);
+  });
+
   it('readResource returns audience-filtered skill content', () => {
     const skills = new SkillRegistry();
     skills.register({

--- a/packages/mcp-toolkit/src/index.ts
+++ b/packages/mcp-toolkit/src/index.ts
@@ -15,5 +15,12 @@ export {
   type ToolCallResult,
   type ToolListing,
 } from './dispatch.ts';
+export {
+  SKILLS_LIST_TOOL,
+  SKILLS_READ_TOOL,
+  SKILL_TOOLS,
+  getSkillToolDescriptor,
+  type SkillToolDescriptor,
+} from './skill-tools.ts';
 export { redactSensitive } from './sensitive.ts';
 export { sensitive, isSensitiveSchema } from '@getmunin/types';

--- a/packages/mcp-toolkit/src/skill-tools.ts
+++ b/packages/mcp-toolkit/src/skill-tools.ts
@@ -1,0 +1,63 @@
+import type { Audience } from '@getmunin/core';
+
+export const SKILLS_LIST_TOOL = 'skills_list';
+export const SKILLS_READ_TOOL = 'skills_read';
+
+/**
+ * Single source of truth for the synthetic skill tools. These mirror the MCP
+ * `resources/list` / `resources/read` surface as plain tools so clients that
+ * don't expose server resources can still discover and read `skill://` guides.
+ *
+ * Consumed both by the dispatch layer (live `tools/list`) and the public tool
+ * catalog so the two never drift. They carry no scopes; output is filtered by
+ * the caller's audience at call time.
+ */
+export interface SkillToolDescriptor {
+  name: string;
+  title: string;
+  description: string;
+  audiences: readonly Audience[];
+  scopes: readonly string[];
+  readOnlyHint: boolean;
+  destructiveHint: boolean;
+  inputSchema: Record<string, unknown>;
+}
+
+export const SKILL_TOOLS: readonly SkillToolDescriptor[] = [
+  {
+    name: SKILLS_LIST_TOOL,
+    title: 'List skills',
+    description:
+      'List the available skills and playbooks — step-by-step guides for multi-step and cross-module workflows (their URIs use the `skill://` scheme). Before any setup-style task (wiring a frontend, launching a support desk, importing leads, …), call this and read the relevant guide with `skills_read` so you follow the canonical approach instead of rediscovering the same gotchas. This mirrors the MCP `resources/list` surface for clients that do not expose server resources to the model.',
+    audiences: ['admin', 'self_service'],
+    scopes: [],
+    readOnlyHint: true,
+    destructiveHint: false,
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: SKILLS_READ_TOOL,
+    title: 'Read a skill',
+    description:
+      'Read the full markdown of one skill or playbook by its `skill://` URI (get URIs from `skills_list`). Mirrors the MCP `resources/read` surface for clients that do not expose server resources to the model.',
+    audiences: ['admin', 'self_service'],
+    scopes: [],
+    readOnlyHint: true,
+    destructiveHint: false,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        uri: {
+          type: 'string',
+          description: 'The skill:// URI to read, e.g. skill://playbooks/frontend-integration',
+        },
+      },
+      required: ['uri'],
+      additionalProperties: false,
+    },
+  },
+];
+
+export function getSkillToolDescriptor(name: string): SkillToolDescriptor | undefined {
+  return SKILL_TOOLS.find((t) => t.name === name);
+}


### PR DESCRIPTION
## Why

A Lovable agent setting up a Munin frontend never found `skill://playbooks/frontend-integration` — even though it exists, is wired correctly, and is named in the server's instructions block. It hunted the KB (`kb_search`, `kb_get_document_by_slug`) and guessed at hosts instead.

Root cause is the transport, not the content: skills/playbooks are exposed **only** as MCP *resources* (`resources/list` / `resources/read`). Most coding-agent MCP clients (Lovable, Bolt, Cursor, …) implement tools only and silently drop the `resources` capability, so the model literally cannot see `skill://` URIs — no matter how prominently the server advertises them.

## What

Two synthetic tools that mirror the resource surface for resource-blind clients:

- **`skills_list`** — audience-filtered listing of `skill://` URIs (uri/name/description).
- **`skills_read`** — full markdown of one skill by URI.

Both honor the same audience gating as resources and appear in `tools/list` only when at least one skill is visible to the caller. The server instructions now point clients without resource support at these tools.

The public tool catalog (`GET /v1/public/mcp-tools`) lists them too, so it stays truthful about what the wire exposes. Both the live MCP surface and the catalog derive from a single `SKILL_TOOLS` descriptor in `@getmunin/mcp-toolkit`, so they cannot drift.

## Tests

- `@getmunin/mcp-toolkit`: 58 passing — new cases for tool visibility, audience filtering, read-by-uri, denial, missing-arg.
- `public-mcp-tools.controller.test.ts`: 6 passing — catalog now includes the skill tools; asserts `skills_read` metadata + schema.
- Added an HTTP-path integration case in `mcp.integration.test.ts` (gated on `TEST_DATABASE_URL`, unrun locally).
- Typecheck clean across both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)