### PR TITLE
fix(cms): stop public delivery wildcard from shadowing draft review route

### DIFF
--- a/.changeset/cms-drafts-route-shadowing.md
+++ b/.changeset/cms-drafts-route-shadowing.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/backend-core": patch
+---
+
+Fix CMS draft review 404: the admin `GET /v1/cms/drafts/:id` route was shadowed by the public delivery wildcard `GET /v1/cms/:orgId/:collectionSlug`. Both are 4-segment routes that match `/v1/cms/drafts/<id>`, and the public controller was registered first (first-match-wins), so draft reads resolved to `resolveOrg("drafts")` and 404'd before reaching the auth-guarded handler. `CmsDraftsController` is now registered before `CmsDeliveryController`.

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -967,6 +967,190 @@
         ]
       }
     },
+    "/v1/cms/drafts/{id}": {
+      "get": {
+        "operationId": "CmsDraftsController_get",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "CmsDrafts"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "CmsDraftsController_patch",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "CmsDrafts"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/cms/drafts/{id}/approve": {
+      "post": {
+        "operationId": "CmsDraftsController_approve",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "CmsDrafts"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/cms/drafts/{id}/schedule": {
+      "post": {
+        "operationId": "CmsDraftsController_schedule",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "CmsDrafts"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/cms/drafts/{id}/assets": {
+      "post": {
+        "operationId": "CmsDraftsController_uploadAsset",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "CmsDrafts"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/cms/drafts/{id}/dismiss": {
+      "post": {
+        "operationId": "CmsDraftsController_dismiss",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "CmsDrafts"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/cms/{orgId}/collections": {
       "get": {
         "operationId": "CmsDeliveryController_listCollections",
@@ -1173,190 +1357,6 @@
           "CmsDelivery"
         ],
         "security": []
-      }
-    },
-    "/v1/cms/drafts/{id}": {
-      "get": {
-        "operationId": "CmsDraftsController_get",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "CmsDrafts"
-        ],
-        "security": [
-          {
-            "bearer": []
-          },
-          {
-            "session": []
-          }
-        ]
-      },
-      "patch": {
-        "operationId": "CmsDraftsController_patch",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "CmsDrafts"
-        ],
-        "security": [
-          {
-            "bearer": []
-          },
-          {
-            "session": []
-          }
-        ]
-      }
-    },
-    "/v1/cms/drafts/{id}/approve": {
-      "post": {
-        "operationId": "CmsDraftsController_approve",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "CmsDrafts"
-        ],
-        "security": [
-          {
-            "bearer": []
-          },
-          {
-            "session": []
-          }
-        ]
-      }
-    },
-    "/v1/cms/drafts/{id}/schedule": {
-      "post": {
-        "operationId": "CmsDraftsController_schedule",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "CmsDrafts"
-        ],
-        "security": [
-          {
-            "bearer": []
-          },
-          {
-            "session": []
-          }
-        ]
-      }
-    },
-    "/v1/cms/drafts/{id}/assets": {
-      "post": {
-        "operationId": "CmsDraftsController_uploadAsset",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "CmsDrafts"
-        ],
-        "security": [
-          {
-            "bearer": []
-          },
-          {
-            "session": []
-          }
-        ]
-      }
-    },
-    "/v1/cms/drafts/{id}/dismiss": {
-      "post": {
-        "operationId": "CmsDraftsController_dismiss",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "CmsDrafts"
-        ],
-        "security": [
-          {
-            "bearer": []
-          },
-          {
-            "session": []
-          }
-        ]
       }
     },
     "/v1/a/v/{token}.gif": {

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -80,8 +80,11 @@ import { AuthProvidersController } from './auth-providers.controller.ts';
     UsageController,
     ExportController,
     WebhooksController,
-    CmsDeliveryController,
+    // CmsDraftsController must precede CmsDeliveryController: its static
+    // `v1/cms/drafts/:id` route otherwise loses (first-match-wins) to the
+    // public `v1/cms/:orgId/:collectionSlug` wildcard, 404ing draft reads.
     CmsDraftsController,
+    CmsDeliveryController,
     AnalyticsViewsController,
     AnalyticsTrackerController,
     AnalyticsTrackersController,

--- a/packages/backend-core/src/modules/cms/cms.integration.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.integration.test.ts
@@ -212,6 +212,42 @@ const skipReason = TEST_URL
     expect(fetched.status).toBe(404);
   }, 30_000);
 
+  it('admin drafts route is not shadowed by the public delivery wildcard', async () => {
+    // `GET /v1/cms/drafts/:id` and the public `GET /v1/cms/:orgId/:collectionSlug`
+    // are both 4-segment routes; `/v1/cms/drafts/<id>` matches both. If the public
+    // controller is registered first it wins (first-match-wins) and 404s with
+    // `cms_not_found: org drafts`, never reaching the auth-guarded drafts route.
+    let draftId = '';
+    await withClient(adminKey, async (c) => {
+      const created = parseToolResult<{ id: string }>(
+        await c.callTool({
+          name: 'cms_create_entry',
+          arguments: {
+            collection: 'pages',
+            slug: 'draft-for-review',
+            data: { title: 'Pending review', slug: 'draft-for-review', body: 'Body.' },
+            status: 'draft',
+          },
+        }),
+      );
+      draftId = created.id;
+    });
+
+    // Unauthenticated: must reach the guarded drafts controller (401), NOT the
+    // anonymous public wildcard (which would 404 on org "drafts").
+    const anon = await fetch(`${baseUrl}/v1/cms/drafts/${draftId}`);
+    expect(anon.status).toBe(401);
+
+    // Authenticated admin: the draft is served for review.
+    const authed = await fetch(`${baseUrl}/v1/cms/drafts/${draftId}`, {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(authed.status).toBe(200);
+    const body = (await authed.json()) as { id: string; status: string };
+    expect(body.id).toBe(draftId);
+    expect(body.status).toBe('draft');
+  }, 30_000);
+
   it('schedule worker promotes due scheduled entries', async () => {
     let entryId = '';
     let entryVersion = 0;


### PR DESCRIPTION
## Problem

Loading a CMS draft for review in the dashboard — `GET /v1/cms/drafts/:id` — returned **404 in production**, even though the entry existed, was a draft, belonged to the logged-in org, and RLS permitted the read.

## Root cause

`GET /v1/cms/drafts/:id` (admin, `CmsDraftsController`, auth-guarded) and the public `GET /v1/cms/:orgId/:collectionSlug` (`CmsDeliveryController`, anonymous) are **both 4-segment routes** that match `/v1/cms/drafts/<id>`. NestJS/Express resolves collisions by registration order (first-match-wins; a static segment like `drafts` gets no priority over `:orgId`). `CmsDeliveryController` was registered first, so the request resolved there as `orgId="drafts"`, hit `resolveOrg("drafts")`, found no such org, and threw `cms_not_found: org drafts` → 404 — never reaching the auth-guarded handler.

This is auth- and environment-independent, which is why org/RLS/draft-status all checked out yet it still 404'd. Only the `GET` detail route collided; `approve`/`schedule`/`dismiss` are POST and unaffected.

## Fix

- Register `CmsDraftsController` before `CmsDeliveryController` in `ControlModule`, with a comment documenting the ordering dependency. No real `orgId` is ever the literal `"drafts"`, so this cannot shadow legitimate public traffic.
- Regression test in `cms.integration.test.ts`: `GET /v1/cms/drafts/:id` now reaches the guarded controller — **401** unauthenticated (not the anonymous wildcard's 404), **200** for an admin with the draft body.
- `openapi.json` regenerated by the pre-commit hook (route-order reflection only).

## Verification

- `pnpm -F @getmunin/backend-core typecheck` passes.
- Full `cms.integration.test.ts` on a fresh DB: **11/11 pass**.
- Reverting the controller order makes the new test fail; restoring it passes — confirming the test guards the bug.

## Notes

- Lives in `@getmunin/backend-core` (patch changeset included), which munin-cloud consumes — worth confirming cloud reuses this `ControlModule` rather than wiring its own controllers array.
- Optional defense-in-depth not included: constraining the public param to the org-id shape (`:orgId(org_[a-z0-9]+)`). The reorder fully fixes the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)