### PR TITLE
fix(dashboard): handle failed detail loads in CMS and KB queue drawers

### DIFF
--- a/.changeset/cms-draft-drawer-loading.md
+++ b/.changeset/cms-draft-drawer-loading.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Fix the CMS and KB queue drawers hanging on "Loading…" when their detail fetch fails. Previously a failed `/v1/cms/drafts/:id` or `/v1/kb/curation/candidates/:id` request (e.g. a 404) was swallowed, leaving the drawer stuck on the loading text indefinitely with the approve/dismiss actions still clickable.
+
+- Surface detail-fetch errors instead of swallowing them, keyed per queue item.
+- Replace the inline "Loading…" text box with a centered spinner in the middle of the drawer.
+- Show a centered error message with a retry button when the detail fails to load.
+- Disable the approve/dismiss/edit/schedule actions (and the ⌘↵ shortcut) while the detail is loading or errored.

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -247,7 +247,9 @@ export interface InboxController {
   kbBodies: Record<string, string>;
   cmsDetails: Record<string, CmsDraftDetailDto>;
   detailErrors: Record<string, string>;
+  queueDetailErrors: Record<string, string>;
   reloadDetail: (id: string) => Promise<void>;
+  reloadQueueDetail: (id: string) => void;
   actionError: ConvActionError;
   clearActionError: () => void;
   connectionStatus: RealtimeStatus;
@@ -279,6 +281,7 @@ export function useInboxData(): InboxController {
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [retrying, setRetrying] = useState(false);
   const [detailErrors, setDetailErrors] = useState<Record<string, string>>({});
+  const [queueDetailErrors, setQueueDetailErrors] = useState<Record<string, string>>({});
   const [actionError, setActionError] = useState<ConvActionError>(null);
 
   const loadInbox = useCallback(async () => {
@@ -344,23 +347,45 @@ export function useInboxData(): InboxController {
     void loadDetail(convDrawer.id);
   }, [convDrawer, loadDetail]);
 
+  const loadKbBody = useCallback(async (id: string) => {
+    try {
+      const doc = await api<KbCandidateDto & { body: string }>(
+        `/v1/kb/curation/candidates/${id}`,
+      );
+      setKbBodies((prev) => ({ ...prev, [id]: doc.body }));
+      setQueueDetailErrors((prev) => clearKey(prev, id));
+    } catch (err) {
+      setQueueDetailErrors((prev) => ({ ...prev, [id]: messageOf(err) }));
+    }
+  }, []);
+
+  const loadCmsDetail = useCallback(async (id: string) => {
+    try {
+      const doc = await api<CmsDraftDetailDto>(`/v1/cms/drafts/${id}`);
+      setCmsDetails((prev) => ({ ...prev, [id]: doc }));
+      setQueueDetailErrors((prev) => clearKey(prev, id));
+    } catch (err) {
+      setQueueDetailErrors((prev) => ({ ...prev, [id]: messageOf(err) }));
+    }
+  }, []);
+
+  const reloadQueueDetail = useCallback((id: string) => {
+    setQueueDetailErrors((prev) => clearKey(prev, id));
+  }, []);
+
   useEffect(() => {
     if (!queueDrawer || queueDrawer.kind !== 'kb') return;
     if (kbBodies[queueDrawer.id] !== undefined) return;
-    void api<KbCandidateDto & { body: string }>(
-      `/v1/kb/curation/candidates/${queueDrawer.id}`,
-    )
-      .then((doc) => setKbBodies((prev) => ({ ...prev, [queueDrawer.id]: doc.body })))
-      .catch(() => {});
-  }, [queueDrawer, kbBodies]);
+    if (queueDetailErrors[queueDrawer.id]) return;
+    void loadKbBody(queueDrawer.id);
+  }, [queueDrawer, kbBodies, queueDetailErrors, loadKbBody]);
 
   useEffect(() => {
     if (!queueDrawer || queueDrawer.kind !== 'cms') return;
     if (cmsDetails[queueDrawer.id] !== undefined) return;
-    void api<CmsDraftDetailDto>(`/v1/cms/drafts/${queueDrawer.id}`)
-      .then((doc) => setCmsDetails((prev) => ({ ...prev, [queueDrawer.id]: doc })))
-      .catch(() => {});
-  }, [queueDrawer, cmsDetails]);
+    if (queueDetailErrors[queueDrawer.id]) return;
+    void loadCmsDetail(queueDrawer.id);
+  }, [queueDrawer, cmsDetails, queueDetailErrors, loadCmsDetail]);
 
   const subscriptions = useMemo<SubscriptionChannel[]>(() => {
     const subs: SubscriptionChannel[] = [{ channel: 'org' }];
@@ -690,7 +715,9 @@ export function useInboxData(): InboxController {
     kbBodies,
     cmsDetails,
     detailErrors,
+    queueDetailErrors,
     reloadDetail,
+    reloadQueueDetail,
     actionError,
     clearActionError,
     connectionStatus,
@@ -808,7 +835,9 @@ export function InboxDrawers({ controller }: { controller: InboxController }) {
     kbBodies,
     cmsDetails,
     detailErrors,
+    queueDetailErrors,
     reloadDetail,
+    reloadQueueDetail,
     actionError,
     clearActionError,
     send,
@@ -890,6 +919,8 @@ export function InboxDrawers({ controller }: { controller: InboxController }) {
               cmsDetail={
                 queueDrawer.kind === 'cms' ? cmsDetails[queueDrawer.id] : undefined
               }
+              detailError={queueDetailErrors[queueDrawer.id]}
+              onRetryDetail={() => reloadQueueDetail(queueDrawer.id)}
               pending={pending}
               onApprove={() => void approveQueue(queueDrawer)}
               onDismiss={() => void dismissQueue(queueDrawer)}
@@ -1606,4 +1637,11 @@ function truncate(s: string, n: number): string {
 function messageOf(err: unknown): string {
   if (err instanceof ApiError) return err.message;
   return err instanceof Error ? err.message : 'Unknown error';
+}
+
+function clearKey<T>(obj: Record<string, T>, key: string): Record<string, T> {
+  if (!(key in obj)) return obj;
+  const next = { ...obj };
+  delete next[key];
+  return next;
 }

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms.tsx
@@ -20,7 +20,14 @@ import {
   DropdownMenuTrigger,
 } from '@getmunin/ui';
 import { useRelative } from '../../../lib/use-relative';
-import { DrawerFooter, DrawerHeader, MD_COMPONENTS, useCmdEnter } from './shared';
+import {
+  DrawerErrorState,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerLoadingState,
+  MD_COMPONENTS,
+  useCmdEnter,
+} from './shared';
 import {
   humanizeFieldName,
   readAssetField,
@@ -35,6 +42,8 @@ type EditableData = Record<string, unknown>;
 export function CmsQueueDrawer({
   item,
   detail,
+  loadError,
+  onRetry,
   pending,
   onApprove,
   onDismiss,
@@ -45,6 +54,8 @@ export function CmsQueueDrawer({
 }: {
   item: { id: string; title: string; createdAt: string; raw: CmsDraftSummaryDto };
   detail: CmsDraftDetailDto | undefined;
+  loadError: string | undefined;
+  onRetry: () => void;
   pending: boolean;
   onApprove: () => void;
   onDismiss: () => void;
@@ -59,6 +70,7 @@ export function CmsQueueDrawer({
 
   const fields = detail?.fields ?? EMPTY_FIELDS;
   const initialData: EditableData = detail?.data ?? EMPTY_DATA;
+  const blocked = pending || !detail;
 
   const [editing, setEditing] = useState(false);
   const [editedData, setEditedData] = useState<EditableData>(initialData);
@@ -136,9 +148,11 @@ export function CmsQueueDrawer({
   };
 
   useCmdEnter(() => {
-    if (pending) return;
-    if (editing) void saveEdit();
-    else onApprove();
+    if (editing) {
+      if (!pending) void saveEdit();
+      return;
+    }
+    if (!blocked) onApprove();
   });
 
   useEffect(() => {
@@ -167,9 +181,9 @@ export function CmsQueueDrawer({
         closeLabel={t('close')}
       />
 
-      <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
-        {detail ? (
-          fields.map((field) => (
+      {detail ? (
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
+          {fields.map((field) => (
             <FieldSection
               key={field.name}
               field={field}
@@ -181,13 +195,17 @@ export function CmsQueueDrawer({
               onChange={(v) => setField(field.name, v)}
               onUploadAsset={onUploadAsset}
             />
-          ))
-        ) : (
-          <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed text-ink-mute italic dark:bg-card dark:border-rule-on-dark">
-            {t('loading')}
-          </div>
-        )}
-      </div>
+          ))}
+        </div>
+      ) : loadError ? (
+        <DrawerErrorState
+          message={t('detailLoadFailed')}
+          retryLabel={t('retry')}
+          onRetry={onRetry}
+        />
+      ) : (
+        <DrawerLoadingState label={t('loading')} />
+      )}
 
       {editing ? (
         <DrawerFooter
@@ -261,10 +279,10 @@ export function CmsQueueDrawer({
           </Dialog>
           <div className="flex items-center justify-between gap-2 px-6 py-3">
             <div className="flex items-center gap-2">
-              <Button variant="accent" size="sm" onClick={onApprove} disabled={pending}>
+              <Button variant="accent" size="sm" onClick={onApprove} disabled={blocked}>
                 {t('cmsApprove')}
               </Button>
-              <Button variant="outline" size="sm" onClick={onDismiss} disabled={pending}>
+              <Button variant="outline" size="sm" onClick={onDismiss} disabled={blocked}>
                 {t('cmsDismiss')}
               </Button>
               <DropdownMenu>
@@ -274,7 +292,7 @@ export function CmsQueueDrawer({
                       variant="outline"
                       size="icon-sm"
                       aria-label={t('cmsMoreMenu')}
-                      disabled={pending}
+                      disabled={blocked}
                     />
                   }
                 >
@@ -282,12 +300,12 @@ export function CmsQueueDrawer({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start">
                   <DropdownMenuItem
-                    disabled={pending || !detail}
+                    disabled={blocked}
                     onClick={() => setEditing(true)}
                   >
                     {t('edit')}
                   </DropdownMenuItem>
-                  <DropdownMenuItem disabled={pending} onClick={openScheduler}>
+                  <DropdownMenuItem disabled={blocked} onClick={openScheduler}>
                     {t('cmsSchedule')}
                   </DropdownMenuItem>
                 </DropdownMenuContent>

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/index.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/index.tsx
@@ -11,6 +11,8 @@ export function QueueDrawer({
   item,
   kbBody,
   cmsDetail,
+  detailError,
+  onRetryDetail,
   pending,
   onApprove,
   onDismiss,
@@ -23,6 +25,8 @@ export function QueueDrawer({
   item: QueueItem;
   kbBody?: string;
   cmsDetail?: CmsDraftDetailDto;
+  detailError?: string;
+  onRetryDetail: () => void;
   pending: boolean;
   onApprove: () => void;
   onDismiss: () => void;
@@ -38,6 +42,8 @@ export function QueueDrawer({
         <KbQueueDrawer
           item={item}
           body={kbBody}
+          loadError={detailError}
+          onRetry={onRetryDetail}
           pending={pending}
           onApprove={onApprove}
           onDismiss={onDismiss}
@@ -81,6 +87,8 @@ export function QueueDrawer({
         <CmsQueueDrawer
           item={item}
           detail={cmsDetail}
+          loadError={detailError}
+          onRetry={onRetryDetail}
           pending={pending}
           onApprove={onApprove}
           onDismiss={onDismiss}

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/kb.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/kb.tsx
@@ -4,12 +4,21 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import { useRelative } from '../../../lib/use-relative';
-import { DrawerFooter, DrawerHeader, MD_COMPONENTS, useCmdEnter } from './shared';
+import {
+  DrawerErrorState,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerLoadingState,
+  MD_COMPONENTS,
+  useCmdEnter,
+} from './shared';
 import type { KbCandidateDto } from './types';
 
 export function KbQueueDrawer({
   item,
   body,
+  loadError,
+  onRetry,
   pending,
   onApprove,
   onDismiss,
@@ -18,6 +27,8 @@ export function KbQueueDrawer({
 }: {
   item: { id: string; title: string; createdAt: string; raw: KbCandidateDto };
   body: string | undefined;
+  loadError: string | undefined;
+  onRetry: () => void;
   pending: boolean;
   onApprove: () => void;
   onDismiss: () => void;
@@ -28,6 +39,7 @@ export function KbQueueDrawer({
   const tQueue = useTranslations('dashboard.overview.queue');
   const age = useRelative();
   const initialBody = body ?? '';
+  const blocked = pending || body === undefined;
   const [editing, setEditing] = useState(false);
   const [editedBody, setEditedBody] = useState(initialBody);
 
@@ -48,9 +60,11 @@ export function KbQueueDrawer({
   };
 
   useCmdEnter(() => {
-    if (pending) return;
-    if (editing) void saveEdit();
-    else onApprove();
+    if (editing) {
+      if (!pending) void saveEdit();
+      return;
+    }
+    if (!blocked) onApprove();
   });
 
   useEffect(() => {
@@ -79,30 +93,36 @@ export function KbQueueDrawer({
         closeLabel={t('close')}
       />
 
-      <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
-        <section className="space-y-2">
-          <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
-            {t('proposal')}
-          </p>
-          {editing ? (
-            <textarea
-              value={editedBody}
-              onChange={(e) => setEditedBody(e.target.value)}
-              rows={14}
-              className="w-full resize-y rounded-input border-[0.5px] border-cobalt bg-paper px-4 py-3 text-sm leading-relaxed outline-none focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:text-foreground"
-              autoFocus
-            />
-          ) : (
-            <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
-              {body !== undefined ? (
+      {body !== undefined ? (
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
+          <section className="space-y-2">
+            <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+              {t('proposal')}
+            </p>
+            {editing ? (
+              <textarea
+                value={editedBody}
+                onChange={(e) => setEditedBody(e.target.value)}
+                rows={14}
+                className="w-full resize-y rounded-input border-[0.5px] border-cobalt bg-paper px-4 py-3 text-sm leading-relaxed outline-none focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:text-foreground"
+                autoFocus
+              />
+            ) : (
+              <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
                 <ReactMarkdown components={MD_COMPONENTS}>{editedBody}</ReactMarkdown>
-              ) : (
-                <span className="text-ink-mute italic">{t('loading')}</span>
-              )}
-            </div>
-          )}
-        </section>
-      </div>
+              </div>
+            )}
+          </section>
+        </div>
+      ) : loadError ? (
+        <DrawerErrorState
+          message={t('detailLoadFailed')}
+          retryLabel={t('retry')}
+          onRetry={onRetry}
+        />
+      ) : (
+        <DrawerLoadingState label={t('loading')} />
+      )}
 
       {editing ? (
         <DrawerFooter
@@ -116,10 +136,10 @@ export function KbQueueDrawer({
         />
       ) : (
         <DrawerFooter
-          primary={{ label: t('approve'), onClick: onApprove, disabled: pending }}
+          primary={{ label: t('approve'), onClick: onApprove, disabled: blocked }}
           secondary={[
-            { label: t('edit'), onClick: () => setEditing(true), disabled: body === undefined },
-            { label: t('dismiss'), onClick: onDismiss, disabled: pending },
+            { label: t('edit'), onClick: () => setEditing(true), disabled: blocked },
+            { label: t('dismiss'), onClick: onDismiss, disabled: blocked },
           ]}
           shortcut={t('shortcutApprove')}
         />

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/shared.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/shared.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { AlertCircle, Loader2 } from 'lucide-react';
 import { Button, Pill, cn } from '@getmunin/ui';
 import type { Components } from 'react-markdown';
 
@@ -53,6 +54,45 @@ export function useCmdEnter(handler: () => void) {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [handler]);
+}
+
+export function DrawerLoadingState({ label }: { label: string }) {
+  return (
+    <div
+      className="flex flex-1 items-center justify-center"
+      role="status"
+      aria-busy="true"
+    >
+      <Loader2
+        className="size-6 animate-spin text-ink-mute dark:text-foreground/60"
+        aria-hidden
+      />
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}
+
+export function DrawerErrorState({
+  message,
+  retryLabel,
+  onRetry,
+}: {
+  message: string;
+  retryLabel: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div
+      className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center"
+      role="alert"
+    >
+      <AlertCircle className="size-6 text-destructive" aria-hidden />
+      <p className="text-sm text-ink-mute">{message}</p>
+      <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+        {retryLabel}
+      </Button>
+    </div>
+  );
 }
 
 export function DrawerHeader({

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -331,6 +331,7 @@
         "seenAt": "Seen {time}",
         "loadFailedEyebrow": "Couldn't load",
         "loadFailedTitle": "This conversation didn't load.",
+        "detailLoadFailed": "This didn't load.",
         "actionFailed": {
           "send": "Couldn't send your reply",
           "takeOver": "Couldn't take over",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -331,6 +331,7 @@
         "seenAt": "Sett {time}",
         "loadFailedEyebrow": "Kunne ikke laste",
         "loadFailedTitle": "Denne samtalen lot seg ikke laste.",
+        "detailLoadFailed": "Innholdet lot seg ikke laste.",
         "actionFailed": {
           "send": "Kunne ikke sende svaret ditt",
           "takeOver": "Kunne ikke overta",


### PR DESCRIPTION
## Problem

The CMS draft drawer hung on **"Laster…"** indefinitely when its detail fetch returned a 404. The `/v1/cms/drafts/:id` request error was swallowed with `.catch(() => {})`, so the detail stayed `undefined`, the loading text never cleared, and the approve/dismiss buttons remained clickable against a draft that never loaded.

The KB queue drawer shared the exact same bug (`/v1/kb/curation/candidates/:id` with the same swallow-all `.catch`). CRM, outreach, and feedback drawers read `item.raw` synchronously with no fetch, so they were unaffected.

## Changes

- **Surface detail-fetch errors** — `useInboxData` now records per-item fetch errors (`queueDetailErrors`) instead of swallowing them, and exposes a `reloadQueueDetail` retry that re-triggers the fetch.
- **Centered spinner** — loading now renders a centered `Loader2` spinner in the middle of the drawer instead of the inline italic text box (new shared `DrawerLoadingState`).
- **Error state** — on fetch failure the drawer shows a centered error message with a **Retry** button (new shared `DrawerErrorState`).
- **Disabled actions** — approve / dismiss / edit / schedule (and the ⌘↵ shortcut) are disabled while the detail is loading or errored.
- Added the `detailLoadFailed` translation to `en.json` / `nb.json`; reused existing `loading` and `retry` keys.

## Verification

- `pnpm -F @getmunin/dashboard-pages typecheck` ✅
- `pnpm -F @getmunin/dashboard-pages lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)