### PR TITLE
docs: add closing line to "Why I built this"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Then our AI agents started doing the prospecting and outreach themselves, and it
 
 So I built the thing I actually wanted. Over roughly a month, with Claude Code as my primary IDE, Munin went from nothing to what's in this repo. I've shipped production software for about twenty years — that experience is what shaped the architecture and let me catch the agent when it got things wrong. Claude Code took the labor of typing it out of the equation; a year ago I don't think this would have been feasible solo.
 
+Munin isn't the AI — it's what your AI uses. You bring the agent, write the prompts, wire up the workflows; Munin's job is to be the cleanest possible tool surface underneath. It's open source and yours to run.
+
 ## What's in the box
 
 - **Knowledge Base** — markdown documents, hybrid search (BM25 + pgvector embeddings), per-document audience scoping.


### PR DESCRIPTION
Ends the backstory on the product-defining beat — "Munin isn't the AI; it's what your AI uses" — instead of dead-ending on the build process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)