### PR TITLE
chore: ignore js-yaml in Dependabot + release security dep patches

### DIFF
--- a/.changeset/patch-security-deps.md
+++ b/.changeset/patch-security-deps.md
@@ -1,0 +1,7 @@
+---
+"@getmunin/core": patch
+"@getmunin/backend-core": patch
+"@getmunin/agent-runtime": patch
+---
+
+Patch security-vulnerable dependencies. Bump nodemailer to ^8.0.9 (CRLF header injection, OAuth2 TLS certificate validation) and ws to ^8.21.0 (memory-exhaustion DoS), and force patched transitive versions of hono, form-data, multer, @opentelemetry/core, and @babel/core via pnpm overrides.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # 0 keeps security updates on while suppressing routine version-update PRs.
+    open-pull-requests-limit: 0
+    ignore:
+      # Pinned transitively at v3 by changesets (read-yaml-file uses the v3-only
+      # safeLoad API); the patched v4.2.0 can't be installed. Dev-scope DoS.
+      - dependency-name: "js-yaml"


### PR DESCRIPTION
Two housekeeping items following the security dependency work:

- **`.github/dependabot.yml`** — stops the failing Dependabot security-update job for js-yaml (its patched v4.2.0 can't be installed under the changesets-pinned v3). Keeps security updates on for everything else; `open-pull-requests-limit: 0` suppresses routine version-update PRs (matching current behavior — there was no config file before).
- **Changeset** — none of the security dep PRs (#463, #469, #471) carried a changeset, so no release was cut. This patch-bumps the `@getmunin/*` fixed group so the published packages actually ship the nodemailer/ws fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)