### PR TITLE
feat(kb): reconcile website imports, follow root redirects, fix titles

### DIFF
--- a/.changeset/website-import-reconcile.md
+++ b/.changeset/website-import-reconcile.md
@@ -1,0 +1,12 @@
+---
+"@getmunin/agent-runtime": minor
+"@getmunin/agent-host": minor
+"@getmunin/backend-core": minor
+---
+
+Website import now reaches client-rendered sites, prunes deleted pages, and titles pages correctly.
+
+- The crawler follows client-side root redirects (`<meta http-equiv="refresh">` / `<link rel="canonical">`), so importing a bare domain that bounces to a locale path (e.g. `/` → `/en/`) discovers the real page tree instead of stalling on an empty shell.
+- Title extraction prefers the first `<h1>` over a shared static `<title>`, so SPA routes no longer collapse to one repeated title.
+- `kb_import_website` reconciles by default: after a healthy crawl, previously imported pages that are individually re-checked and confirmed gone (HTTP 404/410) are deleted from the knowledge base. Pass `reconcile: false` to import additively. Each imported document records its origin as a `source-url:<url>` tag for precise revalidation.
+- `kb_list_documents` now returns each document's `slug`.

--- a/packages/agent-host/src/web-import.handler.test.ts
+++ b/packages/agent-host/src/web-import.handler.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CrawlResult, McpToolHandle, McpToolResult } from '@getmunin/agent-runtime';
+import { reconcileSpace, candidateUrls } from './web-import.handler.ts';
+
+const probeUrlMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@getmunin/agent-runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@getmunin/agent-runtime')>();
+  return { ...actual, probeUrl: probeUrlMock };
+});
+
+type DocRow = {
+  id: string;
+  slug: string | null;
+  title: string;
+  version: number;
+  tags: string[];
+};
+
+function fakeMcp(docs: DocRow[]) {
+  const deleted: string[] = [];
+  const handle = {
+    callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
+      if (name === 'kb_list_documents') {
+        return Promise.resolve({ content: [{ type: 'text', text: JSON.stringify(docs) }], isError: false });
+      }
+      if (name === 'kb_delete_document') {
+        deleted.push(String(args.id));
+        return Promise.resolve({
+          content: [{ type: 'text', text: JSON.stringify({ deleted: true }) }],
+          isError: false,
+        });
+      }
+      return Promise.resolve({ content: [{ type: 'text', text: 'unexpected' }], isError: true });
+    },
+  } as unknown as McpToolHandle;
+  return { handle, deleted };
+}
+
+function crawlWith(paths: string[]): CrawlResult {
+  return {
+    siteUrl: 'https://example.com/',
+    siteTitle: 'Example',
+    pages: paths.map((p) => ({
+      url: `https://example.com${p}`,
+      title: p,
+      markdown: 'x'.repeat(300),
+      wordCount: 50,
+    })),
+    skipped: [],
+  };
+}
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+const src = (url: string) => `source-url:${url}`;
+
+beforeEach(() => {
+  probeUrlMock.mockReset();
+  logger.info.mockReset();
+  logger.warn.mockReset();
+  logger.error.mockReset();
+});
+
+describe('candidateUrls', () => {
+  it('prefers the stored source-url tag', () => {
+    const doc: DocRow = { id: 'd', slug: 'pricing', title: 'P', version: 1, tags: [src('https://x.com/p')] };
+    expect(candidateUrls(doc, 'https://example.com')).toEqual(['https://x.com/p']);
+  });
+  it('reconstructs flat and slashed URLs from the slug when untagged', () => {
+    const doc: DocRow = { id: 'd', slug: 'en-docs-guides', title: 'D', version: 1, tags: ['imported-from-website'] };
+    expect(candidateUrls(doc, 'https://example.com')).toEqual([
+      'https://example.com/en-docs-guides',
+      'https://example.com/en/docs/guides',
+    ]);
+  });
+  it('maps the home slug to the origin root', () => {
+    const doc: DocRow = { id: 'd', slug: 'home', title: 'H', version: 1, tags: [] };
+    expect(candidateUrls(doc, 'https://example.com')).toEqual(['https://example.com/']);
+  });
+});
+
+describe('reconcileSpace', () => {
+  const live = ['/', '/about', '/contact'];
+
+  it('prunes a doc whose source page is confirmed gone (404), keeping live and unverifiable docs', async () => {
+    const docs: DocRow[] = [
+      { id: 'd_pricing', slug: 'pricing', title: 'Pricing', version: 2, tags: ['imported-from-website', src('https://example.com/pricing')] },
+      { id: 'd_about', slug: 'about', title: 'About', version: 1, tags: ['imported-from-website', src('https://example.com/about')] },
+      { id: 'd_profile', slug: 'company-profile', title: 'Company profile', version: 5, tags: ['imported-from-website', 'company-profile'] },
+      { id: 'd_old', slug: 'old', title: 'Old', version: 1, tags: ['imported-from-website', src('https://example.com/old')] },
+      { id: 'd_flaky', slug: 'flaky', title: 'Flaky', version: 1, tags: ['imported-from-website', src('https://example.com/flaky')] },
+    ];
+    probeUrlMock.mockImplementation((url: string) => {
+      if (url === 'https://example.com/pricing') return Promise.resolve({ status: 404, finalUrl: url });
+      if (url === 'https://example.com/old') return Promise.resolve({ status: 200, finalUrl: url });
+      if (url === 'https://example.com/flaky') return Promise.reject(new Error('timeout'));
+      return Promise.resolve({ status: 200, finalUrl: url });
+    });
+
+    const { handle, deleted } = fakeMcp(docs);
+    const pruned = await reconcileSpace(handle, 'spc', crawlWith(live), 4, logger);
+
+    expect(pruned).toBe(1);
+    expect(deleted).toEqual(['d_pricing']);
+  });
+
+  it('refuses to prune when the crawl is too small', async () => {
+    const docs: DocRow[] = [
+      { id: 'd_pricing', slug: 'pricing', title: 'Pricing', version: 2, tags: ['imported-from-website', src('https://example.com/pricing')] },
+    ];
+    probeUrlMock.mockResolvedValue({ status: 404, finalUrl: 'x' });
+    const { handle, deleted } = fakeMcp(docs);
+
+    const pruned = await reconcileSpace(handle, 'spc', crawlWith(['/', '/about']), 2, logger);
+
+    expect(pruned).toBe(0);
+    expect(deleted).toEqual([]);
+    expect(probeUrlMock).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/agent-host/src/web-import.handler.ts
+++ b/packages/agent-host/src/web-import.handler.ts
@@ -2,6 +2,7 @@ import {
   WebCrawler,
   classifyProviderError,
   openAiCompatibleProvider,
+  probeUrl,
   type CrawledPage,
   type CrawlResult,
   type CuratorJob,
@@ -15,6 +16,11 @@ const TARGET_SPACE_SLUG = 'website-import';
 const MAX_PAGES_TO_INSERT = 30;
 const PROFILE_CONTEXT_PAGES = 8;
 const PROFILE_MAX_TOKENS = 1200;
+const IMPORT_TAG = 'imported-from-website';
+const PROFILE_TAG = 'company-profile';
+const PROFILE_SLUG = 'company-profile';
+const SOURCE_URL_TAG_PREFIX = 'source-url:';
+const MIN_PAGES_FOR_PRUNE = 3;
 
 export interface WebImportHandlerOpts {
   job: CuratorJob;
@@ -63,8 +69,12 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
     if (ok) created++;
   }
 
-  const payload = opts.job.sourceEventPayload as { synthesizeCompanyProfile?: boolean } | null;
+  const payload = opts.job.sourceEventPayload as {
+    synthesizeCompanyProfile?: boolean;
+    reconcile?: boolean;
+  } | null;
   const synthesizeCompanyProfile = payload?.synthesizeCompanyProfile !== false;
+  const reconcile = payload?.reconcile !== false;
 
   let profileTokens = 0;
   let providerError: ProviderErrorClassification | null = null;
@@ -96,14 +106,158 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
     };
   }
 
-  const replyText = `Imported ${created} document(s) from ${crawl.siteUrl}; ${crawl.skipped.length} URL(s) skipped.`;
+  let pruned = 0;
+  if (reconcile) {
+    pruned = await reconcileSpace(mcp, spaceId, crawl, created, opts.logger);
+  }
+
+  const prunedText = pruned > 0 ? ` Pruned ${pruned} document(s) no longer on the site.` : '';
+  const replyText = `Imported ${created} document(s) from ${crawl.siteUrl}; ${crawl.skipped.length} URL(s) skipped.${prunedText}`;
   return {
     ok: true,
-    toolCalls: created,
+    toolCalls: created + pruned,
     totalTokens: profileTokens,
     finishReason: 'stop',
     replyText,
   };
+}
+
+export interface DocSummary {
+  id: string;
+  slug: string | null;
+  title: string;
+  version: number;
+  tags: string[];
+}
+
+export async function reconcileSpace(
+  mcp: McpToolHandle,
+  spaceId: string,
+  crawl: CrawlResult,
+  importedDocs: number,
+  logger: WebImportHandlerOpts['logger'],
+): Promise<number> {
+  if (crawl.pages.length < MIN_PAGES_FOR_PRUNE || importedDocs === 0) {
+    logger.warn(
+      `reconcile skipped for ${crawl.siteUrl}: crawl too small (${crawl.pages.length} page(s), ${importedDocs} imported) — refusing to prune`,
+    );
+    return 0;
+  }
+
+  const origin = originOf(crawl.siteUrl);
+  const liveSlugs = new Set<string>([PROFILE_SLUG]);
+  for (const page of crawl.pages) {
+    const slug = slugifyUrl(page.url);
+    if (slug) liveSlugs.add(slug);
+  }
+
+  const listed = await mcp
+    .callTool('kb_list_documents', { spaceId, tag: IMPORT_TAG, limit: 200 })
+    .catch((err: unknown) => toolError(err));
+  if (listed.isError) {
+    logger.warn(`reconcile: kb_list_documents failed: ${stringifyToolResult(listed)}`);
+    return 0;
+  }
+  const docs = parseDocumentSummaries(listed);
+  if (docs.length >= 200) {
+    logger.warn(`reconcile: hit 200-document list cap for space ${spaceId}; some docs were not checked`);
+  }
+
+  let pruned = 0;
+  for (const doc of docs) {
+    if (!doc.slug || liveSlugs.has(doc.slug)) continue;
+    if (doc.slug === PROFILE_SLUG || doc.tags.includes(PROFILE_TAG)) continue;
+
+    const candidates = candidateUrls(doc, origin);
+    if (candidates.length === 0) continue;
+
+    const verdict = await classifyDocLiveness(candidates);
+    if (verdict !== 'gone') {
+      if (verdict === 'unknown') {
+        logger.info(`reconcile: leaving "${doc.title}" (${doc.slug}) — could not confirm its source page is gone`);
+      }
+      continue;
+    }
+
+    const deleted = await mcp
+      .callTool('kb_delete_document', { id: doc.id, ifVersion: doc.version })
+      .catch((err: unknown) => toolError(err));
+    if (deleted.isError) {
+      logger.warn(`reconcile: kb_delete_document failed for ${doc.slug}: ${stringifyToolResult(deleted)}`);
+      continue;
+    }
+    pruned++;
+    logger.info(`reconcile: pruned "${doc.title}" (${doc.slug}) — source page is gone`);
+  }
+  return pruned;
+}
+
+export function candidateUrls(doc: DocSummary, origin: string | null): string[] {
+  const tagged = doc.tags.find((t) => t.startsWith(SOURCE_URL_TAG_PREFIX));
+  if (tagged) {
+    const url = tagged.slice(SOURCE_URL_TAG_PREFIX.length).trim();
+    return url ? [url] : [];
+  }
+  if (!origin || !doc.slug) return [];
+  if (doc.slug === 'home') return [`${origin}/`];
+  const flat = `${origin}/${doc.slug}`;
+  const slashed = `${origin}/${doc.slug.replace(/-/g, '/')}`;
+  return flat === slashed ? [flat] : [flat, slashed];
+}
+
+async function classifyDocLiveness(urls: string[]): Promise<'alive' | 'gone' | 'unknown'> {
+  let sawGone = false;
+  for (const url of urls) {
+    try {
+      const { status } = await probeUrl(url);
+      if (status === 404 || status === 410) {
+        sawGone = true;
+      } else {
+        return 'alive';
+      }
+    } catch {
+      // transient/network error — inconclusive for this candidate, fall through
+    }
+  }
+  return sawGone ? 'gone' : 'unknown';
+}
+
+function originOf(url: string): string | null {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function parseDocumentSummaries(res: McpToolResult): DocSummary[] {
+  for (const item of res.content) {
+    if (item.type !== 'text') continue;
+    const text = (item as { text?: string }).text;
+    if (!text) continue;
+    const parsed = tryParseJson(text);
+    const arr = Array.isArray(parsed)
+      ? parsed
+      : parsed && typeof parsed === 'object' && Array.isArray((parsed as { documents?: unknown }).documents)
+        ? (parsed as { documents: unknown[] }).documents
+        : null;
+    if (!arr) continue;
+    const out: DocSummary[] = [];
+    for (const node of arr) {
+      if (!node || typeof node !== 'object') continue;
+      const obj = node as Record<string, unknown>;
+      if (typeof obj.id !== 'string' || typeof obj.version !== 'number') continue;
+      out.push({
+        id: obj.id,
+        slug: typeof obj.slug === 'string' ? obj.slug : null,
+        title: typeof obj.title === 'string' ? obj.title : '',
+        version: obj.version,
+        tags: Array.isArray(obj.tags) ? obj.tags.filter((t): t is string => typeof t === 'string') : [],
+      });
+    }
+    return out;
+  }
+  return [];
 }
 
 async function ensureSpace(mcp: McpToolHandle): Promise<string> {
@@ -188,7 +342,7 @@ async function upsertPageDocument(
       title: page.title,
       body: page.markdown,
       audiences: ['admin', 'self_service'],
-      tags: ['imported-from-website'],
+      tags: [IMPORT_TAG, `${SOURCE_URL_TAG_PREFIX}${page.url}`],
     },
     `page ${page.url}`,
     logger,
@@ -204,13 +358,13 @@ async function upsertProfileDocument(
   return upsertKbDocumentBySlug(
     mcp,
     TARGET_SPACE_SLUG,
-    'company-profile',
+    PROFILE_SLUG,
     {
       spaceId,
       title: 'Company profile',
       body,
       audiences: ['admin', 'self_service'],
-      tags: ['imported-from-website', 'company-profile'],
+      tags: [IMPORT_TAG, PROFILE_TAG],
     },
     'company profile',
     logger,

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -61,6 +61,7 @@ export {
 } from './skill-pass.ts';
 export {
   WebCrawler,
+  probeUrl,
   type CrawlOptions,
   type CrawlResult,
   type CrawledPage,

--- a/packages/agent-runtime/src/web-crawl.test.ts
+++ b/packages/agent-runtime/src/web-crawl.test.ts
@@ -163,6 +163,16 @@ describe('extractBasic title', () => {
     const html = `<head><title>Pricing</title></head><body><p>${body}</p></body>`;
     expect(extractBasic(html)?.title).toBe('Pricing');
   });
+  it('strips nested tags inside the h1', () => {
+    const html = `<body><h1><span>Lead</span> <b>research</b></h1><p>${body}</p></body>`;
+    expect(extractBasic(html)?.title).toBe('Lead research');
+  });
+  it('stays linear on adversarial unclosed-tag input', () => {
+    const html = `<body><h1>${'<'.repeat(50000)}</h1><p>${body}</p></body>`;
+    const start = Date.now();
+    extractBasic(html);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
 });
 
 describe('rankUrls', () => {

--- a/packages/agent-runtime/src/web-crawl.test.ts
+++ b/packages/agent-runtime/src/web-crawl.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   WebCrawler,
+  extractBasic,
   extractLinks,
+  extractRedirectTarget,
   extractSitemapLocs,
   normalizeCandidateUrl,
   normalizeStartUrl,
@@ -137,6 +139,32 @@ describe('extractLinks', () => {
   });
 });
 
+describe('extractRedirectTarget', () => {
+  it('reads a meta-refresh redirect', () => {
+    const html = `<head><meta http-equiv="refresh" content="0; url=/en/"><link rel="canonical" href="/en/"></head>`;
+    expect(extractRedirectTarget(html, 'https://example.com/')).toBe('https://example.com/en/');
+  });
+  it('falls back to canonical when no meta refresh', () => {
+    const html = `<head><link rel="canonical" href="https://example.com/en/home"></head>`;
+    expect(extractRedirectTarget(html, 'https://example.com/')).toBe('https://example.com/en/home');
+  });
+  it('returns null when neither is present', () => {
+    expect(extractRedirectTarget('<head></head>', 'https://example.com/')).toBeNull();
+  });
+});
+
+describe('extractBasic title', () => {
+  const body = 'The quick brown fox jumps over the lazy dog and recites HTTP poems. '.repeat(6);
+  it('prefers the first h1 over a generic title tag', () => {
+    const html = `<head><title>Munin — The platform</title></head><body><h1>Lead research recipe</h1><p>${body}</p></body>`;
+    expect(extractBasic(html)?.title).toBe('Lead research recipe');
+  });
+  it('falls back to the title tag when no h1', () => {
+    const html = `<head><title>Pricing</title></head><body><p>${body}</p></body>`;
+    expect(extractBasic(html)?.title).toBe('Pricing');
+  });
+});
+
 describe('rankUrls', () => {
   it('puts home, about, pricing first', () => {
     const out = rankUrls(
@@ -202,6 +230,34 @@ describe('WebCrawler.crawl', () => {
     const urls = result.pages.map((p) => p.url);
     expect(urls).toContain('https://example.com/about');
     expect(urls).toContain('https://example.com/pricing');
+  });
+
+  it('follows a client-side root redirect to discover the real site', async () => {
+    const routes: RouteMap = {
+      'https://example.com/robots.txt': { status: 404 },
+      'https://example.com/sitemap.xml': { status: 404 },
+      'https://example.com/sitemap_index.xml': { status: 404 },
+      'https://example.com/sitemap-pages.xml': { status: 404 },
+      'https://example.com/': {
+        body: `<html><head><meta http-equiv="refresh" content="0; url=/en/"><link rel="canonical" href="/en/"></head><body></body></html>`,
+      },
+      'https://example.com/en': {
+        body:
+          `<html><head><title>Home</title></head><body>` +
+          'The quick brown fox jumps over the lazy dog every weekday morning and recites a small poem about HTTP. '.repeat(
+            6,
+          ) +
+          `<a href="/en/about">about</a><a href="/en/pricing">pricing</a></body></html>`,
+      },
+      'https://example.com/en/about': { body: goodBody('About') },
+      'https://example.com/en/pricing': { body: goodBody('Pricing') },
+    };
+    const svc = new WebCrawler({ fetcher: makeFetcher(routes), extractor: passthroughExtractor });
+    const result = await svc.crawl({ url: 'https://example.com' });
+    const urls = result.pages.map((p) => p.url);
+    expect(urls).toContain('https://example.com/en');
+    expect(urls).toContain('https://example.com/en/about');
+    expect(urls).toContain('https://example.com/en/pricing');
   });
 
   it('honors maxPages cap', async () => {

--- a/packages/agent-runtime/src/web-crawl.ts
+++ b/packages/agent-runtime/src/web-crawl.ts
@@ -252,7 +252,10 @@ export class WebCrawler {
           continue;
         }
         if (res.status >= 400 || !res.contentType.includes('html')) continue;
-        for (const link of extractLinks(res.body, res.finalUrl)) {
+        const links = extractLinks(res.body, res.finalUrl);
+        const redirect = extractRedirectTarget(res.body, res.finalUrl);
+        if (redirect) links.push(redirect);
+        for (const link of links) {
           const normalized = normalizeCandidateUrl(link, origin);
           if (!normalized) continue;
           if (visited.has(normalized)) continue;
@@ -348,6 +351,40 @@ export function extractLinks(html: string, baseUrl: string): string[] {
     }
   }
   return out;
+}
+
+export function extractRedirectTarget(html: string, baseUrl: string): string | null {
+  const meta = /<meta\b[^>]*http-equiv\s*=\s*["']?refresh["']?[^>]*>/i.exec(html);
+  if (meta) {
+    const content = /content\s*=\s*["']([^"']*)["']/i.exec(meta[0]);
+    const urlPart = content ? /url\s*=\s*(.+)$/i.exec(content[1]!.trim()) : null;
+    if (urlPart) {
+      const raw = urlPart[1]!.trim().replace(/^["']|["']$/g, '');
+      try {
+        return new URL(decodeEntities(raw), baseUrl).toString();
+      } catch (err) {
+        console.debug(`[web-crawl] bad meta-refresh url "${raw}" in ${baseUrl}: ${describeError(err)}`);
+      }
+    }
+  }
+  const canonical = /<link\b[^>]*rel\s*=\s*["']?canonical["']?[^>]*>/i.exec(html);
+  if (canonical) {
+    const href = /href\s*=\s*["']([^"']+)["']/i.exec(canonical[0]);
+    if (href) {
+      try {
+        return new URL(decodeEntities(href[1]!), baseUrl).toString();
+      } catch (err) {
+        console.debug(`[web-crawl] bad canonical href "${href[1]}" in ${baseUrl}: ${describeError(err)}`);
+      }
+    }
+  }
+  return null;
+}
+
+function extractFirstHeading(html: string): string {
+  const m = /<h1\b[^>]*>([\s\S]*?)<\/h1\s*>/i.exec(html);
+  if (!m) return '';
+  return decodeEntities(m[1]!.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim();
 }
 
 function decodeEntities(s: string): string {
@@ -528,6 +565,11 @@ const defaultFetcher: HtmlFetcher = async (url) => {
   }
 };
 
+export async function probeUrl(url: string): Promise<{ status: number; finalUrl: string }> {
+  const res = await defaultFetcher(url);
+  return { status: res.status, finalUrl: res.finalUrl };
+}
+
 async function readBodyCapped(res: { body: ReadableStream<Uint8Array> | null }, cap: number): Promise<string> {
   if (!res.body) return '';
   const reader = res.body.getReader();
@@ -561,7 +603,12 @@ const defaultExtractor: Extractor = async (html, url) => {
     const result = await withSilencedDefuddleLogs(() => fn(html, url, { markdown: true }));
     const md = (result?.content ?? '').toString().trim();
     if (!md) return null;
-    return { title: (result?.title ?? '').toString().trim(), markdown: md };
+    const defuddleTitle = (result?.title ?? '').toString().trim();
+    const heading = extractFirstHeading(html);
+    const titleTag = extractTitleTag(html);
+    const title =
+      !defuddleTitle || defuddleTitle === titleTag ? heading || defuddleTitle || titleTag : defuddleTitle;
+    return { title, markdown: md };
   } catch (err) {
     console.warn(
       `[web-crawl] defuddle extraction failed for "${url}", falling back: ${describeError(err)}`,
@@ -608,9 +655,13 @@ async function loadDefuddle(): Promise<DefuddleFn | null> {
   }
 }
 
-function extractBasic(html: string): { title: string; markdown: string } | null {
+function extractTitleTag(html: string): string {
   const titleMatch = /<title\b[^>]*>([\s\S]*?)<\/title\s*>/i.exec(html);
-  const title = titleMatch ? decodeEntities(titleMatch[1]!).replace(/\s+/g, ' ').trim() : '';
+  return titleMatch ? decodeEntities(titleMatch[1]!).replace(/\s+/g, ' ').trim() : '';
+}
+
+export function extractBasic(html: string): { title: string; markdown: string } | null {
+  const title = extractFirstHeading(html) || extractTitleTag(html);
   const blockTag = /<(script|style|nav|footer|header)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
   let stripped = html;
   for (;;) {

--- a/packages/agent-runtime/src/web-crawl.ts
+++ b/packages/agent-runtime/src/web-crawl.ts
@@ -384,7 +384,7 @@ export function extractRedirectTarget(html: string, baseUrl: string): string | n
 function extractFirstHeading(html: string): string {
   const m = /<h1\b[^>]*>([\s\S]*?)<\/h1\s*>/i.exec(html);
   if (!m) return '';
-  return decodeEntities(m[1]!.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim();
+  return decodeEntities(m[1]!.replace(/<[^<>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
 }
 
 function decodeEntities(s: string): string {
@@ -669,7 +669,7 @@ export function extractBasic(html: string): { title: string; markdown: string } 
     if (next === stripped) break;
     stripped = next;
   }
-  stripped = stripped.replace(/<[^>]+>/g, ' ');
+  stripped = stripped.replace(/<[^<>]*>/g, ' ');
   const text = decodeEntities(stripped).replace(/\s+/g, ' ').trim();
   if (text.length < MIN_BODY_CHARS) return null;
   return { title, markdown: text };

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -4402,7 +4402,7 @@
   {
     "name": "kb_import_website",
     "title": "KB: Import website",
-    "description": "Crawl a public website and populate the knowledge base from it: one KB document per page. Runs asynchronously on the curator queue — returns a job id you can track with the curator jobs control plane. Pass a homepage URL (a bare domain like `example.com` is accepted). The URL must be publicly reachable; localhost and private/internal addresses are rejected. Re-importing the same URL while a scrape is still pending returns the in-flight job instead of starting a second one.\n\nBy default the import also synthesizes a `company-profile` KB document (slug `company-profile`) that seeds the chat widget — appropriate when importing your own company's site. Set `synthesizeCompanyProfile: false` when importing third-party or topic pages that are NOT your company's website, so the import doesn't overwrite your company profile with unrelated content.",
+    "description": "Crawl a public website and populate the knowledge base from it: one KB document per page. Runs asynchronously on the curator queue — returns a job id you can track with the curator jobs control plane. Pass a homepage URL (a bare domain like `example.com` is accepted). The URL must be publicly reachable; localhost and private/internal addresses are rejected. Re-importing the same URL while a scrape is still pending returns the in-flight job instead of starting a second one.\n\nBy default the import also synthesizes a `company-profile` KB document (slug `company-profile`) that seeds the chat widget — appropriate when importing your own company's site. Set `synthesizeCompanyProfile: false` when importing third-party or topic pages that are NOT your company's website, so the import doesn't overwrite your company profile with unrelated content.\n\nReconciliation is on by default: after a healthy crawl, previously imported pages that are no longer on the site (re-checked individually and confirmed to return 404/410) are deleted from the knowledge base, so a refresh prunes removed pages. Set `reconcile: false` to import additively without pruning.",
     "audiences": [
       "admin"
     ],
@@ -4421,6 +4421,9 @@
           "maxLength": 2048
         },
         "synthesizeCompanyProfile": {
+          "type": "boolean"
+        },
+        "reconcile": {
           "type": "boolean"
         }
       },

--- a/packages/backend-core/src/modules/kb/kb.service.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.ts
@@ -85,6 +85,7 @@ export interface CurationCandidateDto extends DocumentDto {
 export interface DocumentSummary {
   id: string;
   spaceId: string;
+  slug: string | null;
   title: string;
   audiences: Audience[];
   version: number;
@@ -171,6 +172,7 @@ export class KbService {
       .select({
         id: schema.kbDocuments.id,
         spaceId: schema.kbDocuments.spaceId,
+        slug: schema.kbDocuments.slug,
         title: schema.kbDocuments.title,
         audiences: schema.kbDocuments.audiences,
         version: schema.kbDocuments.version,
@@ -184,6 +186,7 @@ export class KbService {
     return rows.map((r) => ({
       id: r.id,
       spaceId: r.spaceId,
+      slug: r.slug,
       title: r.title,
       audiences: r.audiences,
       version: r.version,

--- a/packages/backend-core/src/modules/kb/kb.tools.ts
+++ b/packages/backend-core/src/modules/kb/kb.tools.ts
@@ -88,6 +88,7 @@ const PublishCurationCandidateInput = z.object({
 const ImportWebsiteInput = z.object({
   url: z.string().min(1).max(2048),
   synthesizeCompanyProfile: z.boolean().optional(),
+  reconcile: z.boolean().optional(),
 });
 
 const ImportWebsiteStatusInput = z.object({
@@ -212,7 +213,7 @@ export class KbAdminTools {
     name: 'kb_import_website',
     title: 'KB: Import website',
     description:
-      "Crawl a public website and populate the knowledge base from it: one KB document per page. Runs asynchronously on the curator queue — returns a job id you can track with the curator jobs control plane. Pass a homepage URL (a bare domain like `example.com` is accepted). The URL must be publicly reachable; localhost and private/internal addresses are rejected. Re-importing the same URL while a scrape is still pending returns the in-flight job instead of starting a second one.\n\nBy default the import also synthesizes a `company-profile` KB document (slug `company-profile`) that seeds the chat widget — appropriate when importing your own company's site. Set `synthesizeCompanyProfile: false` when importing third-party or topic pages that are NOT your company's website, so the import doesn't overwrite your company profile with unrelated content.",
+      "Crawl a public website and populate the knowledge base from it: one KB document per page. Runs asynchronously on the curator queue — returns a job id you can track with the curator jobs control plane. Pass a homepage URL (a bare domain like `example.com` is accepted). The URL must be publicly reachable; localhost and private/internal addresses are rejected. Re-importing the same URL while a scrape is still pending returns the in-flight job instead of starting a second one.\n\nBy default the import also synthesizes a `company-profile` KB document (slug `company-profile`) that seeds the chat widget — appropriate when importing your own company's site. Set `synthesizeCompanyProfile: false` when importing third-party or topic pages that are NOT your company's website, so the import doesn't overwrite your company profile with unrelated content.\n\nReconciliation is on by default: after a healthy crawl, previously imported pages that are no longer on the site (re-checked individually and confirmed to return 404/410) are deleted from the knowledge base, so a refresh prunes removed pages. Set `reconcile: false` to import additively without pruning.",
     audiences: ['admin'],
     scopes: ['kb:write'],
     input: ImportWebsiteInput,
@@ -224,7 +225,10 @@ export class KbAdminTools {
     const { job, alreadyPending } = await this.curator.enqueue({
       jobUri: WEB_SCRAPE_SITE_TASK_URI,
       userPrompt: url,
-      sourceEventPayload: { synthesizeCompanyProfile: args.synthesizeCompanyProfile ?? true },
+      sourceEventPayload: {
+        synthesizeCompanyProfile: args.synthesizeCompanyProfile ?? true,
+        reconcile: args.reconcile ?? true,
+      },
       dedupeKey: `kb-import-website:${url}`,
       maxAttempts: 3,
     });


### PR DESCRIPTION
## Why

Refreshing website content into the KB surfaced three defects, found while re-importing getmunin.com:

1. **Bare-domain imports found nothing.** `getmunin.com/` serves a Next.js locale-redirect stub — empty body, `<meta http-equiv="refresh" url=/en/>`, zero `<a>` links, no sitemap. The crawler doesn't follow client-side redirects, so discovery dead-ended at one URL (skipped `too_short`). Only `/en/` worked.
2. **Imports were purely additive.** Pages deleted from the live site (e.g. a removed pricing page) lingered forever, and old-slug docs from a prior crawl coexisted as orphans.
3. **SPA routes collapsed to one title.** Many distinct `/en/docs/*` pages extracted the same static `<title>`, producing a wall of identically-titled docs (the "16 Developer portal" symptom — distinct slugs, shared title, *not* true duplicates).

## What changed

**Crawler (`@getmunin/agent-runtime`)**
- Follows client-side root redirects (`<meta http-equiv="refresh">` preferred, else `<link rel="canonical">`) during BFS discovery, so a bare domain reaches the real page tree (`/` → `/en/`).
- Title extraction prefers the first `<h1>` over a generic `<title>` tag.
- Exports `probeUrl()` for revalidation with identical UA/timeout/redirect semantics.

**Import handler (`@getmunin/agent-host`)**
- Tags every imported page with `source-url:<url>`.
- `reconcileSpace()` (on by default): after a **guarded, healthy crawl** (≥3 pages + ≥1 import), re-checks previously imported pages individually and deletes only those **confirmed gone (HTTP 404/410)**. Resolves each doc's URL from its `source-url:` tag, else best-effort slug reconstruction. Company-profile and transient-error docs are preserved.

**Tool surface (`@getmunin/backend-core`)**
- `kb_import_website` gains a `reconcile` flag (default `true`); pass `false` to import additively.
- `kb_list_documents` / `DocumentSummary` now return each document's `slug`.

## Verification
- `pnpm typecheck` clean across all packages.
- New tests pass: crawl redirect-follow, `<h1>` title preference, `extractRedirectTarget`; reconcile prune-on-404, keep-on-200/transient, company-profile protection, small-crawl guard, `candidateUrls`.
- Full `@getmunin/agent-runtime` (248) and `@getmunin/agent-host` (50) suites green.
- ⚠️ backend-core integration tests need `TEST_DATABASE_URL` (unset locally) — the `slug` addition is additive and typechecks, but the DB-backed `kb` suite wasn't exercised here.

## Notes
- **`reconcile` defaults to true**, so a normal refresh now prunes confirmed-gone pages. The healthy-crawl guard prevents mass deletion on a failed/partial crawl. Easy to flip to opt-in if preferred.
- **Known limitation:** legacy docs without a `source-url:` tag whose reconstructed path *redirects to 200* (e.g. old `/privacy` → `/en/privacy`) won't auto-prune — those need manual cleanup. Everything imported after this carries the tag and reconciles precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)