### PR TITLE
fix(dashboard): render markdown in conversation drawer

### DIFF
--- a/.changeset/conversation-drawer-markdown.md
+++ b/.changeset/conversation-drawer-markdown.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/dashboard-pages": patch
+---
+
+Render markdown in the dashboard conversation drawer. Message bubbles, internal notes, and the agent draft preview now render bold, italics, lists, links, code, and rules instead of showing raw markdown source — matching how the chat widget displays the same content.

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertCircle, MessageSquare, Unplug, User } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import {
   Button,
   Pill,
@@ -28,7 +29,7 @@ import {
   type OutreachProposalDto,
   type QueueItem,
 } from './queue-drawers/types';
-import { DrawerFooter, DrawerHeader, useCmdEnter } from './queue-drawers/shared';
+import { DrawerFooter, DrawerHeader, MD_COMPONENTS, useCmdEnter } from './queue-drawers/shared';
 
 type Status = 'open' | 'snoozed' | 'closed' | 'spam';
 
@@ -1279,8 +1280,8 @@ function SimplifiedConvDrawer({
               autoFocus
             />
           ) : (
-            <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed whitespace-pre-wrap dark:bg-card dark:border-rule-on-dark dark:text-foreground">
-              {draft?.body}
+            <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
+              <ReactMarkdown components={MD_COMPONENTS}>{draft?.body ?? ''}</ReactMarkdown>
             </div>
           )}
         </section>
@@ -1479,6 +1480,35 @@ function FullConvDrawer({
 }
 
 
+const MESSAGE_MD_COMPONENTS: Components = {
+  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+  ul: ({ children }) => <ul className="mb-2 list-disc space-y-1 pl-5 last:mb-0">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-2 list-decimal space-y-1 pl-5 last:mb-0">{children}</ol>,
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  h1: ({ children }) => <p className="mb-2 font-semibold last:mb-0">{children}</p>,
+  h2: ({ children }) => <p className="mb-2 font-semibold last:mb-0">{children}</p>,
+  h3: ({ children }) => <p className="mb-2 font-semibold last:mb-0">{children}</p>,
+  hr: () => <hr className="my-2 border-current/20" />,
+  code: ({ children }) => (
+    <code className="rounded border border-current/20 px-1 font-mono text-[0.85em]">{children}</code>
+  ),
+  a: ({ href, children }) => (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
+      {children}
+    </a>
+  ),
+};
+
+function MessageMarkdown({ body }: { body: string }) {
+  return (
+    <div className="break-words [overflow-wrap:anywhere]">
+      <ReactMarkdown components={MESSAGE_MD_COMPONENTS}>{body}</ReactMarkdown>
+    </div>
+  );
+}
+
 function MessageBubble({ message }: { message: MessageDto }) {
   const t = useTranslations('dashboard.overview.drawer');
   const isStaff = message.authorType === 'user';
@@ -1506,7 +1536,7 @@ function MessageBubble({ message }: { message: MessageDto }) {
         <div className="mb-0.5 flex items-center gap-1 font-mono text-[9px] uppercase tracking-eyebrow text-amber-700 dark:text-amber-200">
           <AlertCircle className="size-3" /> {t('internalLabel', { author: message.authorType })}
         </div>
-        <div className="whitespace-pre-wrap">{message.body}</div>
+        <MessageMarkdown body={message.body} />
       </div>
     );
   }
@@ -1534,7 +1564,7 @@ function MessageBubble({ message }: { message: MessageDto }) {
         >
           {bubbleLabel(message, t)}
         </div>
-        <div className="whitespace-pre-wrap">{message.body}</div>
+        <MessageMarkdown body={message.body} />
       </div>
       {isOutbound && message.seenAt && (
         <div className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">


### PR DESCRIPTION
## Problem

The dashboard conversation drawer rendered message bodies as raw text (`whitespace-pre-wrap`), so markdown produced by the agent (`**bold**`, lists, `---`, links) showed up literally as source. The chat widget renders the same content correctly because it has its own `apps/chat-widget/src/markdown.ts`.

<img width="300" alt="raw markdown in drawer" src="https://github.com/user-attachments/assets/placeholder" />

## Fix

Render with `react-markdown` (already a dependency, already used by the queue drawers):

- **Message bubbles + internal notes** — new color-inheriting `MessageMarkdown`. Agent/staff bubbles are dark-bg/light-text, so the shared `MD_COMPONENTS` (which force `text-ink` and cobalt links) would clash; this set only adjusts weight/style/spacing and inherits color.
- **Agent draft preview** — reuses the shared `MD_COMPONENTS`, matching the KB proposal preview's styling.
- Left the short italic customer-quote snippet as plain text.

## Verification

- `pnpm -F @getmunin/dashboard-pages typecheck` ✅
- `pnpm -F @getmunin/dashboard-pages lint` ✅

Changeset: `patch` for `@getmunin/dashboard-pages`.

Follow-up (separate PR): `inbox-sections.tsx` is ~1.7k lines and will be split into focused modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)