### PR TITLE
chore: enforce branch naming convention

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,16 @@
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Protected and tool-generated branches are exempt.
+case "$branch" in
+  main | HEAD | changeset-release/*) exit 0 ;;
+esac
+
+pattern='^(feat|fix|chore|docs|refactor|test|ci|perf|build|revert)/[a-z0-9._-]+$'
+if ! printf '%s' "$branch" | grep -Eq "$pattern"; then
+  echo "✖ Branch \"$branch\" does not follow the naming convention."
+  echo "  Expected: <type>/<kebab-summary>"
+  echo "  type ∈ feat|fix|chore|docs|refactor|test|ci|perf|build|revert"
+  echo "  e.g. feat/website-import-reconcile, chore/bump-getmunin-4.51.0"
+  echo "  Rename with: git branch -m <new-name>"
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Each module typically has `<mod>.module.ts`, `<mod>.service.ts`, `<mod>.tools.ts
 ## Conventions
 
 - TypeScript strict everywhere. Path-style absolute imports inside packages.
+- Branch names: `<type>/<kebab-summary>`, where `type` is one of `feat|fix|chore|docs|refactor|test|ci|perf|build|revert` (same set as Conventional Commits) — e.g. `feat/website-import-reconcile`, `fix/redos-tag-strip`, `chore/bump-getmunin-4.51.0`. Branch from `main`. Tool-generated branches (`changeset-release/main`) are exempt. Enforced by the `.husky/pre-push` hook.
 - No comments unless they explain a non-obvious *why* (see global rules).
 - Zod schemas for all MCP tool inputs and external boundaries.
 - Tests live alongside source (`*.test.ts`, `*.integration.test.ts`). Integration tests gate on `TEST_DATABASE_URL`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ We use [Conventional Commits](https://www.conventionalcommits.org/). Example: `f
 
 ## Pull requests
 
-- Branch from `main`
+- Branch from `main`, named `<type>/<kebab-summary>` (`type` = a Conventional Commit type like `feat|fix|chore|docs|refactor|test|ci`) — e.g. `feat/hybrid-search`. A `pre-push` hook enforces this.
 - One logical change per PR
 - Keep PRs under ~400 lines where possible
 - Include a `Test plan` section in the description


### PR DESCRIPTION
## Why

Branch names have been ad hoc (`website-import-reconcile`, `bump-getmunin-4.51.0`). This standardizes them and adds a local guardrail.

## Convention

`<type>/<kebab-summary>` where `type` ∈ `feat|fix|chore|docs|refactor|test|ci|perf|build|revert` (same set as Conventional Commits) — e.g. `feat/website-import-reconcile`, `chore/bump-getmunin-4.51.0`. Branch from `main`. Tool-generated branches (`changeset-release/main`) are exempt.

## Changes

- **`CLAUDE.md`** (Conventions) — the agent-facing source of truth.
- **`CONTRIBUTING.md`** (Pull requests) — human-facing pointer, tied to the existing Conventional Commits note.
- **`.husky/pre-push`** — rejects non-conforming names; exempts `main` / `HEAD` / `changeset-release/*`.

## Test plan

- Hook passes on valid names (`feat/…`, `chore/bump-getmunin-4.51.0`, `fix/redos`) and exempt branches (`main`, `changeset-release/main`).
- Hook blocks invalid names (no type, wrong case, empty summary).
- Pushing this very branch (`chore/branch-naming-convention`) exercised the hook and passed.

Note: a `pre-push` hook only runs for contributors who've run `pnpm install` (husky `prepare`) and is bypassable with `--no-verify` — a guardrail, not a hard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)