### PR TITLE
fix(realtime): fan out typing indicators across backend replicas

### DIFF
--- a/.changeset/agent-typing-cross-replica.md
+++ b/.changeset/agent-typing-cross-replica.md
@@ -1,0 +1,9 @@
+---
+"@getmunin/backend-core": patch
+---
+
+fix(realtime): fan out typing indicators across backend replicas
+
+Typing indicators (the widget "writing" bubble) were delivered only within a single Node process, so with multiple backend replicas they were lost in production: the AI agent runner (a per-org singleton) and a human operator's dashboard connection usually live on a different replica than the one holding the visitor's WebSocket.
+
+Typing now travels over a Postgres `NOTIFY agent_typing` channel — the same cross-replica backplane already used for messages. The originating replica still delivers locally (preserving sender-exclusion and the auto-clear timer); a per-instance id on the payload prevents the origin from double-delivering its own echo, while every other replica fans the event out to its own connected clients. Covers all three directions: agent → visitor, human operator → visitor, and visitor → operator.

--- a/packages/backend-core/src/realtime/db-listener.service.ts
+++ b/packages/backend-core/src/realtime/db-listener.service.ts
@@ -15,11 +15,24 @@ export interface EventRow {
 
 export type EventHandler = (row: EventRow) => void;
 
+export interface TypingNotification {
+  orgId: string;
+  conversationId: string;
+  isTyping: boolean;
+  authorType: 'visitor' | 'operator';
+  originInstanceId?: string;
+}
+
+export type TypingHandler = (notification: TypingNotification) => void;
+
+export const AGENT_TYPING_CHANNEL = 'agent_typing';
+
 @Injectable()
 export class DbListenerService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(DbListenerService.name);
   private client: ReturnType<typeof postgres> | null = null;
   private readonly handlers = new Set<EventHandler>();
+  private readonly typingHandlers = new Set<TypingHandler>();
 
   async onModuleInit(): Promise<void> {
     if (parseEnvDisableFlag('MUNIN_REALTIME_DISABLED')) {
@@ -36,7 +49,8 @@ export class DbListenerService implements OnModuleInit, OnModuleDestroy {
       connection: { options: '-c app.bypass_rls=on' },
     });
     await this.client.listen('munin_events', (raw) => this.dispatch(raw));
-    this.logger.log('listening on munin_events');
+    await this.client.listen(AGENT_TYPING_CHANNEL, (raw) => this.dispatchTyping(raw));
+    this.logger.log(`listening on munin_events and ${AGENT_TYPING_CHANNEL}`);
   }
 
   async onModuleDestroy(): Promise<void> {
@@ -48,6 +62,11 @@ export class DbListenerService implements OnModuleInit, OnModuleDestroy {
   subscribe(handler: EventHandler): () => void {
     this.handlers.add(handler);
     return () => this.handlers.delete(handler);
+  }
+
+  subscribeTyping(handler: TypingHandler): () => void {
+    this.typingHandlers.add(handler);
+    return () => this.typingHandlers.delete(handler);
   }
 
   private dispatch(raw: string): void {
@@ -63,6 +82,40 @@ export class DbListenerService implements OnModuleInit, OnModuleDestroy {
         handler(row);
       } catch (err) {
         this.logger.warn(`handler error: ${describe(err)}`);
+      }
+    }
+  }
+
+  private dispatchTyping(raw: string): void {
+    let notification: TypingNotification;
+    try {
+      const parsed = JSON.parse(raw) as Partial<TypingNotification>;
+      if (
+        typeof parsed.orgId !== 'string' ||
+        typeof parsed.conversationId !== 'string' ||
+        typeof parsed.isTyping !== 'boolean' ||
+        (parsed.authorType !== 'visitor' && parsed.authorType !== 'operator')
+      ) {
+        this.logger.warn('malformed agent_typing payload: missing fields');
+        return;
+      }
+      notification = {
+        orgId: parsed.orgId,
+        conversationId: parsed.conversationId,
+        isTyping: parsed.isTyping,
+        authorType: parsed.authorType,
+        originInstanceId:
+          typeof parsed.originInstanceId === 'string' ? parsed.originInstanceId : undefined,
+      };
+    } catch (err) {
+      this.logger.warn(`malformed agent_typing payload: ${describe(err)}`);
+      return;
+    }
+    for (const handler of this.typingHandlers) {
+      try {
+        handler(notification);
+      } catch (err) {
+        this.logger.warn(`typing handler error: ${describe(err)}`);
       }
     }
   }

--- a/packages/backend-core/src/realtime/realtime-event-bus.ts
+++ b/packages/backend-core/src/realtime/realtime-event-bus.ts
@@ -1,6 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { EventEmitter } from 'node:events';
-import { DbListenerService, type EventRow } from './db-listener.service.ts';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+import type { Db } from '@getmunin/db';
+import { DB } from '../common/db/db.module.ts';
+import { AGENT_TYPING_CHANNEL, DbListenerService, type EventRow } from './db-listener.service.ts';
 
 export interface MessageReceivedBusEvent {
   conversationId: string;
@@ -62,20 +64,20 @@ export interface AgentTypingBusEvent {
   orgId: string;
   conversationId: string;
   isTyping: boolean;
+  authorType: 'visitor' | 'operator';
+  originInstanceId?: string;
 }
 
 export type AgentTypingHandler = (event: AgentTypingBusEvent) => void;
 
-const TYPING_CHANNEL = 'agent_typing';
-
 @Injectable()
 export class RealtimeEventBus {
   private readonly logger = new Logger(RealtimeEventBus.name);
-  private readonly typingEmitter = new EventEmitter();
 
-  constructor(private readonly listener: DbListenerService) {
-    this.typingEmitter.setMaxListeners(64);
-  }
+  constructor(
+    private readonly listener: DbListenerService,
+    @Inject(DB) private readonly db: Db,
+  ) {}
 
   subscribe(filter: RealtimeBusSubscriptionFilter, handlers: RealtimeBusHandlers): RealtimeBusSubscription {
     const dbUnsubscribe = this.listener.subscribe((event) => {
@@ -99,19 +101,30 @@ export class RealtimeEventBus {
     return { unsubscribe: dbUnsubscribe };
   }
 
-  publishConversationTyping(orgId: string, conversationId: string, isTyping: boolean): void {
-    this.typingEmitter.emit(TYPING_CHANNEL, {
+  publishConversationTyping(
+    orgId: string,
+    conversationId: string,
+    isTyping: boolean,
+    opts?: { authorType?: 'visitor' | 'operator'; originInstanceId?: string },
+  ): void {
+    const payload = JSON.stringify({
       orgId,
       conversationId,
       isTyping,
+      authorType: opts?.authorType ?? 'operator',
+      originInstanceId: opts?.originInstanceId,
     } satisfies AgentTypingBusEvent);
+    void this.db
+      .execute(sql`SELECT pg_notify(${AGENT_TYPING_CHANNEL}, ${payload})`)
+      .catch((err: unknown) => {
+        this.logger.warn(`publishConversationTyping failed: ${describe(err)}`);
+      });
   }
 
   subscribeAgentTyping(handler: AgentTypingHandler): () => void {
-    this.typingEmitter.on(TYPING_CHANNEL, handler);
-    return () => {
-      this.typingEmitter.off(TYPING_CHANNEL, handler);
-    };
+    return this.listener.subscribeTyping((notification) => {
+      handler(notification satisfies AgentTypingBusEvent);
+    });
   }
 }
 

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -82,6 +82,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
   private readonly selfServiceSubscribersByOrg = new Map<string, Set<WebSocket>>();
   private readonly subscribersByChannel = new Map<string, Set<ConnectionEntry>>();
   private busTypingUnsubscribe: (() => void) | null = null;
+  private readonly instanceId = randomUUID();
 
   selfServiceSubscriberCount(orgId: string): number {
     return this.selfServiceSubscribersByOrg.get(orgId)?.size ?? 0;
@@ -133,7 +134,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     this.upgradeListener = listener;
     httpServer.on('upgrade', listener);
     this.busTypingUnsubscribe = this.bus.subscribeAgentTyping((event) => {
-      this.handleBusAgentTyping(event).catch((err: unknown) =>
+      this.handleBusTyping(event).catch((err: unknown) =>
         this.logger.warn(`bus typing dispatch failed: ${describeError(err)}`),
       );
     });
@@ -562,39 +563,17 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     });
   }
 
-  private async handleBusAgentTyping(event: AgentTypingBusEvent): Promise<void> {
-    const meta = await this.resolveConversationMeta(event.conversationId);
-    if (!meta || meta.sessionId === null) return;
-    const outboundChannel = `widget:${meta.channelId}:${meta.sessionId}`;
-    const subs = this.subscribersByChannel.get(outboundChannel);
-    if (!subs) return;
-    const payload = JSON.stringify({
-      type: 'typing',
-      channel: outboundChannel,
-      isTyping: event.isTyping,
-      authorType: 'operator',
-    });
-    for (const sub of subs) {
-      if (sub.orgId !== event.orgId) continue;
-      if (sub.widgetCtx?.verifiedExternalId) {
-        const cached = sub.conversationMetaCache.get(event.conversationId);
-        if (
-          !cached ||
-          !cached.meta ||
-          cached.meta.contactExternalId !== sub.widgetCtx.verifiedExternalId
-        ) {
-          void this.resolveConversationMeta(event.conversationId).then((resolved) => {
-            sub.conversationMetaCache.set(event.conversationId, { meta: resolved });
-          });
-          continue;
-        }
-      }
-      try {
-        sub.ws.send(payload);
-      } catch (err) {
-        this.logger.debug?.(`fanoutTyping send failed (socket likely mid-close): ${describeError(err)}`);
-      }
+  private async handleBusTyping(event: AgentTypingBusEvent): Promise<void> {
+    if (event.originInstanceId && event.originInstanceId === this.instanceId) return;
+    let outboundChannel: string;
+    if (event.authorType === 'visitor') {
+      outboundChannel = `conversation:${event.conversationId}`;
+    } else {
+      const meta = await this.resolveConversationMeta(event.conversationId);
+      if (!meta || meta.sessionId === null) return;
+      outboundChannel = `widget:${meta.channelId}:${meta.sessionId}`;
     }
+    this.deliverTyping(outboundChannel, event.conversationId, event.authorType, event.isTyping, event.orgId);
   }
 
   private fanoutTyping(
@@ -603,6 +582,21 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     conversationId: string,
     authorType: 'visitor' | 'operator',
     isTyping: boolean,
+  ): void {
+    this.deliverTyping(outboundChannel, conversationId, authorType, isTyping, fromEntry.orgId, fromEntry);
+    this.bus.publishConversationTyping(fromEntry.orgId, conversationId, isTyping, {
+      authorType,
+      originInstanceId: this.instanceId,
+    });
+  }
+
+  private deliverTyping(
+    outboundChannel: string,
+    conversationId: string,
+    authorType: 'visitor' | 'operator',
+    isTyping: boolean,
+    orgId: string,
+    excludeEntry?: ConnectionEntry,
   ): void {
     const subs = this.subscribersByChannel.get(outboundChannel);
     if (!subs) return;
@@ -613,8 +607,8 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       authorType,
     });
     for (const sub of subs) {
-      if (sub === fromEntry) continue;
-      if (sub.orgId !== fromEntry.orgId) continue;
+      if (excludeEntry && sub === excludeEntry) continue;
+      if (sub.orgId !== orgId) continue;
       if (sub.widgetCtx?.verifiedExternalId) {
         const cached = sub.conversationMetaCache.get(conversationId);
         if (
@@ -631,7 +625,7 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
       try {
         sub.ws.send(payload);
       } catch (err) {
-        this.logger.debug?.(`bus typing send failed (socket likely mid-close): ${describeError(err)}`);
+        this.logger.debug?.(`typing send failed (socket likely mid-close): ${describeError(err)}`);
       }
     }
   }


### PR DESCRIPTION
## Problem

The widget "writing" bubble was delivered only **within a single Node process**. With multiple backend replicas, the AI agent runner (a per-org singleton) and a human operator's dashboard connection usually live on a *different* replica than the one holding the visitor's WebSocket — so the typing indicator was silently lost in production while working fine locally.

## Fix

Typing now travels over a Postgres `NOTIFY agent_typing` channel — the same cross-replica backplane already used for messages.

- The originating replica still delivers **locally** (preserving sender-exclusion and the auto-clear timer).
- A per-instance id on the payload prevents the origin from double-delivering its own echo.
- Every other replica fans the event out to its own connected clients.

Covers all three directions: agent → visitor, human operator → visitor, and visitor → operator.

## Changes
- `realtime-event-bus.ts` — publish typing via `pg_notify` instead of an in-process `EventEmitter`.
- `db-listener.service.ts` — listen on the new `agent_typing` channel, validate + dispatch payloads.
- `realtime.gateway.ts` — per-instance id dedup, unified `deliverTyping`, handle visitor/operator origins.

Patch changeset included (`@getmunin/backend-core`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)