### PR TITLE
feat(prompts): add handover policy to seeded self-service system prompt

### DIFF
--- a/.changeset/seed-prompt-handover-policy.md
+++ b/.changeset/seed-prompt-handover-policy.md
@@ -1,0 +1,7 @@
+---
+"@getmunin/core": patch
+---
+
+feat(prompts): add handover policy to the seeded self-service system prompt
+
+The default system prompt that new workspaces are seeded with now tells the self-service agent, when it flags a conversation for a human, to let the end-user know a teammate will follow up in the same conversation — and not to redirect them to email/phone/in-person or volunteer the business's contact details unless explicitly asked. This keeps the lead in the thread the human is about to pick up instead of routing it off-channel.

--- a/packages/core/src/prompts/system.ts
+++ b/packages/core/src/prompts/system.ts
@@ -7,6 +7,8 @@ Your job is to answer end-user questions on the channels available to this org (
 
 If the answer isn't in the knowledge base, or the user is asking for something you can't safely act on (refunds, account changes, anything you're not sure about), call \`conv_request_human\` to flag the conversation for a human teammate. Don't guess and don't fabricate policy.
 
+When you flag a conversation for a human, let the end-user know a teammate will follow up with them here in this conversation shortly. Don't redirect them to email, phone, or an in-person visit, and don't volunteer the business's contact details (address, phone, email, hours), unless the end-user explicitly asks how to reach the business directly. The goal is to keep the lead in this conversation so the human can pick it up where you left off, not to route them off to another channel.
+
 Never use placeholders like \`[Name]\`, \`[Phone Number]\`, \`[Address]\`, \`[Your Company]\`, \`[Link]\`, or any bracketed/parenthesized fill-in markers. Every message you send must be complete prose that can be delivered verbatim. If you don't have a piece of information, either ask the end-user for it directly or omit it from the reply — don't leave a blank for someone else to fill in.
 
 Be honest about what you know. Be brief. Match the user's language and tone.`;


### PR DESCRIPTION
## What

Adds a handover-policy paragraph to `DEFAULT_SYSTEM_PROMPT` — the master prompt seeded into every new workspace's `agent-runtime` KB space on first boot.

When the self-service agent flags a conversation for a human, it now:
- tells the end-user a teammate will follow up **in the same conversation**, and
- does **not** redirect them to email/phone/in-person or volunteer the business's contact details, unless the end-user explicitly asks how to reach the business directly.

This keeps the lead in the thread the human is about to pick up, instead of routing it off-channel. The text matches what was already applied by hand to the live tenant.

## Tool names — checked, nothing wrong

Scanned all eight seeded prompts for tool references. The only one is `conv_request_human` in the system prompt, and it's **correct**: it's the self-service/end-user tool (`audiences: ['self_service']`), distinct from the admin `conv_request_handover`. The runtime hardcodes `conv_request_human` as the handover tool. No changes needed (and changing it would have broken handover, since the self-service agent can't call the admin-audience tool).

## Scope

- New workspaces only. Already-provisioned tenants keep whatever is in their KB; no backfill migration here.
- `runtime.test.ts` uses a self-contained fixture string, not the exported constant — nothing downstream breaks.
- Changeset included (`@getmunin/core` patch). Typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)