### PR TITLE
fix(deps): force transitive nodemailer to 9.0.1 (closes lockfile SSRF alert)

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -27412,7 +27412,7 @@ THE SOFTWARE.
 
 ---
 
-## nodemailer@8.0.9
+## nodemailer@9.0.1
 
 > Easy as cake e-mail sending from your Node.js applications
 - Homepage: https://nodemailer.com/

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "@opentelemetry/core": "^2.8.0",
       "@babel/core@>=7 <8": "^7.29.6",
       "js-yaml@>=4 <4.2.0": "^4.2.0",
-      "nodemailer@<8.0.9": "^8.0.9"
+      "nodemailer@<9.0.1": "^9.0.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   '@opentelemetry/core': ^2.8.0
   '@babel/core@>=7 <8': ^7.29.6
   js-yaml@>=4 <4.2.0: ^4.2.0
-  nodemailer@<8.0.9: ^8.0.9
+  nodemailer@<9.0.1: ^9.0.1
 
 importers:
 
@@ -501,8 +501,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.6
       nodemailer:
-        specifier: ^8.0.9
-        version: 8.0.9
+        specifier: ^9.0.1
+        version: 9.0.1
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
@@ -574,8 +574,8 @@ importers:
         specifier: ^6.0.0
         version: 6.2.3
       nodemailer:
-        specifier: ^8.0.9
-        version: 8.0.9
+        specifier: ^9.0.1
+        version: 9.0.1
       undici:
         specifier: ^7.26.0
         version: 7.26.0
@@ -5666,8 +5666,8 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
-  nodemailer@8.0.9:
-    resolution: {integrity: sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==}
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -11119,7 +11119,7 @@ snapshots:
       libbase64: 1.3.0
       libmime: 5.3.8
       libqp: 2.1.1
-      nodemailer: 8.0.9
+      nodemailer: 9.0.1
       pino: 10.3.1
       socks: 2.8.8
 
@@ -11467,7 +11467,7 @@ snapshots:
       iconv-lite: 0.7.2
       libmime: 5.3.8
       linkify-it: 5.0.0
-      nodemailer: 8.0.9
+      nodemailer: 9.0.1
       punycode.js: 2.3.1
       tlds: 1.261.0
 
@@ -12024,7 +12024,7 @@ snapshots:
 
   node-releases@2.0.38: {}
 
-  nodemailer@8.0.9: {}
+  nodemailer@9.0.1: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Why

Dependabot alert **#83** (GHSA-p6gq-j5cr-w38f, nodemailer SSRF, High) is scoped to `pnpm-lock.yaml` and is **not** closed by #482/#483.

The advisory's vulnerable range is `<= 9.0.0` (first patched at `9.0.1`). Two transitive packages pin nodemailer to 8.x:

- `imapflow@1.3.3` → `nodemailer: 8.0.7`
- `mailparser@3.9.8` → `nodemailer: 8.0.5`

The existing root override `nodemailer@<8.0.9 → ^8.0.9` (added for a prior advisory) only lifts them to `8.0.11`, which is still inside the vulnerable range — so the lockfile copy stays flagged even after the direct deps move to `^9.0.1`.

## Change

Widen the override:

```diff
- "nodemailer@<8.0.9": "^8.0.9"
+ "nodemailer@<9.0.1": "^9.0.1"
```

After install, the only nodemailer in the lockfile is `9.0.1`; `imapflow` and `mailparser` both resolve to it.

## Risk

This forces a **major** bump (8 → 9) onto `imapflow` and `mailparser`, which only declare 8.x. They use nodemailer narrowly; `pnpm typecheck` passes locally. Relying on CI **test** + **e2e (playwright)** to validate the email/IMAP paths before merge.

## Notes

- `THIRD_PARTY_LICENSES.md` regenerated.
- Best merged after/with #482 (which moves the direct deps to `^9.0.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)