### PR TITLE
chore(dashboard): rename analytics nav label to "Page views"

### DIFF
--- a/.changeset/analytics-nav-page-views.md
+++ b/.changeset/analytics-nav-page-views.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/dashboard-pages": patch
+---
+
+Rename the analytics section label to be more concrete and natural. The nav item and section eyebrow change from "Analysesporing" to "Sidevisninger" (Norwegian) and from "Analytics trackers" to "Page views" (English), matching the existing "page-view analytics" subtitle. The individual-item term ("Målepunkter" / "Trackers") is unchanged.

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -172,7 +172,7 @@
     "agents": "Agents",
     "apiKeys": "API keys",
     "channels": "Channels",
-    "trackers": "Analytics trackers",
+    "trackers": "Page views",
     "endUsers": "End-users",
     "usage": "Usage",
     "auditLog": "Audit log",
@@ -703,7 +703,7 @@
       }
     },
     "trackers": {
-      "eyebrow": "Workspace · Analytics trackers",
+      "eyebrow": "Workspace · Page views",
       "title": "What people <em>actually</em> read.",
       "subtitle": "Page-view analytics from your sites and apps.",
       "trackersTitle": "Trackers",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -172,7 +172,7 @@
     "agents": "Agenter",
     "apiKeys": "API-nøkler",
     "channels": "Kanaler",
-    "trackers": "Analysesporing",
+    "trackers": "Sidevisninger",
     "endUsers": "Sluttbrukere",
     "usage": "Bruk",
     "auditLog": "Hendelseslogg",
@@ -703,7 +703,7 @@
       }
     },
     "trackers": {
-      "eyebrow": "Arbeidsområde · Analysesporing",
+      "eyebrow": "Arbeidsområde · Sidevisninger",
       "title": "Hva folk <em>faktisk</em> leser.",
       "subtitle": "Sidevisning-analytikk fra dine nettsteder og apper.",
       "trackersTitle": "Målepunkter",


### PR DESCRIPTION
## What

Improve the localization for the analytics section label, which was a constructed compound rather than natural copy.

| Location | Before | After |
|---|---|---|
| `nb.json` nav | Analysesporing | **Sidevisninger** |
| `nb.json` eyebrow | Arbeidsområde · Analysesporing | **Arbeidsområde · Sidevisninger** |
| `en.json` nav | Analytics trackers | **Page views** |
| `en.json` eyebrow | Workspace · Analytics trackers | **Workspace · Page views** |

## Why

- "Analysesporing" is a non-idiomatic "analyse + sporing" mashup and leads with the surveillance-tinged "sporing"; "Sidevisninger" (page views) is concrete and natural.
- Both locales now match the existing subtitle ("Sidevisning-analytikk" / "Page-view analytics").
- Scoped to the nav item + section eyebrow only — the individual-item term ("Målepunkter" / "Trackers") is unchanged.

Includes a patch changeset for `@getmunin/dashboard-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)