### PR TITLE
feat(channels): dropdown pickers, key-only Threll, auto-webhook + conflict-replace for voice channels

### DIFF
--- a/.changeset/threll-worker-picker.md
+++ b/.changeset/threll-worker-picker.md
@@ -1,0 +1,21 @@
+---
+"@getmunin/backend-core": patch
+"@getmunin/dashboard-pages": patch
+"@getmunin/types": patch
+---
+
+feat(channels): pick voice options from a dropdown, discover them over MCP, and dedup the Threll webhook
+
+Setting up a voice channel no longer makes you hand-type opaque ids. For Threll you now enter just the API key and press Continue — the account is resolved from the key (via `GET /v1/accounts/current`, since a key maps 1:1 to an account) and the dialog fetches that account's workers into a dropdown; nothing is persisted until you pick a worker and confirm, so cancelling leaves no channel and no webhook subscription behind. Vapi follows the same two-step shape: enter the API key (and optional public key / phone number id), press Continue, then pick the assistant from a dropdown — no more hand-typed assistant id. Edit dialogs load the same dropdowns from the channel's stored credentials.
+
+The Threll account ID is no longer required input anywhere (MCP `conv_configure_channel` / control-plane / dashboard) — it's derived from the key when omitted (still accepted as an optional override, and re-derived if the API key is rotated on edit). It's still persisted and shown as a chip on the channel row.
+
+Option discovery is exposed generically so agents get parity with the dashboard: a new `conv_list_channel_options` MCP tool returns a vendor's selectable options (Threll `workers`, Vapi `assistants`) as `{ value, label, hint }` groups — pass `vendor` + credentials before the channel exists, or `channelId` for an existing one. Adding discovery for a new vendor is just a `listOptions` method on its `ChannelAdminProvider`. The control plane exposes the same via `POST /v1/conversations/channels/options` and `POST /v1/conversations/channels/:id/options`.
+
+Threll webhook auto-setup now lists the account's existing subscriptions and reuses a matching one's signing secret instead of blindly creating another. The post-setup "webhook URL" screen is gone — Munin registers the webhook with Threll automatically.
+
+Vapi now auto-configures its webhook too: on create, Munin points the chosen assistant's `server` at the channel's webhook URL (with the shared-secret header) — but only when that server is unset or already a Munin URL, so it never clobbers an assistant you've wired elsewhere (in which case it falls back to the manual connection screen). The prior server config is stashed and restored when the channel is archived, via a new best-effort `onArchive` provider hook.
+
+When auto-setup would collide with an existing webhook, Munin now asks instead of failing. Threll rejects a second account-wide `*` subscription, and Vapi's server URL may already point elsewhere — in both cases setup now returns a `409 webhook_conflict` and the dashboard shows a "Replace existing webhook?" confirm. Confirming retries with `replaceWebhook: true` (Threll deletes the conflicting subscription and registers its own; Vapi overwrites the assistant's server URL); cancelling goes back with nothing changed. The flag is exposed on `conv_configure_channel` too, so agents can resolve the conflict the same way.
+
+Internal: the Threll and Vapi HTTP clients now route every call through one `request` helper that centralizes auth headers, timeouts, and status→error mapping; the dashboard `ApiError` now surfaces the response `code` so callers can branch on `webhook_conflict`.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -2635,6 +2635,44 @@
     }
   },
   {
+    "name": "conv_list_channel_options",
+    "title": "Conv: List a channel vendor’s selectable options",
+    "description": "Discover the selectable options a vendor needs before you configure a channel — e.g. Threll workers, Vapi assistants — so you can pass a valid id to conv_configure_channel instead of guessing. Pass `vendor` + `config` (credentials) before the channel exists, or `channelId` for an existing channel. Returns option `groups` (e.g. `workers`, `assistants`), each with `{ value, label, hint }`.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "conv:read"
+    ],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "vendor": {
+          "description": "Vendor to discover options for (with `config`). Omit when passing `channelId`.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "channelId": {
+          "description": "Discover options for an existing channel using its stored credentials.",
+          "type": "string"
+        },
+        "config": {
+          "description": "Vendor credentials to discover with before the channel exists (e.g. Threll `apiKey`+`accountId`, Vapi `apiKey`). Required with `vendor`.",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "conv_configure_channel",
     "title": "Conv: Configure a voice/SMS channel",
     "description": "Create or update a voice or SMS channel for any supported vendor. Pass `vendor` + a vendor-specific `config` object (see conv_list_channel_vendors). Pass `channelId` to update; omit to create. Plaintext secrets in `config` are encrypted before storage and returned redacted.",

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -2572,6 +2572,59 @@
         ]
       }
     },
+    "/v1/conversations/channels/options": {
+      "post": {
+        "operationId": "ConvChannelsController_listChannelOptions",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ConvChannels"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
+    "/v1/conversations/channels/{id}/options": {
+      "post": {
+        "operationId": "ConvChannelsController_listChannelOptionsForChannel",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ConvChannels"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/conversations/channels/threll/{id}/test": {
       "post": {
         "operationId": "ConvChannelsController_testThrell",

--- a/packages/backend-core/src/control/conv-channels.controller.ts
+++ b/packages/backend-core/src/control/conv-channels.controller.ts
@@ -37,6 +37,7 @@ import {
   ConfigureVapiBody,
   VapiCallInitiateBody,
   ConfigureThrellBody,
+  ChannelListOptionsBody,
   ThrellCallInitiateBody,
   ConfigureChannelBody,
   ChannelVoiceCallBody,
@@ -277,6 +278,24 @@ export class ConvChannelsController {
     return this.threllTools.configure(parsed.data);
   }
 
+  @Post('options')
+  @HttpCode(200)
+  async listChannelOptions(
+    @Body() body: unknown,
+  ): Promise<Awaited<ReturnType<ChannelAdminService['listOptions']>>> {
+    const parsed = ChannelListOptionsBody.safeParse(body ?? {});
+    if (!parsed.success) throw new BadRequestException(parsed.error.message);
+    return this.channelAdmin.listOptions({ vendor: parsed.data.vendor, config: parsed.data.config });
+  }
+
+  @Post(':id/options')
+  @HttpCode(200)
+  async listChannelOptionsForChannel(
+    @Param('id') id: string,
+  ): Promise<Awaited<ReturnType<ChannelAdminService['listOptions']>>> {
+    return this.channelAdmin.listOptions({ channelId: id });
+  }
+
   @Post('threll/:id/test')
   @HttpCode(200)
   async testThrell(
@@ -303,6 +322,7 @@ export class ConvChannelsController {
   @Delete(':id')
   @HttpCode(204)
   async archive(@Param('id') id: string): Promise<void> {
+    await this.channelAdmin.onArchive(id);
     await this.conv.archiveChannel(id);
   }
 

--- a/packages/backend-core/src/modules/conv/channels/channel-admin.service.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-admin.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { and, eq } from 'drizzle-orm';
@@ -11,10 +12,12 @@ import {
   CHANNEL_ADMIN_PROVIDERS,
   type ChannelAdminDto,
   type ChannelAdminProvider,
+  type ChannelOptionsDto,
 } from './channel-admin.ts';
 
 @Injectable()
 export class ChannelAdminService {
+  private readonly logger = new Logger(ChannelAdminService.name);
   private readonly byVendor = new Map<string, ChannelAdminProvider>();
 
   constructor(@Inject(CHANNEL_ADMIN_PROVIDERS) providers: ChannelAdminProvider[]) {
@@ -58,6 +61,22 @@ export class ChannelAdminService {
     return this.providerForChannel(channelId).then((p) => p.test(channelId));
   }
 
+  async listOptions(input: {
+    vendor?: string;
+    channelId?: string;
+    config?: Record<string, unknown>;
+  }): Promise<ChannelOptionsDto> {
+    const provider = input.channelId
+      ? await this.providerForChannel(input.channelId)
+      : this.requireVendor(input.vendor ?? '');
+    if (!provider.listOptions) {
+      throw new BadRequestException(
+        `channel vendor '${provider.vendor}' does not support option discovery`,
+      );
+    }
+    return provider.listOptions({ channelId: input.channelId, config: input.config });
+  }
+
   async call(input: { channelId: string; to: string; customerName?: string }): Promise<unknown> {
     const provider = await this.providerForChannel(input.channelId);
     if (!provider.call) {
@@ -72,6 +91,27 @@ export class ChannelAdminService {
       throw new BadRequestException(`channel vendor '${provider.vendor}' does not support test sends`);
     }
     return provider.sendTest(input);
+  }
+
+  async onArchive(channelId: string): Promise<void> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db
+      .select({ vendor: schema.convChannels.vendor })
+      .from(schema.convChannels)
+      .where(
+        and(eq(schema.convChannels.id, channelId), eq(schema.convChannels.orgId, actor.orgId)),
+      )
+      .limit(1);
+    const provider = rows[0] ? this.byVendor.get(rows[0].vendor) : undefined;
+    if (!provider?.onArchive) return;
+    await provider.onArchive(channelId).catch((err: unknown) => {
+      this.logger.warn(
+        `onArchive hook failed for channel ${channelId} (${provider.vendor}): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    });
   }
 
   private requireVendor(vendor: string): ChannelAdminProvider {

--- a/packages/backend-core/src/modules/conv/channels/channel-admin.tools.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-admin.tools.ts
@@ -43,6 +43,31 @@ const SendTestInput = z.object({
 
 const ListVendorsInput = z.object({});
 
+const ListOptionsInput = z
+  .object({
+    vendor: z
+      .string()
+      .min(1)
+      .max(40)
+      .optional()
+      .describe('Vendor to discover options for (with `config`). Omit when passing `channelId`.'),
+    channelId: z
+      .string()
+      .optional()
+      .describe('Discover options for an existing channel using its stored credentials.'),
+    config: sensitive(
+      z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe(
+          'Vendor credentials to discover with before the channel exists (e.g. Threll `apiKey`+`accountId`, Vapi `apiKey`). Required with `vendor`.',
+        ),
+    ),
+  })
+  .refine((v) => Boolean(v.channelId) || Boolean(v.vendor && v.config), {
+    message: 'pass channelId, or vendor + config',
+  });
+
 @Injectable()
 export class ChannelAdminTools {
   constructor(@Inject(ChannelAdminService) private readonly svc: ChannelAdminService) {}
@@ -60,6 +85,25 @@ export class ChannelAdminTools {
   })
   listVendors(_args: z.infer<typeof ListVendorsInput>) {
     return { vendors: this.svc.listVendors() };
+  }
+
+  @McpTool({
+    name: 'conv_list_channel_options',
+    title: 'Conv: List a channel vendor’s selectable options',
+    description:
+      'Discover the selectable options a vendor needs before you configure a channel — e.g. Threll workers, Vapi assistants — so you can pass a valid id to conv_configure_channel instead of guessing. Pass `vendor` + `config` (credentials) before the channel exists, or `channelId` for an existing channel. Returns option `groups` (e.g. `workers`, `assistants`), each with `{ value, label, hint }`.',
+    audiences: ['admin'],
+    scopes: ['conv:read'],
+    input: ListOptionsInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+  })
+  listOptions(args: z.infer<typeof ListOptionsInput>) {
+    return this.svc.listOptions({
+      vendor: args.vendor,
+      channelId: args.channelId,
+      config: args.config,
+    });
   }
 
   @McpTool({

--- a/packages/backend-core/src/modules/conv/channels/channel-admin.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-admin.ts
@@ -34,6 +34,28 @@ export interface ConfigureChannelInput {
   config: unknown;
 }
 
+export interface ChannelOption {
+  value: string;
+  label: string;
+  hint?: string;
+}
+
+export interface ChannelOptionGroup {
+  key: string;
+  label: string;
+  options: ChannelOption[];
+}
+
+export interface ChannelOptionsDto {
+  groups: ChannelOptionGroup[];
+  context?: { label?: string };
+}
+
+export interface ListChannelOptionsInput {
+  channelId?: string;
+  config?: unknown;
+}
+
 export interface ChannelAdminProvider {
   readonly kind: ChannelAdminKind;
   readonly vendor: string;
@@ -47,6 +69,8 @@ export interface ChannelAdminProvider {
   test(channelId: string): Promise<unknown>;
   call?(input: { channelId: string; to: string; customerName?: string }): Promise<unknown>;
   sendTest?(input: { channelId: string; to: string; body?: string }): Promise<unknown>;
+  listOptions?(input: ListChannelOptionsInput): Promise<ChannelOptionsDto>;
+  onArchive?(channelId: string): Promise<void>;
 }
 
 export const CHANNEL_ADMIN_PROVIDERS = Symbol('CHANNEL_ADMIN_PROVIDERS');

--- a/packages/backend-core/src/modules/conv/channels/json-shape.ts
+++ b/packages/backend-core/src/modules/conv/channels/json-shape.ts
@@ -1,0 +1,18 @@
+export function asRecord(json: unknown): Record<string, unknown> {
+  return typeof json === 'object' && json !== null && !Array.isArray(json)
+    ? (json as Record<string, unknown>)
+    : {};
+}
+
+export function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+export function toRows(json: unknown, ...keys: string[]): Record<string, unknown>[] {
+  const raw = Array.isArray(json)
+    ? json
+    : keys.map((k) => asRecord(json)[k]).find((v) => Array.isArray(v));
+  return asArray(raw).filter(
+    (r): r is Record<string, unknown> => typeof r === 'object' && r !== null,
+  );
+}

--- a/packages/backend-core/src/modules/conv/threll/threll-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-admin.provider.ts
@@ -1,13 +1,21 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
 import { describeConfigFields } from '../channels/channel-admin.ts';
 import type {
   ChannelAdminDto,
   ChannelAdminProvider,
+  ChannelOptionsDto,
   ConfigureChannelInput,
+  ListChannelOptionsInput,
 } from '../channels/channel-admin.ts';
-import { ConfigureInput, ThrellAdminTools } from './threll.tools.ts';
+import { ConfigureInput, ThrellAdminTools, type ThrellListWorkersResult } from './threll.tools.ts';
 
 const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
+
+const OptionsConfig = z.object({
+  apiKey: z.string().min(1).max(256),
+  accountId: z.string().min(1).max(128).optional(),
+});
 
 @Injectable()
 export class ThrellAdminProvider implements ChannelAdminProvider {
@@ -32,4 +40,32 @@ export class ThrellAdminProvider implements ChannelAdminProvider {
   call(input: { channelId: string; to: string; customerName?: string }) {
     return this.tools.callInitiate(input);
   }
+
+  async listOptions(input: ListChannelOptionsInput): Promise<ChannelOptionsDto> {
+    if (input.channelId) {
+      return toChannelOptions(await this.tools.listWorkersForChannel({ channelId: input.channelId }));
+    }
+    const parsed = OptionsConfig.safeParse(input.config);
+    if (!parsed.success) {
+      throw new BadRequestException(`invalid threll discovery config: ${parsed.error.message}`);
+    }
+    return toChannelOptions(await this.tools.listWorkers(parsed.data));
+  }
+}
+
+function toChannelOptions(res: ThrellListWorkersResult): ChannelOptionsDto {
+  return {
+    context: res.account ? { label: res.account.name ?? res.account.id } : undefined,
+    groups: [
+      {
+        key: 'workers',
+        label: 'Workers',
+        options: res.workers.map((w) => ({
+          value: w.id,
+          label: w.name ?? w.id,
+          hint: w.inboundPhoneNumber ?? w.outboundPhoneNumber ?? undefined,
+        })),
+      },
+    ],
+  };
 }

--- a/packages/backend-core/src/modules/conv/threll/threll-client.service.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-client.service.ts
@@ -1,9 +1,10 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { sql } from 'drizzle-orm';
 import { decryptSecretSql, readApiBaseUrl, setEncryptionKeySql } from '@getmunin/core';
 import type { Db, Tx } from '@getmunin/db';
 import { DB } from '../../../common/db/db.module.ts';
+import { asRecord, toRows } from '../channels/json-shape.ts';
 
 const THRELL_API_BASE = 'https://api.threll.io/v1';
 
@@ -24,6 +25,21 @@ export interface PlaceCallResponse {
 export interface ThrellWorkerSummary {
   id: string;
   name: string | null;
+  inboundPhoneNumber?: string | null;
+  outboundPhoneNumber?: string | null;
+}
+
+export interface ThrellAccountSummary {
+  id: string;
+  name: string | null;
+}
+
+export interface ThrellWebhookSubscriptionSummary {
+  id: string;
+  url: string;
+  eventType: string | null;
+  enabled: boolean;
+  signingSecret: string | null;
 }
 
 export interface ThrellExternalTool {
@@ -78,35 +94,153 @@ export class ThrellClientService {
     return this.db.transaction((tx) => this.decryptString(tx, ciphertext));
   }
 
+  private async request(opts: {
+    apiKey: string;
+    path: string;
+    method?: 'GET' | 'POST' | 'DELETE';
+    body?: Record<string, unknown>;
+    notFoundError?: string;
+  }): Promise<{ ok: true; json: unknown } | { ok: false; error: string }> {
+    try {
+      const res = await fetch(`${THRELL_API_BASE}${opts.path}`, {
+        method: opts.method ?? 'GET',
+        headers: {
+          'x-api-key': opts.apiKey,
+          ...(opts.body ? { 'content-type': 'application/json' } : {}),
+        },
+        body: opts.body ? JSON.stringify(opts.body) : undefined,
+        signal: AbortSignal.timeout(10000),
+      });
+      const status: HttpStatus = res.status;
+      if (status === HttpStatus.UNAUTHORIZED || status === HttpStatus.FORBIDDEN) {
+        return { ok: false, error: 'threll_unauthorized' };
+      }
+      if (status === HttpStatus.NOT_FOUND && opts.notFoundError) {
+        return { ok: false, error: opts.notFoundError };
+      }
+      const json: unknown = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const message = asRecord(json).message;
+        return {
+          ok: false,
+          error: `threll_${res.status}: ${typeof message === 'string' ? message : res.status}`,
+        };
+      }
+      return { ok: true, json };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
   async fetchWorker(opts: {
     apiKey: string;
     accountId: string;
     workerId: string;
+  }): Promise<{ ok: true; worker: ThrellWorkerSummary } | { ok: false; error: string }> {
+    const r = await this.request({
+      apiKey: opts.apiKey,
+      path: `/accounts/${encodeURIComponent(opts.accountId)}/workers/${encodeURIComponent(opts.workerId)}`,
+      notFoundError: 'threll_worker_not_found',
+    });
+    if (!r.ok) return r;
+    const worker = toWorker(r.json);
+    return { ok: true, worker: { ...worker, id: worker.id || opts.workerId } };
+  }
+
+  async fetchAccount(opts: {
+    apiKey: string;
+    accountId: string;
+  }): Promise<{ ok: true; account: ThrellAccountSummary } | { ok: false; error: string }> {
+    const r = await this.request({
+      apiKey: opts.apiKey,
+      path: `/accounts/${encodeURIComponent(opts.accountId)}`,
+      notFoundError: 'threll_account_not_found',
+    });
+    if (!r.ok) return r;
+    const json = asRecord(r.json);
+    return {
+      ok: true,
+      account: {
+        id: typeof json.id === 'string' ? json.id : opts.accountId,
+        name: typeof json.name === 'string' ? json.name : null,
+      },
+    };
+  }
+
+  async fetchCurrentAccount(opts: {
+    apiKey: string;
+  }): Promise<{ ok: true; account: ThrellAccountSummary } | { ok: false; error: string }> {
+    const r = await this.request({
+      apiKey: opts.apiKey,
+      path: `/accounts/current`,
+      notFoundError: 'threll_account_not_found',
+    });
+    if (!r.ok) return r;
+    const json = asRecord(r.json);
+    return {
+      ok: true,
+      account: {
+        id: typeof json.id === 'string' ? json.id : '',
+        name: typeof json.name === 'string' ? json.name : null,
+      },
+    };
+  }
+
+  async listWorkers(opts: {
+    apiKey: string;
+    accountId: string;
+  }): Promise<{ ok: true; workers: ThrellWorkerSummary[] } | { ok: false; error: string }> {
+    const r = await this.request({
+      apiKey: opts.apiKey,
+      path: `/accounts/${encodeURIComponent(opts.accountId)}/workers`,
+      notFoundError: 'threll_account_not_found',
+    });
+    if (!r.ok) return r;
+    const workers = toRows(r.json, 'workers')
+      .map(toWorker)
+      .filter((w) => w.id.length > 0);
+    return { ok: true, workers };
+  }
+
+  async listWebhookSubscriptions(opts: {
+    apiKey: string;
+    accountId: string;
   }): Promise<
-    { ok: true; worker: ThrellWorkerSummary } | { ok: false; error: string }
+    { ok: true; subscriptions: ThrellWebhookSubscriptionSummary[] } | { ok: false; error: string }
   > {
-    try {
-      const res = await fetch(
-        `${THRELL_API_BASE}/accounts/${encodeURIComponent(opts.accountId)}/workers/${encodeURIComponent(opts.workerId)}`,
-        { headers: { 'x-api-key': opts.apiKey } },
-      );
-      if (res.status === 401 || res.status === 403) return { ok: false, error: 'threll_unauthorized' };
-      if (res.status === 404) return { ok: false, error: 'threll_worker_not_found' };
-      if (!res.ok) {
-        const text = await res.text().catch(() => '');
-        return { ok: false, error: `threll_${res.status}: ${text.slice(0, 200)}` };
-      }
-      const json = (await res.json()) as Record<string, unknown>;
-      return {
-        ok: true,
-        worker: {
-          id: typeof json.id === 'string' ? json.id : opts.workerId,
-          name: typeof json.name === 'string' ? json.name : null,
-        },
-      };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
+    const r = await this.request({
+      apiKey: opts.apiKey,
+      path: `/accounts/${encodeURIComponent(opts.accountId)}/webhook-subscriptions`,
+      notFoundError: 'threll_account_not_found',
+    });
+    if (!r.ok) return r;
+    const subscriptions = toRows(r.json, 'subscriptions', 'webhookSubscriptions').map((row) => ({
+      id: typeof row.id === 'string' ? row.id : '',
+      url: typeof row.url === 'string' ? row.url : '',
+      eventType: typeof row.eventType === 'string' ? row.eventType : null,
+      enabled: typeof row.enabled === 'boolean' ? row.enabled : true,
+      signingSecret:
+        typeof row.signingSecret === 'string'
+          ? row.signingSecret
+          : typeof row.signing_secret === 'string'
+            ? row.signing_secret
+            : null,
+    }));
+    return { ok: true, subscriptions };
+  }
+
+  async deleteWebhookSubscription(opts: {
+    apiKey: string;
+    accountId: string;
+    subscriptionId: string;
+  }): Promise<{ ok: true } | { ok: false; error: string }> {
+    const r = await this.request({
+      apiKey: opts.apiKey,
+      path: `/accounts/${encodeURIComponent(opts.accountId)}/webhook-subscriptions/${encodeURIComponent(opts.subscriptionId)}`,
+      method: 'DELETE',
+      notFoundError: 'threll_webhook_subscription_not_found',
+    });
+    return r.ok ? { ok: true } : r;
   }
 
   async createWebhookSubscription(opts: {
@@ -114,55 +248,31 @@ export class ThrellClientService {
     accountId: string;
     url: string;
   }): Promise<{ ok: true; signingSecret: string } | { ok: false; error: string }> {
-    try {
-      const res = await fetch(
-        `${THRELL_API_BASE}/accounts/${encodeURIComponent(opts.accountId)}/webhook-subscriptions`,
-        {
-          method: 'POST',
-          headers: { 'x-api-key': opts.apiKey, 'content-type': 'application/json' },
-          body: JSON.stringify({ eventType: '*', url: opts.url, required: true }),
-          signal: AbortSignal.timeout(10000),
-        },
-      );
-      if (res.status === 401 || res.status === 403) return { ok: false, error: 'threll_unauthorized' };
-      if (res.status === 404) return { ok: false, error: 'threll_account_not_found' };
-      const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-      if (!res.ok) {
-        const message =
-          (typeof json.message === 'string' && json.message) ||
-          `threll_webhook_subscription_failed_${res.status}`;
-        return { ok: false, error: `threll_${res.status}: ${message}` };
-      }
-      const signingSecret = readSigningSecret(json);
-      if (!signingSecret) return { ok: false, error: 'threll_missing_signing_secret' };
-      return { ok: true, signingSecret };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
+    const r = await this.request({
+      apiKey: opts.apiKey,
+      path: `/accounts/${encodeURIComponent(opts.accountId)}/webhook-subscriptions`,
+      method: 'POST',
+      body: { eventType: '*', url: opts.url, required: true },
+      notFoundError: 'threll_account_not_found',
+    });
+    if (!r.ok) return r;
+    const signingSecret = readSigningSecret(asRecord(r.json));
+    if (!signingSecret) return { ok: false, error: 'threll_missing_signing_secret' };
+    return { ok: true, signingSecret };
   }
 
   async placeCall(req: PlaceCallRequest): Promise<PlaceCallResponse> {
-    const body: Record<string, unknown> = {
-      workerId: req.workerId,
-      phoneNumber: req.toNumber,
-    };
+    const body: Record<string, unknown> = { workerId: req.workerId, phoneNumber: req.toNumber };
     if (req.context) body.context = req.context;
     if (req.customer) body.customer = req.customer;
-    const res = await fetch(
-      `${THRELL_API_BASE}/accounts/${encodeURIComponent(req.accountId)}/phone-calls`,
-      {
-        method: 'POST',
-        headers: { 'x-api-key': req.apiKey, 'content-type': 'application/json' },
-        body: JSON.stringify(body),
-      },
-    );
-    const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-    if (!res.ok) {
-      const message =
-        (typeof json.message === 'string' && json.message) ||
-        `threll_place_call_failed_${res.status}`;
-      throw new Error(`threll_${res.status}: ${message}`);
-    }
+    const r = await this.request({
+      apiKey: req.apiKey,
+      path: `/accounts/${encodeURIComponent(req.accountId)}/phone-calls`,
+      method: 'POST',
+      body,
+    });
+    if (!r.ok) throw new Error(r.error);
+    const json = asRecord(r.json);
     return {
       id: typeof json.id === 'string' ? json.id : '',
       status: typeof json.status === 'string' ? json.status : '',
@@ -178,36 +288,36 @@ export class ThrellClientService {
     if (req.externalTools && req.externalTools.length > 0) body.externalTools = req.externalTools;
     if (req.allowedOrigins && req.allowedOrigins.length > 0) body.allowedOrigins = req.allowedOrigins;
     if (req.customer) body.customer = req.customer;
-    try {
-      const res = await fetch(
-        `${THRELL_API_BASE}/accounts/${encodeURIComponent(req.accountId)}/web-calls`,
-        {
-          method: 'POST',
-          headers: { 'x-api-key': req.apiKey, 'content-type': 'application/json' },
-          body: JSON.stringify(body),
-        },
-      );
-      const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-      if (!res.ok) {
-        const message =
-          (typeof json.message === 'string' && json.message) || `threll_web_call_failed_${res.status}`;
-        return { ok: false, error: `threll_${res.status}: ${message}` };
-      }
-      return {
-        ok: true,
-        webCall: {
-          callId: typeof json.callId === 'string' ? json.callId : '',
-          sessionId: typeof json.sessionId === 'string' ? json.sessionId : '',
-          signalingUrl: typeof json.signalingUrl === 'string' ? json.signalingUrl : '',
-          token: typeof json.token === 'string' ? json.token : '',
-          iceServers: Array.isArray(json.iceServers) ? (json.iceServers as IceServer[]) : [],
-          expiresAt: typeof json.expiresAt === 'string' ? json.expiresAt : '',
-        },
-      };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
+    const r = await this.request({
+      apiKey: req.apiKey,
+      path: `/accounts/${encodeURIComponent(req.accountId)}/web-calls`,
+      method: 'POST',
+      body,
+    });
+    if (!r.ok) return r;
+    const json = asRecord(r.json);
+    return {
+      ok: true,
+      webCall: {
+        callId: typeof json.callId === 'string' ? json.callId : '',
+        sessionId: typeof json.sessionId === 'string' ? json.sessionId : '',
+        signalingUrl: typeof json.signalingUrl === 'string' ? json.signalingUrl : '',
+        token: typeof json.token === 'string' ? json.token : '',
+        iceServers: Array.isArray(json.iceServers) ? (json.iceServers as IceServer[]) : [],
+        expiresAt: typeof json.expiresAt === 'string' ? json.expiresAt : '',
+      },
+    };
   }
+}
+
+function toWorker(json: unknown): ThrellWorkerSummary {
+  const r = asRecord(json);
+  return {
+    id: typeof r.id === 'string' ? r.id : '',
+    name: typeof r.name === 'string' ? r.name : null,
+    inboundPhoneNumber: typeof r.inboundPhoneNumber === 'string' ? r.inboundPhoneNumber : null,
+    outboundPhoneNumber: typeof r.outboundPhoneNumber === 'string' ? r.outboundPhoneNumber : null,
+  };
 }
 
 function readSigningSecret(json: Record<string, unknown>): string | undefined {

--- a/packages/backend-core/src/modules/conv/threll/threll.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll.integration.test.ts
@@ -1,14 +1,15 @@
 import 'reflect-metadata';
 import { describe, it, expect, beforeAll, afterAll, vi, type MockInstance } from 'vitest';
-import type { INestApplication } from '@nestjs/common';
+import { ConflictException, type INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 import { createHmac, randomUUID } from 'node:crypto';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql, eq, and } from 'drizzle-orm';
 import { AppModule } from '../../../app.module.ts';
 import { createApp } from '../../../bootstrap-app.ts';
-import { ThrellService } from './threll.service.ts';
+import { ThrellService, findReusableSigningSecret } from './threll.service.ts';
 import { ThrellClientService } from './threll-client.service.ts';
+import { ChannelAdminService } from '../channels/channel-admin.service.ts';
 import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
 
 const TEST_URL = process.env.TEST_DATABASE_URL;
@@ -22,6 +23,7 @@ const skipReason = TEST_URL
   let db: ReturnType<typeof createDb>;
   let client: ThrellClientService;
   let createSubSpy: MockInstance;
+  let listSubsSpy: MockInstance;
   let orgId: string;
   let channelId: string;
   const API_KEY = 'threll-api-key-it';
@@ -65,6 +67,9 @@ const skipReason = TEST_URL
       ok: true,
       signingSecret: WEBHOOK_SECRET,
     });
+    listSubsSpy = vi
+      .spyOn(client, 'listWebhookSubscriptions')
+      .mockResolvedValue({ ok: true, subscriptions: [] });
 
     const svc = app.get(ThrellService);
     const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
@@ -132,6 +137,152 @@ const skipReason = TEST_URL
     const ct = (rows[0]!.config as Record<string, string>).encryptedWebhookSecret!;
     const stored = await client.loadSecret(ct);
     expect(stored).toBe(WEBHOOK_SECRET);
+  });
+
+  it('consults existing subscriptions and still creates when none match', async () => {
+    listSubsSpy.mockResolvedValueOnce({
+      ok: true,
+      subscriptions: [
+        { id: 'sub_other', url: 'https://elsewhere.example/hook', eventType: '*', signingSecret: 'nope' },
+      ],
+    });
+    const before = createSubSpy.mock.calls.length;
+    const svc = app.get(ThrellService);
+    const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
+    await runAsActor(actor, () =>
+      svc.createChannel({
+        name: 'Threll no-match',
+        config: { apiKey: API_KEY, accountId: ACCOUNT_ID, workerId: WORKER_ID },
+      }),
+    );
+    expect(listSubsSpy).toHaveBeenCalled();
+    expect(createSubSpy.mock.calls.length).toBe(before + 1);
+  });
+
+  it('discovers workers via the generic listOptions path without persisting a channel', async () => {
+    vi.spyOn(client, 'listWorkers').mockResolvedValueOnce({
+      ok: true,
+      workers: [
+        { id: 'wrk_1', name: 'Front desk', inboundPhoneNumber: '+15551112222', outboundPhoneNumber: null },
+        { id: 'wrk_2', name: null, inboundPhoneNumber: null, outboundPhoneNumber: null },
+      ],
+    });
+    vi.spyOn(client, 'fetchAccount').mockResolvedValueOnce({
+      ok: true,
+      account: { id: ACCOUNT_ID, name: 'Acme Support' },
+    });
+    const before = await db
+      .select({ id: schema.convChannels.id })
+      .from(schema.convChannels)
+      .where(eq(schema.convChannels.orgId, orgId));
+    const res = await app
+      .get(ChannelAdminService)
+      .listOptions({ vendor: 'threll', config: { apiKey: API_KEY, accountId: ACCOUNT_ID } });
+    expect(res.context?.label).toBe('Acme Support');
+    const workers = res.groups.find((g) => g.key === 'workers')?.options ?? [];
+    expect(workers[0]).toEqual({ value: 'wrk_1', label: 'Front desk', hint: '+15551112222' });
+    expect(workers.map((o) => o.value)).toEqual(['wrk_1', 'wrk_2']);
+    const after = await db
+      .select({ id: schema.convChannels.id })
+      .from(schema.convChannels)
+      .where(eq(schema.convChannels.orgId, orgId));
+    expect(after.length).toBe(before.length);
+  });
+
+  it('returns a 409 webhook_conflict when an enabled account-wide subscription already exists', async () => {
+    listSubsSpy.mockResolvedValueOnce({
+      ok: true,
+      subscriptions: [
+        { id: 'sub_other', url: 'https://other.example/hook', eventType: '*', enabled: true, signingSecret: 'x' },
+      ],
+    });
+    const deleteSpy = vi.spyOn(client, 'deleteWebhookSubscription').mockResolvedValue({ ok: true });
+    const createBefore = createSubSpy.mock.calls.length;
+    const svc = app.get(ThrellService);
+    const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
+    let caught: unknown;
+    try {
+      await runAsActor(actor, () =>
+        svc.createChannel({
+          name: 'Threll conflict',
+          config: { apiKey: API_KEY, accountId: ACCOUNT_ID, workerId: WORKER_ID },
+        }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConflictException);
+    expect((caught as ConflictException).getStatus()).toBe(409);
+    expect((caught as ConflictException).getResponse()).toMatchObject({ code: 'webhook_conflict' });
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(createSubSpy.mock.calls.length).toBe(createBefore);
+  });
+
+  it('deletes the conflicting subscription and creates the channel when replaceWebhook is set', async () => {
+    listSubsSpy.mockResolvedValueOnce({
+      ok: true,
+      subscriptions: [
+        { id: 'sub_stale', url: 'https://other.example/hook', eventType: '*', enabled: true, signingSecret: 'x' },
+      ],
+    });
+    const deleteSpy = vi
+      .spyOn(client, 'deleteWebhookSubscription')
+      .mockResolvedValue({ ok: true });
+    const createBefore = createSubSpy.mock.calls.length;
+    const svc = app.get(ThrellService);
+    const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
+    const channel = await runAsActor(actor, () =>
+      svc.createChannel({
+        name: 'Threll replaced',
+        config: { apiKey: API_KEY, accountId: ACCOUNT_ID, workerId: WORKER_ID },
+        replaceWebhook: true,
+      }),
+    );
+    expect(deleteSpy).toHaveBeenCalledWith({
+      apiKey: API_KEY,
+      accountId: ACCOUNT_ID,
+      subscriptionId: 'sub_stale',
+    });
+    expect(createSubSpy.mock.calls.length).toBe(createBefore + 1);
+    expect(channel.id).toBeTruthy();
+  });
+
+  it('discovers workers from the API key alone via /accounts/current', async () => {
+    const currentSpy = vi.spyOn(client, 'fetchCurrentAccount').mockResolvedValueOnce({
+      ok: true,
+      account: { id: 'acct_from_key', name: 'Key Account' },
+    });
+    const listSpy = vi
+      .spyOn(client, 'listWorkers')
+      .mockResolvedValueOnce({ ok: true, workers: [{ id: 'wrk_9', name: 'Sales' }] });
+    const res = await app
+      .get(ChannelAdminService)
+      .listOptions({ vendor: 'threll', config: { apiKey: API_KEY } });
+    expect(currentSpy).toHaveBeenCalledWith({ apiKey: API_KEY });
+    expect(listSpy).toHaveBeenCalledWith({ apiKey: API_KEY, accountId: 'acct_from_key' });
+    expect(res.context?.label).toBe('Key Account');
+    expect(res.groups.find((g) => g.key === 'workers')?.options).toEqual([
+      { value: 'wrk_9', label: 'Sales' },
+    ]);
+  });
+
+  it('creates a channel without an accountId by resolving it from the key', async () => {
+    vi.spyOn(client, 'fetchCurrentAccount').mockResolvedValueOnce({
+      ok: true,
+      account: { id: 'acct_resolved', name: 'Resolved' },
+    });
+    const svc = app.get(ThrellService);
+    const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
+    const channel = await runAsActor(actor, () =>
+      svc.createChannel({ name: 'Threll keyonly', config: { apiKey: API_KEY, workerId: WORKER_ID } }),
+    );
+    expect(channel.config.accountId).toBe('acct_resolved');
+    const [row] = await db
+      .select({ config: schema.convChannels.config })
+      .from(schema.convChannels)
+      .where(eq(schema.convChannels.id, channel.id))
+      .limit(1);
+    expect(row!.config.accountId).toBe('acct_resolved');
   });
 
   it('does not persist a channel when webhook provisioning fails', async () => {
@@ -298,5 +449,36 @@ const skipReason = TEST_URL
     expect(threllCall.recordingAvailable).toBe(true);
     expect(threllCall.analysis).toBe('Resolved.');
     expect(threllCall.endedReason).toBe('completed');
+  });
+});
+
+describe('findReusableSigningSecret', () => {
+  const url = 'https://munin.example/v1/conversations/channels/cch_x/webhook';
+
+  it('returns the signing secret of a subscription with the exact url', () => {
+    expect(
+      findReusableSigningSecret(
+        [
+          { id: 'a', url: 'https://munin.example/other', eventType: '*', enabled: true, signingSecret: 'nope' },
+          { id: 'b', url, eventType: '*', enabled: true, signingSecret: 'whsec_reused' },
+        ],
+        url,
+      ),
+    ).toBe('whsec_reused');
+  });
+
+  it('returns null when no url matches', () => {
+    expect(
+      findReusableSigningSecret(
+        [{ id: 'a', url: 'https://munin.example/other', eventType: '*', enabled: true, signingSecret: 'x' }],
+        url,
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null when the matching subscription has no signing secret', () => {
+    expect(
+      findReusableSigningSecret([{ id: 'a', url, eventType: '*', enabled: true, signingSecret: null }], url),
+    ).toBeNull();
   });
 });

--- a/packages/backend-core/src/modules/conv/threll/threll.service.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll.service.ts
@@ -10,7 +10,11 @@ import { encryptSecretSql, getCurrentContext } from '@getmunin/core';
 import { schema, makeId, type Db } from '@getmunin/db';
 import { z } from 'zod';
 import { DB } from '../../../common/db/db.module.ts';
-import { ThrellClientService, buildWebhookUrl } from './threll-client.service.ts';
+import {
+  ThrellClientService,
+  buildWebhookUrl,
+  type ThrellWebhookSubscriptionSummary,
+} from './threll-client.service.ts';
 
 const REDACTED = '••••';
 
@@ -25,7 +29,7 @@ export type StoredThrellConfig = z.infer<typeof StoredThrellConfigSchema>;
 
 export const ThrellConfigInputSchema = z.object({
   apiKey: z.string().min(1).max(256),
-  accountId: z.string().min(1).max(128),
+  accountId: z.string().min(1).max(128).optional(),
   workerId: z.string().min(1).max(128),
 });
 
@@ -57,18 +61,20 @@ export class ThrellService {
   async createChannel(input: {
     name: string;
     config: ThrellConfigInput;
+    replaceWebhook?: boolean;
   }): Promise<ThrellChannelDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     const channelId = makeId('cch');
     const webhookUrl = buildWebhookUrl(channelId);
-    const sub = await this.client.createWebhookSubscription({
-      apiKey: input.config.apiKey,
-      accountId: input.config.accountId,
-      url: webhookUrl,
-    });
-    if (!sub.ok) throw new BadRequestException(sub.error);
-    const stored = await this.toStored(input.config, sub.signingSecret);
+    const accountId = input.config.accountId ?? (await this.resolveAccountId(input.config.apiKey));
+    const config = { ...input.config, accountId };
+    const signingSecret = await this.ensureWebhookSubscription(
+      { apiKey: config.apiKey, accountId },
+      webhookUrl,
+      input.replaceWebhook ?? false,
+    );
+    const stored = await this.toStored(config, signingSecret);
     const [row] = await ctx.db
       .insert(schema.convChannels)
       .values({
@@ -107,12 +113,14 @@ export class ThrellService {
       throw new BadRequestException(`channel ${input.channelId} is not a voice:threll channel`);
     }
     const prev = jsonbToStored(channel.config);
+    const newApiKey = input.config?.apiKey;
+    const accountId =
+      input.config?.accountId ??
+      (newApiKey ? await this.resolveAccountId(newApiKey) : prev.accountId);
     const merged: StoredThrellConfig = {
-      encryptedApiKey: input.config?.apiKey
-        ? await encryptString(input.config.apiKey)
-        : prev.encryptedApiKey,
+      encryptedApiKey: newApiKey ? await encryptString(newApiKey) : prev.encryptedApiKey,
       encryptedWebhookSecret: prev.encryptedWebhookSecret,
-      accountId: input.config?.accountId ?? prev.accountId,
+      accountId,
       workerId: input.config?.workerId ?? prev.workerId,
     };
     const [row] = await ctx.db
@@ -128,8 +136,49 @@ export class ThrellService {
     return this.toDto(row.id, row.name, row.active, merged);
   }
 
+  private async resolveAccountId(apiKey: string): Promise<string> {
+    const res = await this.client.fetchCurrentAccount({ apiKey });
+    if (!res.ok) throw new BadRequestException(res.error);
+    if (!res.account.id) throw new BadRequestException('threll_account_not_found');
+    return res.account.id;
+  }
+
+  private async ensureWebhookSubscription(
+    creds: { apiKey: string; accountId: string },
+    webhookUrl: string,
+    replaceWebhook: boolean,
+  ): Promise<string> {
+    const existing = await this.client.listWebhookSubscriptions(creds);
+    if (existing.ok) {
+      const reused = findReusableSigningSecret(existing.subscriptions, webhookUrl);
+      if (reused) return reused;
+      const conflicts = existing.subscriptions.filter(
+        (s) => s.eventType === '*' && s.enabled && s.url !== webhookUrl,
+      );
+      if (conflicts.length > 0) {
+        if (!replaceWebhook) {
+          throw new ConflictException({
+            code: 'webhook_conflict',
+            message:
+              'This Threll account already has an account-wide webhook subscription. Replace it to connect this channel.',
+          });
+        }
+        for (const conflict of conflicts) {
+          const del = await this.client.deleteWebhookSubscription({
+            ...creds,
+            subscriptionId: conflict.id,
+          });
+          if (!del.ok) throw new BadRequestException(del.error);
+        }
+      }
+    }
+    const sub = await this.client.createWebhookSubscription({ ...creds, url: webhookUrl });
+    if (!sub.ok) throw new BadRequestException(sub.error);
+    return sub.signingSecret;
+  }
+
   private async toStored(
-    input: ThrellConfigInput,
+    input: ThrellConfigInput & { accountId: string },
     signingSecret: string,
   ): Promise<StoredThrellConfig> {
     return {
@@ -160,6 +209,14 @@ export class ThrellService {
       },
     };
   }
+}
+
+export function findReusableSigningSecret(
+  subscriptions: ThrellWebhookSubscriptionSummary[],
+  webhookUrl: string,
+): string | null {
+  const match = subscriptions.find((s) => s.url === webhookUrl && s.signingSecret);
+  return match?.signingSecret ?? null;
 }
 
 export function storedToJsonb(stored: StoredThrellConfig): Record<string, unknown> {

--- a/packages/backend-core/src/modules/conv/threll/threll.tools.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll.tools.ts
@@ -4,8 +4,17 @@ import { sensitive } from '@getmunin/types';
 import { schema } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
-import { ThrellClientService } from './threll-client.service.ts';
+import {
+  ThrellClientService,
+  type ThrellAccountSummary,
+  type ThrellWorkerSummary,
+} from './threll-client.service.ts';
 import { ThrellService, jsonbToStored, type ThrellChannelDto } from './threll.service.ts';
+
+export interface ThrellListWorkersResult {
+  account: ThrellAccountSummary | null;
+  workers: ThrellWorkerSummary[];
+}
 
 export const ConfigureInput = z.object({
   channelId: z
@@ -28,13 +37,19 @@ export const ConfigureInput = z.object({
     .min(1)
     .max(128)
     .optional()
-    .describe('Threll account ID (shown alongside your API key). Required on create.'),
+    .describe('Threll account ID. Optional — derived from the API key (one account per key) when omitted.'),
   workerId: z
     .string()
     .min(1)
     .max(128)
     .optional()
     .describe('Threll worker ID that handles calls on this channel. Required on create.'),
+  replaceWebhook: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set true to delete a conflicting account-wide webhook subscription and register Munin’s. Without it, a conflict returns a 409 webhook_conflict error.',
+    ),
 });
 
 @Injectable()
@@ -58,7 +73,6 @@ export class ThrellAdminTools {
     }
     if (!args.name) throw new BadRequestException('name is required when creating a channel');
     if (!args.apiKey) throw new BadRequestException('apiKey is required when creating');
-    if (!args.accountId) throw new BadRequestException('accountId is required when creating');
     if (!args.workerId) throw new BadRequestException('workerId is required when creating');
     return this.svc.createChannel({
       name: args.name,
@@ -67,7 +81,28 @@ export class ThrellAdminTools {
         accountId: args.accountId,
         workerId: args.workerId,
       },
+      replaceWebhook: args.replaceWebhook,
     });
+  }
+
+  async listWorkers(args: { apiKey: string; accountId?: string }): Promise<ThrellListWorkersResult> {
+    const account = args.accountId
+      ? await this.client.fetchAccount({ apiKey: args.apiKey, accountId: args.accountId })
+      : await this.client.fetchCurrentAccount({ apiKey: args.apiKey });
+    if (!account.ok) throw new BadRequestException(account.error);
+    const workers = await this.client.listWorkers({
+      apiKey: args.apiKey,
+      accountId: account.account.id,
+    });
+    if (!workers.ok) throw new BadRequestException(workers.error);
+    return { account: account.account, workers: workers.workers };
+  }
+
+  async listWorkersForChannel(args: { channelId: string }): Promise<ThrellListWorkersResult> {
+    const channel = await this.loadChannel(args.channelId);
+    const config = jsonbToStored(channel.config);
+    const apiKey = await this.client.loadSecret(config.encryptedApiKey);
+    return this.listWorkers({ apiKey, accountId: config.accountId });
   }
 
   async testChannel(

--- a/packages/backend-core/src/modules/conv/vapi/vapi-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-admin.provider.ts
@@ -1,13 +1,18 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
 import { describeConfigFields } from '../channels/channel-admin.ts';
 import type {
   ChannelAdminDto,
   ChannelAdminProvider,
+  ChannelOptionsDto,
   ConfigureChannelInput,
+  ListChannelOptionsInput,
 } from '../channels/channel-admin.ts';
-import { ConfigureInput, VapiAdminTools } from './vapi.tools.ts';
+import { ConfigureInput, VapiAdminTools, type VapiListAssistantsResult } from './vapi.tools.ts';
 
 const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
+
+const OptionsConfig = z.object({ apiKey: z.string().min(1).max(256) });
 
 @Injectable()
 export class VapiAdminProvider implements ChannelAdminProvider {
@@ -32,4 +37,31 @@ export class VapiAdminProvider implements ChannelAdminProvider {
   call(input: { channelId: string; to: string; customerName?: string }) {
     return this.tools.callInitiate(input);
   }
+
+  async listOptions(input: ListChannelOptionsInput): Promise<ChannelOptionsDto> {
+    if (input.channelId) {
+      return toChannelOptions(await this.tools.listAssistantsForChannel({ channelId: input.channelId }));
+    }
+    const parsed = OptionsConfig.safeParse(input.config);
+    if (!parsed.success) {
+      throw new BadRequestException(`invalid vapi discovery config: ${parsed.error.message}`);
+    }
+    return toChannelOptions(await this.tools.listAssistants(parsed.data));
+  }
+
+  onArchive(channelId: string): Promise<void> {
+    return this.tools.restoreWebhook(channelId);
+  }
+}
+
+function toChannelOptions(res: VapiListAssistantsResult): ChannelOptionsDto {
+  return {
+    groups: [
+      {
+        key: 'assistants',
+        label: 'Assistants',
+        options: res.assistants.map((a) => ({ value: a.id, label: a.name ?? a.id })),
+      },
+    ],
+  };
 }

--- a/packages/backend-core/src/modules/conv/vapi/vapi-client.service.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-client.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { timingSafeEqual } from 'node:crypto';
 import { sql } from 'drizzle-orm';
 import {
@@ -7,6 +7,7 @@ import {
 } from '@getmunin/core';
 import type { Db, Tx } from '@getmunin/db';
 import { DB } from '../../../common/db/db.module.ts';
+import { asRecord, toRows } from '../channels/json-shape.ts';
 
 const VAPI_API_BASE = 'https://api.vapi.ai';
 
@@ -63,25 +64,87 @@ export class VapiClientService {
     };
   }
 
+  private async request(opts: {
+    apiKey: string;
+    path: string;
+    method?: 'GET' | 'POST' | 'PATCH';
+    body?: Record<string, unknown>;
+    notFoundError?: string;
+  }): Promise<{ ok: true; json: unknown } | { ok: false; error: string }> {
+    try {
+      const res = await fetch(`${VAPI_API_BASE}${opts.path}`, {
+        method: opts.method ?? 'GET',
+        headers: {
+          authorization: `Bearer ${opts.apiKey}`,
+          ...(opts.body ? { 'content-type': 'application/json' } : {}),
+        },
+        body: opts.body ? JSON.stringify(opts.body) : undefined,
+        signal: AbortSignal.timeout(10000),
+      });
+      const status: HttpStatus = res.status;
+      if (status === HttpStatus.UNAUTHORIZED || status === HttpStatus.FORBIDDEN) {
+        return { ok: false, error: 'vapi_unauthorized' };
+      }
+      if (status === HttpStatus.NOT_FOUND && opts.notFoundError) {
+        return { ok: false, error: opts.notFoundError };
+      }
+      const json: unknown = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const message = asRecord(json).message;
+        const detail =
+          typeof message === 'string'
+            ? message
+            : Array.isArray(message)
+              ? message.filter((m): m is string => typeof m === 'string').join('; ')
+              : String(res.status);
+        return { ok: false, error: `vapi_${res.status}: ${detail}` };
+      }
+      return { ok: true, json };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
   async fetchAssistantConfig(opts: {
     apiKey: string;
     assistantId: string;
   }): Promise<{ ok: true; config: Record<string, unknown> } | { ok: false; error: string }> {
-    try {
-      const res = await fetch(`${VAPI_API_BASE}/assistant/${encodeURIComponent(opts.assistantId)}`, {
-        headers: { authorization: `Bearer ${opts.apiKey}` },
-      });
-      if (res.status === 401) return { ok: false, error: 'vapi_unauthorized' };
-      if (res.status === 404) return { ok: false, error: 'vapi_assistant_not_found' };
-      if (!res.ok) {
-        const text = await res.text().catch(() => '');
-        return { ok: false, error: `vapi_${res.status}: ${text.slice(0, 200)}` };
-      }
-      const json = (await res.json()) as Record<string, unknown>;
-      return { ok: true, config: json };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
+    const r = await this.request({
+      apiKey: opts.apiKey,
+      path: `/assistant/${encodeURIComponent(opts.assistantId)}`,
+      notFoundError: 'vapi_assistant_not_found',
+    });
+    if (!r.ok) return r;
+    return { ok: true, config: asRecord(r.json) };
+  }
+
+  async listAssistants(opts: {
+    apiKey: string;
+  }): Promise<{ ok: true; assistants: VapiAssistantSummary[] } | { ok: false; error: string }> {
+    const r = await this.request({ apiKey: opts.apiKey, path: '/assistant' });
+    if (!r.ok) return r;
+    const assistants = toRows(r.json, 'results')
+      .map((row) => ({
+        id: typeof row.id === 'string' ? row.id : '',
+        name: typeof row.name === 'string' ? row.name : null,
+      }))
+      .filter((a) => a.id.length > 0);
+    return { ok: true, assistants };
+  }
+
+  async updateAssistantServer(opts: {
+    apiKey: string;
+    assistantId: string;
+    server: Record<string, unknown> | null;
+  }): Promise<{ ok: true } | { ok: false; error: string }> {
+    const r = await this.request({
+      apiKey: opts.apiKey,
+      path: `/assistant/${encodeURIComponent(opts.assistantId)}`,
+      method: 'PATCH',
+      body: { server: opts.server },
+      notFoundError: 'vapi_assistant_not_found',
+    });
+    return r.ok ? { ok: true } : r;
   }
 
   async placeCall(req: PlaceCallRequest): Promise<PlaceCallResponse> {
@@ -91,22 +154,9 @@ export class VapiClientService {
       customer: { number: req.toNumber, ...(req.customer ?? {}) },
     };
     if (req.assistantOverrides) body.assistantOverrides = req.assistantOverrides;
-    const res = await fetch(`${VAPI_API_BASE}/call`, {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${req.apiKey}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-    const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-    if (!res.ok) {
-      const message =
-        (typeof json.message === 'string' && json.message) ||
-        (Array.isArray(json.message) && (json.message as string[]).join('; ')) ||
-        `vapi_place_call_failed_${res.status}`;
-      throw new Error(`vapi_${res.status}: ${message}`);
-    }
+    const r = await this.request({ apiKey: req.apiKey, path: '/call', method: 'POST', body });
+    if (!r.ok) throw new Error(r.error);
+    const json = asRecord(r.json);
     return {
       id: typeof json.id === 'string' ? json.id : '',
       status: typeof json.status === 'string' ? json.status : '',

--- a/packages/backend-core/src/modules/conv/vapi/vapi.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi.integration.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import type { INestApplication } from '@nestjs/common';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { ConflictException, type INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 import { randomUUID } from 'node:crypto';
 import { createDb, runMigrations, schema } from '@getmunin/db';
@@ -8,6 +8,8 @@ import { sql, eq, and } from 'drizzle-orm';
 import { AppModule } from '../../../app.module.ts';
 import { createApp } from '../../../bootstrap-app.ts';
 import { VapiService } from './vapi.service.ts';
+import { VapiClientService } from './vapi-client.service.ts';
+import { ChannelAdminService } from '../channels/channel-admin.service.ts';
 import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
 
 const TEST_URL = process.env.TEST_DATABASE_URL;
@@ -38,6 +40,7 @@ const skipReason = TEST_URL
     process.env.MUNIN_STORAGE_LOCAL_BASE_URL = 'http://127.0.0.1:0/static/assets';
     process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
     process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED = '1';
+    process.env.MUNIN_API_URL = 'https://munin.example';
 
     await runMigrations(TEST_URL!);
     const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
@@ -58,6 +61,10 @@ const skipReason = TEST_URL
     const address = server.address();
     if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
     baseUrl = `http://127.0.0.1:${address.port}`;
+
+    const bootstrapClient = app.get(VapiClientService);
+    vi.spyOn(bootstrapClient, 'fetchAssistantConfig').mockResolvedValue({ ok: false, error: 'stub' });
+    vi.spyOn(bootstrapClient, 'updateAssistantServer').mockResolvedValue({ ok: true });
 
     const svc = app.get(VapiService);
     const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
@@ -107,6 +114,113 @@ const skipReason = TEST_URL
       body: payload,
     });
   }
+
+  it('discovers assistants via the generic listOptions path', async () => {
+    const client = app.get(VapiClientService);
+    vi.spyOn(client, 'listAssistants').mockResolvedValueOnce({
+      ok: true,
+      assistants: [
+        { id: 'asst_a', name: 'Support' },
+        { id: 'asst_b', name: null },
+      ],
+    });
+    const res = await app
+      .get(ChannelAdminService)
+      .listOptions({ vendor: 'vapi', config: { apiKey: API_KEY } });
+    const assistants = res.groups.find((g) => g.key === 'assistants')?.options ?? [];
+    expect(assistants).toEqual([
+      { value: 'asst_a', label: 'Support' },
+      { value: 'asst_b', label: 'asst_b' },
+    ]);
+  });
+
+  it('auto-configures the assistant server when the assistant has none', async () => {
+    const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
+    const client = app.get(VapiClientService);
+    vi.spyOn(client, 'fetchAssistantConfig').mockResolvedValueOnce({
+      ok: true,
+      config: { id: 'asst_auto', name: 'Auto' },
+    });
+    const updateSpy = vi.spyOn(client, 'updateAssistantServer').mockResolvedValue({ ok: true });
+    updateSpy.mockClear();
+    const dto = await runAsActor(actor, () =>
+      app.get(VapiService).createChannel({
+        name: 'vapi-auto',
+        config: { apiKey: 'k', webhookSecret: 'whsec_auto', assistantId: 'asst_auto' },
+      }),
+    );
+    expect(dto.webhookConfigured).toBe(true);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    const server = updateSpy.mock.calls[0]![0].server as Record<string, unknown>;
+    expect(server.url).toBe(`https://munin.example/v1/conversations/channels/${dto.id}/webhook`);
+    expect((server.headers as Record<string, unknown>)['x-webhook-secret']).toBe('whsec_auto');
+  });
+
+  it('returns a 409 webhook_conflict when the assistant server points elsewhere', async () => {
+    const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
+    const client = app.get(VapiClientService);
+    vi.spyOn(client, 'fetchAssistantConfig').mockResolvedValueOnce({
+      ok: true,
+      config: { server: { url: 'https://customer.example/hook' } },
+    });
+    const updateSpy = vi.spyOn(client, 'updateAssistantServer').mockResolvedValue({ ok: true });
+    const before = updateSpy.mock.calls.length;
+    let caught: unknown;
+    try {
+      await runAsActor(actor, () =>
+        app.get(VapiService).createChannel({
+          name: 'vapi-elsewhere',
+          config: { apiKey: 'k', webhookSecret: 'whsec_x', assistantId: 'asst_elsewhere' },
+        }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConflictException);
+    expect((caught as ConflictException).getResponse()).toMatchObject({ code: 'webhook_conflict' });
+    expect(updateSpy.mock.calls.length).toBe(before);
+  });
+
+  it('overwrites the assistant server when replaceWebhook is set', async () => {
+    const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
+    const client = app.get(VapiClientService);
+    vi.spyOn(client, 'fetchAssistantConfig').mockResolvedValueOnce({
+      ok: true,
+      config: { server: { url: 'https://customer.example/hook' } },
+    });
+    const updateSpy = vi.spyOn(client, 'updateAssistantServer').mockResolvedValue({ ok: true });
+    updateSpy.mockClear();
+    const dto = await runAsActor(actor, () =>
+      app.get(VapiService).createChannel({
+        name: 'vapi-replace',
+        config: { apiKey: 'k', webhookSecret: 'whsec_z', assistantId: 'asst_replace' },
+        replaceWebhook: true,
+      }),
+    );
+    expect(dto.webhookConfigured).toBe(true);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    const server = updateSpy.mock.calls[0]![0].server as Record<string, unknown>;
+    expect(server.url).toBe(`https://munin.example/v1/conversations/channels/${dto.id}/webhook`);
+  });
+
+  it('restores the assistant server when the channel is archived', async () => {
+    const actor = new ActorIdentity('user', 'usr_test', orgId, ['*'], ['admin']);
+    const client = app.get(VapiClientService);
+    vi.spyOn(client, 'fetchAssistantConfig').mockResolvedValueOnce({ ok: true, config: {} });
+    vi.spyOn(client, 'updateAssistantServer').mockResolvedValue({ ok: true });
+    const dto = await runAsActor(actor, () =>
+      app.get(VapiService).createChannel({
+        name: 'vapi-restore',
+        config: { apiKey: 'k', webhookSecret: 'whsec_r', assistantId: 'asst_restore' },
+      }),
+    );
+    expect(dto.webhookConfigured).toBe(true);
+    const restoreSpy = vi.spyOn(client, 'updateAssistantServer').mockResolvedValue({ ok: true });
+    restoreSpy.mockClear();
+    await runAsActor(actor, () => app.get(ChannelAdminService).onArchive(dto.id));
+    expect(restoreSpy).toHaveBeenCalledTimes(1);
+    expect(restoreSpy.mock.calls[0]![0].server).toBeNull();
+  });
 
   it('rejects webhook with wrong shared secret', async () => {
     const payload = JSON.stringify({ message: { type: 'transcript' } });

--- a/packages/backend-core/src/modules/conv/vapi/vapi.service.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi.service.ts
@@ -3,16 +3,20 @@ import {
   ConflictException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { sql, and, eq } from 'drizzle-orm';
 import {
   encryptSecretSql,
   getCurrentContext,
+  readApiBaseUrl,
 } from '@getmunin/core';
-import { schema, type Db } from '@getmunin/db';
+import { schema, makeId, type Db } from '@getmunin/db';
 import { z } from 'zod';
 import { DB } from '../../../common/db/db.module.ts';
+import { asRecord } from '../channels/json-shape.ts';
+import { VapiClientService, VAPI_WEBHOOK_SECRET_HEADER } from './vapi-client.service.ts';
 
 const REDACTED = '••••';
 
@@ -22,6 +26,8 @@ export const StoredVapiConfigSchema = z.object({
   assistantId: z.string().min(1).max(128),
   phoneNumberId: z.string().min(1).max(128).optional(),
   publicKey: z.string().min(1).max(256).optional(),
+  managedWebhook: z.boolean().optional(),
+  priorAssistantServer: z.unknown().optional(),
 });
 
 export type StoredVapiConfig = z.infer<typeof StoredVapiConfigSchema>;
@@ -51,19 +57,43 @@ export interface VapiChannelDto {
   vendor: 'vapi';
   active: boolean;
   config: VapiConfigDto;
+  webhookConfigured?: boolean;
 }
 
 @Injectable()
 export class VapiService {
-  constructor(@Inject(DB) private readonly _db: Db) {}
+  private readonly logger = new Logger(VapiService.name);
 
-  async createChannel(input: { name: string; config: VapiConfigInput }): Promise<VapiChannelDto> {
+  constructor(
+    @Inject(DB) private readonly _db: Db,
+    @Inject(VapiClientService) private readonly client: VapiClientService,
+  ) {}
+
+  async createChannel(input: {
+    name: string;
+    config: VapiConfigInput;
+    replaceWebhook?: boolean;
+  }): Promise<VapiChannelDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    const stored = await this.toStored(input.config);
+    const channelId = makeId('cch');
+    const auto = await this.tryConfigureAssistantWebhook(
+      input.config,
+      buildWebhookUrl(channelId),
+      input.replaceWebhook ?? false,
+    );
+    if (auto.conflict) {
+      throw new ConflictException({
+        code: 'webhook_conflict',
+        message:
+          'This Vapi assistant already has a server URL configured. Replace it to connect this channel.',
+      });
+    }
+    const stored = await this.toStored(input.config, auto);
     const [row] = await ctx.db
       .insert(schema.convChannels)
       .values({
+        id: channelId,
         orgId: actor.orgId,
         type: 'voice',
         vendor: 'vapi',
@@ -72,7 +102,64 @@ export class VapiService {
       })
       .returning();
     if (!row) throw new ConflictException('channel_create_failed');
-    return this.toDto(row.id, row.name, row.active, stored);
+    return this.toDto(row.id, row.name, row.active, stored, auto.configured);
+  }
+
+  private async tryConfigureAssistantWebhook(
+    config: VapiConfigInput,
+    webhookUrl: string,
+    replaceWebhook: boolean,
+  ): Promise<{ configured: boolean; priorServer: unknown; conflict: boolean }> {
+    try {
+      const fetched = await this.client.fetchAssistantConfig({
+        apiKey: config.apiKey,
+        assistantId: config.assistantId,
+      });
+      if (!fetched.ok) return { configured: false, priorServer: undefined, conflict: false };
+      const priorServer = asRecord(fetched.config).server;
+      const prior = asRecord(priorServer);
+      const currentUrl = typeof prior.url === 'string' ? prior.url : '';
+      if (currentUrl && !isMuninWebhookUrl(currentUrl) && !replaceWebhook) {
+        return { configured: false, priorServer: undefined, conflict: true };
+      }
+      const patched = await this.client.updateAssistantServer({
+        apiKey: config.apiKey,
+        assistantId: config.assistantId,
+        server: {
+          ...prior,
+          url: webhookUrl,
+          headers: { ...asRecord(prior.headers), [VAPI_WEBHOOK_SECRET_HEADER]: config.webhookSecret },
+        },
+      });
+      if (!patched.ok) return { configured: false, priorServer: undefined, conflict: false };
+      return { configured: true, priorServer: priorServer ?? null, conflict: false };
+    } catch (err) {
+      this.logger.warn(
+        `vapi assistant webhook auto-config failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return { configured: false, priorServer: undefined, conflict: false };
+    }
+  }
+
+  async restoreAssistantServer(channelId: string): Promise<void> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const [channel] = await ctx.db
+      .select()
+      .from(schema.convChannels)
+      .where(and(eq(schema.convChannels.id, channelId), eq(schema.convChannels.orgId, actor.orgId)))
+      .limit(1);
+    if (!channel || channel.vendor !== 'vapi') return;
+    const config = jsonbToStored(channel.config);
+    if (!config.managedWebhook) return;
+    const apiKey = await this.client.loadSecret(config.encryptedApiKey);
+    await this.client.updateAssistantServer({
+      apiKey,
+      assistantId: config.assistantId,
+      server: (config.priorAssistantServer ?? null) as Record<string, unknown> | null,
+    });
   }
 
   async updateChannel(input: {
@@ -108,6 +195,8 @@ export class VapiService {
       assistantId: input.config?.assistantId ?? prev.assistantId,
       phoneNumberId: input.config?.phoneNumberId ?? prev.phoneNumberId,
       publicKey: input.config?.publicKey ?? prev.publicKey,
+      managedWebhook: prev.managedWebhook,
+      priorAssistantServer: prev.priorAssistantServer,
     };
     const [row] = await ctx.db
       .update(schema.convChannels)
@@ -122,17 +211,28 @@ export class VapiService {
     return this.toDto(row.id, row.name, row.active, merged);
   }
 
-  private async toStored(input: VapiConfigInput): Promise<StoredVapiConfig> {
+  private async toStored(
+    input: VapiConfigInput,
+    auto?: { configured: boolean; priorServer: unknown },
+  ): Promise<StoredVapiConfig> {
     return {
       encryptedApiKey: await encryptString(input.apiKey),
       encryptedWebhookSecret: await encryptString(input.webhookSecret),
       assistantId: input.assistantId,
       phoneNumberId: input.phoneNumberId,
       publicKey: input.publicKey,
+      managedWebhook: auto?.configured ? true : undefined,
+      priorAssistantServer: auto?.configured ? (auto.priorServer ?? null) : undefined,
     };
   }
 
-  private toDto(id: string, name: string, active: boolean, stored: StoredVapiConfig): VapiChannelDto {
+  private toDto(
+    id: string,
+    name: string,
+    active: boolean,
+    stored: StoredVapiConfig,
+    webhookConfigured?: boolean,
+  ): VapiChannelDto {
     return {
       id,
       name,
@@ -146,8 +246,18 @@ export class VapiService {
         phoneNumberId: stored.phoneNumberId ?? null,
         publicKey: stored.publicKey ?? null,
       },
+      ...(webhookConfigured === undefined ? {} : { webhookConfigured }),
     };
   }
+}
+
+function buildWebhookUrl(channelId: string): string {
+  return `${readApiBaseUrl()}/v1/conversations/channels/${channelId}/webhook`;
+}
+
+function isMuninWebhookUrl(url: string): boolean {
+  const base = readApiBaseUrl();
+  return url.startsWith(`${base}/v1/conversations/channels/`) && url.endsWith('/webhook');
 }
 
 export function storedToJsonb(stored: StoredVapiConfig): Record<string, unknown> {

--- a/packages/backend-core/src/modules/conv/vapi/vapi.tools.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi.tools.ts
@@ -4,12 +4,16 @@ import { sensitive } from '@getmunin/types';
 import { schema } from '@getmunin/db';
 import { and, eq } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
-import { VapiClientService } from './vapi-client.service.ts';
+import { VapiClientService, type VapiAssistantSummary } from './vapi-client.service.ts';
 import {
   VapiService,
   jsonbToStored,
   type VapiChannelDto,
 } from './vapi.service.ts';
+
+export interface VapiListAssistantsResult {
+  assistants: VapiAssistantSummary[];
+}
 
 export const ConfigureInput = z.object({
   channelId: z
@@ -53,6 +57,12 @@ export const ConfigureInput = z.object({
     .max(256)
     .optional()
     .describe('Vapi public key — safe to expose to the browser. Required if you want the chat widget to start in-browser voice sessions; not needed for phone-only setups. Find it in the Vapi dashboard under your assistant.'),
+  replaceWebhook: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set true to overwrite a server URL already configured on the assistant. Without it, an existing non-Munin server returns a 409 webhook_conflict error.',
+    ),
 });
 
 @Injectable()
@@ -81,6 +91,7 @@ export class VapiAdminTools {
     if (!args.webhookSecret) throw new BadRequestException('webhookSecret is required when creating');
     if (!args.assistantId) throw new BadRequestException('assistantId is required when creating');
     return this.svc.createChannel({
+      replaceWebhook: args.replaceWebhook,
       name: args.name,
       config: {
         apiKey: args.apiKey,
@@ -90,6 +101,23 @@ export class VapiAdminTools {
         publicKey: args.publicKey,
       },
     });
+  }
+
+  async listAssistants(args: { apiKey: string }): Promise<VapiListAssistantsResult> {
+    const res = await this.client.listAssistants({ apiKey: args.apiKey });
+    if (!res.ok) throw new BadRequestException(res.error);
+    return { assistants: res.assistants };
+  }
+
+  async listAssistantsForChannel(args: { channelId: string }): Promise<VapiListAssistantsResult> {
+    const channel = await this.loadChannel(args.channelId);
+    const config = jsonbToStored(channel.config);
+    const apiKey = await this.client.loadSecret(config.encryptedApiKey);
+    return this.listAssistants({ apiKey });
+  }
+
+  async restoreWebhook(channelId: string): Promise<void> {
+    await this.svc.restoreAssistantServer(channelId);
   }
 
   async testChannel(

--- a/packages/backend-core/src/modules/outreach/outreach.service.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.test.ts
@@ -504,7 +504,9 @@ const skipReason = TEST_URL
         'dGVzdC1lbmNyeXB0aW9uLWtleS1tdXN0LWJlLWxvbmctZW5vdWdoLWZvci1wZ2NyeXB0bw==';
       globalThis.fetch = realFetch;
 
-      const vapiSvc = new VapiService(db);
+      const vapiClient = new VapiClientService(db);
+      vapiClient.fetchAssistantConfig = () => Promise.resolve({ ok: false, error: 'stub' });
+      const vapiSvc = new VapiService(db, vapiClient);
       const voiceChannel = await runAsSystem(() =>
         vapiSvc.createChannel({
           name: 'Vapi voice',

--- a/packages/dashboard-pages/src/api.ts
+++ b/packages/dashboard-pages/src/api.ts
@@ -20,6 +20,7 @@ export class ApiError extends Error {
   readonly method: string;
   readonly requestId: string | null;
   readonly fieldErrors: readonly ApiFieldError[];
+  readonly code: string | null;
 
   constructor(opts: {
     status: number;
@@ -29,6 +30,7 @@ export class ApiError extends Error {
     requestId: string | null;
     message: string;
     fieldErrors?: readonly ApiFieldError[];
+    code?: string | null;
   }) {
     super(opts.message);
     this.status = opts.status;
@@ -37,6 +39,7 @@ export class ApiError extends Error {
     this.method = opts.method;
     this.requestId = opts.requestId;
     this.fieldErrors = opts.fieldErrors ?? [];
+    this.code = opts.code ?? null;
   }
 }
 
@@ -83,14 +86,19 @@ export async function api<T>(path: string, init: ApiOptions = {}): Promise<T> {
       requestId: res.headers.get('x-request-id'),
       message: parsed.message || `${res.status} ${res.statusText}`,
       fieldErrors: parsed.fieldErrors,
+      code: parsed.code,
     });
   }
   if (res.status === 204) return undefined as T;
   return (await res.json()) as T;
 }
 
-function parseErrorBody(body: string): { message: string | null; fieldErrors: ApiFieldError[] } {
-  if (!body) return { message: null, fieldErrors: [] };
+function parseErrorBody(body: string): {
+  message: string | null;
+  fieldErrors: ApiFieldError[];
+  code: string | null;
+} {
+  if (!body) return { message: null, fieldErrors: [], code: null };
   try {
     const parsed: unknown = JSON.parse(body);
     if (parsed && typeof parsed === 'object') {
@@ -102,12 +110,13 @@ function parseErrorBody(body: string): { message: string | null; fieldErrors: Ap
           : typeof obj.error === 'string'
           ? obj.error
           : null;
-      return { message, fieldErrors };
+      const code = typeof obj.code === 'string' ? obj.code : null;
+      return { message, fieldErrors, code };
     }
   } catch (err) {
     console.warn('[munin/api] error body was not JSON, returning raw text', err);
   }
-  return { message: body, fieldErrors: [] };
+  return { message: body, fieldErrors: [], code: null };
 }
 
 function readFieldErrors(obj: Record<string, unknown>): ApiFieldError[] {

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -22,6 +22,7 @@
     "edit": "Edit",
     "close": "Close",
     "back": "Back",
+    "continue": "Continue",
     "copy": "Copy",
     "copied": "Copied",
     "done": "Done",
@@ -622,8 +623,18 @@
           "webhookSecretLabel": "Webhook Secret",
           "webhookSecretHint": "Add as HTTP Header named `X-Webhook-Secret` with this value."
         },
-        "assistantIdLabel": "Assistant ID",
-        "assistantIdHint": "Paste the assistant id from the Vapi dashboard.",
+        "assistantIdLabel": "Assistant",
+        "assistantIdHint": "The Vapi assistant that handles calls on this channel.",
+        "assistantStage": {
+          "title": "Choose an assistant",
+          "description": "Select the Vapi assistant that will handle calls on this channel.",
+          "empty": "No assistants found in this Vapi account. Create one in Vapi, then try again."
+        },
+        "replaceWebhook": {
+          "title": "Replace assistant server URL?",
+          "message": "This Vapi assistant already has a server URL configured. Munin will overwrite it to receive call events. Continue?",
+          "confirm": "Replace"
+        },
         "phoneNumberIdLabel": "Phone Number ID (optional)",
         "phoneNumberIdHint": "Only needed for phone network calls. Paste a phone number id from Vapi.",
         "publicKeyLabel": "Public API Key (optional)",
@@ -651,18 +662,21 @@
         "apiKeyLabel": "API Key",
         "apiKeyHintCreate": "Threll API key (Settings → Developer). Munin uses it to register the webhook with Threll automatically.",
         "apiKeyHintEdit": "Leave blank to keep the existing key. Paste a new value to rotate.",
-        "connectionStage": {
-          "title": "Threll connected",
-          "description": "Munin registered the webhook subscription with Threll automatically — your voice channel is ready.",
-          "serverUrlLabel": "Webhook URL",
-          "serverUrlHint": "Threll delivers call events here. Munin registered this URL for you; no manual setup needed."
+        "workerLabel": "Threll",
+        "workerHint": "The threll that handles calls on this channel.",
+        "workerStage": {
+          "title": "Choose a threll",
+          "description": "Select the threll that will handle calls on this channel.",
+          "descriptionAccount": "Select the threll in {account} that will handle calls on this channel.",
+          "empty": "No thrells found in this account. Create one in Threll, then try again."
         },
-        "accountIdLabel": "Account ID",
-        "accountIdHint": "Threll account ID (shown alongside your API key).",
-        "workerIdLabel": "Worker ID",
-        "workerIdHint": "Threll worker ID that handles calls on this channel.",
         "accountChip": "acct · {id}",
         "workerChip": "worker · {id}",
+        "replaceWebhook": {
+          "title": "Replace existing webhook?",
+          "message": "This Threll account already has an account-wide webhook subscription. Munin will delete it and register its own. Continue?",
+          "confirm": "Replace"
+        },
         "placeCall": "Place a call",
         "placeCallDialog": {
           "title": "Place an outbound call",
@@ -679,6 +693,7 @@
       "errors": {
         "load": "Could not load channels.",
         "create": "Could not create channel.",
+        "required": "Required.",
         "createEmail": "Could not create email channel.",
         "updateEmail": "Could not update email channel.",
         "createTwilioSms": "Could not create Twilio SMS channel.",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -22,6 +22,7 @@
     "edit": "Rediger",
     "close": "Lukk",
     "back": "Tilbake",
+    "continue": "Fortsett",
     "copy": "Kopier",
     "copied": "Kopiert",
     "done": "Ferdig",
@@ -622,8 +623,18 @@
           "webhookSecretLabel": "Webhook-hemmelighet",
           "webhookSecretHint": "Legg til som HTTP Header `X-Webhook-Secret` med denne verdien."
         },
-        "assistantIdLabel": "Assistent-ID",
-        "assistantIdHint": "Lim inn assistentens id fra Vapi-dashbordet.",
+        "assistantIdLabel": "Assistent",
+        "assistantIdHint": "Vapi-assistenten som håndterer anrop på denne kanalen.",
+        "assistantStage": {
+          "title": "Velg en assistent",
+          "description": "Velg Vapi-assistenten som skal håndtere anrop på denne kanalen.",
+          "empty": "Fant ingen assistenter i denne Vapi-kontoen. Opprett en i Vapi og prøv igjen."
+        },
+        "replaceWebhook": {
+          "title": "Erstatt assistentens server-URL?",
+          "message": "Denne Vapi-assistenten har allerede en server-URL konfigurert. Munin overskriver den for å motta samtalehendelser. Fortsette?",
+          "confirm": "Erstatt"
+        },
         "phoneNumberIdLabel": "Telefonnummer-ID (valgfritt)",
         "phoneNumberIdHint": "Bare nødvendig for samtaler over telenettet. Lim inn en telefonnummer-id fra Vapi.",
         "publicKeyLabel": "Public API-nøkkel (valgfritt)",
@@ -651,18 +662,21 @@
         "apiKeyLabel": "API-nøkkel",
         "apiKeyHintCreate": "Threll API-nøkkel (Innstillinger → Utvikler). Munin bruker den til å registrere webhooken i Threll automatisk.",
         "apiKeyHintEdit": "La feltet stå tomt for å beholde eksisterende. Lim inn ny verdi for å rotere.",
-        "connectionStage": {
-          "title": "Threll tilkoblet",
-          "description": "Munin registrerte webhook-abonnementet i Threll automatisk — stemmekanalen er klar.",
-          "serverUrlLabel": "Webhook-URL",
-          "serverUrlHint": "Threll leverer samtalehendelser hit. Munin registrerte denne URL-en for deg; ingen manuell oppsett nødvendig."
+        "workerLabel": "Threll",
+        "workerHint": "Threllen som håndterer anrop på denne kanalen.",
+        "workerStage": {
+          "title": "Velg en threll",
+          "description": "Velg threllen som skal håndtere anrop på denne kanalen.",
+          "descriptionAccount": "Velg threllen i {account} som skal håndtere anrop på denne kanalen.",
+          "empty": "Fant ingen threller i denne kontoen. Opprett en i Threll og prøv igjen."
         },
-        "accountIdLabel": "Konto-ID",
-        "accountIdHint": "Threll konto-ID (vises ved siden av API-nøkkelen din).",
-        "workerIdLabel": "Worker-ID",
-        "workerIdHint": "Threll worker-ID som håndterer anrop på denne kanalen.",
         "accountChip": "acct · {id}",
         "workerChip": "worker · {id}",
+        "replaceWebhook": {
+          "title": "Erstatt eksisterende webhook?",
+          "message": "Denne Threll-kontoen har allerede et kontoomfattende webhook-abonnement. Munin sletter det og registrerer sitt eget. Fortsette?",
+          "confirm": "Erstatt"
+        },
         "placeCall": "Start anrop",
         "placeCallDialog": {
           "title": "Start et utgående anrop",
@@ -679,6 +693,7 @@
       "errors": {
         "load": "Kunne ikke laste kanaler.",
         "create": "Kunne ikke opprette kanal.",
+        "required": "Påkrevd.",
         "createEmail": "Kunne ikke opprette e-postkanal.",
         "updateEmail": "Kunne ikke oppdatere e-postkanal.",
         "createTwilioSms": "Kunne ikke opprette Twilio SMS-kanal.",

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -21,6 +21,7 @@ import { EmptyCallout } from '../components/empty-callout';
 import { SaveErrorStage, type SaveErrorDetail } from '../components/save-error-stage';
 import { useConfirm } from '../components/confirm-dialog';
 import { FormField } from '../components/form-field';
+import { NativeSelect } from '../components/native-select';
 import { useLoadGate } from '../lib/use-load-gate';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
 import { notify } from '../lib/notify';
@@ -134,6 +135,31 @@ interface ThrellChannelDto extends ChannelDto {
     accountId?: string;
     workerId?: string;
   };
+}
+
+interface ChannelOptionItem {
+  value: string;
+  label: string;
+  hint?: string | null;
+}
+
+interface ChannelOptionGroup {
+  key: string;
+  label: string;
+  options: ChannelOptionItem[];
+}
+
+interface ChannelOptionsResponse {
+  groups: ChannelOptionGroup[];
+  context?: { label?: string };
+}
+
+function channelOptionsFor(res: ChannelOptionsResponse, key: string): ChannelOptionItem[] {
+  return res.groups.find((g) => g.key === key)?.options ?? [];
+}
+
+function optionLabel(option: ChannelOptionItem): string {
+  return option.hint ? `${option.label} (${option.hint})` : option.label;
 }
 
 interface CreatedWidget {
@@ -2813,6 +2839,7 @@ function AddVoiceDialog({
   const t = useTranslations('dashboard.channels');
   const tCommon = useTranslations('common');
   const translate = useTranslateError();
+  const confirm = useConfirm();
   const [vendor, setVendor] = useState<VoiceVendor>('threll');
   const [name, setName] = useState('');
   const [apiKey, setApiKey] = useState('');
@@ -2820,13 +2847,14 @@ function AddVoiceDialog({
   const [assistantId, setAssistantId] = useState('');
   const [phoneNumberId, setPhoneNumberId] = useState('');
   const [publicKey, setPublicKey] = useState('');
-  const [accountId, setAccountId] = useState('');
   const [workerId, setWorkerId] = useState('');
+  const [stage, setStage] = useState<'form' | 'options'>('form');
+  const [options, setOptions] = useState<ChannelOptionItem[]>([]);
+  const [optionsAccountLabel, setOptionsAccountLabel] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [submitError, setSubmitError] = useState<SaveErrorDetail | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [createdChannelId, setCreatedChannelId] = useState<string | null>(null);
-  const [createdVendor, setCreatedVendor] = useState<VoiceVendor>('vapi');
 
   useEffect(() => {
     if (!open) return;
@@ -2837,16 +2865,50 @@ function AddVoiceDialog({
     setAssistantId('');
     setPhoneNumberId('');
     setPublicKey('');
-    setAccountId('');
     setWorkerId('');
+    setStage('form');
+    setOptions([]);
+    setOptionsAccountLabel(null);
     setSubmitError(null);
     setFieldErrors({});
     setSaving(false);
     setCreatedChannelId(null);
-    setCreatedVendor('vapi');
   }, [open]);
 
-  async function submitVapi(): Promise<void> {
+  async function fetchVapiAssistants(): Promise<void> {
+    const errors: Record<string, string> = {};
+    if (!name.trim()) errors.name = t('errors.required');
+    if (!apiKey) errors.apiKey = t('errors.required');
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+    setFieldErrors({});
+    setSaving(true);
+    setSubmitError(null);
+    try {
+      const res = await api<ChannelOptionsResponse>('/v1/conversations/channels/options', {
+        method: 'POST',
+        body: JSON.stringify({ vendor: 'vapi', config: { apiKey } }),
+      });
+      const assistants = channelOptionsFor(res, 'assistants');
+      setOptions(assistants);
+      setOptionsAccountLabel(null);
+      setAssistantId(assistants[0]?.value ?? '');
+      setStage('options');
+    } catch (err) {
+      setSubmitError(
+        toSaveErrorDetail(err, translate(err) || t('errors.createVapi'), {
+          endpoint: '/v1/conversations/channels/options',
+          method: 'POST',
+        }),
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function submitVapi(replaceWebhook = false): Promise<void> {
     const generatedSecret = generateWebhookSecret();
     const payload: Record<string, unknown> = {
       ...(name.trim() ? { name: name.trim() } : {}),
@@ -2855,6 +2917,7 @@ function AddVoiceDialog({
       ...(assistantId.trim() ? { assistantId: assistantId.trim() } : {}),
       ...(phoneNumberId.trim() ? { phoneNumberId: phoneNumberId.trim() } : {}),
       ...(publicKey.trim() ? { publicKey: publicKey.trim() } : {}),
+      ...(replaceWebhook ? { replaceWebhook: true } : {}),
     };
     const parsed = ConfigureVapiBody.safeParse(payload);
     if (!parsed.success) {
@@ -2865,15 +2928,33 @@ function AddVoiceDialog({
     setSaving(true);
     setSubmitError(null);
     try {
-      const created = await api<{ id: string }>('/v1/conversations/channels/vapi', {
-        method: 'POST',
-        body: JSON.stringify(parsed.data),
-      });
-      setWebhookSecret(generatedSecret);
-      setCreatedVendor('vapi');
-      setCreatedChannelId(created.id);
+      const created = await api<{ id: string; webhookConfigured?: boolean }>(
+        '/v1/conversations/channels/vapi',
+        {
+          method: 'POST',
+          body: JSON.stringify(parsed.data),
+        },
+      );
       onSaved();
+      if (created.webhookConfigured) {
+        onOpenChange(false);
+      } else {
+        setWebhookSecret(generatedSecret);
+        setCreatedChannelId(created.id);
+      }
     } catch (err) {
+      if (err instanceof ApiError && err.code === 'webhook_conflict') {
+        setSaving(false);
+        const ok = await confirm({
+          title: t('vapi.replaceWebhook.title'),
+          message: t('vapi.replaceWebhook.message'),
+          confirmLabel: t('vapi.replaceWebhook.confirm'),
+          cancelLabel: tCommon('cancel'),
+          destructive: true,
+        });
+        if (ok) await submitVapi(true);
+        return;
+      }
       setSubmitError(
         toSaveErrorDetail(err, translate(err) || t('errors.createVapi'), {
           endpoint: '/v1/conversations/channels/vapi',
@@ -2885,30 +2966,73 @@ function AddVoiceDialog({
     }
   }
 
-  async function submitThrell(): Promise<void> {
-    const payload: Record<string, unknown> = {
-      ...(name.trim() ? { name: name.trim() } : {}),
-      ...(apiKey ? { apiKey } : {}),
-      ...(accountId.trim() ? { accountId: accountId.trim() } : {}),
-      ...(workerId.trim() ? { workerId: workerId.trim() } : {}),
-    };
-    const parsed = ConfigureThrellBody.safeParse(payload);
-    if (!parsed.success) {
-      setFieldErrors(zodIssuesToFieldErrors(parsed.error.issues, t));
+  async function fetchThrellWorkers(): Promise<void> {
+    const errors: Record<string, string> = {};
+    if (!name.trim()) errors.name = t('errors.required');
+    if (!apiKey) errors.apiKey = t('errors.required');
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
       return;
     }
     setFieldErrors({});
     setSaving(true);
     setSubmitError(null);
     try {
-      const created = await api<{ id: string }>('/v1/conversations/channels/threll', {
+      const res = await api<ChannelOptionsResponse>('/v1/conversations/channels/options', {
+        method: 'POST',
+        body: JSON.stringify({ vendor: 'threll', config: { apiKey } }),
+      });
+      const workers = channelOptionsFor(res, 'workers');
+      setOptions(workers);
+      setOptionsAccountLabel(res.context?.label ?? null);
+      setWorkerId(workers[0]?.value ?? '');
+      setStage('options');
+    } catch (err) {
+      setSubmitError(
+        toSaveErrorDetail(err, translate(err) || t('errors.createThrell'), {
+          endpoint: '/v1/conversations/channels/options',
+          method: 'POST',
+        }),
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function createThrell(replaceWebhook = false): Promise<void> {
+    const payload = {
+      name: name.trim(),
+      apiKey,
+      workerId,
+      ...(replaceWebhook ? { replaceWebhook: true } : {}),
+    };
+    const parsed = ConfigureThrellBody.safeParse(payload);
+    if (!parsed.success) {
+      setFieldErrors(zodIssuesToFieldErrors(parsed.error.issues, t));
+      return;
+    }
+    setSaving(true);
+    setSubmitError(null);
+    try {
+      await api<{ id: string }>('/v1/conversations/channels/threll', {
         method: 'POST',
         body: JSON.stringify(parsed.data),
       });
-      setCreatedVendor('threll');
-      setCreatedChannelId(created.id);
       onSaved();
+      onOpenChange(false);
     } catch (err) {
+      if (err instanceof ApiError && err.code === 'webhook_conflict') {
+        setSaving(false);
+        const ok = await confirm({
+          title: t('threll.replaceWebhook.title'),
+          message: t('threll.replaceWebhook.message'),
+          confirmLabel: t('threll.replaceWebhook.confirm'),
+          cancelLabel: tCommon('cancel'),
+          destructive: true,
+        });
+        if (ok) await createThrell(true);
+        return;
+      }
       setSubmitError(
         toSaveErrorDetail(err, translate(err) || t('errors.createThrell'), {
           endpoint: '/v1/conversations/channels/threll',
@@ -2922,8 +3046,13 @@ function AddVoiceDialog({
 
   function submit(): void {
     setFieldErrors({});
+    if (vendor === 'vapi') void fetchVapiAssistants();
+    else if (vendor === 'threll') void fetchThrellWorkers();
+  }
+
+  function createForVendor(): void {
     if (vendor === 'vapi') void submitVapi();
-    else if (vendor === 'threll') void submitThrell();
+    else void createThrell();
   }
 
   return (
@@ -2933,22 +3062,37 @@ function AddVoiceDialog({
           <SaveErrorStage
             detail={submitError}
             onBack={() => setSubmitError(null)}
-            onRetry={() => submit()}
+            onRetry={() => (stage === 'options' ? createForVendor() : submit())}
             retrying={saving}
           />
         ) : createdChannelId ? (
-          createdVendor === 'threll' ? (
-            <ThrellConnectionStage
-              channelId={createdChannelId}
-              onDone={() => onOpenChange(false)}
-            />
-          ) : (
-            <VapiConnectionStage
-              channelId={createdChannelId}
-              webhookSecret={webhookSecret}
-              onDone={() => onOpenChange(false)}
-            />
-          )
+          <VapiConnectionStage
+            channelId={createdChannelId}
+            webhookSecret={webhookSecret}
+            onDone={() => onOpenChange(false)}
+          />
+        ) : stage === 'options' ? (
+          <ChannelOptionStage
+            title={vendor === 'threll' ? t('threll.workerStage.title') : t('vapi.assistantStage.title')}
+            description={
+              vendor === 'threll'
+                ? optionsAccountLabel
+                  ? t('threll.workerStage.descriptionAccount', { account: optionsAccountLabel })
+                  : t('threll.workerStage.description')
+                : t('vapi.assistantStage.description')
+            }
+            fieldLabel={vendor === 'threll' ? t('threll.workerLabel') : t('vapi.assistantIdLabel')}
+            fieldHint={vendor === 'threll' ? t('threll.workerHint') : t('vapi.assistantIdHint')}
+            emptyMessage={
+              vendor === 'threll' ? t('threll.workerStage.empty') : t('vapi.assistantStage.empty')
+            }
+            options={options}
+            value={vendor === 'threll' ? workerId : assistantId}
+            onChange={vendor === 'threll' ? setWorkerId : setAssistantId}
+            saving={saving}
+            onBack={() => setStage('form')}
+            onCreate={createForVendor}
+          />
         ) : (
           <>
             <DialogHeader>
@@ -3003,18 +3147,6 @@ function AddVoiceDialog({
                     />
                   </FormField>
                   <FormField
-                    label={t('vapi.assistantIdLabel')}
-                    hint={t('vapi.assistantIdHint')}
-                    error={fieldErrors.assistantId}
-                  >
-                    <Input
-                      value={assistantId}
-                      onChange={(e) => setAssistantId(e.target.value)}
-                      maxLength={128}
-                      required
-                    />
-                  </FormField>
-                  <FormField
                     label={t('vapi.phoneNumberIdLabel')}
                     hint={t('vapi.phoneNumberIdHint')}
                     error={fieldErrors.phoneNumberId}
@@ -3046,30 +3178,6 @@ function AddVoiceDialog({
                       required
                     />
                   </FormField>
-                  <FormField
-                    label={t('threll.accountIdLabel')}
-                    hint={t('threll.accountIdHint')}
-                    error={fieldErrors.accountId}
-                  >
-                    <Input
-                      value={accountId}
-                      onChange={(e) => setAccountId(e.target.value)}
-                      maxLength={128}
-                      required
-                    />
-                  </FormField>
-                  <FormField
-                    label={t('threll.workerIdLabel')}
-                    hint={t('threll.workerIdHint')}
-                    error={fieldErrors.workerId}
-                  >
-                    <Input
-                      value={workerId}
-                      onChange={(e) => setWorkerId(e.target.value)}
-                      maxLength={128}
-                      required
-                    />
-                  </FormField>
                 </>
               )}
               <DialogFooter className={dialogFooterClass}>
@@ -3089,7 +3197,7 @@ function AddVoiceDialog({
                   disabled={saving}
                   pending={saving}
                 >
-                  {saving ? tCommon('creating') : t('addVoiceDialog.create')}
+                  {saving ? tCommon('creating') : tCommon('continue')}
                   <span aria-hidden className="ml-1 font-mono">↵</span>
                 </Button>
               </DialogFooter>
@@ -3164,6 +3272,7 @@ function VapiChannelDialog({
   const [assistantId, setAssistantId] = useState(editChannel.config?.assistantId ?? '');
   const [phoneNumberId, setPhoneNumberId] = useState(editChannel.config?.phoneNumberId ?? '');
   const [publicKey, setPublicKey] = useState(editChannel.config?.publicKey ?? '');
+  const [assistants, setAssistants] = useState<ChannelOptionItem[]>([]);
   const [saving, setSaving] = useState(false);
   const [submitError, setSubmitError] = useState<SaveErrorDetail | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -3176,9 +3285,23 @@ function VapiChannelDialog({
     setAssistantId(editChannel.config?.assistantId ?? '');
     setPhoneNumberId(editChannel.config?.phoneNumberId ?? '');
     setPublicKey(editChannel.config?.publicKey ?? '');
+    setAssistants([]);
     setSubmitError(null);
     setFieldErrors({});
     setSaving(false);
+    let cancelled = false;
+    void api<ChannelOptionsResponse>(`/v1/conversations/channels/${editChannel.id}/options`, {
+      method: 'POST',
+    })
+      .then((res) => {
+        if (!cancelled) setAssistants(channelOptionsFor(res, 'assistants'));
+      })
+      .catch(() => {
+        if (!cancelled) setAssistants([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [open, editChannel]);
 
   async function submit() {
@@ -3284,11 +3407,24 @@ function VapiChannelDialog({
                 hint={t('vapi.assistantIdHint')}
                 error={fieldErrors.assistantId}
               >
-                <Input
-                  value={assistantId}
-                  onChange={(e) => setAssistantId(e.target.value)}
-                  maxLength={128}
-                />
+                {assistants.length > 0 ? (
+                  <NativeSelect value={assistantId} onChange={(e) => setAssistantId(e.target.value)}>
+                    {!assistants.some((a) => a.value === assistantId) && assistantId ? (
+                      <option value={assistantId}>{assistantId}</option>
+                    ) : null}
+                    {assistants.map((a) => (
+                      <option key={a.value} value={a.value}>
+                        {optionLabel(a)}
+                      </option>
+                    ))}
+                  </NativeSelect>
+                ) : (
+                  <Input
+                    value={assistantId}
+                    onChange={(e) => setAssistantId(e.target.value)}
+                    maxLength={128}
+                  />
+                )}
               </FormField>
               <FormField
                 label={t('vapi.phoneNumberIdLabel')}
@@ -3443,31 +3579,74 @@ function PlaceVapiCallDialog({
   );
 }
 
-function ThrellConnectionStage({
-  channelId,
-  onDone,
+function ChannelOptionStage({
+  title,
+  description,
+  fieldLabel,
+  fieldHint,
+  emptyMessage,
+  options,
+  value,
+  onChange,
+  saving,
+  onBack,
+  onCreate,
 }: {
-  channelId: string;
-  onDone: () => void;
+  title: string;
+  description: string;
+  fieldLabel: string;
+  fieldHint: string;
+  emptyMessage: string;
+  options: ChannelOptionItem[];
+  value: string;
+  onChange: (value: string) => void;
+  saving: boolean;
+  onBack: () => void;
+  onCreate: () => void;
 }) {
   const t = useTranslations('dashboard.channels');
   const tCommon = useTranslations('common');
+  const hasOptions = options.length > 0;
   return (
     <>
       <DialogHeader>
-        <DialogTitle>{t('threll.connectionStage.title')}</DialogTitle>
-        <DialogDescription>{t('threll.connectionStage.description')}</DialogDescription>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
-      <div className="mt-2 flex flex-col gap-4">
-        <CopyableSecret
-          label={t('threll.connectionStage.serverUrlLabel')}
-          value={vapiWebhookUrl(channelId)}
-          hint={t('threll.connectionStage.serverUrlHint')}
-        />
+      <div className="mt-4 flex flex-col gap-4">
+        {hasOptions ? (
+          <FormField label={fieldLabel} hint={fieldHint}>
+            <NativeSelect value={value} onChange={(e) => onChange(e.target.value)}>
+              {options.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {optionLabel(option)}
+                </option>
+              ))}
+            </NativeSelect>
+          </FormField>
+        ) : (
+          <p className={dialogHintClass}>{emptyMessage}</p>
+        )}
       </div>
       <DialogFooter className={dialogFooterClass}>
-        <Button variant="accent" className={dialogButtonClass} onClick={onDone}>
-          {tCommon('done')}
+        <Button
+          type="button"
+          variant="outline"
+          className={dialogButtonClass}
+          onClick={onBack}
+          disabled={saving}
+        >
+          {tCommon('back')}
+        </Button>
+        <Button
+          type="button"
+          variant="accent"
+          className={dialogButtonClass}
+          onClick={onCreate}
+          disabled={saving || !hasOptions}
+          pending={saving}
+        >
+          {saving ? tCommon('creating') : t('addVoiceDialog.create')}
         </Button>
       </DialogFooter>
     </>
@@ -3490,8 +3669,8 @@ function ThrellChannelDialog({
   const translate = useTranslateError();
   const [name, setName] = useState(editChannel.name);
   const [apiKey, setApiKey] = useState('');
-  const [accountId, setAccountId] = useState(editChannel.config?.accountId ?? '');
   const [workerId, setWorkerId] = useState(editChannel.config?.workerId ?? '');
+  const [workers, setWorkers] = useState<ChannelOptionItem[]>([]);
   const [saving, setSaving] = useState(false);
   const [submitError, setSubmitError] = useState<SaveErrorDetail | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -3500,11 +3679,24 @@ function ThrellChannelDialog({
     if (!open) return;
     setName(editChannel.name);
     setApiKey('');
-    setAccountId(editChannel.config?.accountId ?? '');
     setWorkerId(editChannel.config?.workerId ?? '');
+    setWorkers([]);
     setSubmitError(null);
     setFieldErrors({});
     setSaving(false);
+    let cancelled = false;
+    void api<ChannelOptionsResponse>(`/v1/conversations/channels/${editChannel.id}/options`, {
+      method: 'POST',
+    })
+      .then((res) => {
+        if (!cancelled) setWorkers(channelOptionsFor(res, 'workers'));
+      })
+      .catch(() => {
+        if (!cancelled) setWorkers([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [open, editChannel]);
 
   async function submit() {
@@ -3512,7 +3704,6 @@ function ThrellChannelDialog({
       channelId: editChannel.id,
       ...(name.trim() ? { name: name.trim() } : {}),
       ...(apiKey ? { apiKey } : {}),
-      ...(accountId.trim() ? { accountId: accountId.trim() } : {}),
       ...(workerId.trim() ? { workerId: workerId.trim() } : {}),
     };
     const parsed = ConfigureThrellBody.safeParse(payload);
@@ -3583,26 +3774,28 @@ function ThrellChannelDialog({
                 />
               </FormField>
               <FormField
-                label={t('threll.accountIdLabel')}
-                hint={t('threll.accountIdHint')}
-                error={fieldErrors.accountId}
-              >
-                <Input
-                  value={accountId}
-                  onChange={(e) => setAccountId(e.target.value)}
-                  maxLength={128}
-                />
-              </FormField>
-              <FormField
-                label={t('threll.workerIdLabel')}
-                hint={t('threll.workerIdHint')}
+                label={t('threll.workerLabel')}
+                hint={t('threll.workerHint')}
                 error={fieldErrors.workerId}
               >
-                <Input
-                  value={workerId}
-                  onChange={(e) => setWorkerId(e.target.value)}
-                  maxLength={128}
-                />
+                {workers.length > 0 ? (
+                  <NativeSelect value={workerId} onChange={(e) => setWorkerId(e.target.value)}>
+                    {!workers.some((w) => w.value === workerId) && workerId ? (
+                      <option value={workerId}>{workerId}</option>
+                    ) : null}
+                    {workers.map((worker) => (
+                      <option key={worker.value} value={worker.value}>
+                        {optionLabel(worker)}
+                      </option>
+                    ))}
+                  </NativeSelect>
+                ) : (
+                  <Input
+                    value={workerId}
+                    onChange={(e) => setWorkerId(e.target.value)}
+                    maxLength={128}
+                  />
+                )}
               </FormField>
               <DialogFooter className={dialogFooterClass}>
                 <Button

--- a/packages/types/src/channels.ts
+++ b/packages/types/src/channels.ts
@@ -156,6 +156,7 @@ export const ConfigureVapiBody = z
     assistantId: z.string().min(1).max(128).optional(),
     phoneNumberId: z.string().min(1).max(128).optional(),
     publicKey: z.string().min(1).max(256).optional(),
+    replaceWebhook: z.boolean().optional(),
   })
   .refine(
     (v) =>
@@ -183,16 +184,20 @@ export const ConfigureThrellBody = z
     apiKey: sensitive(z.string().min(1).max(256).optional()),
     accountId: z.string().min(1).max(128).optional(),
     workerId: z.string().min(1).max(128).optional(),
+    replaceWebhook: z.boolean().optional(),
   })
-  .refine(
-    (v) =>
-      v.channelId !== undefined || (v.name && v.apiKey && v.accountId && v.workerId),
-    {
-      message: 'name, apiKey, accountId, and workerId are required when creating',
-    },
-  );
+  .refine((v) => v.channelId !== undefined || (v.name && v.apiKey && v.workerId), {
+    message: 'name, apiKey, and workerId are required when creating',
+  });
 
 export type ConfigureThrellBodyT = z.infer<typeof ConfigureThrellBody>;
+
+export const ChannelListOptionsBody = z.object({
+  vendor: z.string().min(1).max(40),
+  config: sensitive(z.record(z.string(), z.unknown())),
+});
+
+export type ChannelListOptionsBodyT = z.infer<typeof ChannelListOptionsBody>;
 
 export const ThrellCallInitiateBody = z.object({
   to: z.string().regex(E164, 'must be E.164').max(32),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -31,6 +31,8 @@ export {
   type VapiCallInitiateBodyT,
   ConfigureThrellBody,
   type ConfigureThrellBodyT,
+  ChannelListOptionsBody,
+  type ChannelListOptionsBodyT,
   ThrellCallInitiateBody,
   type ThrellCallInitiateBodyT,
   ConfigureChannelBody,


### PR DESCRIPTION
## Summary

Reworks Threll and Vapi voice-channel setup into a guided, symmetric flow — no more hand-typing opaque ids, automatic webhook wiring, and a graceful "replace existing webhook?" path when there's a conflict.

## Setup is now a two-step picker (both vendors)
- **Threll** — enter just the **API key** → Continue. The account is resolved from the key via `GET /v1/accounts/current` (a key maps 1:1 to an account), then the dialog lists that account's **workers** in a dropdown. The Account ID field is gone (still accepted as an optional override; re-derived if the key is rotated on edit).
- **Vapi** — enter the API key (+ optional public key / phone number id) → Continue → pick the **assistant** from a dropdown.
- **Cancelling step two creates nothing** — no channel, no provider-side webhook.
- Edit dialogs load the same dropdowns from stored credentials.

## Discovery is generic (agent parity)
- New `conv_list_channel_options` MCP tool + `POST /v1/conversations/channels/options` (and `:id/options`) return a vendor's selectable options (Threll `workers`, Vapi `assistants`) as `{ value, label, hint }` groups.
- Adding a vendor is one `listOptions` method on its `ChannelAdminProvider`.

## Webhooks auto-register
- **Threll** — reuses a matching existing subscription instead of blindly creating another; the post-setup "copy this webhook URL" screen is gone.
- **Vapi** — points the chosen assistant's `server` at the channel's webhook URL, but **only when it's unset or already a Munin URL** (never clobbers a server you wired elsewhere). Prior value is stashed and restored when the channel is archived (new best-effort `onArchive` provider hook).

## Conflict → "Replace existing webhook?"
When auto-setup would collide (Threll rejects a second account-wide `*` subscription; a Vapi assistant `server` already points elsewhere), setup returns **`409 webhook_conflict`** and the dashboard shows a confirm. Confirming retries with `replaceWebhook: true` (Threll **deletes** the conflicting subscription and registers its own; Vapi **overwrites** the assistant server); cancelling goes back with nothing changed. The flag is exposed on `conv_configure_channel` too.

## Internal cleanups
- Both vendor HTTP clients route through one `request()` helper (auth header, 10s timeout, `HttpStatus`-based status→error mapping).
- Shared `asRecord`/`toRows`/`asArray` in one `json-shape` module.
- Dashboard `ApiError` now surfaces the response `code`.

## Verification
- typecheck (backend-core, types, dashboard-pages) ✓, ESLint ✓, OpenAPI + MCP fixtures regenerated ✓
- **263 tests pass** across conv + outreach (gated on `TEST_DATABASE_URL`), including new cases for: generic `listOptions` (both vendors), key-only Threll create via `/accounts/current`, Threll webhook dedup, Threll/Vapi conflict → 409 and replace → delete-and-create / overwrite, and Vapi auto-config + restore-on-archive.

## Notes / known limitations
- Auto-webhook is **create-only** for both vendors (editing to a different worker/assistant doesn't re-register) — consistent across vendors.
- Vapi assistant / Threll worker lists don't paginate yet; the gated picker drops the manual-id escape hatch, so an org past the list limit wouldn't see later entries.
- Changeset included (`@getmunin/backend-core`, `@getmunin/types`, `@getmunin/dashboard-pages` — all patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)