### PR TITLE
fix(chat-widget): open full-screen on mobile

### DIFF
--- a/.changeset/widget-mobile-fullscreen.md
+++ b/.changeset/widget-mobile-fullscreen.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/chat-widget': patch
+---
+
+Open the chat widget full-screen on small viewports (phones in portrait and landscape, plus small tablets — up to 600px wide), matching the behaviour of Intercom/Crisp. The panel now goes edge-to-edge using dynamic viewport units, respects device safe-area insets, and locks page scroll while open so the conversation is usable on small screens.

--- a/apps/chat-widget/src/styles.ts
+++ b/apps/chat-widget/src/styles.ts
@@ -879,11 +879,26 @@ button {
 .composer textarea:disabled { opacity: 0.55; cursor: not-allowed; }
 
 /* ─── Responsive + reduced motion ────────────────────── */
-@media (max-width: 480px) {
-  .panel { width: calc(100vw - 32px); height: calc(100vh - 96px); }
+@media (max-width: 600px) {
   .root { bottom: 16px; }
   .root[data-position='bottom-right'] { right: 16px; }
   .root[data-position='bottom-left']  { left:  16px; }
+
+  .root[data-size] .panel {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    height: 100dvh;
+    max-width: none;
+    max-height: none;
+    border-radius: 0;
+    transform-origin: bottom center;
+  }
+  .panel-head { padding-top: calc(16px + env(safe-area-inset-top)); }
+  .composer { padding-bottom: calc(12px + env(safe-area-inset-bottom)); }
+  .voice-call { padding-top: env(safe-area-inset-top); }
+  .voice-call-controls { padding-bottom: calc(26px + env(safe-area-inset-bottom)); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/chat-widget/src/ui.test.ts
+++ b/apps/chat-widget/src/ui.test.ts
@@ -97,6 +97,55 @@ describe('ui: mount + lifecycle', () => {
   });
 });
 
+describe('ui: mobile full-screen body scroll lock', () => {
+  const origMatchMedia = window.matchMedia;
+  const origScrollTo = window.scrollTo;
+
+  function setViewport(matches: boolean): void {
+    window.matchMedia = vi.fn().mockReturnValue({ matches });
+  }
+
+  beforeEach(() => {
+    window.scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    window.matchMedia = origMatchMedia;
+    window.scrollTo = origScrollTo;
+    document.body.removeAttribute('style');
+    document.documentElement.removeAttribute('style');
+  });
+
+  it('locks body scroll on open and restores it on close when the viewport is phone-sized', () => {
+    setViewport(true);
+    controller = mount(baseConfig, strings, { onSend: () => {}, onTypingIntent: () => {} });
+    ($('.launcher')).click();
+    expect(document.body.style.position).toBe('fixed');
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.documentElement.style.overflow).toBe('hidden');
+    ($('[data-act="close"]')).click();
+    expect(document.body.getAttribute('style')).toBeNull();
+    expect(document.documentElement.getAttribute('style')).toBeNull();
+  });
+
+  it('does not touch body scroll on larger viewports', () => {
+    setViewport(false);
+    controller = mount(baseConfig, strings, { onSend: () => {}, onTypingIntent: () => {} });
+    ($('.launcher')).click();
+    expect(document.body.getAttribute('style')).toBeNull();
+  });
+
+  it('restores body scroll when destroyed while open', () => {
+    setViewport(true);
+    controller = mount(baseConfig, strings, { onSend: () => {}, onTypingIntent: () => {} });
+    ($('.launcher')).click();
+    expect(document.body.style.position).toBe('fixed');
+    controller.destroy();
+    controller = null;
+    expect(document.body.getAttribute('style')).toBeNull();
+  });
+});
+
 describe('ui: launcher unread badge', () => {
   beforeEach(() => {
     controller = mount(baseConfig, strings, { onSend: () => {}, onTypingIntent: () => {} });

--- a/apps/chat-widget/src/ui.ts
+++ b/apps/chat-widget/src/ui.ts
@@ -260,8 +260,39 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
     applyMuteUi();
   }
 
+  const fullscreenMql =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(max-width: 600px)')
+      : null;
+  let scrollLock: { scrollY: number; body: string | null; html: string | null } | null = null;
+
+  function lockBodyScroll(): void {
+    if (scrollLock || !fullscreenMql?.matches || typeof document === 'undefined') return;
+    const body = document.body;
+    const html = document.documentElement;
+    const scrollY = window.scrollY || window.pageYOffset || 0;
+    scrollLock = { scrollY, body: body.getAttribute('style'), html: html.getAttribute('style') };
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.style.left = '0';
+    body.style.right = '0';
+    body.style.width = '100%';
+    body.style.overflow = 'hidden';
+    html.style.overflow = 'hidden';
+  }
+
+  function unlockBodyScroll(): void {
+    if (!scrollLock || typeof document === 'undefined') return;
+    const { scrollY, body: bodyStyle, html: htmlStyle } = scrollLock;
+    scrollLock = null;
+    restoreStyle(document.body, bodyStyle);
+    restoreStyle(document.documentElement, htmlStyle);
+    window.scrollTo(0, scrollY);
+  }
+
   function open(): void {
     panel.el.hidden = false;
+    lockBodyScroll();
     requestAnimationFrame(() => panel.el.classList.add('open'));
     launcher.hidden = true;
     if (view === 'chat') {
@@ -272,6 +303,7 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
 
   function close(): void {
     panel.el.classList.remove('open');
+    unlockBodyScroll();
     launcher.hidden = false;
     setAgentTyping(false);
     setTimeout(() => {
@@ -482,6 +514,7 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
     if (agentTypingTimer) clearTimeout(agentTypingTimer);
     if (typingIdleTimer) clearTimeout(typingIdleTimer);
     stopCallTimer();
+    unlockBodyScroll();
     readObserver?.disconnect();
     host.remove();
   }
@@ -533,6 +566,11 @@ function renderGreeting(raw: string): string {
   const m = /^(.*?[.?!])\s+(.+)$/.exec(trimmed);
   if (m) return `${escapeHtml(m[1]!)} <em>${escapeHtml(m[2]!)}</em>`;
   return escapeHtml(trimmed);
+}
+
+function restoreStyle(el: HTMLElement, prev: string | null): void {
+  if (prev === null) el.removeAttribute('style');
+  else el.setAttribute('style', prev);
 }
 
 function escapeHtml(s: string): string {


### PR DESCRIPTION
## Problem

On mobile the chat widget didn't open full-screen, making it cramped and hard to use. Intercom/Crisp both go edge-to-edge on phones.

Root cause was in `apps/chat-widget/src/styles.ts`: the mobile media query only shrank the panel to a floating inset card (`width: calc(100vw - 32px)`), and the bare `.panel` selector lost on CSS specificity to the `.root[data-size] .panel` size-variant rules — so on a phone the widget rendered as a ~327px floating card regardless.

## Changes

- **`styles.ts`** — full-screen overlay on viewports ≤600px (phones portrait + landscape, small tablets): `position: fixed; inset: 0`, `100vw` × `100dvh` (with a `100vh` fallback so the composer survives the mobile toolbar/keyboard), `max-width/height: none`, `border-radius: 0`. Selector ties the specificity of the size-variant rules and comes later in the sheet, so it actually wins. Safe-area insets added to header, composer, and voice-call controls.
- **`ui.ts`** — page scroll lock while open, gated on `matchMedia('(max-width: 600px)')`, using the iOS-safe `position: fixed` + scroll-restore approach. Wired into `open()`/`close()`/`destroy()`, SSR/no-`matchMedia` guarded so desktop is untouched.
- **`ui.test.ts`** — 3 tests: lock engages on open / restores on close at small width, no-ops on larger viewports, restores on `destroy()` while open.
- **changeset** — patch bump for `@getmunin/chat-widget`.

## Verification

Typecheck, lint, 109 tests, and `vite build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)