### PR TITLE
fix(chat-widget): prevent mobile zoom on input focus

### DIFF
--- a/.changeset/widget-mobile-input-zoom.md
+++ b/.changeset/widget-mobile-input-zoom.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/chat-widget': patch
+---
+
+Stop mobile browsers from zooming in when the message box or email field is focused. iOS Safari auto-zooms when a focused field's font is below 16px, so text-entry fields are now 16px on touch devices.

--- a/apps/chat-widget/src/styles.ts
+++ b/apps/chat-widget/src/styles.ts
@@ -901,6 +901,11 @@ button {
   .voice-call-controls { padding-bottom: calc(26px + env(safe-area-inset-bottom)); }
 }
 
+@media (hover: none) and (pointer: coarse) {
+  .composer textarea,
+  .card-form input { font-size: 16px; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .launcher { transition: none; }
   .panel { transition: none; }


### PR DESCRIPTION
## Problem

On mobile, tapping the message box (or the email-save field) zoomed the page in. iOS Safari auto-zooms whenever a focused `<input>`/`<textarea>` has a `font-size` below 16px — the composer textarea was 13.5px and the email-card input 13px.

## Fix

Bump text-entry fields to 16px on touch devices via `@media (hover: none) and (pointer: coarse)`. This targets phones/tablets (the only devices that auto-zoom) regardless of width/orientation, and leaves the desktop 13.5px/13px typography untouched. No host-page viewport-meta hacks (the widget can't and shouldn't touch those).

## Verification

Typecheck, lint, 109 tests, and `vite build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)