### PR TITLE
fix: make `docker compose up` work from the repo root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Each module typically has `<mod>.module.ts`, `<mod>.service.ts`, `<mod>.tools.ts
 
 ```sh
 pnpm install                                # workspace install
-docker compose up                           # full stack (db + backend + web + adminer)
+docker compose up                           # full stack (db + backend + web; agent runner runs in-process in backend)
 pnpm dev                                    # run backend + web in dev mode
 pnpm typecheck                              # workspace typecheck
 pnpm -F @getmunin/backend-core test         # backend-core test suite (needs TEST_DATABASE_URL)

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 # Self-host Munin in one command:
 #
-#   git clone https://github.com/munin-dev/munin.git
+#   git clone https://github.com/getmunin/munin.git
 #   cd munin
 #   cp .env.example .env
 #   docker compose up
@@ -27,13 +27,13 @@ services:
 
   backend:
     build:
-      context: ..
+      context: .
       dockerfile: apps/backend/Dockerfile
     restart: unless-stopped
     depends_on:
       postgres:
         condition: service_healthy
-    env_file: ../.env
+    env_file: .env
     environment:
       NODE_ENV: production
       PORT: 3001
@@ -45,12 +45,12 @@ services:
 
   web:
     build:
-      context: ..
+      context: .
       dockerfile: apps/web/Dockerfile
     restart: unless-stopped
     depends_on:
       - backend
-    env_file: ../.env
+    env_file: .env
     environment:
       NODE_ENV: production
       PORT: 3000


### PR DESCRIPTION
## Problem

Following the README's self-host quickstart **verbatim** fails:

```
$ cp .env.example .env && docker compose up
no configuration file provided: not found
```

The compose file lived at `docker/compose.yml`, and Docker Compose only auto-discovers `compose.yml`/`docker-compose.yml` in the working directory or its parents — never a subdirectory. The file itself was valid (`docker compose -f docker/compose.yml config` → exit 0); only its location vs. the documented command was wrong. This broke the same instruction in `README.md`, `CONTRIBUTING.md` (`docker compose up -d postgres`), and the compose file's own header.

## Fix

- Move `docker/compose.yml` → `./compose.yml` so `docker compose up` works from the repo root as documented.
- Adjust relative paths: `context: .. → .`, `env_file: ../.env → .env` (both services).
- Correct the stale clone URL in the header comment (`munin-dev` → `getmunin`).
- Fix `CLAUDE.md` stack comment: there is no `adminer` service; the agent runner runs in-process in the backend (`AgentHostModule` in `apps/backend/src/app.module.ts`).

## Verification

`cp .env.example .env && docker compose config` from the repo root now exits 0 with build contexts resolving to the repo root.

This PR came out of an audit of all README claims — every other claim (ports, `/v1/kb/spaces`, `openapi.json`, the analytics tools, the `clean-contact-data`/`review-stale-entries` skills, `/tracker.js`, the delegated-token controller, `pnpm licenses:generate`, the architecture layout) checked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)