### PR TITLE
fix(conv): route Threll web-call transcripts to the widget conversation

### DIFF
--- a/.changeset/threll-widget-transcript-routing.md
+++ b/.changeset/threll-widget-transcript-routing.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Fix Threll in-browser (webrtc) voice calls dropping their transcript, recording/analysis, and mid-call tools. Widget voice/start now passes `{ conversationId, endUserId }` as web-call metadata, which Threll echoes back on every `call.*` webhook, so transcript/tool/ended events resolve to the conversation the visitor is viewing. The adapter also skips conversation creation for `webrtc` `call.worker_request` hooks (which fire before voice/start has linked the call and carry no correlation data — they'd otherwise mint a phantom conversation on the voice channel) and falls back to an org-wide `threllCallId` lookup so resolution still works for calls placed before the metadata round-trip is available.

--- a/packages/backend-core/src/modules/conv/threll/threll-adapter.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-adapter.ts
@@ -52,6 +52,7 @@ interface ThrellEvent {
   data?: {
     callId?: string;
     direction?: 'inbound' | 'outbound';
+    transport?: string;
     customer?: ThrellCustomer;
     toolCallId?: string;
     name?: string;
@@ -135,6 +136,10 @@ export class ThrellAdapter implements ChannelAdapter {
     try {
       const callId = event.data?.callId;
       if (!callId) throw new Error('worker_request_missing_call_id');
+
+      if (event.data?.transport === 'webrtc') {
+        return emptyBody;
+      }
 
       const { conversationId, endUserId, crmContact } = await this.runAsSystem(
         channel,
@@ -237,18 +242,12 @@ export class ThrellAdapter implements ChannelAdapter {
       endUserId = rows[0]?.endUserId ?? null;
     }
     if (!endUserId && event.data?.callId) {
-      const rows = await this.db
-        .select({ endUserId: schema.convConversations.endUserId })
-        .from(schema.convConversations)
-        .where(
-          and(
-            eq(schema.convConversations.orgId, channel.orgId),
-            eq(schema.convConversations.channelId, channel.id),
-            sql`${schema.convConversations.metadata}->>'threllCallId' = ${event.data.callId}`,
-          ),
-        )
-        .limit(1);
-      endUserId = rows[0]?.endUserId ?? null;
+      const linked = await this.findConversationByThrellCallId(
+        this.db,
+        channel.orgId,
+        event.data.callId,
+      );
+      endUserId = linked?.endUserId ?? null;
     }
     if (!endUserId) {
       return jsonResponse({ result: { error: 'voice channel has no associated end-user — tools unavailable' } });
@@ -389,7 +388,27 @@ export class ThrellAdapter implements ChannelAdapter {
     }
     const callId = event.data?.callId;
     if (!callId) throw new Error('threll_event_missing_call_id_or_conversation_id');
+    const linked = await this.findConversationByThrellCallId(tx, channel.orgId, callId);
+    if (linked) return linked;
     return this.findOrCreateConversation(tx, channel, callId, event.data?.customer);
+  }
+
+  private async findConversationByThrellCallId(
+    tx: Db | Tx,
+    orgId: string,
+    callId: string,
+  ): Promise<typeof schema.convConversations.$inferSelect | null> {
+    const rows = await tx
+      .select()
+      .from(schema.convConversations)
+      .where(
+        and(
+          eq(schema.convConversations.orgId, orgId),
+          sql`${schema.convConversations.metadata}->>'threllCallId' = ${callId}`,
+        ),
+      )
+      .limit(1);
+    return rows[0] ?? null;
   }
 
   private async findOrCreateConversation(

--- a/packages/backend-core/src/modules/conv/threll/threll-client.service.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-client.service.ts
@@ -58,6 +58,7 @@ export interface CreateWebCallRequest {
   context?: string;
   externalTools?: ThrellExternalTool[];
   allowedOrigins?: string[];
+  metadata?: Record<string, unknown>;
   customer?: { firstName?: string; lastName?: string; externalId?: string };
 }
 
@@ -287,6 +288,7 @@ export class ThrellClientService {
     if (req.context) body.context = req.context;
     if (req.externalTools && req.externalTools.length > 0) body.externalTools = req.externalTools;
     if (req.allowedOrigins && req.allowedOrigins.length > 0) body.allowedOrigins = req.allowedOrigins;
+    if (req.metadata && Object.keys(req.metadata).length > 0) body.metadata = req.metadata;
     if (req.customer) body.customer = req.customer;
     const r = await this.request({
       apiKey: req.apiKey,

--- a/packages/backend-core/src/modules/conv/threll/threll.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll.integration.test.ts
@@ -358,6 +358,136 @@ const skipReason = TEST_URL
     expect(endUsers.length).toBe(1);
   });
 
+  it('worker_request for an in-browser (webrtc) call creates no conversation', async () => {
+    const callId = 'call_threll_webrtc';
+    const res = await postEvent({
+      type: 'call.worker_request',
+      data: { callId, direction: 'inbound', transport: 'webrtc', customer: {} },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.metadata).toBeUndefined();
+    expect(body.instructions).toBeUndefined();
+
+    const created = await db
+      .select({ id: schema.convConversations.id })
+      .from(schema.convConversations)
+      .where(
+        and(
+          eq(schema.convConversations.orgId, orgId),
+          sql`${schema.convConversations.metadata}->>'threllCallId' = ${callId}`,
+        ),
+      );
+    expect(created.length).toBe(0);
+  });
+
+  it('routes web-call transcripts to the pre-linked widget conversation by callId', async () => {
+    const [widgetChannel] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'chat',
+        vendor: 'munin',
+        name: 'Widget for threll test',
+        config: { provider: 'widget', originAllowlist: [], requireVerifiedIdentity: false },
+      })
+      .returning();
+    const [eu] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: 'eu-threll-widget', name: 'Web Caller' })
+      .returning();
+    const next = await db.execute<{ next: number } & Record<string, unknown>>(
+      sql`SELECT conv_next_display_id(${orgId}) AS next`,
+    );
+    const callId = 'call_threll_widget_web';
+    const [widgetConv] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        displayId: next[0]!.next,
+        channelId: widgetChannel!.id,
+        endUserId: eu!.id,
+        status: 'open',
+        metadata: { sessionId: 'sess_threll_widget', threllCallId: callId },
+      })
+      .returning();
+
+    const transcript = await postEvent({
+      type: 'call.transcript',
+      data: { callId, role: 'user', text: 'Hi from the browser', isFinal: true, turnIndex: 0 },
+    });
+    expect(transcript.status).toBe(204);
+
+    const msgs = await db
+      .select({ body: schema.convMessages.body, conversationId: schema.convMessages.conversationId })
+      .from(schema.convMessages)
+      .where(eq(schema.convMessages.conversationId, widgetConv!.id));
+    expect(msgs.map((m) => m.body)).toContain('Hi from the browser');
+
+    const onVoice = await db
+      .select({ id: schema.convConversations.id })
+      .from(schema.convConversations)
+      .where(
+        and(
+          eq(schema.convConversations.orgId, orgId),
+          eq(schema.convConversations.channelId, channelId),
+          sql`${schema.convConversations.metadata}->>'threllCallId' = ${callId}`,
+        ),
+      );
+    expect(onVoice.length).toBe(0);
+  });
+
+  it('routes web-call transcripts to the conversation named in event metadata', async () => {
+    const [widgetChannel] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'chat',
+        vendor: 'munin',
+        name: 'Widget meta test',
+        config: { provider: 'widget', originAllowlist: [], requireVerifiedIdentity: false },
+      })
+      .returning();
+    const [eu] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: 'eu-threll-meta', name: 'Web Caller 2' })
+      .returning();
+    const next = await db.execute<{ next: number } & Record<string, unknown>>(
+      sql`SELECT conv_next_display_id(${orgId}) AS next`,
+    );
+    const [widgetConv] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        displayId: next[0]!.next,
+        channelId: widgetChannel!.id,
+        endUserId: eu!.id,
+        status: 'open',
+        metadata: { sessionId: 'sess_threll_meta' },
+      })
+      .returning();
+
+    const callId = 'call_threll_meta';
+    const transcript = await postEvent({
+      type: 'call.transcript',
+      data: {
+        callId,
+        role: 'user',
+        text: 'Routed by metadata',
+        isFinal: true,
+        turnIndex: 0,
+        metadata: { conversationId: widgetConv!.id },
+      },
+    });
+    expect(transcript.status).toBe(204);
+
+    const msgs = await db
+      .select({ body: schema.convMessages.body })
+      .from(schema.convMessages)
+      .where(eq(schema.convMessages.conversationId, widgetConv!.id));
+    expect(msgs.map((m) => m.body)).toContain('Routed by metadata');
+  });
+
   it('ingests user + agent transcript turns into one conversation by callId', async () => {
     const callId = 'call_threll_transcript';
     const r1 = await postEvent({

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
@@ -188,6 +188,7 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
           context: historyText || undefined,
           externalTools,
           allowedOrigins: widgetConfig.originAllowlist,
+          metadata: { conversationId: conv.id, endUserId },
         });
         if (!created.ok) {
           this.logger.warn(`threll createWebCall failed: ${created.error}`);


### PR DESCRIPTION
## Problem

In-browser (webrtc) Threll voice calls worked, but **no transcript, recording/analysis, or mid-call tools** ever landed on the conversation the visitor was viewing.

Threll's `call.worker_request` fires **synchronously inside web-call creation** — before `voice/start` has linked the call to its conversation — and carries no correlation data. The adapter was therefore minting a *phantom* conversation on the voice channel and routing every subsequent event (transcripts, recording flag, analysis, tool dispatch) there instead. The phantom also had no end-user, so mid-call tools failed with `voice channel has no associated end-user`.

## Fix

- `voice/start` passes `{ conversationId, endUserId }` as web-call **metadata**, which Threll now echoes on every `call.*` webhook.
- The adapter resolves `transcript` / `tool_call` / `ended` events by `event.data.metadata.conversationId`, with an **org-wide `threllCallId`** fallback so resolution still works for calls placed before the metadata round-trip is available (safe deploy ordering).
- `worker_request` returns empty for `transport === 'webrtc'` — `voice/start` already configured the call, so there's nothing to do and no phantom is created.

Inbound phone calls (transport ≠ webrtc) are unchanged. **Vapi is unaffected** — its metadata already round-trips via `assistantOverrides.metadata`.

## Depends on

The metadata round-trip requires the Threll backend change (`web-calls` accept + echo `metadata`), which is being deployed separately. Until that ships, the org-wide `threllCallId` fallback keeps this working — so deploy order doesn't matter.

## Tests

New Threll integration tests cover all three resolution paths (metadata, `threllCallId` fallback, and the `webrtc` worker_request no-phantom case). Threll + widget-voice suites: 33/33. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)