### PR TITLE
ci: auto-publish to the MCP registry on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,20 @@ jobs:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: node scripts/aggregate-release.mjs
 
+      - name: Publish to MCP Registry
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node -e "process.stdout.write(JSON.parse(process.env.PUBLISHED_PACKAGES)[0].version)")
+          echo "Publishing com.getmunin/munin@$VERSION to the MCP registry"
+          jq --arg v "$VERSION" '.version = $v' server.json > server.json.tmp && mv server.json.tmp server.json
+          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher login dns --domain getmunin.com --private-key "$MCP_PRIVATE_KEY"
+          ./mcp-publisher publish
+
   licenses:
     name: license policy
     runs-on: ubuntu-latest

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.getmunin/munin",
-  "description": "MCP-first customer platform for the agentic era: KB, Conversations, CRM, CMS, Outreach, Analytics",
+  "description": "Open-source all-in-one MCP-first customer platform: KB, Conversations, CRM, CMS, Outreach, Analytics",
   "websiteUrl": "https://getmunin.com",
   "repository": {
     "url": "https://github.com/getmunin/munin",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.getmunin/munin",
+  "description": "MCP-first customer platform for the agentic era: KB, Conversations, CRM, CMS, Outreach, Analytics",
+  "websiteUrl": "https://getmunin.com",
+  "repository": {
+    "url": "https://github.com/getmunin/munin",
+    "source": "github"
+  },
+  "version": "4.51.4",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.getmunin.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Automates re-publishing `com.getmunin/munin` to the [official MCP registry](https://registry.modelcontextprotocol.io) on every release, so the registry entry no longer drifts from the shipped version.

## How it works
- Adds a **Publish to MCP Registry** step to the existing release job in `ci.yml`, gated on `steps.changesets.outputs.published == 'true'` — it only runs when changesets actually publishes.
- The version is read from the same `publishedPackages` output that already drives the `v<version>` release tag (via `aggregate-release.mjs`), then written into `server.json` with `jq` at publish time. Single source of truth; no manual `server.json` version bumps.
- Commits `server.json` (the registry spec). Its committed `version` is just a placeholder — CI overwrites it per release.

## Design notes
- **DNS auth, not GitHub OIDC.** OIDC would force the `io.github.getmunin/*` namespace; we want to keep the domain-verified `com.getmunin/munin` we already published under. DNS auth reuses the apex `TXT` record already on `getmunin.com` plus the `MCP_PRIVATE_KEY` repo secret (already set).
- **Inline step, not a tag-triggered workflow.** The release tag is created by `aggregate-release.mjs` using the default `GITHUB_TOKEN`, and GitHub does not fire `on: push: tags` / `on: release` workflows for `GITHUB_TOKEN`-created refs — so a separate workflow would silently never run.

## Prereqs (already done)
- `MCP_PRIVATE_KEY` repo secret set (Ed25519 private key matching the live `getmunin.com` TXT record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)