### PR TITLE
fix(docs): repair mobile layout and restore in-section nav

### DIFF
--- a/.changeset/docs-mobile-sidebar.md
+++ b/.changeset/docs-mobile-sidebar.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/docs-pages': patch
+---
+
+Fix the developer-portal docs on mobile. The decorative 320px sidebar-column fill (`.docs-body::before`) was painting an opaque stripe over the article on phones — `:has(.docs-side)` still matched the in-DOM sidebar even though it was `display:none` — leaving content clipped against the right edge. The stripe is now hidden below 880px, and each section's sidebar (REST endpoints, MCP tools, guides, skills) becomes a collapsible "Browse…" dropdown so in-section navigation works on mobile instead of disappearing.

--- a/packages/docs-pages/src/_components/docs-side.tsx
+++ b/packages/docs-pages/src/_components/docs-side.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState, type MouseEvent, type ReactNode } from 'react';
+
+export function DocsSide({ label, children }: { label: string; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  const closeOnLink = (e: MouseEvent<HTMLDivElement>) => {
+    if ((e.target as HTMLElement).closest('a')) setOpen(false);
+  };
+
+  return (
+    <nav className="docs-side" data-open={open} aria-label="Section navigation">
+      <button
+        type="button"
+        className="docs-side-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span>{label}</span>
+        <span className="chev" aria-hidden>
+          ▾
+        </span>
+      </button>
+      <div className="docs-side-list" onClick={closeOnLink}>
+        {children}
+      </div>
+    </nav>
+  );
+}

--- a/packages/docs-pages/src/_components/guides-sidebar.tsx
+++ b/packages/docs-pages/src/_components/guides-sidebar.tsx
@@ -2,12 +2,13 @@
 
 import { Link, usePathname } from '../i18n-navigation';
 import { GUIDE_GROUPS, GUIDES, guidesByCategory } from '../guides/_lib/guides';
+import { DocsSide } from './docs-side';
 
 export function GuidesSidebar() {
   const pathname = usePathname() ?? '';
   const byCategory = guidesByCategory();
   return (
-    <aside className="docs-side">
+    <DocsSide label="Browse guides">
       <div className="group">
         <div className="group-h">
           All <span className="ct">· {GUIDES.length}</span>
@@ -35,6 +36,6 @@ export function GuidesSidebar() {
           </div>
         );
       })}
-    </aside>
+    </DocsSide>
   );
 }

--- a/packages/docs-pages/src/_components/mcp-sidebar.tsx
+++ b/packages/docs-pages/src/_components/mcp-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import type { McpTool } from '../_lib/mcp';
+import { DocsSide } from './docs-side';
 
 export function McpSidebar({ admin, selfService }: { admin: McpTool[]; selfService: McpTool[] }) {
   const [activeId, setActiveId] = useState<string>('');
@@ -14,7 +15,7 @@ export function McpSidebar({ admin, selfService }: { admin: McpTool[]; selfServi
   }, []);
 
   return (
-    <aside className="docs-side">
+    <DocsSide label="Browse tools">
       <div className="group">
         <div className="group-h">
           Admin tools <span className="ct">· {admin.length}</span>
@@ -35,6 +36,6 @@ export function McpSidebar({ admin, selfService }: { admin: McpTool[]; selfServi
           </a>
         ))}
       </div>
-    </aside>
+    </DocsSide>
   );
 }

--- a/packages/docs-pages/src/_components/rest-sidebar.tsx
+++ b/packages/docs-pages/src/_components/rest-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { prettifyTag, type TagGroup } from '../_lib/openapi';
+import { DocsSide } from './docs-side';
 
 export function RestSidebar({ groups }: { groups: TagGroup[] }) {
   const [activeId, setActiveId] = useState<string>('');
@@ -14,7 +15,7 @@ export function RestSidebar({ groups }: { groups: TagGroup[] }) {
   }, []);
 
   return (
-    <aside className="docs-side">
+    <DocsSide label="Browse endpoints">
       {groups.map((g) => (
         <div className="group" key={g.tag}>
           <div className="group-h">
@@ -34,6 +35,6 @@ export function RestSidebar({ groups }: { groups: TagGroup[] }) {
           ))}
         </div>
       ))}
-    </aside>
+    </DocsSide>
   );
 }

--- a/packages/docs-pages/src/_components/skills-sidebar.tsx
+++ b/packages/docs-pages/src/_components/skills-sidebar.tsx
@@ -2,11 +2,12 @@
 
 import { Link, usePathname } from '../i18n-navigation';
 import type { Skill } from '../_lib/skills';
+import { DocsSide } from './docs-side';
 
 export function SkillsSidebar({ groups }: { groups: Array<{ module: string; skills: Skill[] }> }) {
   const pathname = usePathname() ?? '';
   return (
-    <aside className="docs-side">
+    <DocsSide label="Browse skills">
       {groups.map((g) => (
         <div className="group" key={g.module}>
           <div className="group-h">
@@ -22,6 +23,6 @@ export function SkillsSidebar({ groups }: { groups: Array<{ module: string; skil
           })}
         </div>
       ))}
-    </aside>
+    </DocsSide>
   );
 }

--- a/packages/docs-pages/src/docs.css
+++ b/packages/docs-pages/src/docs.css
@@ -317,6 +317,11 @@
   font-size: 12px;
 }
 
+/* Mobile section-nav toggle — hidden on desktop, the list shows inline. */
+.docs-side-toggle {
+  display: none;
+}
+
 .docs .m-GET {
   color: var(--docs-accent);
 }
@@ -1244,8 +1249,63 @@
 }
 
 @media (max-width: 880px) {
-  .docs-side {
+  .docs-body {
+    flex-direction: column;
+  }
+  /* The 320px sidebar-column fill would otherwise paint over the article,
+     since :has(.docs-side) still matches the in-DOM (hidden) sidebar. */
+  .docs-body:has(.docs-side)::before {
     display: none;
+  }
+  .docs-side {
+    width: auto;
+    align-self: stretch;
+    padding: 0;
+    max-height: none;
+    overflow: visible;
+    z-index: 5;
+    border-bottom: 1px solid var(--docs-rule);
+    background: var(--docs-page);
+  }
+  .docs-side-toggle {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 13px 20px;
+    background: var(--docs-page);
+    border: 0;
+    font-family: var(--munin-mono);
+    font-size: 11px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--docs-soft);
+    cursor: pointer;
+  }
+  .docs-side-toggle .chev {
+    font-size: 13px;
+    transition: transform 160ms ease;
+  }
+  .docs-side[data-open='true'] .docs-side-toggle .chev {
+    transform: rotate(180deg);
+  }
+  .docs-side-list {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    padding: 8px 20px 16px;
+    max-height: min(70vh, 460px);
+    overflow: auto;
+    background: var(--docs-page);
+    border-bottom: 1px solid var(--docs-rule);
+    box-shadow: 0 14px 30px -18px rgb(0 0 0 / 0.4);
+    z-index: 5;
+  }
+  .docs-side[data-open='true'] .docs-side-list {
+    display: block;
   }
   .docs-main {
     padding: 24px 20px 80px;


### PR DESCRIPTION
### Problem
On phones the developer-portal docs rendered the article clipped against the right edge with a wide empty band on the left (see the reported screenshot — REST tab). 

**Root cause:** the `.docs-body::before` decorative *sidebar-column fill* is a 320px-wide, opaque, absolutely-positioned (`z-index:0`) element. At `max-width:880px` the sidebar is `display:none`, but `:has(.docs-side)` **still matches** because `display:none` doesn't remove the element from the DOM — so the stripe kept rendering and painted over the left 320px of the article. Nothing was pushed off-screen; it was *covered*.

Secondarily, with the sidebar hidden, phones lost all in-section navigation (REST endpoints / MCP tools / guides / skills lists).

### Fix
- Hide the `::before` stripe below 880px and stack `.docs-body` into a column.
- New shared `DocsSide` wrapper turns each section's sidebar into a collapsible **"Browse…"** dropdown on mobile (sticky bar under the section switcher, expands as an overlay, auto-closes on link tap). The four sidebars (`rest`/`mcp`/`guides`/`skills`) now wrap their existing groups in `<DocsSide>` — internals (scroll-spy, links) untouched.
- **Desktop layout is unchanged** (toggle is `display:none`, list renders inline as before).

### Verification
- `@getmunin/docs-pages` typecheck + lint pass; `apps/web` typecheck passes.
- Visually verified at iPhone-13 viewport via Playwright — REST + MCP, collapsed and expanded. Article is full-width/readable; the dropdown lists endpoints/tools correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)