### PR TITLE
feat: agent-host provider extensibility hooks

### DIFF
--- a/.changeset/agent-host-provider-extensibility.md
+++ b/.changeset/agent-host-provider-extensibility.md
@@ -1,0 +1,14 @@
+---
+"@getmunin/backend-core": minor
+"@getmunin/agent-runtime": minor
+"@getmunin/agent-host": minor
+"@getmunin/dashboard-pages": minor
+---
+
+Add host extensibility hooks for the agent runner and provider configuration:
+
+- Rate-limit counters can be incremented by an arbitrary amount (`record(bucket, amount)`); add monthly `ai_tokens` and per-minute `ai_generates` buckets.
+- The usage summary (`/v1/usage/summary`) reports monthly AI token usage, surfaced as a tile on the usage and overview pages.
+- Agent passes can report a `quota_exceeded` skip outcome.
+- The agent host accepts an optional provider factory, credential resolver, and pre-generate gate via `runnerOptions`. The gate is consulted for both live chat and scheduled background work (distinguished by a `trigger` argument), so a host can supply its own provider implementation and meter or limit usage per org without forking the runner.
+- The provider picker accepts host-supplied presets — including a credential-less "managed" preset that renders host content and clears the org key on selection — plus a default selection. The AI settings and usage pages accept an optional content slot.

--- a/.changeset/web-import-survives-provider-error.md
+++ b/.changeset/web-import-survives-provider-error.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/agent-host": patch
+---
+
+Website import no longer fails the whole job when company-profile generation hits an LLM provider error (e.g. invalid credentials). The crawled pages are imported regardless — the optional profile step is skipped, a warning is logged, and the job completes successfully.

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -596,7 +596,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
               trigger: 'scheduled',
             }),
           { orgId: opts.orgId },
-        ).catch((err) => {
+        ).catch((err): { allowed: boolean; reason?: string } => {
           log.warn(`beforeGenerate failed, proceeding: ${describe(err)}`);
           return { allowed: true };
         });

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -34,6 +34,7 @@ import {
   type HandlerConfig,
   type MuninRestClient,
   type PromptResolver,
+  type Provider,
   type SkillPassResult,
   type SkillReader,
 } from '@getmunin/agent-runtime';
@@ -56,6 +57,7 @@ interface TaskHandlerContext {
   providerBaseUrl: string;
   providerApiKey: string;
   model: string;
+  provider?: Provider;
   logger: { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void };
 }
 
@@ -77,8 +79,32 @@ const DEFAULT_END_USER_AGENT_SCOPES: readonly string[] = [
   'crm:write',
 ];
 
+export type GenerateTrigger = 'chat' | 'scheduled';
+
+export interface ResolvedProviderAuth {
+  apiKey: string;
+  baseUrl?: string;
+  model?: string;
+  managed: boolean;
+}
+
 export interface AgentHostRunnerOptions {
   databaseUrl?: string;
+  resolveProviderAuth?: (
+    orgId: string,
+    config: AgentConfigRow,
+  ) => Promise<ResolvedProviderAuth | null>;
+  createProvider?: (args: {
+    orgId: string;
+    config: AgentConfigRow;
+    managed: boolean;
+  }) => Provider;
+  beforeGenerate?: (args: {
+    orgId: string;
+    config: AgentConfigRow;
+    managed: boolean;
+    trigger: GenerateTrigger;
+  }) => Promise<{ allowed: boolean; reason?: string }>;
 }
 
 interface PerConfigRunner {
@@ -104,6 +130,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
   private stopped = false;
   private readonly holderId: string;
   private readonly lockManager: ReplicaLockManager | null;
+  private readonly options?: AgentHostRunnerOptions;
 
   constructor(
     @Inject(AGENT_CONFIG_REPOSITORY) private readonly repo: AgentConfigRepository,
@@ -116,6 +143,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     @Inject(AgentHealthService) private readonly health: AgentHealthService,
     @Optional() @Inject('AGENT_HOST_RUNNER_OPTIONS') options?: AgentHostRunnerOptions,
   ) {
+    this.options = options;
     this.holderId =
       process.env.MUNIN_AGENT_HOLDER_ID ??
       `agent-host-${hostname()}-${randomUUID().slice(0, 8)}`;
@@ -265,17 +293,35 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     }
   }
 
+  private async defaultResolveProviderAuth(id: string): Promise<ResolvedProviderAuth | null> {
+    const apiKey = await this.repo.readDecryptedProviderKey(id);
+    return apiKey ? { apiKey, managed: false } : null;
+  }
+
   private async spawnRunner(id: string): Promise<PerConfigRunner | null> {
     const config = await runWithServiceContext(this.db, id, () => this.repo.read(id));
     const orgId = await runWithServiceContext(this.db, id, () => this.repo.resolveOrgId(id));
-    const providerApiKey = await runWithServiceContext(this.db, id, () =>
-      this.repo.readDecryptedProviderKey(id),
+    const auth = await runWithServiceContext(
+      this.db,
+      id,
+      () =>
+        this.options?.resolveProviderAuth
+          ? this.options.resolveProviderAuth(orgId, config)
+          : this.defaultResolveProviderAuth(id),
+      { orgId },
     );
 
-    if (!providerApiKey) {
-      this.logger.warn(`${id}: enabled but no LLM provider API key`);
+    if (!auth) {
+      this.logger.warn(`${id}: enabled but no LLM provider available`);
       return null;
     }
+
+    const providerApiKey = auth.apiKey;
+    const providerBaseUrl = auth.baseUrl ?? config.providerBaseUrl;
+    const fastModel = auth.model ?? config.fastModel;
+    const smartModel = auth.model ?? config.smartModel ?? config.fastModel;
+    const managed = auth.managed;
+    const provider = this.options?.createProvider?.({ orgId, config, managed });
 
     const rest = this.restClientFactory.forOrg(orgId);
 
@@ -292,15 +338,26 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     });
 
     const handlerConfig: HandlerConfig = {
-      providerBaseUrl: config.providerBaseUrl,
+      providerBaseUrl,
       providerApiKey,
-      model: config.fastModel,
+      model: fastModel,
       maxToolIterations: config.maxToolIterations,
       maxHistoryChars: config.maxHistoryChars,
       debounceMs: config.debounceMs,
     };
 
-    const curatorWorker = this.buildCuratorWorker({ id, orgId, config, providerApiKey, rest });
+    const curatorWorker = this.buildCuratorWorker({
+      id,
+      orgId,
+      config,
+      rest,
+      providerBaseUrl,
+      providerApiKey,
+      fastModel,
+      smartModel,
+      provider,
+      managed,
+    });
 
     const handlerRef: { current: ConversationHandler | null } = { current: null };
     const realtime = this.eventBus.subscribe(
@@ -346,6 +403,17 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
             scopes: DEFAULT_END_USER_AGENT_SCOPES,
           }),
         ),
+      provider,
+      beforeGenerate: this.options?.beforeGenerate
+        ? () =>
+            runWithServiceContext(
+              this.db,
+              id,
+              () =>
+                this.options!.beforeGenerate!({ orgId, config, managed, trigger: 'chat' }),
+              { orgId },
+            )
+        : undefined,
       holderId: this.holderId,
       logger: this.scopedLogger(id, 'chat'),
       onTyping: (conversationId, isTyping) =>
@@ -377,8 +445,13 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     id: string;
     orgId: string;
     config: AgentConfigRow;
-    providerApiKey: string;
     rest: MuninRestClient;
+    providerBaseUrl: string;
+    providerApiKey: string;
+    fastModel: string;
+    smartModel: string;
+    provider?: Provider;
+    managed: boolean;
   }): CuratorWorker {
     const log = this.scopedLogger(opts.id, 'curator');
     const inFlight = new Set<Promise<unknown>>();
@@ -392,8 +465,8 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       return p;
     };
 
-    const smartModel = opts.config.smartModel ?? opts.config.fastModel;
-    const fastModel = opts.config.fastModel;
+    const smartModel = opts.smartModel;
+    const fastModel = opts.fastModel;
 
     const executeOne = async (job: CuratorJob): Promise<void> => {
       log.info(`running ${job.jobUri} for ${job.id} (attempt ${job.attempts}/${job.maxAttempts})`);
@@ -421,9 +494,10 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
         const ctx: TaskHandlerContext = {
           job,
           mcp: jobMcp,
-          providerBaseUrl: opts.config.providerBaseUrl,
+          providerBaseUrl: opts.providerBaseUrl,
           providerApiKey: opts.providerApiKey,
           model,
+          provider: opts.provider,
           logger: log,
         };
         const kind = jobKindOf(job.jobUri);
@@ -439,7 +513,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
           result = await runSkillPass({
             mcp: jobMcp,
             skills,
-            providerBaseUrl: opts.config.providerBaseUrl,
+            providerBaseUrl: opts.providerBaseUrl,
             providerApiKey: opts.providerApiKey,
             model,
             skillUri: job.jobUri,
@@ -447,6 +521,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
             assistantName: job.assistantName,
             maxToolIterations: 24,
             maxHistoryChars: opts.config.maxHistoryChars,
+            providerImpl: opts.provider,
             allowedToolPrefixes: prefixes ? [...prefixes] : undefined,
             logger: log,
           });
@@ -484,7 +559,8 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       const retryable =
         result.skipped !== 'skill_missing' &&
         result.skipped !== 'no_admin_key' &&
-        result.skipped !== 'no_provider_key';
+        result.skipped !== 'no_provider_key' &&
+        result.skipped !== 'quota_exceeded';
       log.warn(`${job.id} skipped: ${result.skipped}${result.error ? ` (${result.error})` : ''}`);
       const failBody: { error: string; retryable: boolean; code?: string; failedStep?: string } = {
         error: `${result.skipped}${result.error ? `: ${result.error}` : ''}`,
@@ -508,6 +584,27 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
 
     const pollOnce = async (): Promise<void> => {
       if (stopped) return;
+      if (this.options?.beforeGenerate) {
+        const verdict = await runWithServiceContext(
+          this.db,
+          opts.id,
+          () =>
+            this.options!.beforeGenerate!({
+              orgId: opts.orgId,
+              config: opts.config,
+              managed: opts.managed,
+              trigger: 'scheduled',
+            }),
+          { orgId: opts.orgId },
+        ).catch((err) => {
+          log.warn(`beforeGenerate failed, proceeding: ${describe(err)}`);
+          return { allowed: true };
+        });
+        if (!verdict.allowed) {
+          log.info(`scheduled work suppressed: ${verdict.reason ?? 'gate denied'}`);
+          return;
+        }
+      }
       let jobs: CuratorJob[];
       try {
         jobs = await opts.rest.claimCuratorJobs({

--- a/packages/agent-host/src/web-import.handler.test.ts
+++ b/packages/agent-host/src/web-import.handler.test.ts
@@ -1,12 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CrawlResult, McpToolHandle, McpToolResult } from '@getmunin/agent-runtime';
-import { reconcileSpace, candidateUrls } from './web-import.handler.ts';
+import { ProviderError } from '@getmunin/agent-runtime';
+import type {
+  CrawlResult,
+  CuratorJob,
+  McpToolHandle,
+  McpToolResult,
+  Provider,
+} from '@getmunin/agent-runtime';
+import { reconcileSpace, candidateUrls, runWebImportJob } from './web-import.handler.ts';
 
 const probeUrlMock = vi.hoisted(() => vi.fn());
+const crawlMock = vi.hoisted(() => vi.fn<(args: { url: string }) => Promise<CrawlResult>>());
 
 vi.mock('@getmunin/agent-runtime', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@getmunin/agent-runtime')>();
-  return { ...actual, probeUrl: probeUrlMock };
+  return {
+    ...actual,
+    probeUrl: probeUrlMock,
+    WebCrawler: class {
+      crawl(args: { url: string }): Promise<CrawlResult> {
+        return crawlMock(args);
+      }
+    },
+  };
 });
 
 type DocRow = {
@@ -19,7 +35,8 @@ type DocRow = {
 
 function fakeMcp(docs: DocRow[]) {
   const deleted: string[] = [];
-  const handle = {
+  const handle: McpToolHandle = {
+    listTools: () => Promise.resolve([]),
     callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
       if (name === 'kb_list_documents') {
         return Promise.resolve({ content: [{ type: 'text', text: JSON.stringify(docs) }], isError: false });
@@ -33,7 +50,7 @@ function fakeMcp(docs: DocRow[]) {
       }
       return Promise.resolve({ content: [{ type: 'text', text: 'unexpected' }], isError: true });
     },
-  } as unknown as McpToolHandle;
+  };
   return { handle, deleted };
 }
 
@@ -56,9 +73,82 @@ const src = (url: string) => `source-url:${url}`;
 
 beforeEach(() => {
   probeUrlMock.mockReset();
+  crawlMock.mockReset();
   logger.info.mockReset();
   logger.warn.mockReset();
   logger.error.mockReset();
+});
+
+function okResult(obj: unknown): Promise<McpToolResult> {
+  return Promise.resolve({ content: [{ type: 'text', text: JSON.stringify(obj) }], isError: false });
+}
+
+function importMcp() {
+  const createdSlugs: string[] = [];
+  const handle: McpToolHandle = {
+    listTools: () => Promise.resolve([]),
+    callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
+      if (name === 'kb_list_spaces') return okResult([{ id: 'spc1', slug: 'website-import' }]);
+      if (name === 'kb_get_document_by_slug') {
+        return Promise.resolve({ content: [{ type: 'text', text: 'null' }], isError: false });
+      }
+      if (name === 'kb_create_document') {
+        createdSlugs.push(String(args.slug));
+        return okResult({ id: `doc_${createdSlugs.length}` });
+      }
+      return Promise.resolve({ content: [{ type: 'text', text: 'unexpected' }], isError: true });
+    },
+  };
+  return { handle, createdSlugs };
+}
+
+describe('runWebImportJob', () => {
+  it('completes the import when company-profile generation fails on a provider error', async () => {
+    crawlMock.mockResolvedValue(crawlWith(['/', '/about']));
+    const { handle, createdSlugs } = importMcp();
+    const failingProvider: Provider = () => Promise.reject(new ProviderError('unauthorized', 401));
+
+    const job: CuratorJob = {
+      id: 'job1',
+      orgId: 'org1',
+      jobUri: 'task://web/scrape-website',
+      userPrompt: 'https://example.com',
+      sourceEventType: null,
+      sourceEventPayload: { synthesizeCompanyProfile: true, reconcile: false },
+      dedupeKey: null,
+      status: 'pending',
+      attempts: 1,
+      maxAttempts: 3,
+      nextAttemptAt: '2026-01-01T00:00:00.000Z',
+      leaseExpiresAt: null,
+      leaseHolder: null,
+      lastError: null,
+      lastReplyText: null,
+      lastToolCalls: null,
+      lastTotalTokens: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      doneAt: null,
+      assistantName: null,
+    };
+
+    const result = await runWebImportJob({
+      job,
+      mcp: handle,
+      providerBaseUrl: 'https://api.example/v1',
+      providerApiKey: 'bad-key',
+      model: 'm',
+      provider: failingProvider,
+      logger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(createdSlugs).toEqual(['home', 'about']);
+    expect(result.replyText).toContain('Imported 2 document');
+    expect(result.replyText).toContain('Company profile was skipped');
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('company profile skipped'));
+  });
 });
 
 describe('candidateUrls', () => {

--- a/packages/agent-host/src/web-import.handler.ts
+++ b/packages/agent-host/src/web-import.handler.ts
@@ -8,6 +8,7 @@ import {
   type CuratorJob,
   type McpToolHandle,
   type McpToolResult,
+  type Provider,
   type ProviderErrorClassification,
   type SkillPassResult,
 } from '@getmunin/agent-runtime';
@@ -28,6 +29,7 @@ export interface WebImportHandlerOpts {
   providerBaseUrl: string;
   providerApiKey: string;
   model: string;
+  provider?: Provider;
   logger: {
     info: (msg: string) => void;
     warn: (msg: string) => void;
@@ -81,6 +83,7 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
   if (crawl.pages.length > 0 && synthesizeCompanyProfile) {
     const outcome = await generateCompanyProfile({
       provider: { baseUrl: opts.providerBaseUrl, apiKey: opts.providerApiKey },
+      providerImpl: opts.provider,
       model: opts.model,
       siteTitle: crawl.siteTitle,
       siteUrl: crawl.siteUrl,
@@ -383,6 +386,7 @@ type GenerateProfileOutcome =
 
 async function generateCompanyProfile(opts: {
   provider: { baseUrl: string; apiKey: string };
+  providerImpl?: Provider;
   model: string;
   siteTitle: string | null;
   siteUrl: string;
@@ -404,7 +408,8 @@ async function generateCompanyProfile(opts: {
   const userPrompt = buildProfileUserPrompt(opts.siteTitle, opts.siteUrl, opts.pages);
 
   try {
-    const response = await openAiCompatibleProvider({
+    const callProvider = opts.providerImpl ?? openAiCompatibleProvider;
+    const response = await callProvider({
       config: {
         provider: { baseUrl: opts.provider.baseUrl, apiKey: opts.provider.apiKey },
         model: opts.model,

--- a/packages/agent-host/src/web-import.handler.ts
+++ b/packages/agent-host/src/web-import.handler.ts
@@ -79,7 +79,7 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
   const reconcile = payload?.reconcile !== false;
 
   let profileTokens = 0;
-  let providerError: ProviderErrorClassification | null = null;
+  let profileSkipped = false;
   if (crawl.pages.length > 0 && synthesizeCompanyProfile) {
     const outcome = await generateCompanyProfile({
       provider: { baseUrl: opts.providerBaseUrl, apiKey: opts.providerApiKey },
@@ -95,18 +95,13 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
       const ok = await upsertProfileDocument(mcp, spaceId, outcome.profile.markdown, opts.logger);
       if (ok) created++;
     } else if (outcome.providerError) {
-      providerError = outcome.providerError;
+      profileSkipped = true;
+      opts.logger.warn(
+        `company profile skipped for ${crawl.siteUrl} — LLM provider error ` +
+          `(${outcome.providerError.code}): ${outcome.providerError.message}. ` +
+          `Imported the pages without it; check the agent's provider credentials.`,
+      );
     }
-  }
-
-  if (providerError) {
-    return {
-      ok: false,
-      skipped: 'provider_error',
-      code: providerError.code,
-      error: providerError.message,
-      failedStep: 'generate_company_profile',
-    };
   }
 
   let pruned = 0;
@@ -115,7 +110,8 @@ export async function runWebImportJob(opts: WebImportHandlerOpts): Promise<Skill
   }
 
   const prunedText = pruned > 0 ? ` Pruned ${pruned} document(s) no longer on the site.` : '';
-  const replyText = `Imported ${created} document(s) from ${crawl.siteUrl}; ${crawl.skipped.length} URL(s) skipped.${prunedText}`;
+  const profileText = profileSkipped ? ' Company profile was skipped (LLM provider error).' : '';
+  const replyText = `Imported ${created} document(s) from ${crawl.siteUrl}; ${crawl.skipped.length} URL(s) skipped.${prunedText}${profileText}`;
   return {
     ok: true,
     toolCalls: created + pruned,

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -46,9 +46,11 @@ export interface ConversationHandlerDeps {
     delay: (ms: number, signal: AbortSignal) => Promise<void>;
   };
   provider?: Provider;
+  beforeGenerate?: (args: { trigger: 'chat' }) => Promise<{ allowed: boolean; reason?: string }>;
   onTyping?: (conversationId: string, isTyping: boolean) => void;
   onProviderError?: (code: ProviderErrorCode, message: string) => void;
   onProviderSuccess?: () => void;
+  onGenerateBlocked?: (reason?: string) => void;
 }
 
 export interface IncomingMessage {
@@ -217,6 +219,15 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
       ? `${baseSystem}${companyBlock}\n\n${channelDescriptor}${conversationContext}`
       : `${baseSystem}${companyBlock}${conversationContext}`;
     const systemPrompt = `${namePreamble}${systemBody}`;
+
+    if (deps.beforeGenerate) {
+      const verdict = await deps.beforeGenerate({ trigger: 'chat' });
+      if (!verdict.allowed) {
+        log.info(`${conversationId} reply suppressed: ${verdict.reason ?? 'gate denied'}`);
+        deps.onGenerateBlocked?.(verdict.reason);
+        return;
+      }
+    }
 
     let lastError: Error | null = null;
     let providerErrorCode: ProviderErrorCode | null = null;

--- a/packages/agent-runtime/src/skill-pass.ts
+++ b/packages/agent-runtime/src/skill-pass.ts
@@ -43,7 +43,8 @@ export type SkillPassResult =
         | 'skill_missing'
         | 'mcp_connect_failed'
         | 'agent_error'
-        | 'provider_error';
+        | 'provider_error'
+        | 'quota_exceeded';
       error?: string;
       code?: ProviderErrorCode;
       failedStep?: string;

--- a/packages/backend-core/src/common/rate-limit/rate-limit.service.test.ts
+++ b/packages/backend-core/src/common/rate-limit/rate-limit.service.test.ts
@@ -117,6 +117,13 @@ const skipReason = TEST_URL
     expect(u.day.used).toBe(102);
   });
 
+  it('record increments by an explicit amount', async () => {
+    const c1 = await run(() => svc.record('ai_tokens_month', 500));
+    const c2 = await run(() => svc.record('ai_tokens_month', 250));
+    expect(c1).toBe(500);
+    expect(c2).toBe(750);
+  });
+
   it('different orgs have isolated counters', async () => {
     const [otherOrg] = await db
       .insert(schema.orgs)

--- a/packages/backend-core/src/common/rate-limit/rate-limit.service.ts
+++ b/packages/backend-core/src/common/rate-limit/rate-limit.service.ts
@@ -24,13 +24,16 @@ const FREE_TIER_LIMITS: OrgLimits = {
   perDay: 1_000,
 };
 
-type Granularity = 'day' | 'month';
+type Granularity = 'minute' | 'day' | 'month';
 
 const BUCKETS = {
   mcp_calls_day: 'day',
   api_calls_day: 'day',
   mcp_calls_month: 'month',
   api_calls_month: 'month',
+  ai_tokens_day: 'day',
+  ai_tokens_month: 'month',
+  ai_generates_min: 'minute',
 } as const satisfies Record<string, Granularity>;
 
 export type Bucket = keyof typeof BUCKETS;
@@ -53,12 +56,12 @@ type BucketCountRow = {
  */
 @Injectable()
 export class RateLimitService {
-  async record(bucket: Bucket): Promise<number> {
+  async record(bucket: Bucket, amount = 1): Promise<number> {
     const ctx = getCurrentContext();
     const orgId = ctx.actor?.orgId;
     if (!orgId) return 0;
     const windowStart = windowStartFor(BUCKETS[bucket], new Date());
-    return this.bumpAndCount(orgId, bucket, windowStart);
+    return this.bumpAndCount(orgId, bucket, windowStart, amount);
   }
 
   async consume(): Promise<void> {
@@ -79,11 +82,16 @@ export class RateLimitService {
     }
   }
 
-  private async bumpAndCount(orgId: string, bucket: Bucket, windowStart: Date): Promise<number> {
+  private async bumpAndCount(
+    orgId: string,
+    bucket: Bucket,
+    windowStart: Date,
+    amount: number,
+  ): Promise<number> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
       .insert(schema.rateLimitCounters)
-      .values({ orgId, bucket, windowStart, count: 1 })
+      .values({ orgId, bucket, windowStart, count: amount })
       .onConflictDoUpdate({
         target: [
           schema.rateLimitCounters.orgId,
@@ -91,7 +99,7 @@ export class RateLimitService {
           schema.rateLimitCounters.windowStart,
         ],
         set: {
-          count: sql`${schema.rateLimitCounters.count} + 1`,
+          count: sql`${schema.rateLimitCounters.count} + ${amount}`,
         },
       })
       .returning({ count: schema.rateLimitCounters.count });
@@ -140,6 +148,16 @@ export class RateLimitService {
 
 function windowStartFor(granularity: Granularity, now: Date): Date {
   switch (granularity) {
+    case 'minute':
+      return new Date(
+        Date.UTC(
+          now.getUTCFullYear(),
+          now.getUTCMonth(),
+          now.getUTCDate(),
+          now.getUTCHours(),
+          now.getUTCMinutes(),
+        ),
+      );
     case 'day':
       return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
     case 'month':

--- a/packages/backend-core/src/control/usage.controller.ts
+++ b/packages/backend-core/src/control/usage.controller.ts
@@ -19,6 +19,7 @@ export interface UsageSummaryTile {
 export interface UsageSummaryDto {
   mcpCalls: UsageSummaryTile & { period: 'month' };
   apiCalls: UsageSummaryTile & { period: 'month' };
+  aiTokens: UsageSummaryTile & { period: 'month' };
   conversations: UsageSummaryTile & { period: 'month' };
   avgLatencyMs: UsageSummaryTile & { period: '7d' };
 }
@@ -83,9 +84,10 @@ export class UsageController {
 
     const monthSparkStart = addDays(startOfDay(now), -29);
 
-    const [mcp, api, conv, lat] = await Promise.all([
+    const [mcp, api, aiTokens, conv, lat] = await Promise.all([
       this.mcpCallsTile(orgId, monthStart, prevMonthStart, monthSparkStart, now),
       this.apiCallsTile(orgId, monthStart, prevMonthStart, monthSparkStart, now),
+      this.dailyCounterTile(orgId, 'ai_tokens_day', monthStart, prevMonthStart, monthSparkStart, now),
       this.conversationsTile(orgId, monthStart, prevMonthStart, monthSparkStart, now),
       this.latencyTile(orgId, sevenAgo, fourteenAgo, now),
     ]);
@@ -93,6 +95,7 @@ export class UsageController {
     return {
       mcpCalls: { ...mcp, period: 'month' },
       apiCalls: { ...api, period: 'month' },
+      aiTokens: { ...aiTokens, period: 'month' },
       conversations: { ...conv, period: 'month' },
       avgLatencyMs: { ...lat, period: '7d' },
     };
@@ -147,34 +150,29 @@ export class UsageController {
     return { rangeDays: days, agents: items };
   }
 
-  private async mcpCallsTile(
+  private mcpCallsTile(
     orgId: string,
     monthStart: Date,
     prevMonthStart: Date,
     sparkStart: Date,
     now: Date,
   ): Promise<UsageSummaryTile> {
-    const ctx = getCurrentContext();
-    const rows = await ctx.db.execute<DailyBigIntRow>(sql`
-      SELECT to_char(date_trunc('day', window_start AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS day,
-             sum(count)::bigint AS value
-      FROM rate_limit_counters
-      WHERE org_id = ${orgId}
-        AND bucket = 'mcp_calls_day'
-        AND window_start >= ${prevMonthStart.toISOString()}::timestamptz
-      GROUP BY 1
-    `);
-    const byDay = mapDailyRows(rows.map((r) => ({ day: r.day, value: Number(r.value) || 0 })));
-    const monthKey = toUtcDateKey(monthStart);
-    return {
-      current: sumWhere(byDay, (k) => k >= monthKey),
-      previous: sumWhere(byDay, (k) => k < monthKey),
-      sparkline: dailySeries(byDay, sparkStart, now),
-    };
+    return this.dailyCounterTile(orgId, 'mcp_calls_day', monthStart, prevMonthStart, sparkStart, now);
   }
 
-  private async apiCallsTile(
+  private apiCallsTile(
     orgId: string,
+    monthStart: Date,
+    prevMonthStart: Date,
+    sparkStart: Date,
+    now: Date,
+  ): Promise<UsageSummaryTile> {
+    return this.dailyCounterTile(orgId, 'api_calls_day', monthStart, prevMonthStart, sparkStart, now);
+  }
+
+  private async dailyCounterTile(
+    orgId: string,
+    bucket: string,
     monthStart: Date,
     prevMonthStart: Date,
     sparkStart: Date,
@@ -186,7 +184,7 @@ export class UsageController {
              sum(count)::bigint AS value
       FROM rate_limit_counters
       WHERE org_id = ${orgId}
-        AND bucket = 'api_calls_day'
+        AND bucket = ${bucket}
         AND window_start >= ${prevMonthStart.toISOString()}::timestamptz
       GROUP BY 1
     `);

--- a/packages/dashboard-pages/src/components/agent-config/models-card.tsx
+++ b/packages/dashboard-pages/src/components/agent-config/models-card.tsx
@@ -24,13 +24,21 @@ import {
 interface ModelsCardProps {
   config: AgentConfigDto;
   models: ListModelsResult | null;
+  managed?: boolean;
   saveLabel?: string;
   /** Extra action rendered after the Save button (e.g., wizard's Back). */
   extraActions?: ReactNode;
   onSaved?: (updated: AgentConfigDto) => void;
 }
 
-export function ModelsCard({ config, models, saveLabel, extraActions, onSaved }: ModelsCardProps) {
+export function ModelsCard({
+  config,
+  models,
+  managed,
+  saveLabel,
+  extraActions,
+  onSaved,
+}: ModelsCardProps) {
   const t = useTranslations('agentSetup');
   const tCommon = useTranslations('common');
   const translate = useTranslateError();
@@ -71,7 +79,8 @@ export function ModelsCard({ config, models, saveLabel, extraActions, onSaved }:
     }
   }
 
-  const canSave = config.providerApiKeySet && fastModel.length > 0 && !saving;
+  const credentialed = config.providerApiKeySet || managed === true;
+  const canSave = credentialed && fastModel.length > 0 && !saving;
   const label = saveLabel ?? tCommon('save');
 
   return (
@@ -81,7 +90,7 @@ export function ModelsCard({ config, models, saveLabel, extraActions, onSaved }:
         <CardDescription>{t('models.smartHint')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {!config.providerApiKeySet ? (
+        {!credentialed ? (
           <p className="text-sm text-muted-foreground">{t('models.needKey')}</p>
         ) : models?.supported ? (
           <>

--- a/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
+++ b/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
@@ -95,7 +95,8 @@ export function ProviderCard({
       });
       setApiKey('');
       setKeyDirty(false);
-      onSaved?.(updated, { supported: false, models: [] });
+      const managedModels = managedPreset?.models ?? [];
+      onSaved?.(updated, { supported: managedModels.length > 0, models: managedModels });
     } catch (err) {
       setError(translate(err) || t('errors.test'));
     } finally {

--- a/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
+++ b/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, type ComponentType, type SVGProps } from 'react';
+import { useState, type ComponentType, type ReactNode, type SVGProps } from 'react';
 import { useTranslations } from 'next-intl';
-import { Plug } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, Plug, Sparkles } from 'lucide-react';
 import {
   Button,
   Card,
@@ -32,20 +32,37 @@ const PROVIDER_ICONS: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
   custom: Plug,
 };
 
+const BUILTIN_PRESET_IDS = new Set<string>(PROVIDER_PRESETS.map((p) => p.id));
+
 interface ProviderCardProps {
   config: AgentConfigDto;
   extraPresets?: ProviderPreset[];
   defaultPresetId?: string;
+  lede?: string;
   onSaved?: (updated: AgentConfigDto, models: ListModelsResult) => void;
 }
 
-export function ProviderCard({ config, extraPresets, defaultPresetId, onSaved }: ProviderCardProps) {
+export function ProviderCard({
+  config,
+  extraPresets,
+  defaultPresetId,
+  lede,
+  onSaved,
+}: ProviderCardProps) {
   const t = useTranslations('agentSetup');
   const translate = useTranslateError();
 
-  const presets: ProviderPreset[] = [...(extraPresets ?? []), ...PROVIDER_PRESETS];
+  const managedPreset = (extraPresets ?? []).find((p) => p.managed);
+  const byokPresets: ProviderPreset[] = [
+    ...(extraPresets ?? []).filter((p) => !p.managed),
+    ...PROVIDER_PRESETS,
+  ];
+  const allPresets = managedPreset ? [managedPreset, ...byokPresets] : byokPresets;
+
   const initialPreset =
-    !config.providerApiKeySet && defaultPresetId ? defaultPresetId : presetForUrl(config.providerBaseUrl);
+    !config.providerApiKeySet && defaultPresetId
+      ? defaultPresetId
+      : presetForUrl(config.providerBaseUrl);
 
   const [preset, setPreset] = useState<string>(initialPreset);
   const [providerBaseUrl, setProviderBaseUrl] = useState(config.providerBaseUrl);
@@ -54,13 +71,16 @@ export function ProviderCard({ config, extraPresets, defaultPresetId, onSaved }:
   const [testing, setTesting] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showByok, setShowByok] = useState<boolean>(
+    !(allPresets.find((p) => p.id === initialPreset)?.managed ?? false),
+  );
 
-  const selected = presets.find((p) => p.id === preset);
+  const selected = allPresets.find((p) => p.id === preset);
   const isManaged = selected?.managed ?? false;
 
   function selectPreset(id: string) {
     setPreset(id);
-    const match = presets.find((p) => p.id === id);
+    const match = allPresets.find((p) => p.id === id);
     if (match && !match.managed && id !== 'custom') setProviderBaseUrl(match.url);
   }
 
@@ -114,81 +134,163 @@ export function ProviderCard({ config, extraPresets, defaultPresetId, onSaved }:
   const saveDisabled =
     testing || providerBaseUrl.length === 0 || (!config.providerApiKeySet && apiKey.length === 0);
 
+  function presetDescription(p: ProviderPreset): ReactNode {
+    if (p.description != null) return p.description;
+    if (BUILTIN_PRESET_IDS.has(p.id)) return t(`provider.presets.${p.id}`);
+    return null;
+  }
+
+  function presetGrid(items: ProviderPreset[]) {
+    return (
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {items.map((p) => {
+          const Icon = PROVIDER_ICONS[p.id] ?? Plug;
+          const description = presetDescription(p);
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => selectPreset(p.id)}
+              className={
+                'flex items-center gap-3 rounded-input border-[0.5px] px-4 py-3 text-left transition-colors ' +
+                (preset === p.id
+                  ? 'border-cobalt bg-cobalt/5 ring-1 ring-inset ring-cobalt'
+                  : 'border-rule-soft hover:border-ink/30')
+              }
+            >
+              <Icon className="size-5 shrink-0" aria-hidden />
+              <span className="min-w-0">
+                <span className="block font-semibold text-ink dark:text-foreground">{p.name}</span>
+                {description && (
+                  <span className="block text-sm text-muted-foreground">{description}</span>
+                )}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  const credentialInputs = (
+    <>
+      <div className="space-y-1.5">
+        <Label htmlFor="providerBaseUrl">{t('provider.urlLabel')}</Label>
+        <Input
+          id="providerBaseUrl"
+          value={providerBaseUrl}
+          onChange={(e) => {
+            setProviderBaseUrl(e.target.value);
+            setPreset('custom');
+          }}
+          placeholder="https://..."
+        />
+      </div>
+      <div className="space-y-1.5 pt-2">
+        <Label htmlFor="apiKey">{t('apiKey.label')}</Label>
+        <Input
+          id="apiKey"
+          type="password"
+          value={apiKey}
+          placeholder={
+            config.providerApiKeySet ? t('apiKey.placeholderStored') : t('apiKey.ledeMissing')
+          }
+          onChange={(e) => {
+            setApiKey(e.target.value);
+            setKeyDirty(true);
+          }}
+        />
+      </div>
+    </>
+  );
+
+  function submitRow(onClick: () => void, disabled: boolean) {
+    return (
+      <div className="flex items-center gap-3">
+        <Button type="button" onClick={onClick} disabled={disabled}>
+          {testing ? t('connection.testing') : t('provider.use')}
+        </Button>
+        {message && <span className="text-sm text-muted-foreground">{message}</span>}
+      </div>
+    );
+  }
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>{t('provider.title')}</CardTitle>
-        <CardDescription>{t('provider.lede')}</CardDescription>
+        <CardDescription>{lede ?? t('provider.lede')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-          {presets.map((p) => {
-            const Icon = PROVIDER_ICONS[p.id] ?? Plug;
-            return (
-              <button
-                key={p.id}
-                type="button"
-                onClick={() => selectPreset(p.id)}
-                className={
-                  'flex items-center justify-center gap-2 rounded-input border-[0.5px] px-3 py-2 text-sm transition-colors ' +
-                  (preset === p.id
-                    ? 'border-cobalt bg-cobalt/5 text-ink dark:text-foreground'
-                    : 'border-rule-soft text-muted-foreground hover:text-ink dark:hover:text-foreground')
-                }
-              >
-                <Icon className="size-4 shrink-0" aria-hidden />
-                <span>{p.name}</span>
-              </button>
-            );
-          })}
-        </div>
-        {isManaged ? (
+        {managedPreset ? (
           <>
-            {selected?.description && (
-              <div className="text-sm text-muted-foreground">{selected.description}</div>
+            <button
+              type="button"
+              onClick={() => selectPreset(managedPreset.id)}
+              className={
+                'flex w-full items-center gap-4 rounded-input border-[0.5px] px-4 py-3.5 text-left transition-colors ' +
+                (preset === managedPreset.id
+                  ? 'border-cobalt bg-cobalt/5 ring-1 ring-inset ring-cobalt'
+                  : 'border-rule-soft hover:border-ink/30')
+              }
+            >
+              <span className="flex size-10 shrink-0 items-center justify-center rounded-input bg-cobalt/10 text-cobalt">
+                {managedPreset.icon ?? <Sparkles className="size-5" aria-hidden />}
+              </span>
+              <span className="flex-1">
+                <span className="flex items-center gap-2">
+                  <span className="font-semibold text-ink dark:text-foreground">
+                    {managedPreset.name}
+                  </span>
+                  {managedPreset.badge && (
+                    <span className="rounded bg-cobalt/10 px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-eyebrow text-cobalt">
+                      {managedPreset.badge}
+                    </span>
+                  )}
+                </span>
+                {managedPreset.description && (
+                  <span className="mt-0.5 block text-sm text-muted-foreground">
+                    {managedPreset.description}
+                  </span>
+                )}
+              </span>
+              {preset === managedPreset.id && (
+                <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-cobalt text-white">
+                  <Check className="size-3.5" aria-hidden />
+                </span>
+              )}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setShowByok((v) => !v)}
+              className="flex w-full items-center justify-center gap-2 rounded-input border border-dashed border-rule-soft px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:text-ink dark:hover:text-foreground"
+            >
+              {showByok ? (
+                <ChevronDown className="size-4 shrink-0" aria-hidden />
+              ) : (
+                <ChevronRight className="size-4 shrink-0" aria-hidden />
+              )}
+              <span>{showByok ? t('provider.hideAlternatives') : t('provider.useOwnKey')}</span>
+            </button>
+
+            {showByok && (
+              <>
+                {presetGrid(byokPresets)}
+                {!isManaged && credentialInputs}
+              </>
             )}
-            <div className="flex items-center gap-3">
-              <Button type="button" onClick={() => void saveManaged()} disabled={testing}>
-                {testing ? t('connection.testing') : t('provider.useManaged')}
-              </Button>
-              {message && <span className="text-sm text-muted-foreground">{message}</span>}
-            </div>
+
+            {submitRow(
+              isManaged ? () => void saveManaged() : () => void saveAndTest(),
+              isManaged ? testing : saveDisabled,
+            )}
           </>
         ) : (
           <>
-            <div className="space-y-1.5">
-              <Label htmlFor="providerBaseUrl">{t('provider.urlLabel')}</Label>
-              <Input
-                id="providerBaseUrl"
-                value={providerBaseUrl}
-                onChange={(e) => {
-                  setProviderBaseUrl(e.target.value);
-                  setPreset('custom');
-                }}
-                placeholder="https://..."
-              />
-            </div>
-            <div className="space-y-1.5 pt-2">
-              <Label htmlFor="apiKey">{t('apiKey.label')}</Label>
-              <Input
-                id="apiKey"
-                type="password"
-                value={apiKey}
-                placeholder={
-                  config.providerApiKeySet ? t('apiKey.placeholderStored') : t('apiKey.ledeMissing')
-                }
-                onChange={(e) => {
-                  setApiKey(e.target.value);
-                  setKeyDirty(true);
-                }}
-              />
-            </div>
-            <div className="flex items-center gap-3">
-              <Button type="button" onClick={() => void saveAndTest()} disabled={saveDisabled}>
-                {testing ? t('connection.testing') : t('connection.test')}
-              </Button>
-              {message && <span className="text-sm text-muted-foreground">{message}</span>}
-            </div>
+            {presetGrid(byokPresets)}
+            {credentialInputs}
+            {submitRow(() => void saveAndTest(), saveDisabled)}
           </>
         )}
         {error && <p className="text-sm text-destructive">{error}</p>}

--- a/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
+++ b/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
@@ -21,11 +21,11 @@ import {
   presetForUrl,
   type AgentConfigDto,
   type ListModelsResult,
-  type PresetId,
+  type ProviderPreset,
   type UpsertBody,
 } from './types';
 
-const PROVIDER_ICONS: Record<PresetId, ComponentType<SVGProps<SVGSVGElement>>> = {
+const PROVIDER_ICONS: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
   openrouter: OpenRouterIcon,
   anthropic: AnthropicIcon,
   openai: OpenAiIcon,
@@ -34,14 +34,20 @@ const PROVIDER_ICONS: Record<PresetId, ComponentType<SVGProps<SVGSVGElement>>> =
 
 interface ProviderCardProps {
   config: AgentConfigDto;
+  extraPresets?: ProviderPreset[];
+  defaultPresetId?: string;
   onSaved?: (updated: AgentConfigDto, models: ListModelsResult) => void;
 }
 
-export function ProviderCard({ config, onSaved }: ProviderCardProps) {
+export function ProviderCard({ config, extraPresets, defaultPresetId, onSaved }: ProviderCardProps) {
   const t = useTranslations('agentSetup');
   const translate = useTranslateError();
 
-  const [preset, setPreset] = useState<PresetId>(presetForUrl(config.providerBaseUrl));
+  const presets: ProviderPreset[] = [...(extraPresets ?? []), ...PROVIDER_PRESETS];
+  const initialPreset =
+    !config.providerApiKeySet && defaultPresetId ? defaultPresetId : presetForUrl(config.providerBaseUrl);
+
+  const [preset, setPreset] = useState<string>(initialPreset);
   const [providerBaseUrl, setProviderBaseUrl] = useState(config.providerBaseUrl);
   const [apiKey, setApiKey] = useState('');
   const [keyDirty, setKeyDirty] = useState(false);
@@ -49,10 +55,32 @@ export function ProviderCard({ config, onSaved }: ProviderCardProps) {
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  function selectPreset(id: PresetId) {
+  const selected = presets.find((p) => p.id === preset);
+  const isManaged = selected?.managed ?? false;
+
+  function selectPreset(id: string) {
     setPreset(id);
-    const match = PROVIDER_PRESETS.find((p) => p.id === id);
-    if (match && id !== 'custom') setProviderBaseUrl(match.url);
+    const match = presets.find((p) => p.id === id);
+    if (match && !match.managed && id !== 'custom') setProviderBaseUrl(match.url);
+  }
+
+  async function saveManaged() {
+    setError(null);
+    setMessage(null);
+    setTesting(true);
+    try {
+      const updated = await api<AgentConfigDto>('/v1/agent-config', {
+        method: 'PUT',
+        body: JSON.stringify({ providerApiKey: null } satisfies UpsertBody),
+      });
+      setApiKey('');
+      setKeyDirty(false);
+      onSaved?.(updated, { supported: false, models: [] });
+    } catch (err) {
+      setError(translate(err) || t('errors.test'));
+    } finally {
+      setTesting(false);
+    }
   }
 
   async function saveAndTest() {
@@ -94,8 +122,8 @@ export function ProviderCard({ config, onSaved }: ProviderCardProps) {
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-          {PROVIDER_PRESETS.map((p) => {
-            const Icon = PROVIDER_ICONS[p.id];
+          {presets.map((p) => {
+            const Icon = PROVIDER_ICONS[p.id] ?? Plug;
             return (
               <button
                 key={p.id}
@@ -114,39 +142,55 @@ export function ProviderCard({ config, onSaved }: ProviderCardProps) {
             );
           })}
         </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="providerBaseUrl">{t('provider.urlLabel')}</Label>
-          <Input
-            id="providerBaseUrl"
-            value={providerBaseUrl}
-            onChange={(e) => {
-              setProviderBaseUrl(e.target.value);
-              setPreset('custom');
-            }}
-            placeholder="https://..."
-          />
-        </div>
-        <div className="space-y-1.5 pt-2">
-          <Label htmlFor="apiKey">{t('apiKey.label')}</Label>
-          <Input
-            id="apiKey"
-            type="password"
-            value={apiKey}
-            placeholder={
-              config.providerApiKeySet ? t('apiKey.placeholderStored') : t('apiKey.ledeMissing')
-            }
-            onChange={(e) => {
-              setApiKey(e.target.value);
-              setKeyDirty(true);
-            }}
-          />
-        </div>
-        <div className="flex items-center gap-3">
-          <Button type="button" onClick={() => void saveAndTest()} disabled={saveDisabled}>
-            {testing ? t('connection.testing') : t('connection.test')}
-          </Button>
-          {message && <span className="text-sm text-muted-foreground">{message}</span>}
-        </div>
+        {isManaged ? (
+          <>
+            {selected?.description && (
+              <div className="text-sm text-muted-foreground">{selected.description}</div>
+            )}
+            <div className="flex items-center gap-3">
+              <Button type="button" onClick={() => void saveManaged()} disabled={testing}>
+                {testing ? t('connection.testing') : t('provider.useManaged')}
+              </Button>
+              {message && <span className="text-sm text-muted-foreground">{message}</span>}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="space-y-1.5">
+              <Label htmlFor="providerBaseUrl">{t('provider.urlLabel')}</Label>
+              <Input
+                id="providerBaseUrl"
+                value={providerBaseUrl}
+                onChange={(e) => {
+                  setProviderBaseUrl(e.target.value);
+                  setPreset('custom');
+                }}
+                placeholder="https://..."
+              />
+            </div>
+            <div className="space-y-1.5 pt-2">
+              <Label htmlFor="apiKey">{t('apiKey.label')}</Label>
+              <Input
+                id="apiKey"
+                type="password"
+                value={apiKey}
+                placeholder={
+                  config.providerApiKeySet ? t('apiKey.placeholderStored') : t('apiKey.ledeMissing')
+                }
+                onChange={(e) => {
+                  setApiKey(e.target.value);
+                  setKeyDirty(true);
+                }}
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <Button type="button" onClick={() => void saveAndTest()} disabled={saveDisabled}>
+                {testing ? t('connection.testing') : t('connection.test')}
+              </Button>
+              {message && <span className="text-sm text-muted-foreground">{message}</span>}
+            </div>
+          </>
+        )}
         {error && <p className="text-sm text-destructive">{error}</p>}
       </CardContent>
     </Card>

--- a/packages/dashboard-pages/src/components/agent-config/types.ts
+++ b/packages/dashboard-pages/src/components/agent-config/types.ts
@@ -38,6 +38,7 @@ export interface ProviderPreset {
   description?: ReactNode;
   badge?: string;
   icon?: ReactNode;
+  models?: ModelEntry[];
 }
 
 export const PROVIDER_PRESETS = [

--- a/packages/dashboard-pages/src/components/agent-config/types.ts
+++ b/packages/dashboard-pages/src/components/agent-config/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 export interface AgentConfigDto {
   id: string;
   fastModel: string;
@@ -26,6 +28,16 @@ export interface UpsertBody {
   providerApiKey?: string | null;
   fastModel?: string;
   smartModel?: string | null;
+}
+
+export interface ProviderPreset {
+  id: string;
+  name: string;
+  url: string;
+  /** When true, the preset uses no host credentials; selecting it clears the org key. */
+  managed?: boolean;
+  /** Host-supplied content shown in place of the URL/key inputs for a managed preset. */
+  description?: ReactNode;
 }
 
 export const PROVIDER_PRESETS = [

--- a/packages/dashboard-pages/src/components/agent-config/types.ts
+++ b/packages/dashboard-pages/src/components/agent-config/types.ts
@@ -34,10 +34,10 @@ export interface ProviderPreset {
   id: string;
   name: string;
   url: string;
-  /** When true, the preset uses no host credentials; selecting it clears the org key. */
   managed?: boolean;
-  /** Host-supplied content shown in place of the URL/key inputs for a managed preset. */
   description?: ReactNode;
+  badge?: string;
+  icon?: ReactNode;
 }
 
 export const PROVIDER_PRESETS = [

--- a/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
@@ -14,6 +14,7 @@ interface SummaryTile {
 export interface UsageSummary {
   mcpCalls: SummaryTile;
   apiCalls: SummaryTile;
+  aiTokens: SummaryTile;
   conversations: SummaryTile;
   avgLatencyMs: SummaryTile;
 }
@@ -52,6 +53,13 @@ export function UsageKpis({ summary }: UsageKpisProps) {
           value={summary?.apiCalls.current}
           previous={summary?.apiCalls.previous}
           spark={summary?.apiCalls.sparkline ?? []}
+          format={formatCount}
+        />
+        <Kpi
+          label={t('aiTokens')}
+          value={summary?.aiTokens.current}
+          previous={summary?.aiTokens.previous}
+          spark={summary?.aiTokens.sparkline ?? []}
           format={formatCount}
         />
         <Kpi

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -93,6 +93,7 @@ export { safeRedirect, resumeOauthAuthorizeUrl } from './auth/post-signin-redire
 export { AcceptInvitePage } from './pages/accept-invite';
 export { AccountPage, type AccountPageProps } from './pages/account';
 export { AiSettingsPage } from './pages/ai-settings';
+export type { ProviderPreset } from './components/agent-config/types';
 export {
   OAuthConsentPage,
   type OAuthClientInfo,

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1010,6 +1010,7 @@
         "byAgentBreakdown": "By-agent breakdown →",
         "mcpCalls": "MCP calls",
         "apiCalls": "API calls",
+        "aiTokens": "AI tokens",
         "conversations": "Conversations",
         "avgLatency": "Avg latency",
         "avgLatency7d": "Avg latency · 7d",
@@ -1145,7 +1146,8 @@
     "provider": {
       "title": "Provider",
       "lede": "OpenAI-compatible endpoint. OpenRouter offers a single key with access to many providers.",
-      "urlLabel": "Base URL"
+      "urlLabel": "Base URL",
+      "useManaged": "Use this provider"
     },
     "apiKey": {
       "title": "API key",

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1145,9 +1145,17 @@
     },
     "provider": {
       "title": "Provider",
-      "lede": "OpenAI-compatible endpoint. OpenRouter offers a single key with access to many providers.",
+      "lede": "Connect any OpenAI-compatible provider with your own key.",
       "urlLabel": "Base URL",
-      "useManaged": "Use this provider"
+      "use": "Use this provider",
+      "useOwnKey": "Use your own provider key",
+      "hideAlternatives": "Hide provider options",
+      "presets": {
+        "openrouter": "One key, many models",
+        "anthropic": "Claude models",
+        "openai": "GPT models",
+        "custom": "OpenAI-compatible URL"
+      }
     },
     "apiKey": {
       "title": "API key",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1010,6 +1010,7 @@
         "byAgentBreakdown": "Detaljer per agent →",
         "mcpCalls": "MCP-kall",
         "apiCalls": "API-kall",
+        "aiTokens": "AI-tokens",
         "conversations": "Samtaler",
         "avgLatency": "Snitt-forsinkelse",
         "avgLatency7d": "Snitt-forsinkelse · 7d",
@@ -1145,7 +1146,8 @@
     "provider": {
       "title": "Leverandør",
       "lede": "OpenAI-kompatibelt endepunkt. OpenRouter gir én nøkkel med tilgang til mange leverandører.",
-      "urlLabel": "Base-URL"
+      "urlLabel": "Base-URL",
+      "useManaged": "Bruk denne leverandøren"
     },
     "apiKey": {
       "title": "API-nøkkel",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1145,9 +1145,17 @@
     },
     "provider": {
       "title": "Leverandør",
-      "lede": "OpenAI-kompatibelt endepunkt. OpenRouter gir én nøkkel med tilgang til mange leverandører.",
+      "lede": "Koble til en hvilken som helst OpenAI-kompatibel leverandør med din egen nøkkel.",
       "urlLabel": "Base-URL",
-      "useManaged": "Bruk denne leverandøren"
+      "use": "Bruk denne leverandøren",
+      "useOwnKey": "Bruk din egen leverandørnøkkel",
+      "hideAlternatives": "Skjul leverandørvalg",
+      "presets": {
+        "openrouter": "Én nøkkel, mange modeller",
+        "anthropic": "Claude-modeller",
+        "openai": "GPT-modeller",
+        "custom": "OpenAI-kompatibel URL"
+      }
     },
     "apiKey": {
       "title": "API-nøkkel",

--- a/packages/dashboard-pages/src/pages/account.tsx
+++ b/packages/dashboard-pages/src/pages/account.tsx
@@ -80,7 +80,7 @@ export function AccountPage({ extraSections }: AccountPageProps) {
   }
 
   return (
-    <>
+    <div className="max-w-3xl space-y-10">
       <Hero
         eyebrow={t('eyebrow')}
         title={t.rich('title', { em: (chunks) => <em>{chunks}</em> })}
@@ -90,7 +90,7 @@ export function AccountPage({ extraSections }: AccountPageProps) {
       <section className="space-y-4">
         <SectionHead title={t('orgSectionTitle')} divider={false} />
 
-        <form className="max-w-md space-y-4" onSubmit={(e) => void submit(e)}>
+        <form className="space-y-4" onSubmit={(e) => void submit(e)}>
           <FormField label={t('orgNameLabel')} hint={t('orgNameHint')} error={error}>
             <Input
               value={name}
@@ -116,6 +116,6 @@ export function AccountPage({ extraSections }: AccountPageProps) {
       </section>
 
       {extraSections}
-    </>
+    </div>
   );
 }

--- a/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
@@ -12,13 +12,18 @@ import { ProviderCard } from '../components/agent-config/provider-card';
 import { ModelsCard } from '../components/agent-config/models-card';
 import { WebsiteImportCard } from '../components/agent-config/website-import-card';
 import { hasOauthAuthorizeParams } from '../auth/post-signin-redirect';
-import type { AgentConfigDto } from '../components/agent-config/types';
+import type { AgentConfigDto, ProviderPreset } from '../components/agent-config/types';
 import { api } from '../api';
 
 type Step = 1 | 2 | 3 | 4 | 5;
 const TOTAL_STEPS = 5;
 
-export function AgentSetupWizard() {
+interface AgentSetupWizardProps {
+  extraPresets?: ProviderPreset[];
+  defaultPresetId?: string;
+}
+
+export function AgentSetupWizard({ extraPresets, defaultPresetId }: AgentSetupWizardProps = {}) {
   const t = useTranslations('agentSetup');
   const tCommon = useTranslations('common');
   const { config, loadErrorMessage, models, setConfig, setModels } = useAgentConfig();
@@ -99,10 +104,12 @@ export function AgentSetupWizard() {
         {step === 2 && (
           <ProviderCard
             config={config}
+            extraPresets={extraPresets}
+            defaultPresetId={defaultPresetId}
             onSaved={(updated, result) => {
               setConfig(updated);
               setModels(result);
-              setStep(3);
+              setStep(updated.providerApiKeySet ? 3 : 4);
             }}
           />
         )}

--- a/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
@@ -69,6 +69,13 @@ export function AgentSetupWizard({
     );
   }
 
+  const managedPreset = (extraPresets ?? []).find((p) => p.managed);
+  const isManaged = !!managedPreset && !config.providerApiKeySet;
+  const managedModelsResult =
+    isManaged && (managedPreset?.models?.length ?? 0) > 0
+      ? { supported: true, models: managedPreset?.models ?? [] }
+      : null;
+
   return (
     <main className="mx-auto w-full max-w-3xl px-6 py-12">
       <Hero
@@ -115,7 +122,7 @@ export function AgentSetupWizard({
             onSaved={(updated, result) => {
               setConfig(updated);
               setModels(result);
-              setStep(updated.providerApiKeySet ? 3 : 4);
+              setStep(3);
             }}
           />
         )}
@@ -123,7 +130,8 @@ export function AgentSetupWizard({
         {step === 3 && (
           <ModelsCard
             config={config}
-            models={models}
+            models={managedModelsResult ?? models}
+            managed={isManaged}
             saveLabel={t('wizard.saveAndContinue')}
             extraActions={
               <Button type="button" variant="outline" onClick={() => setStep(2)}>

--- a/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
@@ -21,9 +21,14 @@ const TOTAL_STEPS = 5;
 interface AgentSetupWizardProps {
   extraPresets?: ProviderPreset[];
   defaultPresetId?: string;
+  providerLede?: string;
 }
 
-export function AgentSetupWizard({ extraPresets, defaultPresetId }: AgentSetupWizardProps = {}) {
+export function AgentSetupWizard({
+  extraPresets,
+  defaultPresetId,
+  providerLede,
+}: AgentSetupWizardProps = {}) {
   const t = useTranslations('agentSetup');
   const tCommon = useTranslations('common');
   const { config, loadErrorMessage, models, setConfig, setModels } = useAgentConfig();
@@ -106,6 +111,7 @@ export function AgentSetupWizard({ extraPresets, defaultPresetId }: AgentSetupWi
             config={config}
             extraPresets={extraPresets}
             defaultPresetId={defaultPresetId}
+            lede={providerLede}
             onSaved={(updated, result) => {
               setConfig(updated);
               setModels(result);

--- a/packages/dashboard-pages/src/pages/ai-settings.tsx
+++ b/packages/dashboard-pages/src/pages/ai-settings.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
 import { Hero } from '@getmunin/ui';
+import type { ProviderPreset } from '../components/agent-config/types';
 import { useAgentConfig } from '../components/agent-config/use-agent-config';
 import { ProviderCard } from '../components/agent-config/provider-card';
 import { ModelsCard } from '../components/agent-config/models-card';
@@ -13,7 +15,13 @@ import { useSkills } from '../components/assistants/use-skills';
 import { LoadFailed } from '../components/load-failed';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
 
-export function AiSettingsPage() {
+interface AiSettingsPageProps {
+  extraPresets?: ProviderPreset[];
+  defaultPresetId?: string;
+  slot?: ReactNode;
+}
+
+export function AiSettingsPage({ extraPresets, defaultPresetId, slot }: AiSettingsPageProps = {}) {
   const t = useTranslations('agentSetup');
   const tList = useTranslations('assistants.list');
   const tCommon = useTranslations('common');
@@ -54,6 +62,8 @@ export function AiSettingsPage() {
         lede={t('settings.lede')}
       />
 
+      {slot}
+
       {config === null && (
         <p className="mt-6 text-sm text-muted-foreground">{tCommon('loading')}</p>
       )}
@@ -76,12 +86,16 @@ export function AiSettingsPage() {
             <div className="space-y-6">
               <ProviderCard
                 config={config}
+                extraPresets={extraPresets}
+                defaultPresetId={defaultPresetId}
                 onSaved={(updated, result) => {
                   setConfig(updated);
                   setModels(result);
                 }}
               />
-              <ModelsCard config={config} models={models} onSaved={setConfig} />
+              {config.providerApiKeySet && (
+                <ModelsCard config={config} models={models} onSaved={setConfig} />
+              )}
             </div>
           </section>
 

--- a/packages/dashboard-pages/src/pages/ai-settings.tsx
+++ b/packages/dashboard-pages/src/pages/ai-settings.tsx
@@ -18,10 +18,16 @@ import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
 interface AiSettingsPageProps {
   extraPresets?: ProviderPreset[];
   defaultPresetId?: string;
+  providerLede?: string;
   slot?: ReactNode;
 }
 
-export function AiSettingsPage({ extraPresets, defaultPresetId, slot }: AiSettingsPageProps = {}) {
+export function AiSettingsPage({
+  extraPresets,
+  defaultPresetId,
+  providerLede,
+  slot,
+}: AiSettingsPageProps = {}) {
   const t = useTranslations('agentSetup');
   const tList = useTranslations('assistants.list');
   const tCommon = useTranslations('common');
@@ -55,7 +61,7 @@ export function AiSettingsPage({ extraPresets, defaultPresetId, slot }: AiSettin
   const scheduledTasks = remainingSkills.filter((s) => s.kind === 'task');
 
   return (
-    <>
+    <div className="max-w-3xl space-y-10">
       <Hero
         eyebrow={t('settings.eyebrow')}
         title={t.rich('settings.title', { em: (chunks) => <em>{chunks}</em> })}
@@ -65,11 +71,11 @@ export function AiSettingsPage({ extraPresets, defaultPresetId, slot }: AiSettin
       {slot}
 
       {config === null && (
-        <p className="mt-6 text-sm text-muted-foreground">{tCommon('loading')}</p>
+        <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
       )}
 
       {config && (
-        <div className="mt-8 space-y-10">
+        <div className="space-y-10">
           <section className="space-y-4">
             <SectionHeader title={tList('persona.title')} blurb={tList('persona.blurb')} />
             <div className="space-y-6">
@@ -88,6 +94,7 @@ export function AiSettingsPage({ extraPresets, defaultPresetId, slot }: AiSettin
                 config={config}
                 extraPresets={extraPresets}
                 defaultPresetId={defaultPresetId}
+                lede={providerLede}
                 onSaved={(updated, result) => {
                   setConfig(updated);
                   setModels(result);
@@ -149,7 +156,7 @@ export function AiSettingsPage({ extraPresets, defaultPresetId, slot }: AiSettin
           </section>
         </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/packages/dashboard-pages/src/pages/ai-settings.tsx
+++ b/packages/dashboard-pages/src/pages/ai-settings.tsx
@@ -60,6 +60,13 @@ export function AiSettingsPage({
   const aiDrivenSkills = remainingSkills.filter((s) => s.kind === 'skill');
   const scheduledTasks = remainingSkills.filter((s) => s.kind === 'task');
 
+  const managedPreset = (extraPresets ?? []).find((p) => p.managed);
+  const isManaged = !!managedPreset && config != null && !config.providerApiKeySet;
+  const managedModelsResult =
+    isManaged && (managedPreset?.models?.length ?? 0) > 0
+      ? { supported: true, models: managedPreset?.models ?? [] }
+      : null;
+
   return (
     <div className="max-w-3xl space-y-10">
       <Hero
@@ -100,9 +107,12 @@ export function AiSettingsPage({
                   setModels(result);
                 }}
               />
-              {config.providerApiKeySet && (
-                <ModelsCard config={config} models={models} onSaved={setConfig} />
-              )}
+              <ModelsCard
+                config={config}
+                models={managedModelsResult ?? models}
+                managed={isManaged}
+                onSaved={setConfig}
+              />
             </div>
           </section>
 

--- a/packages/dashboard-pages/src/pages/usage.tsx
+++ b/packages/dashboard-pages/src/pages/usage.tsx
@@ -79,7 +79,7 @@ export function UsagePage({ slot }: { slot?: ReactNode } = {}) {
 
       {slot}
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-px bg-rule-soft border-[0.5px] border-rule-soft dark:bg-rule-on-dark dark:border-rule-on-dark">
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 border-l-[0.5px] border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
         <Tile
           label={t('tiles.mcpCalls')}
           period={t('tiles.thisMonth')}
@@ -139,7 +139,7 @@ function Tile({
   const delta = useMemo(() => computeDelta(tile, mode), [tile, mode]);
 
   return (
-    <div className="bg-paper dark:bg-card p-6 flex flex-col gap-4 min-h-[180px]">
+    <div className="bg-paper dark:bg-card p-6 flex flex-col gap-4 min-h-[180px] border-r-[0.5px] border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
       <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
         {label} · {period}
       </p>

--- a/packages/dashboard-pages/src/pages/usage.tsx
+++ b/packages/dashboard-pages/src/pages/usage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
 import { api } from '../api';
 import { useRealtime } from '../realtime';
@@ -18,6 +18,7 @@ interface SummaryTile {
 interface UsageSummaryDto {
   mcpCalls: SummaryTile & { period: 'month' };
   apiCalls: SummaryTile & { period: 'month' };
+  aiTokens: SummaryTile & { period: 'month' };
   conversations: SummaryTile & { period: 'month' };
   avgLatencyMs: SummaryTile & { period: '7d' };
 }
@@ -35,7 +36,7 @@ interface UsageByAgentDto {
   agents: AgentUsageDto[];
 }
 
-export function UsagePage() {
+export function UsagePage({ slot }: { slot?: ReactNode } = {}) {
   const t = useTranslations('dashboard.usage');
   const [summary, setSummary] = useState<UsageSummaryDto | null>(null);
   const [byAgent, setByAgent] = useState<UsageByAgentDto | null>(null);
@@ -76,6 +77,8 @@ export function UsagePage() {
         lede={t('subtitle')}
       />
 
+      {slot}
+
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-px bg-rule-soft border-[0.5px] border-rule-soft dark:bg-rule-on-dark dark:border-rule-on-dark">
         <Tile
           label={t('tiles.mcpCalls')}
@@ -88,6 +91,13 @@ export function UsagePage() {
           label={t('tiles.apiCalls')}
           period={t('tiles.thisMonth')}
           tile={summary?.apiCalls}
+          format={formatCount}
+          mode="count"
+        />
+        <Tile
+          label={t('tiles.aiTokens')}
+          period={t('tiles.thisMonth')}
+          tile={summary?.aiTokens}
           format={formatCount}
           mode="count"
         />


### PR DESCRIPTION
## Summary

Adds generic extension points so a host application can run the bundled agent on its own provider implementation, with its own credential resolution and usage gating — without forking the runner. Default behavior is unchanged when none of the new hooks are supplied.

### `@getmunin/backend-core`
- `RateLimitService.record(bucket, amount = 1)` — counters can be incremented by an arbitrary amount (backward compatible).
- New buckets: `ai_tokens_day`, `ai_tokens_month`, `ai_generates_min` (adds a `minute` granularity).
- `GET /v1/usage/summary` now returns an `aiTokens` tile (monthly, from `ai_tokens_day`).

### `@getmunin/agent-runtime`
- Agent passes can report a `quota_exceeded` skip outcome.
- `ConversationHandlerDeps` gains an optional `beforeGenerate({ trigger: 'chat' })` gate and `onGenerateBlocked` callback.

### `@getmunin/agent-host`
- `AgentHostRunnerOptions` gains three optional hooks: `resolveProviderAuth` (managed-credential fallback for keyless orgs), `createProvider` (per-org provider factory), and `beforeGenerate` (pre-generate gate, consulted for both live `chat` and `scheduled` background work). The scheduled gate runs before jobs are claimed, so a gated org does no background work.
- The resolved provider threads through chat, curator/skill passes, and website-import.

### `@getmunin/dashboard-pages`
- Provider picker accepts host-supplied `extraPresets` + `defaultPresetId`, including a credential-less `managed` preset that renders host content and clears the org key on selection; the model picker is hidden while on a managed/keyless provider.
- `AiSettingsPage` / `UsagePage` accept an optional content `slot`; `AgentSetupWizard` accepts the same preset props and skips the model step for managed providers.
- New "AI tokens" usage tile + i18n.

## Testing
- `pnpm -F @getmunin/agent-runtime -F @getmunin/agent-host test` — 302 passing.
- Typecheck clean across backend-core, agent-runtime, agent-host, dashboard-pages.
- Added a rate-limit increment-by-N unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)