### PR TITLE
chore: rename "Page views" nav label to "Trackers" / "Målepunkter"

### DIFF
--- a/.changeset/rename-page-views-trackers.md
+++ b/.changeset/rename-page-views-trackers.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/dashboard-pages": patch
+---
+
+Rename the "Page views" nav label and section eyebrow to "Trackers" (nb: "Målepunkter") to match the section header and actions, and reword the subtitle to lead with the action.

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -173,7 +173,7 @@
     "agents": "Agents",
     "apiKeys": "API keys",
     "channels": "Channels",
-    "trackers": "Page views",
+    "trackers": "Trackers",
     "endUsers": "End-users",
     "usage": "Usage",
     "auditLog": "Audit log",
@@ -717,9 +717,9 @@
       }
     },
     "trackers": {
-      "eyebrow": "Workspace · Page views",
+      "eyebrow": "Workspace · Trackers",
       "title": "What people <em>actually</em> read.",
-      "subtitle": "Page-view analytics from your sites and apps.",
+      "subtitle": "Track page views across your sites and apps.",
       "trackersTitle": "Trackers",
       "trackersTitleCount": "Trackers · {count}",
       "addTracker": "Add tracker",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -173,7 +173,7 @@
     "agents": "Agenter",
     "apiKeys": "API-nøkler",
     "channels": "Kanaler",
-    "trackers": "Sidevisninger",
+    "trackers": "Målepunkter",
     "endUsers": "Sluttbrukere",
     "usage": "Bruk",
     "auditLog": "Hendelseslogg",
@@ -717,9 +717,9 @@
       }
     },
     "trackers": {
-      "eyebrow": "Arbeidsområde · Sidevisninger",
+      "eyebrow": "Arbeidsområde · Målepunkter",
       "title": "Hva folk <em>faktisk</em> leser.",
-      "subtitle": "Sidevisning-analytikk fra dine nettsteder og apper.",
+      "subtitle": "Spor sidevisninger på tvers av dine nettsteder og apper.",
       "trackersTitle": "Målepunkter",
       "trackersTitleCount": "Målepunkter · {count}",
       "addTracker": "Legg til målepunkt",


### PR DESCRIPTION
## What

Renames the **"Page views"** workspace nav label and section eyebrow to **"Trackers"** (Norwegian: **"Målepunkter"**), and rewords the subtitle to lead with the action.

## Why

The section header and every action below it already say "Trackers" / "Målepunkter" (`trackersTitle`, "Add tracker", empty states, errors). The nav label and eyebrow said "Page views" / "Sidevisninger", introducing a third term for the same thing. This aligns them.

## Changes (`packages/dashboard-pages/src/messages/`)

| Key | EN before → after | NB before → after |
|---|---|---|
| `nav.trackers` | Page views → **Trackers** | Sidevisninger → **Målepunkter** |
| `trackers.eyebrow` | Workspace · Page views → **Workspace · Trackers** | Arbeidsområde · Sidevisninger → **Arbeidsområde · Målepunkter** |
| `trackers.subtitle` | Page-view analytics from your sites and apps. → **Track page views across your sites and apps.** | Sidevisning-analytikk … → **Spor sidevisninger på tvers av dine nettsteder og apper.** |

Descriptive copy that uses "page views"/"sidevisninger" as the measured concept (embed instructions, hash hints) is intentionally left unchanged.

Changeset included (patch on `@getmunin/dashboard-pages`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)