### PR TITLE
fix: match fullpage spinner background to onboarding and dashboard

### DIFF
--- a/.changeset/fullpage-spinner-bg.md
+++ b/.changeset/fullpage-spinner-bg.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/dashboard-pages": patch
+---
+
+Give the settings shell's full-screen loading spinner the same `bg-bone dark:bg-background` backdrop as the dashboard and onboarding spinners, so initial loads no longer flash a mismatched background.

--- a/apps/web/app/[locale]/loading.tsx
+++ b/apps/web/app/[locale]/loading.tsx
@@ -1,5 +1,5 @@
 import { PageSpinner } from '@getmunin/ui';
 
 export default function RootLoading() {
-  return <PageSpinner className="min-h-screen" />;
+  return <PageSpinner className="min-h-screen bg-bone dark:bg-background" />;
 }

--- a/packages/dashboard-pages/src/shells/settings-shell.tsx
+++ b/packages/dashboard-pages/src/shells/settings-shell.tsx
@@ -42,7 +42,7 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
   }, [pathname]);
 
   if (loading || !isOwnerOrAdmin(role)) {
-    return <PageSpinner />;
+    return <PageSpinner className="min-h-screen bg-bone dark:bg-background" />;
   }
 
   const signOut = () => {


### PR DESCRIPTION
## Problem

The main full-screen loading spinner rendered with no explicit background, so on initial load it showed the body default (a `bg-paper`-ish white in light mode) and then flashed to the warmer `bg-bone` once the onboarding/dashboard mounted.

Two spinners were affected:
- `apps/web/app/[locale]/loading.tsx` — root route loader (was bare `min-h-screen`)
- `packages/dashboard-pages/src/shells/settings-shell.tsx` — settings shell's initial loading state (was a bare `<PageSpinner />`)

Meanwhile the onboarding (`setup/page.tsx`) and dashboard (`dashboard-shell.tsx`) spinners already used `bg-bone dark:bg-background`.

## Fix

Give both affected spinners the same `min-h-screen bg-bone dark:bg-background` backdrop so all full-screen initial loaders match — no more white-to-bone flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)