### PR TITLE
feat: meter AI token usage on the default provider path

### DIFF
--- a/.changeset/agent-host-meter-byok-tokens.md
+++ b/.changeset/agent-host-meter-byok-tokens.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/agent-host": minor
+---
+
+Record AI token usage for the agent's own configured LLM provider. The runner now meters token consumption on its default provider path — covering live chat, scheduled curator work, and website imports — so the monthly AI-tokens figure on the usage and overview pages reflects real usage instead of staying at zero.

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -13,6 +13,7 @@ import {
   InProcessMuninRestClientFactoryService,
   McpRegistryService,
   McpSkillRegistryService,
+  RateLimitService,
   RealtimeEventBus,
   openAdminAgentMcpClient,
   openEndUserAgentMcpClient,
@@ -28,6 +29,7 @@ import { parseEnvBool } from '@getmunin/core';
 import {
   createConversationHandler,
   createPromptResolver,
+  openAiCompatibleProvider,
   runSkillPass,
   type ConversationHandler,
   type CuratorJob,
@@ -51,6 +53,7 @@ import { runWithServiceContext } from './service-context.ts';
 import { ReplicaLockManager } from './replica-lock.ts';
 import { runWebImportJob } from './web-import.handler.ts';
 import { AgentHealthService } from './agent-health.service.ts';
+import { createMeteringProvider } from './usage-metering.ts';
 
 interface TaskHandlerContext {
   job: CuratorJob;
@@ -143,6 +146,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     @Inject(InProcessMuninRestClientFactoryService)
     private readonly restClientFactory: InProcessMuninRestClientFactoryService,
     @Inject(AgentHealthService) private readonly health: AgentHealthService,
+    @Optional() @Inject(RateLimitService) private readonly rateLimit: RateLimitService | undefined,
     @Optional() @Inject('AGENT_HOST_RUNNER_OPTIONS') options?: AgentHostRunnerOptions,
   ) {
     this.options = options;
@@ -300,6 +304,24 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     return apiKey ? { apiKey, managed: false } : null;
   }
 
+  private meteringProvider(id: string, orgId: string): Provider {
+    return createMeteringProvider(openAiCompatibleProvider, (totalTokens) => {
+      const rateLimit = this.rateLimit;
+      if (!rateLimit) return;
+      void runWithServiceContext(
+        this.db,
+        id,
+        async () => {
+          await rateLimit.record('ai_tokens_day', totalTokens);
+          await rateLimit.record('ai_tokens_month', totalTokens);
+        },
+        { orgId },
+      ).catch((err) =>
+        this.scopedLogger(id, 'usage').warn(`ai-token record failed: ${describe(err)}`),
+      );
+    });
+  }
+
   private async spawnRunner(id: string): Promise<PerConfigRunner | null> {
     const config = await runWithServiceContext(this.db, id, () => this.repo.read(id));
     const orgId = await runWithServiceContext(this.db, id, () => this.repo.resolveOrgId(id));
@@ -323,7 +345,9 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     const fastModel = auth.model ?? config.fastModel;
     const smartModel = auth.model ?? config.smartModel ?? config.fastModel;
     const managed = auth.managed;
-    const provider = this.options?.createProvider?.({ orgId, config, managed });
+    const provider =
+      this.options?.createProvider?.({ orgId, config, managed }) ??
+      this.meteringProvider(id, orgId);
 
     const rest = this.restClientFactory.forOrg(orgId);
 

--- a/packages/agent-host/src/usage-metering.test.ts
+++ b/packages/agent-host/src/usage-metering.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Provider, ProviderCallArgs, ProviderResponse } from '@getmunin/agent-runtime';
+import { createMeteringProvider } from './usage-metering.ts';
+
+const ARGS: ProviderCallArgs = {
+  config: {
+    provider: { baseUrl: 'https://example.test/v1', apiKey: 'sk-test' },
+    model: 'test-model',
+    systemPrompt: 'you are a test',
+  },
+  messages: [],
+  tools: [],
+};
+
+function response(usage?: ProviderResponse['usage']): ProviderResponse {
+  return { message: { role: 'assistant', content: 'hi' }, finishReason: 'stop', usage };
+}
+
+describe('createMeteringProvider', () => {
+  it('reports total tokens from the provider response', async () => {
+    const base: Provider = vi.fn().mockResolvedValue(response({ total_tokens: 1234 }));
+    const onTokens = vi.fn();
+
+    await createMeteringProvider(base, onTokens)(ARGS);
+
+    expect(onTokens).toHaveBeenCalledExactlyOnceWith(1234);
+  });
+
+  it('returns the underlying response unchanged', async () => {
+    const out = response({ total_tokens: 10 });
+    const provider = createMeteringProvider(vi.fn().mockResolvedValue(out), vi.fn());
+
+    expect(await provider(ARGS)).toBe(out);
+  });
+
+  it('does not report when usage is absent or zero', async () => {
+    const onTokens = vi.fn();
+
+    await createMeteringProvider(vi.fn().mockResolvedValue(response()), onTokens)(ARGS);
+    await createMeteringProvider(
+      vi.fn().mockResolvedValue(response({ total_tokens: 0 })),
+      onTokens,
+    )(ARGS);
+
+    expect(onTokens).not.toHaveBeenCalled();
+  });
+
+  it('propagates provider errors without reporting', async () => {
+    const onTokens = vi.fn();
+    const base: Provider = vi.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(createMeteringProvider(base, onTokens)(ARGS)).rejects.toThrow('boom');
+    expect(onTokens).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-host/src/usage-metering.ts
+++ b/packages/agent-host/src/usage-metering.ts
@@ -1,0 +1,13 @@
+import type { Provider } from '@getmunin/agent-runtime';
+
+export function createMeteringProvider(
+  base: Provider,
+  onTokens: (totalTokens: number) => void,
+): Provider {
+  return async (args) => {
+    const response = await base(args);
+    const total = response.usage?.total_tokens ?? 0;
+    if (total > 0) onTokens(total);
+    return response;
+  };
+}


### PR DESCRIPTION
## Summary

The agent runner only recorded `ai_tokens_*` when a host injected a custom provider factory, so on the default (own-key) provider path the AI-tokens usage tile always read zero.

This wraps the default `openAiCompatibleProvider` with a metering provider that records `total_tokens` into the `ai_tokens_day` / `ai_tokens_month` buckets the usage summary reads. The wrapper is the one chokepoint every LLM call funnels through, so it covers **live chat**, **scheduled curator work**, and **website imports** with a single change. Recording runs fire-and-forget inside the runner's existing service context, so it adds no latency to a reply and degrades gracefully if rate-limiting isn't wired.

## Changes

- `usage-metering.ts` (new) — small, testable `createMeteringProvider(base, onTokens)` wrapper.
- `runner.service.ts` — injects `RateLimitService` (optional) and uses the metering provider as the default when no custom `createProvider` is supplied.

## Testing

- `pnpm -F @getmunin/agent-host test` — 69 passing (incl. new `usage-metering` cases)
- `pnpm -F @getmunin/agent-host typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)