### PR TITLE
fix: remove polynomial ReDoS in provider credential validation

### DIFF
--- a/.changeset/redos-provider-auth.md
+++ b/.changeset/redos-provider-auth.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/agent-host": patch
+---
+
+Fix a polynomial-time ReDoS in provider credential validation: the trailing-slash trim on the user-supplied provider base URL used a backtracking regex (`/\/+$/`) on attacker-controllable input. Replace it with a linear scan.

--- a/packages/agent-host/src/provider-auth.test.ts
+++ b/packages/agent-host/src/provider-auth.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BadGatewayException, UnauthorizedException } from '@nestjs/common';
 import * as core from '@getmunin/core';
-import { validateProviderCredentials } from './provider-auth.ts';
+import { stripTrailingSlashes, validateProviderCredentials } from './provider-auth.ts';
 
 function mockSafeFetch(response: {
   status: number;
@@ -125,5 +125,28 @@ describe('validateProviderCredentials', () => {
         BadGatewayException,
       );
     });
+  });
+});
+
+describe('stripTrailingSlashes', () => {
+  it('matches the trailing-slash semantics of the previous regex', () => {
+    const cases = [
+      'https://api.example.com/',
+      'https://api.example.com///',
+      'https://api.example.com',
+      'https://api.example.com/v1',
+      'https://api.example.com/v1/',
+      '',
+      '/',
+      '////',
+    ];
+    for (const value of cases) {
+      expect(stripTrailingSlashes(value)).toBe(value.replace(/\/+$/, ''));
+    }
+  });
+
+  it('runs in linear time on pathological all-slash input', () => {
+    const input = `${'/'.repeat(200_000)}a`;
+    expect(stripTrailingSlashes(input)).toBe(input);
   });
 });

--- a/packages/agent-host/src/provider-auth.ts
+++ b/packages/agent-host/src/provider-auth.ts
@@ -1,8 +1,14 @@
 import { BadGatewayException, HttpStatus, UnauthorizedException } from '@nestjs/common';
 import { describeError, safeFetch } from '@getmunin/core';
 
+export function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
+}
+
 export async function validateProviderCredentials(baseUrl: string, apiKey: string): Promise<void> {
-  const root = baseUrl.replace(/\/+$/, '');
+  const root = stripTrailingSlashes(baseUrl);
   if (/openrouter\.ai/i.test(baseUrl)) {
     const body = await probe(`${root}/auth/key`, authHeaders(baseUrl, apiKey));
     if (!hasObjectData(body)) {


### PR DESCRIPTION
Resolves code-scanning alert [#35](https://github.com/getmunin/munin/security/code-scanning/35) (`js/polynomial-redos`, high).

## Problem

`validateProviderCredentials` trimmed trailing slashes off the **user-supplied** provider base URL with `baseUrl.replace(/\/+$/, '')`. Because the input is attacker-controllable (set when configuring an agent's LLM provider) and the regex backtracks, CodeQL flagged it as quadratic-time ReDoS — a base URL with many `/` characters can pin a request handler at O(n²).

## Fix

Replace the regex with a linear, regex-free scan (`stripTrailingSlashes`) that walks back over trailing `/`. Behavior is identical to the old regex (verified by a test comparing against `/\/+$/` across edge cases including empty, all-slash, and internal-slash inputs).

The same trailing-slash regex appears in ~30 other places, but those operate on env vars / constants and aren't on a tainted path — this is the only instance CodeQL flagged, so the change is scoped to it.

## Testing

- `pnpm -F @getmunin/agent-host test provider-auth` — 15 passing (13 existing + 2 new, incl. a 200k-slash pathological-input case that completes instantly)
- `pnpm -F @getmunin/agent-host typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)