### PR TITLE
chore: stop tracking next-env.d.ts; regenerate it for typecheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 dist/
 build/
 .next/
+next-env.d.ts
 out/
 *.tsbuildinfo
 

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "dev": "next dev --port 3000",
     "start": "next start --port 3000",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "next typegen && tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
     "test": "vitest run --passWithNoTests",
     "e2e": "playwright test",


### PR DESCRIPTION
## Problem

`apps/web/next-env.d.ts` shows as a modified file in the working tree constantly. Next.js 16 generates it differently depending on the command:

- `next dev` → `import "./.next/dev/types/routes.d.ts";`
- `next build` → `import "./.next/types/routes.d.ts";`

So whichever variant is committed, the other mode re-dirties it on every run. This is a [known, still-open Next.js bug](https://github.com/vercel/next.js/issues/86001) that fires even with `typedRoutes: false` (our config).

## Fix

Follow the [official Next.js guidance](https://nextjs.org/docs/app/api-reference/config/typescript) — the file is auto-generated and should be gitignored:

> *"We recommend adding `next-env.d.ts` to your `.gitignore` file."*

1. Add `next-env.d.ts` to `.gitignore` and stop tracking it.
2. Prepend `next typegen` to the web `typecheck` script.

Step 2 is the important part for **this** repo: CI runs `pnpm typecheck` **before** `pnpm build`, and `tsconfig.json` includes `next-env.d.ts` — so a bare gitignore would break the web typecheck on a fresh checkout (the exact failure documented in [t3-oss/create-t3-turbo#472](https://github.com/t3-oss/create-t3-turbo/issues/472)). `next typegen` regenerates the file and route types without a full build, so typecheck stays green everywhere.

## Verification

Simulated a fresh clone (deleted the untracked file) and ran the web typecheck:

```
$ pnpm -F @getmunin/web typecheck
> next typegen && tsc -p tsconfig.json --noEmit
Generating route types...
✓ Types generated successfully
```

`tsc` passed, and `git status` no longer reports `next-env.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)