### PR TITLE
feat: AgentHostModule.forRootAsync for DI-built runnerOptions

### DIFF
--- a/.changeset/agent-host-forrootasync.md
+++ b/.changeset/agent-host-forrootasync.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/agent-host": minor
+---
+
+Add `AgentHostModule.forRootAsync({ configRepository, imports, inject, useFactory })` so `runnerOptions` (provider factory, credential resolver, pre-generate gate) can be built from a DI factory with injected services, instead of only a static value.

--- a/packages/agent-host/src/module.ts
+++ b/packages/agent-host/src/module.ts
@@ -1,4 +1,12 @@
-import { DynamicModule, Module, Provider, Type } from '@nestjs/common';
+import {
+  DynamicModule,
+  Module,
+  Provider,
+  Type,
+  type InjectionToken,
+  type ModuleMetadata,
+  type OptionalFactoryDependency,
+} from '@nestjs/common';
 import {
   AgentRunnerSupportModule,
   AlertsService,
@@ -15,52 +23,67 @@ import { AgentHostRunner, type AgentHostRunnerOptions } from './runner.service.t
 import { AGENT_CONFIG_REPOSITORY, AGENT_HOST_DB, ALERT_RECORDER } from './injection-tokens.ts';
 import type { AgentConfigRepository } from './config.repository.ts';
 
+const RUNNER_OPTIONS = 'AGENT_HOST_RUNNER_OPTIONS';
+
 export interface AgentHostModuleOptions {
   configRepository: Type<AgentConfigRepository>;
   runnerOptions?: AgentHostRunnerOptions;
 }
 
+export interface AgentHostModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+  configRepository: Type<AgentConfigRepository>;
+  inject?: Array<InjectionToken | OptionalFactoryDependency>;
+  useFactory: (...args: never[]) => AgentHostRunnerOptions | Promise<AgentHostRunnerOptions>;
+}
+
 @Module({})
 export class AgentHostModule {
   static forRoot(options: AgentHostModuleOptions): DynamicModule {
-    const repoProvider: Provider = {
-      provide: AGENT_CONFIG_REPOSITORY,
-      useClass: options.configRepository,
-    };
-    const dbAliasProvider: Provider = {
-      provide: AGENT_HOST_DB,
-      useExisting: DB,
-    };
-    const runnerOptionsProvider: Provider = {
-      provide: 'AGENT_HOST_RUNNER_OPTIONS',
+    return buildModule(options.configRepository, {
+      provide: RUNNER_OPTIONS,
       useValue: options.runnerOptions ?? {},
-    };
-    const alertRecorderProvider: Provider = {
-      provide: ALERT_RECORDER,
-      useExisting: AlertsService,
-    };
-    return {
-      module: AgentHostModule,
-      imports: [DbModule, McpModule, RealtimeModule, AgentRunnerSupportModule],
-      providers: [
-        repoProvider,
-        dbAliasProvider,
-        runnerOptionsProvider,
-        alertRecorderProvider,
-        options.configRepository,
-        AgentConfigService,
-        AgentModelsService,
-        AgentHealthService,
-        AgentHostRunner,
-      ],
-      controllers: [AgentConfigController],
-      exports: [
-        AgentConfigService,
-        AgentModelsService,
-        AgentHealthService,
-        AGENT_CONFIG_REPOSITORY,
-        AGENT_HOST_DB,
-      ],
-    };
+    });
   }
+
+  static forRootAsync(options: AgentHostModuleAsyncOptions): DynamicModule {
+    return buildModule(
+      options.configRepository,
+      {
+        provide: RUNNER_OPTIONS,
+        useFactory: options.useFactory,
+        inject: options.inject ?? [],
+      },
+      options.imports ?? [],
+    );
+  }
+}
+
+function buildModule(
+  configRepository: Type<AgentConfigRepository>,
+  runnerOptionsProvider: Provider,
+  extraImports: NonNullable<ModuleMetadata['imports']> = [],
+): DynamicModule {
+  return {
+    module: AgentHostModule,
+    imports: [DbModule, McpModule, RealtimeModule, AgentRunnerSupportModule, ...extraImports],
+    providers: [
+      { provide: AGENT_CONFIG_REPOSITORY, useClass: configRepository },
+      { provide: AGENT_HOST_DB, useExisting: DB },
+      runnerOptionsProvider,
+      { provide: ALERT_RECORDER, useExisting: AlertsService },
+      configRepository,
+      AgentConfigService,
+      AgentModelsService,
+      AgentHealthService,
+      AgentHostRunner,
+    ],
+    controllers: [AgentConfigController],
+    exports: [
+      AgentConfigService,
+      AgentModelsService,
+      AgentHealthService,
+      AGENT_CONFIG_REPOSITORY,
+      AGENT_HOST_DB,
+    ],
+  };
 }


### PR DESCRIPTION
## Summary

Adds `AgentHostModule.forRootAsync({ configRepository, imports?, inject?, useFactory })` so a host can build `runnerOptions` (the provider factory, credential resolver, and pre-generate gate added in 4.53.0) from a **DI factory** with injected services — not only a static value.

`forRoot` is unchanged; both paths share a single internal module builder, so the provider/controller/export wiring stays identical.

## Why
Hosts that resolve the provider/gate from NestJS singletons (e.g. a quota service) couldn't inject them through the static `runnerOptions`. `forRootAsync` closes that gap.

## Testing
- `pnpm exec turbo run typecheck --filter=@getmunin/agent-host` — clean.
- `pnpm -F @getmunin/agent-host test` — 71 passing.
- eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)