### PR TITLE
fix: recover chat replies missed by a stale NOTIFY listener

### DIFF
--- a/.changeset/agent-reply-recovery-sweep.md
+++ b/.changeset/agent-reply-recovery-sweep.md
@@ -1,0 +1,9 @@
+---
+"@getmunin/agent-runtime": minor
+"@getmunin/backend-core": minor
+"@getmunin/agent-host": minor
+---
+
+Recover chat replies when the in-memory NOTIFY misses a live runner. A widget/chat reply was driven purely by an in-process `conversation.message.received` event reaching a subscribed runner; if no runner was resident when the NOTIFY fired (cold start, restart, scale-to-zero, dropped listener), the reply was silently lost because nothing durable recorded that one was owed.
+
+The runner now also drives replies from a durable recovery set: `GET /v1/conversations/awaiting-reply` returns open, auto-mode, unassigned, non-voice conversations whose latest non-internal message is from the visitor. The agent host sweeps this on every (re)spawn — the same on-boot drain that lets the curator queue survive scale-to-zero — and on each reconcile tick, re-driving anything that slipped through. Already-answered and staff-handled threads are excluded, and the existing `shouldRespond` + conversation-claim + `sinceMessageId` guards keep a redundant trigger a no-op, so no duplicate replies.

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -31,6 +31,7 @@ import {
   createPromptResolver,
   openAiCompatibleProvider,
   runSkillPass,
+  type AwaitingReplyConversation,
   type ConversationHandler,
   type CuratorJob,
   type HandlerConfig,
@@ -75,6 +76,7 @@ const TASK_HANDLERS: ReadonlyMap<string, TaskHandler> = new Map([
 const RECONCILE_INTERVAL_MS = 30_000;
 const CURATOR_LEASE_SECONDS = 600;
 const CURATOR_MAX_SCHEDULED_DELAY_MS = 24 * 60 * 60 * 1000;
+const CONVERSATION_SWEEP_LIMIT = 50;
 
 const DEFAULT_END_USER_AGENT_SCOPES: readonly string[] = [
   'conv:read',
@@ -118,11 +120,17 @@ interface PerConfigRunner {
   prompts: PromptResolver;
   adminMcp: AgentMcpClient;
   curatorWorker: CuratorWorker;
+  sweeper: ConversationSweeper;
 }
 
 interface CuratorWorker {
   onPending(event: CuratorJobPendingBusEvent): void;
   onConnected(): void;
+  stop(): Promise<void>;
+}
+
+interface ConversationSweeper {
+  sweep(): void;
   stop(): Promise<void>;
 }
 
@@ -182,6 +190,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
         r.realtime.unsubscribe();
         await r.handler.stop();
         await r.curatorWorker.stop();
+        await r.sweeper.stop();
         await r.adminMcp.close().catch((err: unknown) => {
           this.logger.warn(`adminMcp.close() on shutdown failed: ${describe(err)}`);
         });
@@ -211,6 +220,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
         runner.realtime.unsubscribe();
         await runner.handler.stop();
         await runner.curatorWorker.stop();
+        await runner.sweeper.stop();
         await runner.adminMcp.close().catch((err: unknown) => {
           this.logger.warn(`${id}: adminMcp.close() on stop failed: ${describe(err)}`);
         });
@@ -241,6 +251,10 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
         }
       }
     }
+
+    for (const runner of this.runners.values()) {
+      runner.sweeper.sweep();
+    }
   }
 
   private readonly respawnInFlight = new Set<string>();
@@ -261,6 +275,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
           existing.realtime.unsubscribe();
           await existing.handler.stop();
           await existing.curatorWorker.stop();
+          await existing.sweeper.stop();
           await existing.adminMcp.close();
         } catch (err) {
           this.logger.warn(`respawn: teardown failed for ${id}: ${describe(err)}`);
@@ -386,6 +401,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     });
 
     const handlerRef: { current: ConversationHandler | null } = { current: null };
+    const sweeper = this.buildConversationSweeper({ id, rest, handlerRef });
     const realtime = this.eventBus.subscribe(
       { orgId },
       {
@@ -401,7 +417,10 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
           handlerRef.current?.greet({ conversationId: event.conversationId });
         },
         onCuratorJobPending: (event) => curatorWorker.onPending(event),
-        onConnected: () => curatorWorker.onConnected(),
+        onConnected: () => {
+          curatorWorker.onConnected();
+          sweeper.sweep();
+        },
         onKbDocumentChanged: (event: KbDocumentChangedBusEvent) => {
           if (event.type === 'deleted') return;
           if (!event.slug || !prompts.isPromptDocument(event.slug)) return;
@@ -464,7 +483,51 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     });
     handlerRef.current = handler;
 
-    return { realtime, handler, prompts, adminMcp, curatorWorker };
+    return { realtime, handler, prompts, adminMcp, curatorWorker, sweeper };
+  }
+
+  private buildConversationSweeper(opts: {
+    id: string;
+    rest: MuninRestClient;
+    handlerRef: { current: ConversationHandler | null };
+  }): ConversationSweeper {
+    const log = this.scopedLogger(opts.id, 'sweep');
+    let stopped = false;
+    let pending: Promise<void> | null = null;
+
+    const runSweep = async (): Promise<void> => {
+      if (stopped) return;
+      if (this.lockManager && !this.lockManager.holds(opts.id)) return;
+      let candidates: AwaitingReplyConversation[];
+      try {
+        candidates = await opts.rest.listConversationsAwaitingReply({
+          limit: CONVERSATION_SWEEP_LIMIT,
+        });
+      } catch (err) {
+        log.warn(`sweep failed: ${describe(err)}`);
+        return;
+      }
+      if (stopped || candidates.length === 0) return;
+      log.info(`recovering ${candidates.length} unanswered conversation(s)`);
+      for (const c of candidates) {
+        if (stopped) break;
+        opts.handlerRef.current?.handle({ conversationId: c.id, authorType: 'end_user' });
+      }
+    };
+
+    return {
+      sweep() {
+        if (stopped || pending) return;
+        pending = runSweep().finally(() => {
+          pending = null;
+        });
+        void pending;
+      },
+      async stop() {
+        stopped = true;
+        await pending?.catch(() => undefined);
+      },
+    };
   }
 
   private buildCuratorWorker(opts: {

--- a/packages/agent-host/src/web-import.handler.test.ts
+++ b/packages/agent-host/src/web-import.handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ProviderError } from '@getmunin/agent-runtime';
+import type * as AgentRuntime from '@getmunin/agent-runtime';
 import type {
   CrawlResult,
   CuratorJob,
@@ -13,7 +14,7 @@ const probeUrlMock = vi.hoisted(() => vi.fn());
 const crawlMock = vi.hoisted(() => vi.fn<(args: { url: string }) => Promise<CrawlResult>>());
 
 vi.mock('@getmunin/agent-runtime', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@getmunin/agent-runtime')>();
+  const actual = await importOriginal<typeof AgentRuntime>();
   return {
     ...actual,
     probeUrl: probeUrlMock,

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -83,6 +83,7 @@ function buildConversation(overrides: Partial<ConversationDetail> = {}): Convers
 function buildRest(overrides: Partial<MuninRestClient> = {}): MuninRestClient {
   return {
     getConversation: vi.fn(() => Promise.resolve(buildConversation())),
+    listConversationsAwaitingReply: vi.fn(() => Promise.resolve([])),
     postAgentMessage: vi.fn(() => Promise.resolve()),
     postInternalNote: vi.fn(() => Promise.resolve()),
     mintDelegatedToken: vi.fn(() =>

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -35,6 +35,7 @@ export {
 export {
   createMuninRestClient,
   type AckCuratorJobInput,
+  type AwaitingReplyConversation,
   type ClaimCuratorJobsInput,
   type ConversationDetail,
   type ConversationStatus,

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -106,8 +106,16 @@ export interface UpdateCuratorJobProgressInput {
   progress: unknown;
 }
 
+export interface AwaitingReplyConversation {
+  id: string;
+}
+
 export interface MuninRestClient {
   getConversation(id: string): Promise<ConversationDetail>;
+  listConversationsAwaitingReply(input?: {
+    limit?: number;
+    lookbackMinutes?: number;
+  }): Promise<AwaitingReplyConversation[]>;
   postAgentMessage(
     conversationId: string,
     body: string,
@@ -170,6 +178,20 @@ export function createMuninRestClient(opts: CreateMuninRestClientOptions): Munin
   return {
     async getConversation(id: string): Promise<ConversationDetail> {
       return call<ConversationDetail>(`/v1/conversations/${encodeURIComponent(id)}`);
+    },
+    async listConversationsAwaitingReply(
+      input: { limit?: number; lookbackMinutes?: number } = {},
+    ): Promise<AwaitingReplyConversation[]> {
+      const params = new URLSearchParams();
+      if (input.limit !== undefined) params.set('limit', String(input.limit));
+      if (input.lookbackMinutes !== undefined) {
+        params.set('lookbackMinutes', String(input.lookbackMinutes));
+      }
+      const query = params.toString();
+      const result = await call<{ items: AwaitingReplyConversation[] }>(
+        `/v1/conversations/awaiting-reply${query ? `?${query}` : ''}`,
+      );
+      return result.items;
     },
     async postAgentMessage(
       conversationId: string,

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -2864,6 +2864,45 @@
         ]
       }
     },
+    "/v1/conversations/awaiting-reply": {
+      "get": {
+        "operationId": "ConversationsController_awaitingReply",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lookbackMinutes",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Conversations"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/conversations/{id}": {
       "get": {
         "operationId": "ConversationsController_get",

--- a/packages/backend-core/src/agent/in-process-rest-client.ts
+++ b/packages/backend-core/src/agent/in-process-rest-client.ts
@@ -11,6 +11,7 @@ import { type Db } from '@getmunin/db';
 import { type WebImportProgress } from '@getmunin/types';
 import {
   type AckCuratorJobInput,
+  type AwaitingReplyConversation,
   type ClaimCuratorJobsInput,
   type ConversationDetail,
   type ConversationStatus,
@@ -118,6 +119,12 @@ function buildClient(opts: BuildOptions): MuninRestClient {
           })),
         };
       });
+    },
+
+    async listConversationsAwaitingReply(
+      input: { limit?: number; lookbackMinutes?: number } = {},
+    ): Promise<AwaitingReplyConversation[]> {
+      return withTenancy(() => opts.conv.listConversationsAwaitingAgentReply(input));
     },
 
     async postAgentMessage(

--- a/packages/backend-core/src/control/conversations.controller.ts
+++ b/packages/backend-core/src/control/conversations.controller.ts
@@ -134,6 +134,20 @@ export class ConversationsController {
     return translate(() => this.conv.listTopics());
   }
 
+  @Get('awaiting-reply')
+  async awaitingReply(
+    @Query('limit') limit?: string,
+    @Query('lookbackMinutes') lookbackMinutes?: string,
+  ): Promise<{ items: Array<{ id: string }> }> {
+    const items = await translate(() =>
+      this.conv.listConversationsAwaitingAgentReply({
+        limit: parseLimit(limit),
+        lookbackMinutes: parsePositiveInt(lookbackMinutes),
+      }),
+    );
+    return { items };
+  }
+
   @Get(':id')
   async get(@Param('id') id: string): Promise<ConversationDetailResponse> {
     const detail = await translate(() => this.conv.getConversation(id));
@@ -306,6 +320,12 @@ function parseLimit(value: string | undefined): number | undefined {
   const n = value ? Number.parseInt(value, 10) : NaN;
   if (!Number.isFinite(n) || n <= 0) return undefined;
   return Math.min(n, 200);
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  const n = value ? Number.parseInt(value, 10) : NaN;
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return n;
 }
 
 function encodeListCursor(c: { lastMessageAt: string | null; id: string }): string {

--- a/packages/backend-core/src/modules/conv/conv.awaiting-reply.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.awaiting-reply.integration.test.ts
@@ -1,0 +1,231 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { AppModule } from '../../app.module.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to run conv awaiting-reply integration tests.';
+
+(skipReason ? describe.skip : describe)('conv awaiting-reply sweep selection', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let adminKey: string;
+  let chatChannelId: string;
+  let voiceChannelId: string;
+  let euId: string;
+  let contactId: string;
+  let staffUserId: string;
+  let displayCounter = 0;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_BUILTIN_AGENT = '0';
+
+    await runMigrations(TEST_URL!);
+
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Awaiting Reply Org' })
+      .returning();
+    orgId = org!.id;
+
+    adminKey = buildApiKey('admin');
+    await db.insert(schema.apiKeys).values({
+      orgId,
+      type: 'admin',
+      name: 'ar-admin',
+      keyHash: hashSecret(adminKey),
+      keyPrefix: keyPrefix(adminKey),
+      scopes: ['*'],
+    });
+
+    const [chat] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'chat',
+        vendor: 'munin',
+        name: 'ar-chat',
+        config: { provider: 'widget', originAllowlist: [] },
+      })
+      .returning();
+    chatChannelId = chat!.id;
+
+    const [voice] = await db
+      .insert(schema.convChannels)
+      .values({ orgId, type: 'voice', vendor: 'vapi', name: 'ar-voice', config: {} })
+      .returning();
+    voiceChannelId = voice!.id;
+
+    const [eu] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: 'ar-eu', name: 'EU' })
+      .returning();
+    euId = eu!.id;
+
+    const [contact] = await db
+      .insert(schema.convContacts)
+      .values({ orgId, endUserId: euId, name: 'EU' })
+      .returning();
+    contactId = contact!.id;
+
+    const [staff] = await db
+      .insert(schema.users)
+      .values({ email: `ar-staff-${Date.now()}@example.com`, name: 'Staff' })
+      .returning();
+    staffUserId = staff!.id;
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+      await db.delete(schema.users).where(sql`id = ${staffUserId}`);
+    }
+  });
+
+  async function mkConv(opts: {
+    channelId?: string;
+    status?: 'open' | 'snoozed' | 'closed' | 'spam';
+    agentMode?: 'auto' | 'draft_only' | 'off';
+    assigneeUserId?: string | null;
+    endUserId?: string | null;
+    lastMessageAt?: Date;
+    messages: Array<{
+      authorType: 'user' | 'agent' | 'end_user' | 'system';
+      internal?: boolean;
+      offsetMs: number;
+    }>;
+  }): Promise<string> {
+    displayCounter += 1;
+    const base = Date.now();
+    const [conv] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        channelId: opts.channelId ?? chatChannelId,
+        endUserId: opts.endUserId === undefined ? euId : opts.endUserId,
+        contactId,
+        displayId: displayCounter,
+        status: opts.status ?? 'open',
+        agentMode: opts.agentMode ?? 'auto',
+        assigneeUserId: opts.assigneeUserId ?? null,
+        lastMessageAt: opts.lastMessageAt ?? new Date(),
+      })
+      .returning();
+    for (const m of opts.messages) {
+      await db.insert(schema.convMessages).values({
+        orgId,
+        conversationId: conv!.id,
+        authorType: m.authorType,
+        authorId: 'author',
+        body: 'x',
+        internal: m.internal ?? false,
+        createdAt: new Date(base + m.offsetMs),
+      });
+    }
+    return conv!.id;
+  }
+
+  async function awaitingIds(query = ''): Promise<string[]> {
+    const res = await fetch(`${baseUrl}/v1/conversations/awaiting-reply${query}`, {
+      headers: { authorization: `Bearer ${adminKey}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: Array<{ id: string }> };
+    return body.items.map((i) => i.id);
+  }
+
+  it('includes a conversation whose latest message is from the visitor', async () => {
+    const id = await mkConv({ messages: [{ authorType: 'end_user', offsetMs: 0 }] });
+    expect(await awaitingIds()).toContain(id);
+  });
+
+  it('excludes a conversation the agent already answered', async () => {
+    const id = await mkConv({
+      messages: [
+        { authorType: 'end_user', offsetMs: 0 },
+        { authorType: 'agent', offsetMs: 1000 },
+      ],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('treats an internal agent note as not answering the visitor', async () => {
+    const id = await mkConv({
+      messages: [
+        { authorType: 'end_user', offsetMs: 0 },
+        { authorType: 'agent', internal: true, offsetMs: 1000 },
+      ],
+    });
+    expect(await awaitingIds()).toContain(id);
+  });
+
+  it('excludes conversations assigned to staff', async () => {
+    const id = await mkConv({
+      assigneeUserId: staffUserId,
+      messages: [{ authorType: 'end_user', offsetMs: 0 }],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('excludes non-auto agent modes', async () => {
+    const id = await mkConv({
+      agentMode: 'draft_only',
+      messages: [{ authorType: 'end_user', offsetMs: 0 }],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('excludes voice conversations', async () => {
+    const id = await mkConv({
+      channelId: voiceChannelId,
+      messages: [{ authorType: 'end_user', offsetMs: 0 }],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('excludes conversations that are not open', async () => {
+    const id = await mkConv({
+      status: 'snoozed',
+      messages: [{ authorType: 'end_user', offsetMs: 0 }],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('respects the lookback window', async () => {
+    const id = await mkConv({
+      lastMessageAt: new Date(Date.now() - 3 * 60 * 60 * 1000),
+      messages: [{ authorType: 'end_user', offsetMs: 0 }],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+    expect(await awaitingIds('?lookbackMinutes=300')).toContain(id);
+  });
+});

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -44,6 +44,8 @@ export type ChannelType = (typeof CHANNEL_TYPES)[number];
 export type ConversationStatus = (typeof STATUSES)[number];
 export type AgentMode = (typeof AGENT_MODES)[number];
 
+const AWAITING_REPLY_LOOKBACK_MINUTES = 60;
+
 export interface ChannelDto {
   id: string;
   type: ChannelType;
@@ -437,6 +439,41 @@ export class ConvService {
     const nextCursor =
       rows.length > limit && last ? { lastMessageAt: last.lastMessageAt, id: last.id } : null;
     return { items, nextCursor };
+  }
+
+  async listConversationsAwaitingAgentReply(input?: {
+    limit?: number;
+    lookbackMinutes?: number;
+  }): Promise<Array<{ id: string }>> {
+    const ctx = getCurrentContext();
+    const limit = clampLimit(input?.limit, 50, 200);
+    const lookbackMinutes = input?.lookbackMinutes ?? AWAITING_REPLY_LOOKBACK_MINUTES;
+    return ctx.db
+      .select({ id: schema.convConversations.id })
+      .from(schema.convConversations)
+      .innerJoin(
+        schema.convChannels,
+        eq(schema.convChannels.id, schema.convConversations.channelId),
+      )
+      .where(
+        and(
+          eq(schema.convConversations.status, 'open'),
+          eq(schema.convConversations.agentMode, 'auto'),
+          isNull(schema.convConversations.assigneeUserId),
+          isNotNull(schema.convConversations.endUserId),
+          sql`${schema.convChannels.type} <> 'voice'`,
+          sql`${schema.convConversations.lastMessageAt} > now() - make_interval(mins => ${lookbackMinutes})`,
+          sql`(
+            SELECT author_type FROM conv_messages
+            WHERE conversation_id = ${schema.convConversations.id}
+              AND internal = false
+            ORDER BY created_at DESC
+            LIMIT 1
+          ) = 'end_user'`,
+        ),
+      )
+      .orderBy(desc(schema.convConversations.lastMessageAt))
+      .limit(limit);
   }
 
   async getConversation(id: string): Promise<ConversationDetail> {


### PR DESCRIPTION
## Problem

A widget/chat reply was driven **purely by an in-memory `conversation.message.received` NOTIFY** reaching a subscribed runner. Nothing durable recorded that a reply was owed — so when no runner was resident at the instant the NOTIFY fired (cold start, restart, scale-to-zero, dropped listener), the reply was **silently lost**. No error, no retry.

The curator queue survives the same conditions precisely because it's durable and drained on every boot via `onConnected`; live chat had no equivalent. (This is the root cause behind "chat works in prod but never replies in dev" — dev runs the backend at `min_scale=0`, so the container is reaped before any in-flight generation completes and the missed NOTIFY is never re-driven.)

## Fix (recovery sweep)

Make the chat-reply path self-healing by giving the runner a durable recovery set to re-drive, mirroring how curator already survives scale-to-zero:

- **`ConvService.listConversationsAwaitingAgentReply()`** — open, `auto`-mode, unassigned, non-voice, end-user-bound conversations whose **latest non-internal message is from the visitor**, within a 60-min lookback. That "latest message is `end_user`" condition is the safety lynchpin: already-answered and staff-handled threads are excluded.
- **`GET /v1/conversations/awaiting-reply`** + the method on both `MuninRestClient` implementations (HTTP + in-process).
- **Conversation sweeper in the agent host** — fires on every (re)spawn via `onConnected` (the same on-boot drain curator uses) and on each 30s reconcile tick, gated on the replica lock, deduped against concurrent runs, torn down in all lifecycle paths.

### Why this can't double-reply

A redundant trigger is a no-op thanks to four existing layers: `shouldRespond` re-validation, the cross-process conversation claim (`tryAcquireConversation`), in-flight abort in `spawn`, and the `sinceMessageId` race guard (throws `agent_reply_race` if a reply already landed since generation started).

## Complementary, not a substitute for infra

This closes a real correctness gap — replies were silently lost on *every* runner restart, including in prod. It does **not** remove the need for a warm runner: durable work still needs the container alive long enough to drain it. For dev specifically, bumping `min_scale 0 → 1` remains the simpler reliability win; this hardens prod against restart races on top of that.

## Testing

- New integration test `conv.awaiting-reply.integration.test.ts` (8 cases) run against real Postgres with RLS: visitor-latest included; **already-answered excluded** (anti-double-reply); internal note doesn't count as an answer; assigned / `draft_only` / voice / non-open excluded; lookback window respected.
- Adjacent conv suites (43 tests) + agent-runtime units (254) pass.
- Full workspace typecheck (29/29), lint clean (also fixed a preexisting `consistent-type-imports` warning in `web-import.handler.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)