### PR TITLE
fix: fail open when the chat pre-generate gate errors

### DIFF
--- a/.changeset/chat-gate-fail-open.md
+++ b/.changeset/chat-gate-fail-open.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/agent-runtime": patch
+---
+
+Fail open when the chat pre-generate gate errors. The `beforeGenerate` hook (a quota/usage gate) was awaited without a guard, so a thrown error rejected the whole reply attempt and silently dropped the visitor's reply. It now degrades to allow — mirroring the curator's scheduled-work gate — and logs the error (`beforeGenerate failed, proceeding: …`) and any explicit denial (`reply suppressed: …`) so the verdict is observable. A gate outage can no longer swallow a customer's reply.

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -562,4 +562,68 @@ describe('createConversationHandler', () => {
 
     expect(captured[0]).toMatch(/^JUST_BASE\n\n\[Conversation context\]/);
   });
+
+  it('proceeds with the reply when beforeGenerate throws (fail-open like the curator)', async () => {
+    const rest = buildRest();
+    const postSpy = vi.fn(() => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+
+    const stubProvider: Provider = () =>
+      Promise.resolve({
+        message: { role: 'assistant', content: 'hi' },
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        finishReason: 'stop',
+      });
+
+    const onGenerateBlocked = vi.fn();
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      prompts: buildPrompts(),
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+      provider: stubProvider,
+      beforeGenerate: () => Promise.reject(new Error('quota check unavailable')),
+      onGenerateBlocked,
+    });
+
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(onGenerateBlocked).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the reply when beforeGenerate denies', async () => {
+    const rest = buildRest();
+    const postSpy = vi.fn(() => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+
+    const stubProvider: Provider = () =>
+      Promise.resolve({
+        message: { role: 'assistant', content: 'hi' },
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        finishReason: 'stop',
+      });
+
+    const onGenerateBlocked = vi.fn();
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      prompts: buildPrompts(),
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+      provider: stubProvider,
+      beforeGenerate: () => Promise.resolve({ allowed: false, reason: 'quota_exhausted' }),
+      onGenerateBlocked,
+    });
+
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(onGenerateBlocked).toHaveBeenCalledWith('quota_exhausted');
+  });
 });

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -221,7 +221,14 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     const systemPrompt = `${namePreamble}${systemBody}`;
 
     if (deps.beforeGenerate) {
-      const verdict = await deps.beforeGenerate({ trigger: 'chat' });
+      const verdict = await deps
+        .beforeGenerate({ trigger: 'chat' })
+        .catch((err): { allowed: boolean; reason?: string } => {
+          log.warn(
+            `${conversationId} beforeGenerate failed, proceeding: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          return { allowed: true };
+        });
       if (!verdict.allowed) {
         log.info(`${conversationId} reply suppressed: ${verdict.reason ?? 'gate denied'}`);
         deps.onGenerateBlocked?.(verdict.reason);


### PR DESCRIPTION
## What

The agent runner awaited the `beforeGenerate` hook (a quota/usage gate) bare, so a thrown error rejected the entire reply attempt and the visitor's chat reply was **silently dropped** — no message, no handover, no log.

It now fails **open**: a gate error degrades to allow, mirroring the curator's scheduled-work gate in `runner.service.ts`. A quota gate should suppress a reply only when it deliberately denies, never when it errors.

```ts
const verdict = await deps
  .beforeGenerate({ trigger: 'chat' })
  .catch((err): { allowed: boolean; reason?: string } => {
    log.warn(`${conversationId} beforeGenerate failed, proceeding: ${...}`);
    return { allowed: true };
  });
if (!verdict.allowed) {
  log.info(`${conversationId} reply suppressed: ${verdict.reason ?? 'gate denied'}`);
  deps.onGenerateBlocked?.(verdict.reason);
  return;
}
```

## Why this also pinpoints the cause

The new log lines make the gate verdict observable on the next reply:
- threw → `beforeGenerate failed, proceeding: <error>` (reply still goes out)
- denied → `reply suppressed: <reason>`

So a single test message after deploy tells us whether the gate was throwing or denying — diagnosis and fix in one change, no logging-only pass needed.

## Tests
- `beforeGenerate` throws → reply still posts, `onGenerateBlocked` not called.
- `beforeGenerate` denies → reply suppressed, `onGenerateBlocked` called with the reason.
- `pnpm -F @getmunin/agent-runtime test` → 256 passed; typecheck clean.

Changeset: patch bump for `@getmunin/agent-runtime`.

Sibling to #515 (chat reply recovery); independent and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)