### PR TITLE
fix: debounce chat widget reconnecting status bar with a grace period

### DIFF
--- a/.changeset/chat-widget-reconnect-grace.md
+++ b/.changeset/chat-widget-reconnect-grace.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/chat-widget": patch
+---
+
+Chat widget: defer the "Reconnecting…" status bar by a short grace period (1.5s) so a quick websocket reconnect no longer flashes the bar and shifts the layout. The bar now appears only if the connection stays down past the grace window, matching the admin dashboard's disconnect banner.

--- a/apps/chat-widget/src/ui.test.ts
+++ b/apps/chat-widget/src/ui.test.ts
@@ -502,11 +502,44 @@ describe('ui: connection state banner', () => {
     ($('.launcher')).click();
   });
 
-  it('hides on connected, shows on reconnecting', () => {
+  it('shows the reconnecting bar only after the grace period, then hides on connected', () => {
+    vi.useFakeTimers();
     controller!.setConnectionState('reconnecting');
+    expect(($('.status')).hidden).toBe(true);
+    vi.advanceTimersByTime(1400);
+    expect(($('.status')).hidden).toBe(true);
+    vi.advanceTimersByTime(200);
     expect(($('.status')).hidden).toBe(false);
     expect($('.status').textContent).toMatch(/reconnect/i);
     controller!.setConnectionState('connected');
     expect(($('.status')).hidden).toBe(true);
+  });
+
+  it('never shows the bar when a reconnect succeeds within the grace period', () => {
+    vi.useFakeTimers();
+    controller!.setConnectionState('reconnecting');
+    vi.advanceTimersByTime(800);
+    controller!.setConnectionState('connecting');
+    controller!.setConnectionState('connected');
+    expect(($('.status')).hidden).toBe(true);
+    vi.advanceTimersByTime(5000);
+    expect(($('.status')).hidden).toBe(true);
+  });
+
+  it('keeps the grace clock running across reconnecting/connecting bounces', () => {
+    vi.useFakeTimers();
+    controller!.setConnectionState('reconnecting');
+    vi.advanceTimersByTime(1000);
+    controller!.setConnectionState('connecting');
+    controller!.setConnectionState('reconnecting');
+    expect(($('.status')).hidden).toBe(true);
+    vi.advanceTimersByTime(600);
+    expect(($('.status')).hidden).toBe(false);
+  });
+
+  it('shows the disconnected bar immediately on closed', () => {
+    controller!.setConnectionState('closed');
+    expect(($('.status')).hidden).toBe(false);
+    expect($('.status').textContent).toMatch(/disconnect/i);
   });
 });

--- a/apps/chat-widget/src/ui.ts
+++ b/apps/chat-widget/src/ui.ts
@@ -8,6 +8,8 @@ import { renderMarkdownInto } from './markdown.ts';
 
 export type ConnectionLabel = 'connected' | 'reconnecting' | 'closed' | 'idle' | 'connecting';
 
+const RECONNECT_STATUS_GRACE_MS = 1500;
+
 export interface UiHooks {
   onSend: (text: string) => void;
   onTypingIntent: (intent: 'typing' | 'stopped') => void;
@@ -386,16 +388,46 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
   let connectionDisabled = false;
   let sendingNow = false;
 
+  let reconnectGraceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function showReconnectingStatus(): void {
+    panel.statusEl.hidden = false;
+    panel.statusEl.textContent = strings.statusReconnecting;
+    connectionDisabled = true;
+    refreshComposerState();
+  }
+
   function setConnectionState(state: ConnectionLabel): void {
-    if (state === 'connected' || state === 'idle' || state === 'connecting') {
+    if (state === 'connecting') {
+      // Part of an in-flight (re)connect. Leave the bar and any pending grace
+      // timer untouched: a first connect shows nothing, and a mid-outage bounce
+      // (reconnecting → connecting → reconnecting) must not reset the grace clock,
+      // otherwise the bar would never appear during a sustained outage.
+      return;
+    }
+    if (state === 'connected' || state === 'idle') {
+      if (reconnectGraceTimer) {
+        clearTimeout(reconnectGraceTimer);
+        reconnectGraceTimer = null;
+      }
       panel.statusEl.hidden = true;
       panel.statusEl.textContent = '';
       connectionDisabled = false;
     } else if (state === 'reconnecting') {
-      panel.statusEl.hidden = false;
-      panel.statusEl.textContent = strings.statusReconnecting;
-      connectionDisabled = true;
+      // Defer the status bar by a grace period so a quick reconnect doesn't flash
+      // the bar and shift the layout. If we're already showing it (or already
+      // waiting), keep the existing timer running.
+      if (!panel.statusEl.hidden || reconnectGraceTimer) return;
+      reconnectGraceTimer = setTimeout(() => {
+        reconnectGraceTimer = null;
+        showReconnectingStatus();
+      }, RECONNECT_STATUS_GRACE_MS);
+      return;
     } else if (state === 'closed') {
+      if (reconnectGraceTimer) {
+        clearTimeout(reconnectGraceTimer);
+        reconnectGraceTimer = null;
+      }
       panel.statusEl.hidden = false;
       panel.statusEl.textContent = strings.statusDisconnected;
       connectionDisabled = true;


### PR DESCRIPTION
## What

In the chat widget, a brief websocket disconnect that reconnects quickly would flash the **"Reconnecting…"** status bar for a moment, pushing the conversation layout down and back up.

This defers the status bar behind a **1.5s grace period**: a fast reconnect now surfaces nothing, and the bar only appears if the connection stays down past the grace window.

## How

All in `apps/chat-widget/src/ui.ts` `setConnectionState` — `realtime.ts` keeps reporting true connection state; the UI decides whether the blip is worth showing.

- `reconnecting` → arms a `RECONNECT_STATUS_GRACE_MS` (1500ms) timer instead of showing the bar immediately.
- `connected`/`idle` → cancels the timer and hides the bar, so recovery within the window shows nothing and never shifts the layout.
- `connecting` is a no-op that doesn't reset the grace clock — during a sustained outage the state oscillates `reconnecting → connecting → reconnecting` (backoff starts at 250ms), so the grace measures cumulative downtime, not time in the current state. Otherwise the bar would never appear.
- First-ever connect (`idle → connecting → connected`) still shows nothing, since only `reconnecting` arms the timer.
- `closed` (caller-initiated teardown) stays immediate.

The 1.5s window matches the existing admin-dashboard disconnect banner (`DISCONNECT_GRACE_MS` in `packages/dashboard-pages/src/components/system-alerts-banner.tsx`). The widget is a standalone embeddable bundle and can't import that React code, so this is the same idea implemented independently.

## Tests

`apps/chat-widget/src/ui.test.ts` — updated the banner test and added coverage for: shows only after the grace period, never shows when reconnect succeeds within it, grace clock spans reconnecting/connecting bounces, and immediate `closed`. **39/39 pass**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)