### PR TITLE
fix(dashboard-pages): show "Saved" confirmation for the managed provider

### DIFF
--- a/.changeset/managed-ai-saved-confirmation.md
+++ b/.changeset/managed-ai-saved-confirmation.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Show a "Saved" confirmation after selecting the managed provider in AI settings. Previously the confirmation only appeared for BYOK providers, because the managed save path never set the message.

--- a/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
+++ b/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
@@ -104,6 +104,7 @@ export function ProviderCard({
       setApiKey('');
       setKeyDirty(false);
       const managedModels = managedPreset?.models ?? [];
+      setMessage(tCommon('saved'));
       onSaved?.(updated, { supported: managedModels.length > 0, models: managedModels });
     } catch (err) {
       setError(translate(err) || t('errors.test'));


### PR DESCRIPTION
## What

The AI settings provider card only set the confirmation message on the BYOK save path. Selecting the managed provider saved successfully but showed no feedback, because `saveManaged()` cleared the message at the start and never set it again on success — so the `message` span had nothing to render.

This sets it to the shared `common.saved` ("Saved.") string after a successful managed save, matching the BYOK flow.

## Change

`packages/dashboard-pages/src/components/agent-config/provider-card.tsx` — add `setMessage(tCommon('saved'))` in the success branch of `saveManaged()`. `tCommon` and `setMessage` were already in scope; `common.saved` is an existing key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)