### PR TITLE
fix: keep chat widget composer focused after sending

### DIFF
--- a/.changeset/chat-widget-input-focus.md
+++ b/.changeset/chat-widget-input-focus.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/chat-widget": patch
+---
+
+Keep the composer focused after sending a message. Disabling the textarea while a send was in flight dropped its focus and re-enabling it didn't restore it, forcing the user to click back into the field before each new message. The widget now restores focus to the composer once the send completes.

--- a/apps/chat-widget/src/ui.test.ts
+++ b/apps/chat-widget/src/ui.test.ts
@@ -482,6 +482,26 @@ describe('ui: composer', () => {
     expect(onTypingIntent).toHaveBeenCalledWith('stopped');
   });
 
+  it('restores focus to the textarea after a send completes', () => {
+    const ta = $<HTMLTextAreaElement>('textarea');
+    ta.focus();
+    controller!.setSending(true);
+    expect(ta.disabled).toBe(true);
+    controller!.setSending(false);
+    expect(ta.disabled).toBe(false);
+    expect(shadowRoot().activeElement).toBe(ta);
+  });
+
+  it('does not refocus the textarea while still disconnected', () => {
+    const ta = $<HTMLTextAreaElement>('textarea');
+    controller!.setConnectionState('reconnecting');
+    const focusSpy = vi.spyOn(ta, 'focus');
+    controller!.setSending(true);
+    controller!.setSending(false);
+    expect(ta.disabled).toBe(true);
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+
   it('sends on Enter, not on Shift+Enter', () => {
     setText('hi');
     const ta = $<HTMLTextAreaElement>('textarea');

--- a/apps/chat-widget/src/ui.ts
+++ b/apps/chat-widget/src/ui.ts
@@ -404,8 +404,12 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
   }
 
   function setSending(sending: boolean): void {
+    const wasSending = sendingNow;
     sendingNow = sending;
     refreshComposerState();
+    if (wasSending && !sending && !connectionDisabled && view === 'chat') {
+      panel.textarea.focus();
+    }
   }
 
   function canSend(): boolean {


### PR DESCRIPTION
## Problem

In the chat widget, after pressing send the input box loses focus, so you have to click back into the field before typing each new message.

## Root cause

Sending calls `setSending(true)` → `refreshComposerState()`, which disables the textarea while the send is in flight (`panel.textarea.disabled = true`). Disabling a focused element makes the browser drop its focus, and re-enabling it on completion (`setSending(false)`) doesn't restore it.

## Fix

`setSending` now restores focus to the composer on the sending→idle transition, guarded the same way as the existing focus calls in `open()` / `setView()` — only when finishing a send, the composer isn't locked by a connection drop, and we're in the chat view.

## Notes

On mobile this keeps the on-screen keyboard open between messages (matches the desktop "keep typing" intent, but is a behavior change from today where the keyboard collapsed after each send). Happy to suppress the refocus on touch devices if preferred.

## Verification

- `pnpm -F @getmunin/chat-widget test` → 111 passed, including two new tests (focus restored after send completes; focus not stolen while disconnected).
- `pnpm -F @getmunin/chat-widget typecheck` → clean.
- Added a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)