### PR TITLE
fix(chat-widget): reconcile refocus test with reconnect grace period

### DIFF
--- a/apps/chat-widget/src/ui.test.ts
+++ b/apps/chat-widget/src/ui.test.ts
@@ -492,9 +492,9 @@ describe('ui: composer', () => {
     expect(shadowRoot().activeElement).toBe(ta);
   });
 
-  it('does not refocus the textarea while still disconnected', () => {
+  it('does not refocus the textarea while disconnected', () => {
     const ta = $<HTMLTextAreaElement>('textarea');
-    controller!.setConnectionState('reconnecting');
+    controller!.setConnectionState('closed');
     const focusSpy = vi.spyOn(ta, 'focus');
     controller!.setSending(true);
     controller!.setSending(false);


### PR DESCRIPTION
## Why

`main` went red after #519 and #521 merged. Each was green alone, but they conflict on the chat-widget composer:

- **#519** defers the `reconnecting` state behind a 1.5s grace period, so `setConnectionState('reconnecting')` no longer locks the composer immediately (the lock now happens when the bar actually shows, after grace).
- **#521** added a refocus-after-send test asserting that `'reconnecting'` locks the composer and suppresses refocus *immediately* — which was true before #519.

Combined, `setSending(false)` re-enables and refocuses the textarea during the grace window, failing `does not refocus the textarea while still disconnected`.

## Fix

Test-only. Drive the test with the `'closed'` state, which represents a real disconnect and locks the composer immediately (per #519, `'closed'` "stays immediate"). This preserves both features' intended behavior — a sub-grace reconnect blip keeps the composer usable (#519), and a genuine disconnect blocks re-enable/refocus (#521) — and the assertion now reflects the merged design.

`pnpm -F @getmunin/chat-widget test` → 114 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)