### PR TITLE
fix(dashboard-pages): use providerConfigured in server-side setup gate

### DIFF
--- a/.changeset/setup-gate-server-managed-provider.md
+++ b/.changeset/setup-gate-server-managed-provider.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Fix infinite /setup ↔ /oauth/consent redirect loop for managed-provider orgs.
+
+The server-side onboarding gate (`redirectIfSetupIncomplete`) still keyed off `providerApiKeySet`, while the client setup/dashboard gates were migrated to `providerConfigured` (= own key OR a usable host-supplied default provider) in #513. For orgs running on a managed default provider — which never set their own key — the two gates permanently disagreed: the setup page considered onboarding complete and forwarded to OAuth consent, while the consent page considered it incomplete and bounced back to setup. `redirectIfSetupIncomplete` now reads `providerConfigured`, matching the client gates.

--- a/packages/dashboard-pages/src/auth/server-session.ts
+++ b/packages/dashboard-pages/src/auth/server-session.ts
@@ -16,7 +16,7 @@ interface MembershipDto {
 }
 
 interface AgentConfigStatusDto {
-  providerApiKeySet: boolean;
+  providerConfigured: boolean;
 }
 
 async function fetchWithCookies<T>(path: string, cookieHeader: string): Promise<T | null> {
@@ -87,7 +87,7 @@ export async function redirectIfSetupIncomplete(opts: {
   if (role !== 'owner' && role !== 'admin') return;
 
   const orgNamed = active.name.trim().length > 0;
-  const setupIncomplete = !config.providerApiKeySet || !orgNamed;
+  const setupIncomplete = !config.providerConfigured || !orgNamed;
   if (!setupIncomplete) return;
 
   const query = serializeSearchParams(opts.searchParams);


### PR DESCRIPTION
## Problem

Authorizing the Munin MCP server via OAuth lands managed-provider orgs in an infinite `/setup ↔ /dashboard/oauth/consent` redirect loop (observed in both dev and prod; affects both new signups and existing logins).

## Root cause

#513 introduced `/v1/agent-config.providerConfigured` (`providerApiKeySet || defaultProviderAvailable`) and migrated the **client** setup/dashboard gates (`useAgentConfigStatus` → `useSetupGate`, `useDashboardGate`) to read it — but the **server-side** gate `redirectIfSetupIncomplete` (used by the OAuth consent page) was missed and still keyed off `providerApiKeySet`.

For an org running on a managed/host-supplied default provider, `providerApiKeySet = false` but `providerConfigured = true`, so the two gates permanently disagree:

| Gate | Reads | Verdict for managed org |
|------|-------|------|
| Setup page (client) | `providerConfigured` = true | "complete" → forward to `/dashboard/oauth/consent` |
| Consent page (server) | `providerApiKeySet` = false | "incomplete" → bounce back to `/setup` |

→ infinite loop.

## Fix

`redirectIfSetupIncomplete` now reads `providerConfigured`, matching the client gates. Two-line change; the remaining `providerApiKeySet` references (managed-badge detection, stored-key placeholders, the managed model-fetch skip) are intentional and unchanged.

## Verification

- Audited every setup/dashboard/consent redirect decision: this server gate was the only consumer #513 missed; both client gates already use `providerConfigured`.
- `pnpm -F @getmunin/dashboard-pages typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)