### PR TITLE
fix(conv): treat human teammate replies as colleague turns, not customer questions

### DIFF
--- a/.changeset/teammate-not-customer.md
+++ b/.changeset/teammate-not-customer.md
@@ -1,0 +1,8 @@
+---
+'@getmunin/agent-runtime': patch
+'@getmunin/core': patch
+---
+
+Stop the self-service bot from mistaking a human teammate's reply for a customer question.
+
+When a human teammate replied in a conversation, their message was fed to the model as a `user` turn with only a weak `[human teammate]` text prefix — the same role as the end-user — so the model couldn't reliably tell its own colleague from the customer. It would answer a teammate's question to the customer as if it had been asked of the bot. A teammate's message now maps to the `staff` author type in `toRuntimeHistory` and renders as an assistant-side colleague (`role: 'assistant'`, `name: 'teammate'`) in `historyToChatMessage`, and the default system prompt now explains that teammate messages are on the bot's side and never questions for it to answer.

--- a/packages/agent-runtime/src/munin-rest.test.ts
+++ b/packages/agent-runtime/src/munin-rest.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { createMuninRestClient, type ConversationDetail } from './munin-rest.ts';
+
+function makeDetail(messages: ConversationDetail['messages']): ConversationDetail {
+  return {
+    id: 'conv_1',
+    status: 'open',
+    endUserId: 'eu_1',
+    assigneeUserId: null,
+    claim: null,
+    messages,
+  };
+}
+
+describe('toRuntimeHistory', () => {
+  const client = createMuninRestClient({
+    baseUrl: 'http://stub',
+    adminApiKey: 'stub',
+    fetch: () => Promise.reject(new Error('network not used in this test')),
+  });
+
+  it('remaps a human teammate (authorType "user") to the assistant-side staff role', () => {
+    const history = client.toRuntimeHistory(
+      makeDetail([
+        { id: 'm1', authorType: 'end_user', body: 'can you source this wood?', createdAt: 't1' },
+        { id: 'm2', authorType: 'agent', body: 'a teammate will follow up', createdAt: 't2' },
+        { id: 'm3', authorType: 'user', body: 'what are you planning to make?', createdAt: 't3' },
+        { id: 'm4', authorType: 'end_user', body: 'a rocking chair', createdAt: 't4' },
+      ]),
+    );
+
+    expect(history.map((m) => m.authorType)).toEqual(['end_user', 'agent', 'staff', 'end_user']);
+    const teammate = history[2];
+    expect(teammate?.authorType).toBe('staff');
+    expect(teammate?.body).toBe('what are you planning to make?');
+  });
+
+  it('drops internal messages', () => {
+    const history = client.toRuntimeHistory(
+      makeDetail([
+        { id: 'm1', authorType: 'end_user', body: 'hi', createdAt: 't1' },
+        { id: 'm2', authorType: 'agent', body: 'internal note', createdAt: 't2', internal: true },
+      ]),
+    );
+    expect(history).toHaveLength(1);
+    expect(history[0]?.authorType).toBe('end_user');
+  });
+});

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -274,11 +274,8 @@ export function createMuninRestClient(opts: CreateMuninRestClientOptions): Munin
       return detail.messages
         .filter((m) => !m.internal)
         .map((m) => ({
-          authorType: m.authorType,
-          body:
-            m.authorType === 'user'
-              ? `[human teammate] ${m.body}`
-              : m.body,
+          authorType: m.authorType === 'user' ? 'staff' : m.authorType,
+          body: m.body,
           createdAt: m.createdAt,
         }));
     },

--- a/packages/agent-runtime/src/runtime.test.ts
+++ b/packages/agent-runtime/src/runtime.test.ts
@@ -222,8 +222,9 @@ describe('runAgent', () => {
     expect(sent[1]?.content).toContain('<tool_result');
     expect(sent[2]).toMatchObject({ role: 'user', content: 'first user msg' });
     expect(sent[3]).toMatchObject({ role: 'assistant', content: 'agent reply' });
-    expect(sent[4]?.role).toBe('user');
-    expect(sent[4]?.name).toBe('staff');
+    expect(sent[4]?.role).toBe('assistant');
+    expect(sent[4]?.name).toBe('teammate');
+    expect(sent[4]?.content).toBe('[Human teammate] staff note');
     expect(sent[5]).toMatchObject({ role: 'user', content: 'second user msg' });
   });
 });

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -135,7 +135,7 @@ function historyToChatMessage(msg: ConversationMessage): ChatMessage {
     case 'agent':
       return { role: 'assistant', content: msg.body };
     case 'staff':
-      return { role: 'user', name: 'staff', content: `[staff message] ${msg.body}` };
+      return { role: 'assistant', name: 'teammate', content: `[Human teammate] ${msg.body}` };
     case 'system':
       return { role: 'system', content: msg.body };
     default:

--- a/packages/core/src/prompts/system.ts
+++ b/packages/core/src/prompts/system.ts
@@ -9,6 +9,8 @@ If the answer isn't in the knowledge base, or the user is asking for something y
 
 When you flag a conversation for a human, let the end-user know a teammate will follow up with them here in this conversation shortly. Don't redirect them to email, phone, or an in-person visit, and don't volunteer the business's contact details (address, phone, email, hours), unless the end-user explicitly asks how to reach the business directly. The goal is to keep the lead in this conversation so the human can pick it up where you left off, not to route them off to another channel.
 
+You're not the only one who can reply here — a human teammate from your own team may step into the conversation. Their messages are marked as coming from a teammate and are on your side, not the customer's. A teammate's message is never a question for you to answer, and if a teammate asks the customer something, let the customer's reply answer it — don't respond on the teammate's or the customer's behalf. Only the end-user's messages are addressed to you. Don't repeat or contradict something a teammate already said, and don't tell the customer "a teammate will follow up" when a teammate is already replying here. Keep helping with whatever the customer still needs.
+
 Never use placeholders like \`[Name]\`, \`[Phone Number]\`, \`[Address]\`, \`[Your Company]\`, \`[Link]\`, or any bracketed/parenthesized fill-in markers. Every message you send must be complete prose that can be delivered verbatim. If you don't have a piece of information, either ask the end-user for it directly or omit it from the reply — don't leave a blank for someone else to fill in.
 
 Be honest about what you know. Be brief. Match the user's language and tone.`;


### PR DESCRIPTION
## Problem

When a human teammate replies in a live conversation, the self-service bot mistakes their message for a customer question and answers it.

Two real examples (chat widget):

- Teammate asks the customer *"Sure, we can source that. What are you planning to make?"* → customer answers *"A rocking chair."* → bot replies *"We don't have a specific project in mind—we're here to help **you** source the wood…"* — i.e. it answered its own teammate's question as if it had been asked of the bot.
- Teammate says *"Sure, no problem. I will be here to 6 PM today."* → customer says *"Great thanks!"* → bot re-emits *"A teammate will follow up with you shortly to confirm the after-hours pickup."* on top of the teammate who just followed up.

## Root cause

Both the customer (`end_user`) and a human teammate (`user`) collapsed into OpenAI `role: 'user'`, distinguished only by a weak `[human teammate]` text prefix injected in `toRuntimeHistory`. The system prompt never explained that prefix or that a teammate is on the bot's own side. Structurally the model saw two consecutive `user` turns and answered the latest — losing track of who asked what.

## Fix

Model the teammate as the assistant-side colleague they are, regardless of prompt customization:

- `munin-rest.ts` (`toRuntimeHistory`): a teammate message (`authorType: 'user'`) now maps to the `staff` author type instead of a prefixed `user`.
- `runtime.ts` (`historyToChatMessage`): the `staff` branch now renders as `role: 'assistant'`, `name: 'teammate'`, `[Human teammate] …`.
- `core/src/prompts/system.ts`: the default system prompt now explains that teammate messages are on the bot's side, are never questions for it to answer, and that it shouldn't repeat "a teammate will follow up" when a teammate is already replying.

The runtime still triggers a reply pass on raw teammate messages (`handle`/`lastInbound` read the unmapped conversation detail), so the bot stays in the loop and keeps collaborating — it just understands the roles now. The audit pass's "what was the customer's question" anchor also improves: it no longer mistakes a teammate line for the customer's question.

## Tests

- Updated the role-mapping test in `runtime.test.ts`.
- Added `munin-rest.test.ts` covering the teammate→staff remap and internal-message filtering.
- `pnpm -F @getmunin/agent-runtime test` → 133 passed; Turbo typecheck on `@getmunin/core` + `@getmunin/agent-runtime` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)