### PR TITLE
perf(curator): cut token usage via tighter tool allowlists and lower iteration cap

### DIFF
--- a/.changeset/curator-tool-allowlists.md
+++ b/.changeset/curator-tool-allowlists.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/types': patch
+'@getmunin/agent-host': patch
+---
+
+Reduce curator token usage: tighter per-skill tool allowlists and a lower iteration cap.
+
+- **Tighter tool allowlists.** `TOOL_PREFIXES_BY_URI` in the job catalog gated each curator skill by broad module prefixes (`conv_`, `kb_`, `crm_`, `outreach_`), which loaded 10–30 tool schemas into the model context on every turn of the tool loop — re-sent on each iteration. Each scheduled/event-driven skill now allowlists only the exact tools its procedure actually calls (e.g. `set-topic-and-title` drops from all `conv_*` to 5 tools; `clean-contact-data` drops the unused `conv_` prefix entirely; `review-stale-entries` drops every mutating `cms_*` tool, enforcing its propose-only invariant at the runtime layer). Behavior is unchanged — the dropped tools were either operator-review-loop tools or ones the skills never call.
+- **Lower iteration cap.** Curator skill passes now stop after `CURATOR_MAX_TOOL_ITERATIONS` (16) tool-loop iterations instead of 24. Since the full prompt prefix is re-sent on every iteration, this clips the worst-case per-job token spend; batch sweeps that don't finish in one pass resume on the next scheduled run (dedupe keeps them idempotent).

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -77,6 +77,7 @@ const RECONCILE_INTERVAL_MS = 30_000;
 const CURATOR_LEASE_SECONDS = 600;
 const CURATOR_MAX_SCHEDULED_DELAY_MS = 24 * 60 * 60 * 1000;
 const CONVERSATION_SWEEP_LIMIT = 50;
+const CURATOR_MAX_TOOL_ITERATIONS = 16;
 
 const DEFAULT_END_USER_AGENT_SCOPES: readonly string[] = [
   'conv:read',
@@ -609,7 +610,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
             skillUri: job.jobUri,
             userPrompt: job.userPrompt,
             assistantName: job.assistantName,
-            maxToolIterations: 24,
+            maxToolIterations: CURATOR_MAX_TOOL_ITERATIONS,
             maxHistoryChars: opts.config.maxHistoryChars,
             providerImpl: opts.provider,
             allowedToolPrefixes: prefixes ? [...prefixes] : undefined,

--- a/packages/backend-core/src/modules/conv/set-topic-job.test.ts
+++ b/packages/backend-core/src/modules/conv/set-topic-job.test.ts
@@ -7,7 +7,13 @@ describe('buildSetTopicAndTitleJob', () => {
     expect(SET_TOPIC_AND_TITLE_SKILL_URI).toBe('skill://conv/set-topic-and-title');
     expect(KNOWN_SKILL_URIS.has(SET_TOPIC_AND_TITLE_SKILL_URI)).toBe(true);
     expect(tierFor(SET_TOPIC_AND_TITLE_SKILL_URI)).toBe('fast');
-    expect(toolPrefixesFor(SET_TOPIC_AND_TITLE_SKILL_URI)).toEqual(['conv_']);
+    expect(toolPrefixesFor(SET_TOPIC_AND_TITLE_SKILL_URI)).toEqual([
+      'conv_get_conversation',
+      'conv_list_topics',
+      'conv_create_topic',
+      'conv_set_topic',
+      'conv_set_subject',
+    ]);
   });
 
   it('names the conversation and carries an idempotent dedupe key', () => {

--- a/packages/types/src/job-catalog.test.ts
+++ b/packages/types/src/job-catalog.test.ts
@@ -34,8 +34,14 @@ describe('tierFor', () => {
 });
 
 describe('toolPrefixesFor', () => {
-  it('returns the configured prefixes for a known skill', () => {
-    expect(toolPrefixesFor('skill://kb/review-content')).toEqual(['conv_', 'kb_']);
+  it('returns the configured tool allowlist for a known skill', () => {
+    expect(toolPrefixesFor('skill://kb/review-content')).toEqual([
+      'conv_list_conversations',
+      'conv_get_conversation',
+      'kb_search',
+      'kb_list_documents',
+      'kb_propose_curation_candidate',
+    ]);
   });
   it('returns undefined for unmapped URIs', () => {
     expect(toolPrefixesFor('task://web/scrape-website')).toBeUndefined();

--- a/packages/types/src/job-catalog.ts
+++ b/packages/types/src/job-catalog.ts
@@ -40,14 +40,60 @@ export function priorityFor(uri: string): number {
 }
 
 const TOOL_PREFIXES_BY_URI: ReadonlyMap<string, readonly string[]> = new Map([
-  ['skill://kb/review-content', ['conv_', 'kb_']],
-  ['skill://crm/clean-contact-data', ['conv_', 'crm_']],
-  ['skill://crm/extract-contact-from-message', ['conv_', 'crm_']],
-  ['skill://outreach/draft-initial-email', ['conv_', 'kb_', 'crm_', 'outreach_']],
-  ['skill://outreach/draft-reply-email', ['conv_', 'kb_', 'crm_', 'outreach_']],
-  ['skill://cms/review-stale-entries', ['cms_']],
+  [
+    'skill://kb/review-content',
+    [
+      'conv_list_conversations',
+      'conv_get_conversation',
+      'kb_search',
+      'kb_list_documents',
+      'kb_propose_curation_candidate',
+    ],
+  ],
+  [
+    'skill://crm/clean-contact-data',
+    ['crm_list_merge_proposals', 'crm_list_contacts', 'crm_propose_merge'],
+  ],
+  [
+    'skill://crm/extract-contact-from-message',
+    ['conv_get_conversation', 'crm_find_contact', 'crm_create_contact', 'crm_update_contact'],
+  ],
+  [
+    'skill://outreach/draft-initial-email',
+    [
+      'outreach_list_campaigns',
+      'crm_list_contacts_in_segment',
+      'outreach_list_proposals',
+      'outreach_propose_initial',
+      'kb_search',
+    ],
+  ],
+  [
+    'skill://outreach/draft-reply-email',
+    [
+      'conv_get_conversation',
+      'outreach_get_campaign',
+      'outreach_list_proposals',
+      'outreach_propose_reply',
+      'kb_search',
+    ],
+  ],
+  [
+    'skill://cms/review-stale-entries',
+    [
+      'cms_list_collections',
+      'cms_list_entries',
+      'cms_list_inbound_references',
+      'cms_list_assets',
+      'cms_search',
+      'cms_list_versions',
+    ],
+  ],
   ['skill://conv/strip-email-signature', ['conv_strip_message_signature']],
-  ['skill://conv/set-topic-and-title', ['conv_']],
+  [
+    'skill://conv/set-topic-and-title',
+    ['conv_get_conversation', 'conv_list_topics', 'conv_create_topic', 'conv_set_topic', 'conv_set_subject'],
+  ],
 ]);
 
 export function toolPrefixesFor(uri: string): readonly string[] | undefined {


### PR DESCRIPTION
## Why

The curator background agent was consuming **18k–58k tokens per job** in prod. The static prompt prefix (skill markdown + tool JSON schemas) is re-sent on *every* turn of the tool loop (`runtime.ts:63`), so both the **tool-set size** and the **iteration count** compound the cost. This PR attacks both.

## Changes

### 1. Tighter per-skill tool allowlists (`packages/types/src/job-catalog.ts`)

`TOOL_PREFIXES_BY_URI` gated each curator skill by broad module prefixes (`conv_`, `kb_`, `crm_`, `outreach_`), loading 10–30 tool schemas into context every turn. Each skill now allowlists **only the exact tools its procedure calls**, verified against the skill markdown:

| Skill | Before | After |
|---|---|---|
| `conv/set-topic-and-title` (per-conversation, highest volume) | all `conv_*` (~30) | 5 exact |
| `kb/review-content` | `conv_`,`kb_` (~47) | 5 exact |
| `crm/clean-contact-data` | `conv_`,`crm_` (~45) | 3 exact (drops unused `conv_`) |
| `crm/extract-contact-from-message` | `conv_`,`crm_` (~45) | 4 exact |
| `outreach/draft-initial-email` | 4 prefixes (~60) | 5 exact |
| `outreach/draft-reply-email` | 4 prefixes (~60) | 5 exact |
| `cms/review-stale-entries` | `cms_` (~28) | 6 read-only |

**Behavior is unchanged** — dropped tools were either operator-review-loop tools or ones the skill never calls. A disallowed call returns a recoverable `isError` result (not a throw), and dropped tools are filtered out of `listTools()` entirely, so the model never sees them.

Bonus: `review-stale-entries` drops every mutating `cms_*` tool, so its propose-only invariant is now enforced at the runtime layer instead of by prompt instruction alone.

### 2. Lower the curator iteration cap (`packages/agent-host/src/runner.service.ts`)

Curator skill passes now stop after `CURATOR_MAX_TOOL_ITERATIONS` (**16**, was a hardcoded 24). Clips worst-case per-job token spend; unfinished batch sweeps resume on the next scheduled run (dedupe keys keep them idempotent). Kept well above the conversation-side default of 8 so batch sweeps retain headroom.

## Verification

- `pnpm typecheck` — all 29 tasks pass (incl. `backend-core`/`agent-host` which consume `toolPrefixesFor`).
- `@getmunin/types`, `@getmunin/agent-host`, and `set-topic-job` test suites pass; updated the two tests asserting the old allowlists.
- No docs-fixture/OpenAPI regen needed — curator tool allowlists aren't part of the public MCP catalog (pre-commit `openapi:generate` produced no diff).

## Changeset

`patch` on `@getmunin/types` + `@getmunin/agent-host`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)