### PR TITLE
fix(auth): resume OAuth authorize request through social login

### DIFF
--- a/.changeset/social-login-oauth-resume.md
+++ b/.changeset/social-login-oauth-resume.md
@@ -1,0 +1,7 @@
+---
+"@getmunin/dashboard-pages": patch
+---
+
+fix(auth): carry the pending OAuth authorize request through Google/GitHub social login
+
+When a client (e.g. an MCP server in Claude) starts the OAuth 2.1 authorization flow and the user signs in with a social provider, the social `callbackURL` now resumes the original `/auth/oauth2/authorize` request instead of dropping to the dashboard. Previously only the email/password path preserved the pending authorize request, so social logins skipped the consent screen and never completed authorization.

--- a/packages/dashboard-pages/src/auth/post-signin-redirect.ts
+++ b/packages/dashboard-pages/src/auth/post-signin-redirect.ts
@@ -25,3 +25,7 @@ export function oauthParamString(params: URLSearchParams): string {
   if (!hasOauthAuthorizeParams(params)) return '';
   return params.toString();
 }
+
+export function socialCallbackUrl(params: URLSearchParams, redirectTo: string): string {
+  return resumeOauthAuthorizeUrl(params) ?? absoluteCallbackUrl(redirectTo);
+}

--- a/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
@@ -7,10 +7,10 @@ import { authClient } from '../../auth-client';
 import { Link, useRouter } from '../../i18n-navigation';
 import { useTranslateError } from '../../i18n/translate-error';
 import {
-  absoluteCallbackUrl,
   safeRedirect,
   resumeOauthAuthorizeUrl,
   hasOauthAuthorizeParams,
+  socialCallbackUrl,
 } from '../../auth/post-signin-redirect';
 import {
   AuthShell,
@@ -107,7 +107,7 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
               onClick={() => {
                 void authClient.signIn.social({
                   provider: 'google',
-                  callbackURL: absoluteCallbackUrl(redirectTo),
+                  callbackURL: socialCallbackUrl(params, redirectTo),
                 });
               }}
             >
@@ -121,7 +121,7 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
               onClick={() => {
                 void authClient.signIn.social({
                   provider: 'github',
-                  callbackURL: absoluteCallbackUrl(redirectTo),
+                  callbackURL: socialCallbackUrl(params, redirectTo),
                 });
               }}
             >

--- a/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
@@ -11,6 +11,7 @@ import {
   absoluteCallbackUrl,
   safeRedirect,
   hasOauthAuthorizeParams,
+  socialCallbackUrl,
 } from '../../auth/post-signin-redirect';
 import {
   AuthShell,
@@ -132,7 +133,7 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
               onClick={() => {
                 void authClient.signIn.social({
                   provider: 'google',
-                  callbackURL: absoluteCallbackUrl(redirectTo),
+                  callbackURL: socialCallbackUrl(params, redirectTo),
                 });
               }}
             >
@@ -146,7 +147,7 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
               onClick={() => {
                 void authClient.signIn.social({
                   provider: 'github',
-                  callbackURL: absoluteCallbackUrl(redirectTo),
+                  callbackURL: socialCallbackUrl(params, redirectTo),
                 });
               }}
             >


### PR DESCRIPTION
## Problem

When a client (e.g. an MCP server added in Claude) starts the OAuth 2.1 authorization flow against `/mcp` and the user is sent to log in, signing in with **Google/GitHub social login** never reaches the consent screen — the authorization silently drops to the dashboard and never completes. Email/password login works fine.

## Root cause

The pending OAuth authorize request (`client_id`, `redirect_uri`, `response_type=code`, `scope`…) was only preserved on the email/password path:

- **Email/password** (`login-form.tsx`): after sign-in, calls `resumeOauthAuthorizeUrl(params)` → redirects to `${apiBase}/auth/oauth2/authorize?…` → consent screen.
- **Social** (`login-form.tsx` / `signup-form.tsx`): handed BetterAuth `callbackURL: absoluteCallbackUrl(redirectTo)` (i.e. `/dashboard`). The authorize params never round-tripped through Google, so the request was lost.

## Fix

Added `socialCallbackUrl(params, redirectTo)` which returns the resume authorize URL when OAuth params are present, otherwise the normal redirect. Wired into the Google and GitHub buttons in both the login and signup forms. The resume URL targets the backend `baseUrl` origin, which is already in BetterAuth's `trustedOrigins`, so the cross-origin `callbackURL` is honored.

After the social round-trip, BetterAuth redirects to `/auth/oauth2/authorize?…`, the provider sees an authenticated session, and the user reaches consent — matching the email/password behavior.

## Notes

- Social **signup** now goes straight to consent (like login) rather than detouring through `/setup`; the setup wizard remains reachable from the dashboard.
- `pnpm typecheck` passes across the workspace.
- Could not execute the live Google round-trip from the dev environment (needs a real Google client + browser); the final hop is verified by reading the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)