### PR TITLE
docs(readme): move "See it in action" up under the hero video

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Munin is an open-source customer platform built for the agentic era (Knowledge B
   </a>
 </p>
 
+## See it in action
+
+> Lovable builds your frontend. Munin spins up your operations. One prompt, one MCP endpoint — and the agents do the rest.
+
+<p align="center">
+  <a href="https://vimeo.com/1204180225?autoplay=0&utm_source=github&utm_medium=readme&utm_campaign=demo-video">
+    <img src=".github/assets/demo-thumbnail.png" alt="Watch: Lovable builds the frontend while Munin stands up everything behind it" width="100%">
+  </a>
+</p>
+
+Watch Lovable build a real website from a single prompt while Munin stands up everything behind it — the CMS the blog reads from, a seeded knowledge base, analytics, and a chat widget that already knows the business. No admin UI, no dashboard to wire up; the agent does the work, over one MCP endpoint. Then a real customer conversation plays out: answered from the knowledge base, handed off to a human when it matters, and picked back up by the agent to close.
+
 ## Why I built this
 
 Hi — Kjell here. Last year my company was paying HubSpot $500/month for three users who barely touched it. Every workflow worth having lived a tier above the one we were on.
@@ -32,18 +44,6 @@ Munin isn't the AI — it's what your AI uses. You bring the agent, write the pr
 - **Playbooks + skills** — packaged markdown procedures (`skill://module/<verb-object>`) the agent reads via MCP resources to follow multi-step flows.
 - **Data portability** — symmetric `*_export` / `*_import` MCP tools (and `/v1/<module>/export|import` REST) per module, so an agent can move an org's data between a self-hosted server and the cloud in either direction. See `skill://playbooks/data-migration`.
 - **Cross-cutting** — audit log, webhooks, team invites, OAuth 2.1 dynamic-client registration, BetterAuth-backed sign-in.
-
-## See it in action
-
-> Lovable builds your frontend. Munin spins up your operations. One prompt, one MCP endpoint — and the agents do the rest.
-
-<p align="center">
-  <a href="https://vimeo.com/1204180225?autoplay=0&utm_source=github&utm_medium=readme&utm_campaign=demo-video">
-    <img src=".github/assets/demo-thumbnail.png" alt="Watch: Lovable builds the frontend while Munin stands up everything behind it" width="100%">
-  </a>
-</p>
-
-Watch Lovable build a real website from a single prompt while Munin stands up everything behind it — the CMS the blog reads from, a seeded knowledge base, analytics, and a chat widget that already knows the business. No admin UI, no dashboard to wire up; the agent does the work, over one MCP endpoint. Then a real customer conversation plays out: answered from the knowledge base, handed off to a human when it matters, and picked back up by the agent to close.
 
 ## Two ways to run
 


### PR DESCRIPTION
Repositions the **See it in action** demo section to sit directly below the hero explainer video, instead of after *What's in the box*. Both videos now sit at the top of the README — the conceptual explainer first, the concrete end-to-end demo immediately below it.

Content unchanged; this is a pure move. No changeset (root docs only).

Follow-up to #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)