### PR TITLE
fix(auth): move Turnstile widget below auth form footnote links

### DIFF
--- a/.changeset/turnstile-below-footnote.md
+++ b/.changeset/turnstile-below-footnote.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+fix(auth): move Turnstile widget below the footnote links on auth forms
+
+Repositions the Cloudflare Turnstile widget to render below the "Create an account · Forgot password?" (and equivalent) footnote links on the login, signup, and forgot-password forms, instead of between the password field and the submit button. Submit gating is unchanged — the button still stays disabled until a captcha token is present.

--- a/packages/dashboard-pages/src/components/auth-shell/forgot-password-page.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/forgot-password-page.tsx
@@ -112,15 +112,6 @@ export function ForgotPasswordPage({ footer }: ForgotPasswordPageProps) {
                   onChange={(e) => setEmail(e.target.value)}
                 />
               </AuthField>
-              {captcha && (
-                <div className="mb-[18px]">
-                  <Turnstile
-                    ref={turnstileRef}
-                    siteKey={captcha.siteKey}
-                    onToken={setCaptchaToken}
-                  />
-                </div>
-              )}
               <AuthSubmit type="submit" disabled={submitting || (!!captcha && !captchaToken)}>
                 {submitting ? t('submitting') : t('submit')}
               </AuthSubmit>
@@ -134,6 +125,16 @@ export function ForgotPasswordPage({ footer }: ForgotPasswordPageProps) {
                 {t('backToSignIn')}
               </Link>
             </AuthFootnote>
+
+            {captcha && (
+              <div className="mt-[18px]">
+                <Turnstile
+                  ref={turnstileRef}
+                  siteKey={captcha.siteKey}
+                  onToken={setCaptchaToken}
+                />
+              </div>
+            )}
           </>
         )
       }

--- a/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
@@ -174,15 +174,6 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
                 onChange={(e) => setPassword(e.target.value)}
               />
             </AuthField>
-            {captcha && (
-              <div className="mb-[18px]">
-                <Turnstile
-                  ref={turnstileRef}
-                  siteKey={captcha.siteKey}
-                  onToken={setCaptchaToken}
-                />
-              </div>
-            )}
             <AuthSubmit type="submit" disabled={submitting || (!!captcha && !captchaToken)}>
               {submitting ? t('submitting') : t('submit')}
             </AuthSubmit>
@@ -204,6 +195,16 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
               {tForgot('linkLabel')}
             </Link>
           </AuthFootnote>
+
+          {captcha && (
+            <div className="mt-[18px]">
+              <Turnstile
+                ref={turnstileRef}
+                siteKey={captcha.siteKey}
+                onToken={setCaptchaToken}
+              />
+            </div>
+          )}
         </>
       }
     />

--- a/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
@@ -207,15 +207,6 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
                 onChange={(e) => setPassword(e.target.value)}
               />
             </AuthField>
-            {captcha && (
-              <div className="mb-[18px]">
-                <Turnstile
-                  ref={turnstileRef}
-                  siteKey={captcha.siteKey}
-                  onToken={setCaptchaToken}
-                />
-              </div>
-            )}
             <AuthSubmit type="submit" disabled={submitting || (!!captcha && !captchaToken)}>
               {submitting ? t('submitting') : t('submit')}
             </AuthSubmit>
@@ -230,6 +221,16 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
               {t('signInLink')}
             </Link>
           </AuthFootnote>
+
+          {captcha && (
+            <div className="mt-[18px]">
+              <Turnstile
+                ref={turnstileRef}
+                siteKey={captcha.siteKey}
+                onToken={setCaptchaToken}
+              />
+            </div>
+          )}
         </>
       }
     />


### PR DESCRIPTION
Repositions the Cloudflare Turnstile widget to render **below** the footnote links ("Create an account · Forgot password?" and equivalents) on the login, signup, and forgot-password forms, instead of between the password field and the submit button.

Submit gating is unchanged — the button still stays disabled until a captcha token is present, since that logic is state-driven and unaffected by DOM position.

## Files
- `login-form.tsx`
- `signup-form.tsx`
- `forgot-password-page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)