### PR TITLE
fix(control): show OAuth-authorized agents in the flock

### DIFF
--- a/.changeset/flock-shows-oauth-agents.md
+++ b/.changeset/flock-shows-oauth-agents.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+fix(control): show OAuth-authorized agents in the flock
+
+The Settings → Agents page ("The flock") read only the `tokens` table, which is populated solely by delegated end-user tokens. OAuth-authorized MCP clients (Claude Code, Cursor, Claude Desktop, …) have their access/refresh tokens persisted by BetterAuth in the separate `oauth_*` tables, so a fully-connected agent always showed up as "Agents · 0 / No connected agents yet".
+
+`GET /v1/tokens` now also lists live (non-expired) OAuth access tokens — one row per (client, user), scoped to the calling org via `org_members` — with the OAuth client name as the origin. Revoking such a row (`DELETE /v1/tokens/:id` for an `oat_*` id) deletes both the access and refresh tokens so the agent can't silently refresh back in.

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -435,6 +435,86 @@ interface OrgFixture {
       });
       expect(wrongOrg.status).toBe(404);
     });
+
+    it('surfaces OAuth-authorized agents and revokes their access + refresh tokens', async () => {
+      const label = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+      const clientId = `oauth-client-${label}`;
+      await db.insert(schema.oauthClient).values({
+        clientId,
+        name: 'Claude Code',
+        redirectUris: ['https://example.com/cb'],
+      });
+      const [refresh] = await db
+        .insert(schema.oauthRefreshToken)
+        .values({
+          token: `rt-${label}`,
+          clientId,
+          userId: orgA.userId,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          scopes: ['mcp:admin', 'kb:read'],
+        })
+        .returning({ id: schema.oauthRefreshToken.id });
+      const [access] = await db
+        .insert(schema.oauthAccessToken)
+        .values({
+          token: `at-${label}`,
+          clientId,
+          userId: orgA.userId,
+          refreshId: refresh!.id,
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+          scopes: ['mcp:admin', 'kb:read'],
+        })
+        .returning({ id: schema.oauthAccessToken.id });
+      // An already-expired access token for the same client must not surface.
+      await db.insert(schema.oauthAccessToken).values({
+        token: `at-expired-${label}`,
+        clientId,
+        userId: orgA.userId,
+        expiresAt: new Date(Date.now() - 60 * 1000),
+        scopes: ['mcp:admin'],
+      });
+
+      const list = await fetch(`${baseUrl}/v1/tokens`, { headers: authHeaders(orgA.adminKey) });
+      const tokens = (await list.json()) as Array<{
+        id: string;
+        type: string;
+        origin: string | null;
+      }>;
+      const oauthRow = tokens.filter((t) => t.id.startsWith('oat_'));
+      expect(oauthRow).toHaveLength(1);
+      expect(oauthRow[0]!.id).toBe(access!.id);
+      expect(oauthRow[0]!.type).toBe('oauth_access');
+      expect(oauthRow[0]!.origin).toBe('Claude Code');
+
+      // Org B can't see org A's OAuth agent, nor revoke it.
+      const listB = await fetch(`${baseUrl}/v1/tokens`, { headers: authHeaders(orgB.adminKey) });
+      const tokensB = (await listB.json()) as Array<{ id: string }>;
+      expect(tokensB.find((t) => t.id === access!.id)).toBeFalsy();
+      const wrongOrg = await fetch(`${baseUrl}/v1/tokens/${access!.id}`, {
+        method: 'DELETE',
+        headers: authHeaders(orgB.adminKey),
+      });
+      expect(wrongOrg.status).toBe(404);
+
+      // Revoke from org A removes both the access and refresh tokens.
+      const rv = await fetch(`${baseUrl}/v1/tokens/${access!.id}`, {
+        method: 'DELETE',
+        headers: authHeaders(orgA.adminKey),
+      });
+      expect(rv.status).toBe(204);
+      const remainingAccess = await db
+        .select({ id: schema.oauthAccessToken.id })
+        .from(schema.oauthAccessToken)
+        .where(eq(schema.oauthAccessToken.clientId, clientId));
+      expect(remainingAccess).toHaveLength(0);
+      const remainingRefresh = await db
+        .select({ id: schema.oauthRefreshToken.id })
+        .from(schema.oauthRefreshToken)
+        .where(eq(schema.oauthRefreshToken.clientId, clientId));
+      expect(remainingRefresh).toHaveLength(0);
+
+      await db.delete(schema.oauthClient).where(eq(schema.oauthClient.clientId, clientId));
+    });
   });
 
   // ─── delegated-token ─────────────────────────────────────────────────

--- a/packages/backend-core/src/control/tokens.controller.ts
+++ b/packages/backend-core/src/control/tokens.controller.ts
@@ -8,8 +8,8 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { schema } from '@getmunin/db';
-import { and, desc, eq } from 'drizzle-orm';
+import { schema, type Db, type Tx } from '@getmunin/db';
+import { and, desc, eq, gt } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
@@ -23,6 +23,7 @@ interface TokenDto {
   type: string;
   scopes: string[];
   audiences: string[];
+  origin: string | null;
   endUserId: string | null;
   expiresAt: string | null;
   lastUsedAt: string | null;
@@ -39,12 +40,17 @@ export class TokensController {
   async list(): Promise<TokenDto[]> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    const rows = await ctx.db
-      .select()
-      .from(schema.tokens)
-      .where(eq(schema.tokens.orgId, actor.orgId))
-      .orderBy(desc(schema.tokens.createdAt));
-    return rows.map(toDto);
+    const [issued, oauth] = await Promise.all([
+      ctx.db
+        .select()
+        .from(schema.tokens)
+        .where(eq(schema.tokens.orgId, actor.orgId))
+        .orderBy(desc(schema.tokens.createdAt)),
+      listOauthAgents(ctx.db),
+    ]);
+    return [...issued.map(toDto), ...oauth].sort((a, b) =>
+      b.createdAt.localeCompare(a.createdAt),
+    );
   }
 
   @Delete(':id')
@@ -52,6 +58,10 @@ export class TokensController {
   async revoke(@Param('id') id: string): Promise<void> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
+    if (id.startsWith('oat_')) {
+      await revokeOauthAgent(ctx.db, id);
+      return;
+    }
     const result = await ctx.db
       .update(schema.tokens)
       .set({ revokedAt: new Date() })
@@ -61,12 +71,107 @@ export class TokensController {
   }
 }
 
+/**
+ * OAuth-authorized agents (Claude Code, Cursor, …) don't get rows in `tokens` —
+ * BetterAuth persists their access/refresh tokens in the `oauth_*` tables. Surface
+ * them as one row per (client, user) so they show up in the flock alongside
+ * delegated tokens.
+ */
+async function listOauthAgents(db: Db | Tx): Promise<TokenDto[]> {
+  const rows = await db
+    .select({
+      id: schema.oauthAccessToken.id,
+      clientId: schema.oauthAccessToken.clientId,
+      userId: schema.oauthAccessToken.userId,
+      scopes: schema.oauthAccessToken.scopes,
+      expiresAt: schema.oauthAccessToken.expiresAt,
+      createdAt: schema.oauthAccessToken.createdAt,
+      clientName: schema.oauthClient.name,
+    })
+    .from(schema.oauthAccessToken)
+    // org_members is RLS-scoped to the caller's org, so this join is the tenant
+    // filter: only tokens whose user belongs to the current org survive.
+    .innerJoin(
+      schema.orgMembers,
+      eq(schema.orgMembers.userId, schema.oauthAccessToken.userId),
+    )
+    .leftJoin(
+      schema.oauthClient,
+      eq(schema.oauthClient.clientId, schema.oauthAccessToken.clientId),
+    )
+    .where(gt(schema.oauthAccessToken.expiresAt, new Date()))
+    .orderBy(desc(schema.oauthAccessToken.createdAt));
+
+  const seen = new Set<string>();
+  const dtos: TokenDto[] = [];
+  for (const row of rows) {
+    const key = `${row.clientId}:${row.userId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dtos.push({
+      id: row.id,
+      type: 'oauth_access',
+      scopes: row.scopes,
+      audiences: [],
+      origin: row.clientName ?? row.clientId,
+      endUserId: null,
+      expiresAt: row.expiresAt.toISOString(),
+      lastUsedAt: null,
+      revokedAt: null,
+      createdAt: row.createdAt.toISOString(),
+    });
+  }
+  return dtos;
+}
+
+async function revokeOauthAgent(db: Db | Tx, accessTokenId: string): Promise<void> {
+  const rows = await db
+    .select({
+      clientId: schema.oauthAccessToken.clientId,
+      userId: schema.oauthAccessToken.userId,
+    })
+    .from(schema.oauthAccessToken)
+    .where(eq(schema.oauthAccessToken.id, accessTokenId))
+    .limit(1);
+  const row = rows[0];
+  if (!row?.userId) throw new NotFoundException(`token ${accessTokenId} not found`);
+
+  // A hit in the RLS-scoped org_members proves the user belongs to the caller's
+  // org — blocks revoking an agent that lives in another tenant.
+  const membership = await db
+    .select({ orgId: schema.orgMembers.orgId })
+    .from(schema.orgMembers)
+    .where(eq(schema.orgMembers.userId, row.userId))
+    .limit(1);
+  if (membership.length === 0) throw new NotFoundException(`token ${accessTokenId} not found`);
+
+  // Drop access and refresh tokens together so the agent can't silently refresh
+  // back in after the access token is gone.
+  await db
+    .delete(schema.oauthAccessToken)
+    .where(
+      and(
+        eq(schema.oauthAccessToken.clientId, row.clientId),
+        eq(schema.oauthAccessToken.userId, row.userId),
+      ),
+    );
+  await db
+    .delete(schema.oauthRefreshToken)
+    .where(
+      and(
+        eq(schema.oauthRefreshToken.clientId, row.clientId),
+        eq(schema.oauthRefreshToken.userId, row.userId),
+      ),
+    );
+}
+
 function toDto(row: typeof schema.tokens.$inferSelect): TokenDto {
   return {
     id: row.id,
     type: row.type,
     scopes: row.scopes,
     audiences: row.audiences,
+    origin: null,
     endUserId: row.endUserId,
     expiresAt: row.expiresAt?.toISOString() ?? null,
     lastUsedAt: row.lastUsedAt?.toISOString() ?? null,

--- a/packages/dashboard-pages/src/pages/agents.tsx
+++ b/packages/dashboard-pages/src/pages/agents.tsx
@@ -16,6 +16,7 @@ interface TokenDto {
   type: string;
   scopes: string[];
   audiences: string[];
+  origin: string | null;
   endUserId: string | null;
   expiresAt: string | null;
   lastUsedAt: string | null;
@@ -140,7 +141,7 @@ export function AgentsPage() {
                       </div>
                     </td>
                     <td className="hidden md:table-cell py-4 pr-4 font-mono text-xs text-ink-mute">
-                      {token.audiences.join(', ') || '—'}
+                      {token.origin ?? (token.audiences.join(', ') || '—')}
                     </td>
                     <td className="py-4 pr-4">
                       <StatusChip status={status} t={t} />


### PR DESCRIPTION
## Problem

The **Settings → Agents** page ("The flock") showed `Agents · 0 / No connected agents yet` even when connected via Claude Code, Cowork, Cursor, etc.

`GET /v1/tokens` read only the `tokens` table, which is populated **exclusively** by delegated end-user tokens (the one non-test insert is in `delegated-token.controller.ts`). OAuth-authorized MCP clients have their access/refresh tokens persisted by BetterAuth in the separate `oauth_access_token` / `oauth_refresh_token` tables, so a fully-connected agent never appeared — and the count stayed at 0 despite the page being built to render `oauth_access` token types.

## Fix

- **`GET /v1/tokens`** now also lists live (non-expired) OAuth access tokens, one row per `(client, user)`, merged and sorted with the issued tokens. Org scoping comes from the `INNER JOIN org_members` — that table is RLS-gated on `app.org_id`, so under the `TenancyInterceptor` it only returns the caller's org's members. The oauth tables themselves have no RLS (BetterAuth-managed). The OAuth client name is surfaced as the row's origin.
- **`DELETE /v1/tokens/:id`** detects `oat_*` ids, verifies the token's user belongs to the caller's org (again via the RLS-scoped `org_members`, so cross-tenant revoke → 404), then deletes **both** the access and refresh tokens so the agent can't silently refresh back in.
- **`agents.tsx`**: added `origin` to the DTO and render it in the Origin column (falling back to audiences for delegated tokens).

## Tests

Added an integration test (`control-plane.integration.test.ts`) covering: OAuth agent appears in the list, expired access tokens are excluded, cross-org isolation (list + revoke 404), and revoke wipes both access and refresh rows. Passes against a real Postgres.

## Notes / design choices

- **One row per connection, not per token** — access tokens are short-lived and refresh often; deduped to the latest non-expired access token per `(client, user)`.
- **Brief invisibility window** — if an access token has expired but hasn't refreshed yet, the agent won't show until its next call.
- **Multi-org users (cloud only)** — an OAuth token surfaces under every org the user belongs to. In single-tenant OSS each user is in one org, so this only matters for cloud; can be narrowed to the user's default org if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)