### PR TITLE
feat(settings): standardize loading with content-shaped skeletons

### DIFF
--- a/.changeset/settings-loading-skeletons.md
+++ b/.changeset/settings-loading-skeletons.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+feat(settings): standardize settings page loading with content-shaped skeletons
+
+Replaces the inconsistent per-page "Loading…" text with content-shaped skeletons across every settings page (API keys, channels, trackers, team, end-users, activity, audit log, usage, agents, AI, account). Table pages render proportional column-width row skeletons, list pages render card placeholders, the usage page shows tile and by-agent placeholders, and the activity feed shows row placeholders with a vertically-centered empty state. The AI settings page now renders each section header with its own per-section loading instead of a single global loader.

--- a/packages/dashboard-pages/src/components/skeleton.tsx
+++ b/packages/dashboard-pages/src/components/skeleton.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { cn } from '@getmunin/ui';
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn('animate-pulse bg-ink/10 dark:bg-foreground/10', className)}
+    />
+  );
+}
+
+export interface SkeletonColumn {
+  grow: number;
+  bar: string;
+  right?: boolean;
+}
+
+export function TableSkeleton({ columns, rows = 4 }: { columns: SkeletonColumn[]; rows?: number }) {
+  const cells = (height: string) =>
+    columns.map((c, i) => (
+      <div
+        key={i}
+        className={cn('flex min-w-0', c.right && 'justify-end')}
+        style={{ flexGrow: c.grow, flexBasis: 0 }}
+      >
+        <Skeleton className={cn(height, 'max-w-full', c.bar)} />
+      </div>
+    ));
+  return (
+    <div role="status" aria-busy="true">
+      <span className="sr-only">Loading…</span>
+      <div className="flex items-center gap-6 border-b-[0.5px] border-rule-soft pb-3 dark:border-rule-on-dark">
+        {cells('h-2.5')}
+      </div>
+      {Array.from({ length: rows }).map((_, r) => (
+        <div
+          key={r}
+          className="flex items-center gap-6 border-b-[0.5px] border-rule-soft py-4 dark:border-rule-on-dark"
+        >
+          {cells('h-4')}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function CardSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'space-y-3 border-[0.5px] border-rule-soft p-4 dark:border-rule-on-dark',
+        className,
+      )}
+    >
+      <Skeleton className="h-4 w-40" />
+      <Skeleton className="h-3 w-3/5" />
+    </div>
+  );
+}
+
+export function CardListSkeleton({ rows = 3, className }: { rows?: number; className?: string }) {
+  return (
+    <div role="status" aria-busy="true" className={cn('space-y-3', className)}>
+      <span className="sr-only">Loading…</span>
+      {Array.from({ length: rows }).map((_, i) => (
+        <CardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/packages/dashboard-pages/src/pages/account.tsx
+++ b/packages/dashboard-pages/src/pages/account.tsx
@@ -8,6 +8,7 @@ import { invalidateActiveMembershipCache } from '../auth/use-active-role';
 import { useTranslateError } from '../i18n/translate-error';
 import { FormField } from '../components/form-field';
 import { LoadFailed } from '../components/load-failed';
+import { Skeleton } from '../components/skeleton';
 import { useLoadGate } from '../lib/use-load-gate';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
 
@@ -90,29 +91,40 @@ export function AccountPage({ extraSections }: AccountPageProps) {
       <section className="space-y-4">
         <SectionHead title={t('orgSectionTitle')} divider={false} />
 
-        <form className="space-y-4" onSubmit={(e) => void submit(e)}>
-          <FormField label={t('orgNameLabel')} hint={t('orgNameHint')} error={error}>
-            <Input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t('orgNamePlaceholder')}
-              maxLength={128}
-              disabled={!org || saving}
-              aria-invalid={error ? true : undefined}
-            />
-          </FormField>
-
-          <div className="flex items-center gap-3">
-            <Button type="submit" disabled={!dirty || saving}>
-              {saving ? tCommon('saving') : tCommon('save')}
-            </Button>
-            {savedAt && !dirty && !error ? (
-              <span key={savedAt} className="text-sm text-muted-foreground">
-                {tCommon('saved')}
-              </span>
-            ) : null}
+        {org === null ? (
+          <div role="status" aria-busy="true" className="space-y-4">
+            <span className="sr-only">{tCommon('loading')}</span>
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-9 w-full" />
+            </div>
+            <Skeleton className="h-9 w-24" />
           </div>
-        </form>
+        ) : (
+          <form className="space-y-4" onSubmit={(e) => void submit(e)}>
+            <FormField label={t('orgNameLabel')} hint={t('orgNameHint')} error={error}>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t('orgNamePlaceholder')}
+                maxLength={128}
+                disabled={saving}
+                aria-invalid={error ? true : undefined}
+              />
+            </FormField>
+
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={!dirty || saving}>
+                {saving ? tCommon('saving') : tCommon('save')}
+              </Button>
+              {savedAt && !dirty && !error ? (
+                <span key={savedAt} className="text-sm text-muted-foreground">
+                  {tCommon('saved')}
+                </span>
+              ) : null}
+            </div>
+          </form>
+        )}
       </section>
 
       {extraSections}

--- a/packages/dashboard-pages/src/pages/activity.tsx
+++ b/packages/dashboard-pages/src/pages/activity.tsx
@@ -59,6 +59,7 @@ function fromRealtime(
 
 export function ActivityPage() {
   const t = useTranslations('dashboard.activity');
+  const tCommon = useTranslations('common');
   const [items, setItems] = useState<ActivityDto[]>([]);
   const [now, setNow] = useState(() => Date.now());
   const actorCache = useRef(new Map<string, { kind: ActorKind; label: string }>());
@@ -136,15 +137,31 @@ export function ActivityPage() {
           </span>
         </header>
 
-        <div className="bg-ink dark:bg-card text-paper dark:text-foreground font-mono text-[12px] leading-relaxed px-6 py-4 min-h-[12rem]">
+        <div className="flex min-h-[12rem] flex-col bg-ink dark:bg-card text-paper dark:text-foreground font-mono text-[12px] leading-relaxed px-6 py-4">
           <div className="grid grid-cols-[6rem_minmax(0,11rem)_minmax(0,12rem)_1fr] gap-x-6 pb-2 mb-1 border-b-[0.5px] border-paper/15 dark:border-rule-on-dark text-[10px] uppercase tracking-eyebrow text-paper/45 dark:text-foreground/45">
             <span>{t('colTime')}</span>
             <span>{t('colType')}</span>
             <span>{t('colActor')}</span>
             <span>{t('colDetail')}</span>
           </div>
-          <ul>
-            {visible.map((e) => (
+          <ul className="flex flex-1 flex-col">
+            {!hasLoadedOnce && (
+              <>
+                <li className="sr-only">{tCommon('loading')}</li>
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <li
+                    key={i}
+                    className="grid grid-cols-[6rem_minmax(0,11rem)_minmax(0,12rem)_1fr] items-center gap-x-6 py-1"
+                  >
+                    <div className="h-3 w-14 animate-pulse bg-paper/15 dark:bg-foreground/15" />
+                    <div className="h-3 w-24 animate-pulse bg-paper/15 dark:bg-foreground/15" />
+                    <div className="h-3 w-28 animate-pulse bg-paper/15 dark:bg-foreground/15" />
+                    <div className="h-3 w-40 animate-pulse bg-paper/15 dark:bg-foreground/15" />
+                  </li>
+                ))}
+              </>
+            )}
+            {hasLoadedOnce && visible.map((e) => (
               <li
                 key={e.id}
                 className="grid grid-cols-[6rem_minmax(0,11rem)_minmax(0,12rem)_1fr] gap-x-6 items-baseline py-0.5"
@@ -159,8 +176,8 @@ export function ActivityPage() {
                 <span className="truncate text-paper/90 dark:text-foreground/90">{summary(e)}</span>
               </li>
             ))}
-            {visible.length === 0 && (
-              <li className="py-8 text-center text-paper/50 dark:text-foreground/50">
+            {hasLoadedOnce && visible.length === 0 && (
+              <li className="flex grow items-center justify-center text-paper/50 dark:text-foreground/50">
                 {t('empty')}
               </li>
             )}

--- a/packages/dashboard-pages/src/pages/agents.tsx
+++ b/packages/dashboard-pages/src/pages/agents.tsx
@@ -5,6 +5,7 @@ import { useFormatter, useTranslations } from 'next-intl';
 import { api } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 import { LoadFailed } from '../components/load-failed';
+import { TableSkeleton } from '../components/skeleton';
 import { EmptyCallout } from '../components/empty-callout';
 import { useLoadGate } from '../lib/use-load-gate';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
@@ -81,7 +82,17 @@ export function AgentsPage() {
         />
 
         {tokens === null ? (
-          <p className="text-sm text-ink-mute">{tCommon('loading')}</p>
+          <TableSkeleton
+            columns={[
+              { grow: 3, bar: 'w-3/4' },
+              { grow: 2, bar: 'w-1/2' },
+              { grow: 1.5, bar: 'w-12' },
+              { grow: 2, bar: 'w-3/4' },
+              { grow: 2, bar: 'w-3/4' },
+              { grow: 2, bar: 'w-3/4' },
+              { grow: 1, bar: 'w-10', right: true },
+            ]}
+          />
         ) : tokens.length === 0 ? (
           <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
         ) : (

--- a/packages/dashboard-pages/src/pages/ai-settings.tsx
+++ b/packages/dashboard-pages/src/pages/ai-settings.tsx
@@ -13,6 +13,7 @@ import { IdentityCard } from '../components/assistants/identity-card';
 import { useAssistant } from '../components/assistants/use-assistant';
 import { useSkills } from '../components/assistants/use-skills';
 import { LoadFailed } from '../components/load-failed';
+import { CardSkeleton } from '../components/skeleton';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
 
 interface AiSettingsPageProps {
@@ -30,7 +31,6 @@ export function AiSettingsPage({
 }: AiSettingsPageProps = {}) {
   const t = useTranslations('agentSetup');
   const tList = useTranslations('assistants.list');
-  const tCommon = useTranslations('common');
 
   const {
     config,
@@ -77,95 +77,92 @@ export function AiSettingsPage({
 
       {slot}
 
-      {config === null && (
-        <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
-      )}
+      <div className="space-y-10">
+        <section className="space-y-4">
+          <SectionHeader title={tList('persona.title')} blurb={tList('persona.blurb')} />
+          <div className="space-y-6">
+            {assistant ? (
+              <IdentityCard assistant={assistant} onSaved={setAssistant} />
+            ) : (
+              <CardSkeleton />
+            )}
+          </div>
+        </section>
 
-      {config && (
-        <div className="space-y-10">
-          <section className="space-y-4">
-            <SectionHeader title={tList('persona.title')} blurb={tList('persona.blurb')} />
-            <div className="space-y-6">
-              {assistant ? (
-                <IdentityCard assistant={assistant} onSaved={setAssistant} />
-              ) : (
-                <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
-              )}
-            </div>
-          </section>
+        <section className="space-y-4">
+          <SectionHeader title={tList('models.title')} blurb={tList('models.blurb')} />
+          <div className="space-y-6">
+            {config ? (
+              <>
+                <ProviderCard
+                  config={config}
+                  extraPresets={extraPresets}
+                  defaultPresetId={defaultPresetId}
+                  lede={providerLede}
+                  onSaved={(updated, result) => {
+                    setConfig(updated);
+                    setModels(result);
+                  }}
+                />
+                <ModelsCard
+                  config={config}
+                  models={managedModelsResult ?? models}
+                  managed={isManaged}
+                  onSaved={setConfig}
+                />
+              </>
+            ) : (
+              <>
+                <CardSkeleton />
+                <CardSkeleton />
+              </>
+            )}
+          </div>
+        </section>
 
-          <section className="space-y-4">
-            <SectionHeader title={tList('models.title')} blurb={tList('models.blurb')} />
-            <div className="space-y-6">
-              <ProviderCard
-                config={config}
-                extraPresets={extraPresets}
-                defaultPresetId={defaultPresetId}
-                lede={providerLede}
-                onSaved={(updated, result) => {
-                  setConfig(updated);
-                  setModels(result);
-                }}
-              />
-              <ModelsCard
-                config={config}
-                models={managedModelsResult ?? models}
-                managed={isManaged}
-                onSaved={setConfig}
-              />
-            </div>
-          </section>
+        <section className="space-y-4">
+          <SectionHeader
+            title={tList('conversational.title')}
+            blurb={tList('conversational.blurb')}
+          />
+          <div className="space-y-3">
+            <ChatAssistantCard />
+            {conversationalSkills.map((skill) => (
+              <BackgroundSkillCard key={skill.uri} skill={skill} />
+            ))}
+          </div>
+        </section>
 
-          <section className="space-y-4">
-            <SectionHeader
-              title={tList('conversational.title')}
-              blurb={tList('conversational.blurb')}
-            />
-            <div className="space-y-3">
-              <ChatAssistantCard />
-              {conversationalSkills.map((skill) => (
+        <section className="space-y-4">
+          <SectionHeader title={tList('aiDriven.title')} blurb={tList('aiDriven.blurb')} />
+          <div className="space-y-3">
+            {skills === null ? (
+              <CardSkeleton />
+            ) : aiDrivenSkills.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{tList('aiDriven.empty')}</p>
+            ) : (
+              aiDrivenSkills.map((skill) => (
                 <BackgroundSkillCard key={skill.uri} skill={skill} />
-              ))}
-            </div>
-          </section>
+              ))
+            )}
+          </div>
+        </section>
 
-          <section className="space-y-4">
-            <SectionHeader
-              title={tList('aiDriven.title')}
-              blurb={tList('aiDriven.blurb')}
-            />
-            <div className="space-y-3">
-              {skills === null ? (
-                <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
-              ) : aiDrivenSkills.length === 0 ? (
-                <p className="text-sm text-muted-foreground">{tList('aiDriven.empty')}</p>
-              ) : (
-                aiDrivenSkills.map((skill) => (
-                  <BackgroundSkillCard key={skill.uri} skill={skill} />
-                ))
-              )}
-            </div>
-          </section>
-
-          <section className="space-y-4">
-            <SectionHeader
-              title={tList('tasks.title')}
-              blurb={tList('tasks.blurb')}
-            />
-            <div className="space-y-3">
-              {skills === null ? (
-                <p className="text-sm text-muted-foreground">{tCommon('loading')}</p>
-              ) : scheduledTasks.length === 0 ? (
-                <p className="text-sm text-muted-foreground">{tList('tasks.empty')}</p>
-              ) : (
-                scheduledTasks.map((skill) => (
-                  <BackgroundSkillCard key={skill.uri} skill={skill} />
-                ))
-              )}
-            </div>
-          </section>
-        </div>
-      )}
+        <section className="space-y-4">
+          <SectionHeader title={tList('tasks.title')} blurb={tList('tasks.blurb')} />
+          <div className="space-y-3">
+            {skills === null ? (
+              <CardSkeleton />
+            ) : scheduledTasks.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{tList('tasks.empty')}</p>
+            ) : (
+              scheduledTasks.map((skill) => (
+                <BackgroundSkillCard key={skill.uri} skill={skill} />
+              ))
+            )}
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/packages/dashboard-pages/src/pages/api-keys.tsx
+++ b/packages/dashboard-pages/src/pages/api-keys.tsx
@@ -6,6 +6,7 @@ import { useFormatter, useTranslations } from 'next-intl';
 import { api } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 import { LoadFailed } from '../components/load-failed';
+import { TableSkeleton } from '../components/skeleton';
 import { EmptyCallout } from '../components/empty-callout';
 import { useLoadGate } from '../lib/use-load-gate';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
@@ -111,7 +112,15 @@ export function ApiKeysPage() {
         />
 
         {keys === null ? (
-          <p className="text-sm text-ink-mute">{tCommon('loading')}</p>
+          <TableSkeleton
+            columns={[
+              { grow: 4, bar: 'w-2/3' },
+              { grow: 2, bar: 'w-1/2' },
+              { grow: 2, bar: 'w-3/4' },
+              { grow: 2, bar: 'w-3/4' },
+              { grow: 1, bar: 'w-10', right: true },
+            ]}
+          />
         ) : keys.length === 0 ? (
           <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
         ) : (

--- a/packages/dashboard-pages/src/pages/audit-log.tsx
+++ b/packages/dashboard-pages/src/pages/audit-log.tsx
@@ -5,6 +5,7 @@ import { useFormatter, useTranslations } from 'next-intl';
 import { api } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 import { LoadFailed } from '../components/load-failed';
+import { TableSkeleton } from '../components/skeleton';
 import { EmptyCallout } from '../components/empty-callout';
 import { useLoadGate } from '../lib/use-load-gate';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
@@ -162,7 +163,19 @@ export function AuditLogPage() {
           divider={false}
         />
 
-        {items.length === 0 ? (
+        {!hasLoadedOnce ? (
+          <TableSkeleton
+            columns={[
+              { grow: 2, bar: 'w-3/4' },
+              { grow: 1.5, bar: 'w-1/2' },
+              { grow: 1.5, bar: 'w-12' },
+              { grow: 2.5, bar: 'w-2/3' },
+              { grow: 1.5, bar: 'w-12' },
+              { grow: 1, bar: 'w-10', right: true },
+              { grow: 1.5, bar: 'w-16', right: true },
+            ]}
+          />
+        ) : items.length === 0 ? (
           <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
         ) : (
           <div className="-mx-6 overflow-x-auto px-6 md:mx-0 md:px-0">

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -17,6 +17,7 @@ import { api, ApiError } from '../api';
 import { authClient } from '../auth-client';
 import { useTranslateError } from '../i18n/translate-error';
 import { LoadFailed } from '../components/load-failed';
+import { CardListSkeleton } from '../components/skeleton';
 import { EmptyCallout } from '../components/empty-callout';
 import { SaveErrorStage, type SaveErrorDetail } from '../components/save-error-stage';
 import { useConfirm } from '../components/confirm-dialog';
@@ -519,7 +520,7 @@ export function ChannelsPage() {
         />
 
         {channels === null ? (
-          <p className="text-sm text-ink-mute">{tCommon('loading')}</p>
+          <CardListSkeleton rows={3} />
         ) : channels.length === 0 ? (
           <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
         ) : (

--- a/packages/dashboard-pages/src/pages/end-users.tsx
+++ b/packages/dashboard-pages/src/pages/end-users.tsx
@@ -5,6 +5,7 @@ import { useFormatter, useNow, useTranslations } from 'next-intl';
 import { api } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 import { LoadFailed } from '../components/load-failed';
+import { TableSkeleton } from '../components/skeleton';
 import { EmptyCallout } from '../components/empty-callout';
 import { useLoadGate } from '../lib/use-load-gate';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
@@ -24,7 +25,6 @@ interface EndUserDto {
 
 export function EndUsersPage() {
   const t = useTranslations('dashboard.endUsers');
-  const tCommon = useTranslations('common');
   const translate = useTranslateError();
   const format = useFormatter();
   const now = useNow();
@@ -105,7 +105,14 @@ export function EndUsersPage() {
         />
 
         {filtered === null ? (
-          <p className="text-sm text-ink-mute">{tCommon('loading')}</p>
+          <TableSkeleton
+            columns={[
+              { grow: 4, bar: 'w-2/3' },
+              { grow: 3, bar: 'w-1/2' },
+              { grow: 2, bar: 'w-3/4' },
+              { grow: 1, bar: 'w-10', right: true },
+            ]}
+          />
         ) : filtered.length === 0 ? (
           <EmptyCallout
             title={items && items.length === 0 ? t('emptyTitle') : t('emptyTitle')}

--- a/packages/dashboard-pages/src/pages/team.tsx
+++ b/packages/dashboard-pages/src/pages/team.tsx
@@ -8,6 +8,7 @@ import { authClient } from '../auth-client';
 import { useActiveRole, isOwnerOrAdmin } from '../auth/use-active-role';
 import { useTranslateError } from '../i18n/translate-error';
 import { LoadFailed } from '../components/load-failed';
+import { TableSkeleton } from '../components/skeleton';
 import { EmptyCallout } from '../components/empty-callout';
 import { useConfirm } from '../components/confirm-dialog';
 import { CopyableSecret } from '../components/copyable-secret';
@@ -193,7 +194,15 @@ export function TeamPage() {
           divider={false}
         />
         {members === null ? (
-          <p className="text-sm text-ink-mute">{tCommon('loading')}</p>
+          <TableSkeleton
+            columns={[
+              { grow: 3, bar: 'w-2/3' },
+              { grow: 3, bar: 'w-3/4' },
+              { grow: 2, bar: 'w-20' },
+              { grow: 2, bar: 'w-1/2' },
+              { grow: 2, bar: 'w-16', right: true },
+            ]}
+          />
         ) : (
           <div className="-mx-6 overflow-x-auto px-6 md:mx-0 md:px-0">
           <table className="w-full min-w-[640px]">
@@ -255,7 +264,15 @@ export function TeamPage() {
           divider={false}
         />
         {invites === null ? (
-          <p className="text-sm text-ink-mute">{tCommon('loading')}</p>
+          <TableSkeleton
+            columns={[
+              { grow: 3, bar: 'w-3/4' },
+              { grow: 2, bar: 'w-20' },
+              { grow: 2, bar: 'w-1/2' },
+              { grow: 2, bar: 'w-1/2' },
+              { grow: 1, bar: 'w-12', right: true },
+            ]}
+          />
         ) : invites.length === 0 ? (
           <EmptyCallout title={t('invitesEmptyTitle')} body={t('invitesEmptyBody')} />
         ) : (

--- a/packages/dashboard-pages/src/pages/trackers.tsx
+++ b/packages/dashboard-pages/src/pages/trackers.tsx
@@ -7,6 +7,7 @@ import { CreateTrackerBody } from '@getmunin/types';
 import { api, ApiError } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 import { LoadFailed } from '../components/load-failed';
+import { CardListSkeleton } from '../components/skeleton';
 import { EmptyCallout } from '../components/empty-callout';
 import { CopyableSecret } from '../components/copyable-secret';
 import { useConfirm } from '../components/confirm-dialog';
@@ -235,7 +236,7 @@ export function TrackersPage() {
         />
 
         {trackers === null ? (
-          <p className="text-sm text-ink-mute">{tCommon('loading')}</p>
+          <CardListSkeleton rows={3} />
         ) : trackers.length === 0 ? (
           <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
         ) : (

--- a/packages/dashboard-pages/src/pages/usage.tsx
+++ b/packages/dashboard-pages/src/pages/usage.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { api } from '../api';
 import { useRealtime } from '../realtime';
 import { LoadFailed } from '../components/load-failed';
+import { Skeleton } from '../components/skeleton';
 import { useLoadGate } from '../lib/use-load-gate';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
 import { Hero, cn } from '@getmunin/ui';
@@ -79,45 +80,85 @@ export function UsagePage({ slot }: { slot?: ReactNode } = {}) {
 
       {slot}
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 border-l-[0.5px] border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
-        <Tile
-          label={t('tiles.mcpCalls')}
-          period={t('tiles.thisMonth')}
-          tile={summary?.mcpCalls}
-          format={formatCount}
-          mode="count"
-        />
-        <Tile
-          label={t('tiles.apiCalls')}
-          period={t('tiles.thisMonth')}
-          tile={summary?.apiCalls}
-          format={formatCount}
-          mode="count"
-        />
-        <Tile
-          label={t('tiles.aiTokens')}
-          period={t('tiles.thisMonth')}
-          tile={summary?.aiTokens}
-          format={formatCount}
-          mode="count"
-        />
-        <Tile
-          label={t('tiles.conversations')}
-          period={t('tiles.thisMonth')}
-          tile={summary?.conversations}
-          format={formatCount}
-          mode="count"
-        />
-        <Tile
-          label={t('tiles.avgLatency')}
-          period={t('tiles.sevenDay')}
-          tile={summary?.avgLatencyMs}
-          format={formatLatency}
-          mode="latency"
-        />
-      </div>
+      {!hasLoadedOnce ? (
+        <UsageSkeleton />
+      ) : (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 border-l-[0.5px] border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+            <Tile
+              label={t('tiles.mcpCalls')}
+              period={t('tiles.thisMonth')}
+              tile={summary?.mcpCalls}
+              format={formatCount}
+              mode="count"
+            />
+            <Tile
+              label={t('tiles.apiCalls')}
+              period={t('tiles.thisMonth')}
+              tile={summary?.apiCalls}
+              format={formatCount}
+              mode="count"
+            />
+            <Tile
+              label={t('tiles.aiTokens')}
+              period={t('tiles.thisMonth')}
+              tile={summary?.aiTokens}
+              format={formatCount}
+              mode="count"
+            />
+            <Tile
+              label={t('tiles.conversations')}
+              period={t('tiles.thisMonth')}
+              tile={summary?.conversations}
+              format={formatCount}
+              mode="count"
+            />
+            <Tile
+              label={t('tiles.avgLatency')}
+              period={t('tiles.sevenDay')}
+              tile={summary?.avgLatencyMs}
+              format={formatLatency}
+              mode="latency"
+            />
+          </div>
 
-      <ByAgentSection data={byAgent} />
+          <ByAgentSection data={byAgent} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function UsageSkeleton() {
+  return (
+    <div role="status" aria-busy="true" className="space-y-10">
+      <span className="sr-only">Loading…</span>
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 border-l-[0.5px] border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex min-h-[180px] flex-col gap-4 border-b-[0.5px] border-r-[0.5px] border-rule-soft bg-paper p-6 dark:border-rule-on-dark dark:bg-card"
+          >
+            <Skeleton className="h-2.5 w-24" />
+            <Skeleton className="h-9 w-20" />
+            <Skeleton className="mt-auto h-[42px] w-full" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-6">
+        <Skeleton className="h-6 w-56" />
+        <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between gap-12 border-b-[0.5px] border-rule-soft px-1 py-5 dark:border-rule-on-dark"
+            >
+              <Skeleton className="h-4 w-48" />
+              <Skeleton className="h-4 w-16" />
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Standardizes loading across **all settings pages**, replacing the inconsistent per-page "Loading…" text (and a few pages that showed nothing) with **content-shaped skeletons** that mirror each page's real layout.

## Changes

- New shared primitives in `components/skeleton.tsx`: `Skeleton`, `TableSkeleton`, `CardSkeleton`, `CardListSkeleton` (square corners to match the design system).
- **Table pages** (API keys, agents, end-users, audit log, team) → `TableSkeleton` with **proportional column weights** matching each table's `table-auto` layout (wide primary column, narrow right-aligned action), filling the full width.
- **List pages** (channels, trackers) → `CardListSkeleton`.
- **Usage** → tile-grid + by-agent placeholders (previously rendered cards with `—`).
- **Activity** → row placeholders styled for the dark feed; empty state ("No events yet.") is now vertically centered in the panel.
- **AI settings** → renders each section header with its **own per-section loading** instead of a single global loader.
- **account** → form-field skeleton.
- A11y: each skeleton block is `role="status" aria-busy`, with the localized loading label kept as sr-only text where applicable.

## Notes

- The skeleton column widths are a close **proportional** match to the real tables (which are content-driven `table-auto`), not pixel-identical.
- Verified with `tsc` and `eslint` (both pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)