### PR TITLE
chore(copy): drop hardcoded tool count, refresh tagline

### DIFF
--- a/.changeset/clean-stale-tagline-tool-count.md
+++ b/.changeset/clean-stale-tagline-tool-count.md
@@ -1,0 +1,6 @@
+---
+"@getmunin/backend-core": patch
+"@getmunin/dashboard-pages": patch
+---
+
+Refresh stale product copy: drop the hardcoded "~80 tools" count from the MCP server instructions (the surface has long since outgrown it) and replace the old "agent-native business apps" tagline with "the customer platform for the agentic era" in the dashboard metadata titles.

--- a/apps/web/e2e/locale.spec.ts
+++ b/apps/web/e2e/locale.spec.ts
@@ -8,7 +8,7 @@ test.describe('OSS locale switching', () => {
       await page.goto('/');
       // Norwegian translations live in messages/nb.json — assert the
       // tagline differs from the English version.
-      const englishTagline = 'Agent-native business apps. The AI agent is the UI.';
+      const englishTagline = 'The open source customer platform for the agentic era.';
       const tagline = await page.locator('main').first().innerText();
       expect(tagline).not.toContain(englishTagline);
     } finally {
@@ -24,7 +24,7 @@ test.describe('OSS locale switching', () => {
     const page = await ctx.newPage();
     try {
       await page.goto('/');
-      const taglineEn = 'Agent-native business apps. The AI agent is the UI.';
+      const taglineEn = 'The open source customer platform for the agentic era.';
       const main = page.locator('main').first();
       await expect(main).toBeVisible();
       const text = await main.innerText();

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Munin",
   "short_name": "Munin",
-  "description": "Agent-native business apps. The AI agent is the UI.",
+  "description": "The customer platform for the agentic era. The AI agent is the UI.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#fafaf6",

--- a/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
+++ b/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
@@ -40,7 +40,7 @@ function buildInstructions(
     '/v1/cms/* and this /mcp endpoint. Use it directly when scaffolding a frontend; do not ask',
     'for it. Skill bodies have it (and your org id) pre-filled.',
     '',
-    'Munin: agent-native business apps. You have ~80 tools across these modules:',
+    'Munin: the customer platform for the agentic era. Your tools span these modules:',
     '  • Knowledge Base (kb_*)        — articles, search, versions',
     '  • Conversations (conv_*)       — channels, messages, assignments',
     '  • CRM (crm_*)                  — contacts, companies, deals, activities',

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Munin — agent-native business apps",
+    "title": "Munin — the customer platform for the agentic era",
     "description": "Open-source headless business app suite (Knowledge Base, Conversations, CRM, CMS) where the AI agent is the UI."
   },
   "common": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Munin — agent-native forretningsapper",
+    "title": "Munin — kundeplattformen for den agentiske æraen",
     "description": "Open source headless forretningsapp-suite (kunnskapsbase, samtaler, CRM, CMS) der AI-agenten er brukergrensesnittet."
   },
   "common": {


### PR DESCRIPTION
## What

Cleans up stale product copy flagged in review:

- **Hardcoded tool count** — the MCP server instructions string (`mcp.skill-registry.service.ts`) advertised "~80 tools", which the surface has long since outgrown. Reworded to "Your tools span these modules:" so it never goes stale again.
- **Old tagline** — replaced "agent-native business apps" with "the customer platform for the agentic era" in the dashboard metadata titles (`en.json`, `nb.json`) and the PWA manifest description.
- **e2e test** — `locale.spec.ts` asserted against `Agent-native business apps. The AI agent is the UI.`, a string the landing page no longer renders, so the "nb ≠ en" checks passed trivially. Repointed them at the tagline actually rendered (`The open source customer platform for the agentic era.`).

Historical CHANGELOG entries and the longer prose meta descriptions were left untouched.

## Notes

`apps/web` (`@getmunin/web`) is changeset-ignored, so the changeset lists only the published packages (`@getmunin/backend-core`, `@getmunin/dashboard-pages`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)