### PR TITLE
feat(oauth): pin OAuth/MCP agent connections to an organization

### DIFF
--- a/.changeset/oauth-org-pinned-connections.md
+++ b/.changeset/oauth-org-pinned-connections.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/core': patch
+'@getmunin/db': patch
+---
+
+feat(oauth): pin OAuth/MCP agent connections to an organization
+
+OAuth agents used to float to the user's current default org, resolved live on every request — so the flock listed an agent under whichever org happened to be default, switching the default silently retargeted live agents, and revoke was user-global.
+
+Connections are now pinned to a specific org at consent time via BetterAuth's `consentReferenceId`, which persists the org as `reference_id` on the refresh token and as an `org_id` claim on the issued JWT access token (carried forward on refresh). The credential resolvers read that pinned org and require the user to still be a member of it — removing someone from an org now kills their agents there. Tokens issued before this change fall back to the default org and are backfilled by a migration.
+
+As a result the flock is truthful per-org (lists only agents pinned to the calling org) and revoke is org-scoped (only revokes grants pinned to the caller's org, leaving the same user's other-org agents alone). Which org an agent binds to is the user's active org at consent time, set with the existing topbar org switcher.

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -3,6 +3,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { jwt, captcha } from 'better-auth/plugins';
 import { oauthProvider } from '@better-auth/oauth-provider';
 import { schema, type Db } from '@getmunin/db';
+import { readMembershipsForUser } from '@getmunin/core';
 import {
   SUPPORTED_SCOPES as MUNIN_SUPPORTED_SCOPES,
   mcpResourceUrl,
@@ -88,6 +89,12 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
 
   const socialProviders = buildSocialProviders(opts.socialProviders);
 
+  const resolveDefaultOrgId = async (userId: string): Promise<string | undefined> => {
+    const memberships = await readMembershipsForUser(opts.db, userId);
+    const active = memberships.find((m) => m.isDefault) ?? memberships[0];
+    return active?.orgId;
+  };
+
   return asMuninAuth(betterAuth({
     baseURL: opts.baseUrl,
     basePath: '/auth',
@@ -119,6 +126,14 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
         scopes: [...SUPPORTED_AUTH_SCOPES],
         validAudiences,
         silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
+        postLogin: {
+          page: `${dashboardUrl}/dashboard/oauth/consent`,
+          shouldRedirect: () => false,
+          consentReferenceId: async ({ user }) =>
+            user?.id ? await resolveDefaultOrgId(user.id) : undefined,
+        },
+        customAccessTokenClaims: ({ referenceId }) =>
+          referenceId ? { org_id: referenceId } : {},
       }),
       ...(opts.captcha
         ? [

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -429,34 +429,47 @@ interface OrgFixture {
       expect(wrongOrg.status).toBe(404);
     });
 
-    it('collapses an OAuth agent reconnected under many clients into one flock row and revokes the group', async () => {
+    it('collapses an OAuth agent into one flock row per org, scoped by pinned reference_id, and revokes only the caller org', async () => {
       const label = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
       const name = `Claude Code ${label}`;
       const clientA = `oauth-client-a-${label}`;
       const clientB = `oauth-client-b-${label}`;
-      await db.insert(schema.oauthClient).values([
-        { clientId: clientA, name, redirectUris: ['https://example.com/cb'] },
-        { clientId: clientB, name, redirectUris: ['https://example.com/cb'] },
-      ]);
+      const clientC = `oauth-client-c-${label}`;
+      const allClients = [clientA, clientB, clientC];
+      const live = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      await db.insert(schema.oauthClient).values(
+        allClients.map((clientId) => ({ clientId, name, redirectUris: ['https://example.com/cb'] })),
+      );
       await db.insert(schema.oauthRefreshToken).values([
         {
           token: `rt-a-${label}`,
           clientId: clientA,
           userId: orgA.userId,
-          expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          referenceId: orgA.id,
+          expiresAt: live,
           scopes: ['mcp:admin', 'kb:read'],
         },
         {
           token: `rt-b-${label}`,
           clientId: clientB,
           userId: orgA.userId,
-          expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          referenceId: orgA.id,
+          expiresAt: live,
           scopes: ['mcp:admin', 'crm:write'],
+        },
+        {
+          token: `rt-c-${label}`,
+          clientId: clientC,
+          userId: orgA.userId,
+          referenceId: orgB.id,
+          expiresAt: live,
+          scopes: ['mcp:admin'],
         },
         {
           token: `rt-expired-${label}`,
           clientId: clientA,
           userId: orgA.userId,
+          referenceId: orgA.id,
           expiresAt: new Date(Date.now() - 60 * 1000),
           scopes: ['mcp:admin'],
         },
@@ -464,7 +477,8 @@ interface OrgFixture {
           token: `rt-revoked-${label}`,
           clientId: clientA,
           userId: orgA.userId,
-          expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          referenceId: orgA.id,
+          expiresAt: live,
           revoked: new Date(),
           scopes: ['mcp:admin'],
         },
@@ -487,7 +501,10 @@ interface OrgFixture {
       expect(agentRow.scopes.sort()).toEqual(['crm:write', 'kb:read', 'mcp:admin']);
 
       const listB = await fetch(`${baseUrl}/v1/tokens`, { headers: authHeaders(orgB.adminKey) });
-      const tokensB = (await listB.json()) as Array<{ id: string }>;
+      const tokensB = (await listB.json()) as Array<{ id: string; origin: string | null; count: number }>;
+      const oauthRowsB = tokensB.filter((t) => t.origin === name);
+      expect(oauthRowsB).toHaveLength(1);
+      expect(oauthRowsB[0]!.count).toBe(1);
       expect(tokensB.find((t) => t.id === agentRow.id)).toBeFalsy();
       const wrongOrg = await fetch(`${baseUrl}/v1/tokens/${agentRow.id}`, {
         method: 'DELETE',
@@ -501,17 +518,27 @@ interface OrgFixture {
       });
       expect(rv.status).toBe(204);
       const remaining = await db
-        .select({ id: schema.oauthRefreshToken.id, revoked: schema.oauthRefreshToken.revoked })
+        .select({
+          clientId: schema.oauthRefreshToken.clientId,
+          revoked: schema.oauthRefreshToken.revoked,
+        })
         .from(schema.oauthRefreshToken)
-        .where(inArray(schema.oauthRefreshToken.clientId, [clientA, clientB]));
-      expect(remaining.every((r) => r.revoked !== null)).toBe(true);
+        .where(inArray(schema.oauthRefreshToken.clientId, allClients));
+      const revokedFor = (clientId: string) =>
+        remaining.filter((r) => r.clientId === clientId).every((r) => r.revoked !== null);
+      expect(revokedFor(clientA)).toBe(true);
+      expect(revokedFor(clientB)).toBe(true);
+      expect(remaining.find((r) => r.clientId === clientC)!.revoked).toBeNull();
 
-      const after = await fetch(`${baseUrl}/v1/tokens`, { headers: authHeaders(orgA.adminKey) });
-      const afterTokens = (await after.json()) as Array<{ origin: string | null }>;
-      expect(afterTokens.find((t) => t.origin === name)).toBeFalsy();
+      const afterA = await fetch(`${baseUrl}/v1/tokens`, { headers: authHeaders(orgA.adminKey) });
+      const afterTokensA = (await afterA.json()) as Array<{ origin: string | null }>;
+      expect(afterTokensA.find((t) => t.origin === name)).toBeFalsy();
+      const afterB = await fetch(`${baseUrl}/v1/tokens`, { headers: authHeaders(orgB.adminKey) });
+      const afterTokensB = (await afterB.json()) as Array<{ origin: string | null }>;
+      expect(afterTokensB.find((t) => t.origin === name)).toBeTruthy();
 
-      await db.delete(schema.oauthRefreshToken).where(inArray(schema.oauthRefreshToken.clientId, [clientA, clientB]));
-      await db.delete(schema.oauthClient).where(inArray(schema.oauthClient.clientId, [clientA, clientB]));
+      await db.delete(schema.oauthRefreshToken).where(inArray(schema.oauthRefreshToken.clientId, allClients));
+      await db.delete(schema.oauthClient).where(inArray(schema.oauthClient.clientId, allClients));
     });
   });
 

--- a/packages/backend-core/src/control/tokens.controller.ts
+++ b/packages/backend-core/src/control/tokens.controller.ts
@@ -47,7 +47,7 @@ export class TokensController {
         .from(schema.tokens)
         .where(eq(schema.tokens.orgId, actor.orgId))
         .orderBy(desc(schema.tokens.createdAt)),
-      listOauthAgents(ctx.db),
+      listOauthAgents(ctx.db, actor.orgId),
     ]);
     return [...issued.map(toDto), ...oauth].sort((a, b) =>
       b.createdAt.localeCompare(a.createdAt),
@@ -60,7 +60,7 @@ export class TokensController {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     if (id.startsWith('orft_')) {
-      await revokeOauthAgent(ctx.db, id);
+      await revokeOauthAgent(ctx.db, id, actor.orgId);
       return;
     }
     const result = await ctx.db
@@ -72,15 +72,7 @@ export class TokensController {
   }
 }
 
-/**
- * OAuth-authorized agents (Claude Code, Cursor, …) don't get rows in `tokens` —
- * BetterAuth persists their grants in the `oauth_*` tables. Their access tokens
- * are stateless JWTs (no DB row), so the durable record of a connected agent is
- * the *refresh* token. MCP dynamic client registration also mints a fresh
- * `client_id` on every connect, so one user reconnecting Claude piles up many
- * refresh tokens — we collapse them to one row per (client name, user).
- */
-async function listOauthAgents(db: Db | Tx): Promise<TokenDto[]> {
+async function listOauthAgents(db: Db | Tx, orgId: string): Promise<TokenDto[]> {
   const rows = await db
     .select({
       id: schema.oauthRefreshToken.id,
@@ -92,16 +84,13 @@ async function listOauthAgents(db: Db | Tx): Promise<TokenDto[]> {
       clientName: schema.oauthClient.name,
     })
     .from(schema.oauthRefreshToken)
-    .innerJoin(
-      schema.orgMembers,
-      eq(schema.orgMembers.userId, schema.oauthRefreshToken.userId),
-    )
     .leftJoin(
       schema.oauthClient,
       eq(schema.oauthClient.clientId, schema.oauthRefreshToken.clientId),
     )
     .where(
       and(
+        eq(schema.oauthRefreshToken.referenceId, orgId),
         gt(schema.oauthRefreshToken.expiresAt, new Date()),
         isNull(schema.oauthRefreshToken.revoked),
       ),
@@ -138,30 +127,24 @@ async function listOauthAgents(db: Db | Tx): Promise<TokenDto[]> {
   return [...groups.values()];
 }
 
-/**
- * Revokes a connected OAuth agent given the refresh-token id that represents its
- * flock row. Soft-revokes (`revoked = now()`) every live refresh token in the
- * same (client name, user) group — the refresh grant rejects revoked tokens, so
- * the agent can't refresh back in once its short-lived JWT expires.
- */
-async function revokeOauthAgent(db: Db | Tx, refreshTokenId: string): Promise<void> {
+async function revokeOauthAgent(
+  db: Db | Tx,
+  refreshTokenId: string,
+  orgId: string,
+): Promise<void> {
   const rows = await db
     .select({
       clientId: schema.oauthRefreshToken.clientId,
       userId: schema.oauthRefreshToken.userId,
+      referenceId: schema.oauthRefreshToken.referenceId,
     })
     .from(schema.oauthRefreshToken)
     .where(eq(schema.oauthRefreshToken.id, refreshTokenId))
     .limit(1);
   const row = rows[0];
-  if (!row?.userId) throw new NotFoundException(`token ${refreshTokenId} not found`);
-
-  const membership = await db
-    .select({ orgId: schema.orgMembers.orgId })
-    .from(schema.orgMembers)
-    .where(eq(schema.orgMembers.userId, row.userId))
-    .limit(1);
-  if (membership.length === 0) throw new NotFoundException(`token ${refreshTokenId} not found`);
+  if (!row?.userId || row.referenceId !== orgId) {
+    throw new NotFoundException(`token ${refreshTokenId} not found`);
+  }
 
   const nameRow = (
     await db
@@ -185,6 +168,7 @@ async function revokeOauthAgent(db: Db | Tx, refreshTokenId: string): Promise<vo
     .where(
       and(
         eq(schema.oauthRefreshToken.userId, row.userId),
+        eq(schema.oauthRefreshToken.referenceId, orgId),
         inArray(schema.oauthRefreshToken.clientId, clientIds),
         isNull(schema.oauthRefreshToken.revoked),
       ),
@@ -194,6 +178,7 @@ async function revokeOauthAgent(db: Db | Tx, refreshTokenId: string): Promise<vo
     .where(
       and(
         eq(schema.oauthAccessToken.userId, row.userId),
+        eq(schema.oauthAccessToken.referenceId, orgId),
         inArray(schema.oauthAccessToken.clientId, clientIds),
       ),
     );

--- a/packages/backend-core/src/oauth/oauth-jwt-resolver.integration.test.ts
+++ b/packages/backend-core/src/oauth/oauth-jwt-resolver.integration.test.ts
@@ -19,6 +19,7 @@ const skipReason = TEST_URL
   let baseUrl: string;
   let db: ReturnType<typeof createDb>;
   let userId: string;
+  let memberOrgId: string;
   let signingKey: Awaited<ReturnType<typeof generateKeyPair>>['privateKey'];
   let kid: string;
 
@@ -55,7 +56,18 @@ const skipReason = TEST_URL
       role: 'owner',
       isDefault: true,
     });
+    const [memberOrg] = await db
+      .insert(schema.orgs)
+      .values({ name: 'JWT Resolver IT Org (secondary)' })
+      .returning();
+    await db.insert(schema.orgMembers).values({
+      orgId: memberOrg!.id,
+      userId: user!.id,
+      role: 'member',
+      isDefault: false,
+    });
     userId = user!.id;
+    memberOrgId = memberOrg!.id;
 
     const { publicKey, privateKey } = await generateKeyPair('EdDSA', { extractable: true });
     const publicJwk = await exportJWK(publicKey);
@@ -88,6 +100,7 @@ const skipReason = TEST_URL
     iss?: string;
     scope?: string;
     expSeconds?: number;
+    orgId?: string;
   }): Promise<string> {
     const iat = Math.floor(Date.now() / 1000);
     const jwt = new SignJWT({
@@ -95,6 +108,7 @@ const skipReason = TEST_URL
       aud: claims.aud ?? `${baseUrl}/mcp`,
       scope: claims.scope ?? 'mcp:tools kb:read',
       azp: 'test-client',
+      ...(claims.orgId ? { org_id: claims.orgId } : {}),
       iat,
       exp: iat + (claims.expSeconds ?? 3600),
     })
@@ -175,5 +189,18 @@ const skipReason = TEST_URL
     const token = await sign({ sub: 'usr_does_not_exist_xxxxxxxxxxxx' });
     const { status } = await callMcp(token);
     expect(status).toBe(401);
+  });
+
+  it('accepts a JWT pinned (org_id) to a non-default org the user belongs to', async () => {
+    const token = await sign({ orgId: memberOrgId });
+    const { status } = await callMcp(token);
+    expect(status).not.toBe(401);
+  });
+
+  it('rejects a JWT pinned (org_id) to an org the user is not a member of', async () => {
+    const token = await sign({ orgId: 'org_user_is_not_a_member_xxxx' });
+    const { status, wwwAuth } = await callMcp(token);
+    expect(status).toBe(401);
+    expect(wwwAuth).toContain('Bearer');
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,11 @@ export {
 } from './request/synth-agent-actor.ts';
 export { AuditLogger, type AuditEventInput } from './request/audit.ts';
 export { ClaimManager, type ClaimResult } from './request/claims.ts';
-export { CredentialResolver, type ResolvedCredential } from './request/credentials.ts';
+export {
+  CredentialResolver,
+  type ResolvedCredential,
+  readMembershipsForUser,
+} from './request/credentials.ts';
 
 export {
   hashSecret,

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -21,6 +21,16 @@ async function readMembershipsForUser(
 
 export { readMembershipsForUser };
 
+function resolvePinnedMembership(
+  memberships: Array<typeof schema.orgMembers.$inferSelect>,
+  pinnedOrgId: string | null,
+): (typeof schema.orgMembers.$inferSelect) | undefined {
+  if (pinnedOrgId) return memberships.find((m) => m.orgId === pinnedOrgId);
+  return memberships.find((m) => m.isDefault) ?? memberships[0];
+}
+
+export { resolvePinnedMembership };
+
 function hashOauthOpaqueToken(rawToken: string): string {
   return createHash('sha256').update(rawToken).digest('base64url');
 }
@@ -93,7 +103,7 @@ export class CredentialResolver {
     if (!tokenRow.userId) return null;
 
     const memberships = await readMembershipsForUser(this.db, tokenRow.userId);
-    const active = memberships.find((m) => m.isDefault) ?? memberships[0];
+    const active = resolvePinnedMembership(memberships, tokenRow.referenceId);
     if (!active) return null;
 
     const scopes = tokenRow.scopes;

--- a/packages/core/src/request/oauth-jwt.ts
+++ b/packages/core/src/request/oauth-jwt.ts
@@ -7,6 +7,7 @@ import {
   deriveAudiencesFromScopes,
   oauthMcpResourceAudience,
   readMembershipsForUser,
+  resolvePinnedMembership,
   type ResolvedCredential,
 } from './credentials.ts';
 
@@ -65,7 +66,10 @@ export async function resolveOauthJwtAccessToken(
     typeof payload['scope'] === 'string' ? payload['scope'].split(/\s+/).filter(Boolean) : [];
 
   const memberships = await readMembershipsForUser(db, userId);
-  const active = memberships.find((m) => m.isDefault) ?? memberships[0];
+  const active = resolvePinnedMembership(
+    memberships,
+    typeof payload['org_id'] === 'string' ? payload['org_id'] : null,
+  );
   if (!active) return null;
 
   const audiences = deriveAudiencesFromScopes(scopes);

--- a/packages/db/drizzle/0045_oauth_token_org_pin.sql
+++ b/packages/db/drizzle/0045_oauth_token_org_pin.sql
@@ -1,0 +1,13 @@
+UPDATE "oauth_refresh_token" AS rt
+SET "reference_id" = om."org_id"
+FROM "org_members" om
+WHERE rt."reference_id" IS NULL
+  AND om."user_id" = rt."user_id"
+  AND om."is_default" = true;
+--> statement-breakpoint
+UPDATE "oauth_access_token" AS act
+SET "reference_id" = om."org_id"
+FROM "org_members" om
+WHERE act."reference_id" IS NULL
+  AND om."user_id" = act."user_id"
+  AND om."is_default" = true;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1782374000638,
       "tag": "0044_conv_channels_default_agent_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1782460000000,
+      "tag": "0045_oauth_token_org_pin",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Stacked on #546 (refresh-token flock). Review/merge that first.

## Problem

OAuth/MCP agents weren't bound to an org. The token carries only the user id (`sub`); the resolver picked the user's **default** org live on every request. Consequences for multi-org users:

- the flock listed an agent under whichever org happened to be default,
- switching the default org silently retargeted every live agent,
- revoke was user-global (killed the agent across all the user's orgs).

## Fix — pin the org at consent, resolve from the pin

**Bind at consent** (`auth-factory.ts`): `postLogin.consentReferenceId` returns the user's active (default) org, which BetterAuth persists as `reference_id` on the refresh token and threads through every refresh. `customAccessTokenClaims` emits an `org_id` claim into the stateless JWT access token (which has no DB row to read from).

**Resolve from the pin** (`packages/core`): new `resolvePinnedMembership` — the JWT path reads the `org_id` claim, the opaque path reads `reference_id`, and the user must **still be a member** of the pinned org or access is denied (removing someone from an org now kills their agents there). Tokens issued before this change carry no pin and fall back to the default org.

**Migration `0045`** backfills `reference_id` on existing refresh/access tokens to each user's default org, so current connections converge to pinned on their next refresh.

**Flock truthful per-org + revoke org-scoped** (`tokens.controller.ts`): the list filters `reference_id = caller org`; revoke only touches grants pinned to the caller's org, so the same user's agent in another org survives.

## Choosing which org an agent connects to

The agent binds to the user's **active org at consent time** — chosen with the existing topbar org switcher (already shipped in cloud). No picker on the consent screen, and no silent default-org mutation as a side effect of connecting.

## Tests
- JWT-resolver `/mcp` integration: **10/10**, incl. new "pinned to a member org → accepted" and "pinned to a non-member org → 401".
- Control-plane: **108/108** — flock test rewritten to prove per-org truthfulness (org B sees only its own grant) and org-scoped revoke (org B's grant survives org A's revoke).
- Core 350/350; auth-factory 9/9. Typecheck + lint clean; migration applies on a fresh DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)