### PR TITLE
fix(db): backfill OAuth token reference_id under bypass_rls (0046)

### DIFF
--- a/.changeset/oauth-token-org-backfill-rls.md
+++ b/.changeset/oauth-token-org-backfill-rls.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/db': patch
+---
+
+fix(db): backfill OAuth token reference_id under bypass_rls
+
+Migration `0045` backfilled `oauth_refresh_token.reference_id` (and access tokens) by joining `org_members`, but that table has `FORCE ROW LEVEL SECURITY`. Real deploys run migrations as the database **owner** (Scaleway RDB has no Postgres superuser), and `FORCE` RLS applies to the owner — so without `app.bypass_rls` set, the `org_members` join saw zero rows and the backfill silently updated nothing, leaving every existing OAuth agent unpinned and hidden from the flock. (It only appeared to work in tests, which run as a superuser that bypasses RLS.)
+
+`0046` re-runs the backfill inside a `DO` block that sets `app.bypass_rls` first, so it works under the owner role too.

--- a/packages/db/drizzle/0046_oauth_token_org_backfill_rls.sql
+++ b/packages/db/drizzle/0046_oauth_token_org_backfill_rls.sql
@@ -1,0 +1,18 @@
+DO $$
+BEGIN
+  PERFORM set_config('app.bypass_rls', 'on', true);
+
+  UPDATE "oauth_refresh_token" AS rt
+  SET "reference_id" = om."org_id"
+  FROM "org_members" om
+  WHERE rt."reference_id" IS NULL
+    AND om."user_id" = rt."user_id"
+    AND om."is_default" = true;
+
+  UPDATE "oauth_access_token" AS act
+  SET "reference_id" = om."org_id"
+  FROM "org_members" om
+  WHERE act."reference_id" IS NULL
+    AND om."user_id" = act."user_id"
+    AND om."is_default" = true;
+END $$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1782460000000,
       "tag": "0045_oauth_token_org_pin",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1782800000000,
+      "tag": "0046_oauth_token_org_backfill_rls",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Problem
After the org-pinning rollout (4.59.1), prod still showed **no agents in the flock**. Diagnosis: all 217 `oauth_refresh_token` rows had `reference_id = NULL` — migration `0045`'s backfill matched **zero rows** despite being recorded as applied.

## Cause
`0045` joins `org_members` to derive each token-user's default org. That table has `FORCE ROW LEVEL SECURITY`. Deploys run migrations as the database **owner** (Scaleway RDB exposes no Postgres superuser), and `FORCE` RLS applies even to the owner — so without `app.bypass_rls` set, the `org_members` read returned nothing and the `UPDATE` silently no-opped. It passed CI only because the test DB connects as a superuser, which bypasses RLS.

## Fix
`0046` re-runs the backfill inside a `DO` block that calls `set_config('app.bypass_rls', 'on', true)` first (the same mechanism the app's runtime resolvers use), so it works under the owner role.

## Verified
Reproduced the exact condition locally by running both variants as the non-bypassing `munin_app` role under FORCE RLS:
- old `0045` logic → `UPDATE 0`, `reference_id` stays NULL
- new `0046` DO-block → `reference_id` set ✅

Shipping this and deploying re-runs the backfill against prod/dev and pins all existing live agents to their owner's default org. New connections were already pinned correctly (they go through `consentReferenceId`, which reads memberships with bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)