### PR TITLE
feat(access): OAuth-only flock with client identity; tidy end-user display

### DIFF
--- a/.changeset/flock-client-identity.md
+++ b/.changeset/flock-client-identity.md
@@ -1,0 +1,8 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+feat(agents): show client name + icon in the flock, drop the Origin column
+
+The flock row now leads with the OAuth client's name (e.g. "Claude · 3 connections") and a small client icon/glyph — matching the consent screen — instead of the generic "OAuth refresh token" label. The separate Origin column is dropped (its information moved into the primary label), and the table uses a fixed layout so the scopes list wraps inside the Token column instead of squeezing the other columns. `GET /v1/tokens` now returns the client `iconUrl`. Delegated end-user tokens (no client) keep their type label and a letter glyph.

--- a/.changeset/flock-client-identity.md
+++ b/.changeset/flock-client-identity.md
@@ -3,6 +3,8 @@
 '@getmunin/dashboard-pages': patch
 ---
 
-feat(agents): show client name + icon in the flock, drop the Origin column
+feat(access): OAuth-only flock with client identity; tidy end-user display
 
-The flock row now leads with the OAuth client's name (e.g. "Claude · 3 connections") and a small client icon/glyph — matching the consent screen — instead of the generic "OAuth refresh token" label. The separate Origin column is dropped (its information moved into the primary label), and the table uses a fixed layout so the scopes list wraps inside the Token column instead of squeezing the other columns. `GET /v1/tokens` now returns the client `iconUrl`. Delegated end-user tokens (no client) keep their type label and a letter glyph.
+**The flock (Settings → Agents)** now lists only OAuth-authorized agents. Delegated end-user tokens are no longer mixed in — they're managed on the End-users page. Each row leads with the OAuth client's name (e.g. "Claude · 3 connections") and a small client icon/glyph (matching the consent screen) instead of a generic "OAuth refresh token" label, the Origin column is dropped (its info moved into the primary label), and the table uses a fixed layout so the scopes list wraps inside the Token column instead of squeezing the other columns. `GET /v1/tokens` returns only OAuth agents (with `iconUrl`) and no longer merges the `tokens` table.
+
+**The End-users page** now shows a single identity line (name, else email, else phone, else "—") with an avatar of initials derived from the name ("Jens Pettersen" → "JP") or the email's first letter ("kjell@apps.no" → "K").

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -393,7 +393,7 @@ interface OrgFixture {
       expect(res.status).toBe(401);
     });
 
-    it('returns tokens for the calling org only', async () => {
+    it('mints and revokes delegated tokens with org scoping; they stay out of the OAuth-only flock', async () => {
       const mint = await fetch(`${baseUrl}/v1/tokens/delegated`, {
         method: 'POST',
         headers: authHeaders(orgA.adminKey),
@@ -403,12 +403,8 @@ interface OrgFixture {
       const minted = (await mint.json()) as { tokenId: string };
 
       const list = await fetch(`${baseUrl}/v1/tokens`, { headers: authHeaders(orgA.adminKey) });
-      const tokens = (await list.json()) as Array<{ id: string; endUserId: string }>;
-      expect(tokens.find((t) => t.id === minted.tokenId)).toBeTruthy();
-
-      const listB = await fetch(`${baseUrl}/v1/tokens`, { headers: authHeaders(orgB.adminKey) });
-      const tokensB = (await listB.json()) as Array<{ id: string }>;
-      expect(tokensB.find((t) => t.id === minted.tokenId)).toBeFalsy();
+      const tokens = (await list.json()) as Array<{ id: string }>;
+      expect(tokens.find((t) => t.id === minted.tokenId)).toBeFalsy();
 
       const rv = await fetch(`${baseUrl}/v1/tokens/${minted.tokenId}`, {
         method: 'DELETE',

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -437,8 +437,9 @@ interface OrgFixture {
       const clientC = `oauth-client-c-${label}`;
       const allClients = [clientA, clientB, clientC];
       const live = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      const icon = 'https://example.com/icon.png';
       await db.insert(schema.oauthClient).values(
-        allClients.map((clientId) => ({ clientId, name, redirectUris: ['https://example.com/cb'] })),
+        allClients.map((clientId) => ({ clientId, name, icon, redirectUris: ['https://example.com/cb'] })),
       );
       await db.insert(schema.oauthRefreshToken).values([
         {
@@ -489,6 +490,7 @@ interface OrgFixture {
         id: string;
         type: string;
         origin: string | null;
+        iconUrl: string | null;
         count: number;
         scopes: string[];
       }>;
@@ -498,6 +500,7 @@ interface OrgFixture {
       expect(agentRow.id.startsWith('orft_')).toBe(true);
       expect(agentRow.type).toBe('oauth_refresh');
       expect(agentRow.count).toBe(2);
+      expect(agentRow.iconUrl).toBe(icon);
       expect(agentRow.scopes.sort()).toEqual(['crm:write', 'kb:read', 'mcp:admin']);
 
       const listB = await fetch(`${baseUrl}/v1/tokens`, { headers: authHeaders(orgB.adminKey) });

--- a/packages/backend-core/src/control/tokens.controller.ts
+++ b/packages/backend-core/src/control/tokens.controller.ts
@@ -42,17 +42,8 @@ export class TokensController {
   async list(): Promise<TokenDto[]> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
-    const [issued, oauth] = await Promise.all([
-      ctx.db
-        .select()
-        .from(schema.tokens)
-        .where(eq(schema.tokens.orgId, actor.orgId))
-        .orderBy(desc(schema.tokens.createdAt)),
-      listOauthAgents(ctx.db, actor.orgId),
-    ]);
-    return [...issued.map(toDto), ...oauth].sort((a, b) =>
-      b.createdAt.localeCompare(a.createdAt),
-    );
+    const agents = await listOauthAgents(ctx.db, actor.orgId);
+    return agents.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
   }
 
   @Delete(':id')
@@ -187,19 +178,3 @@ async function revokeOauthAgent(
     );
 }
 
-function toDto(row: typeof schema.tokens.$inferSelect): TokenDto {
-  return {
-    id: row.id,
-    type: row.type,
-    scopes: row.scopes,
-    audiences: row.audiences,
-    origin: null,
-    iconUrl: null,
-    endUserId: row.endUserId,
-    expiresAt: row.expiresAt?.toISOString() ?? null,
-    lastUsedAt: row.lastUsedAt?.toISOString() ?? null,
-    revokedAt: row.revokedAt?.toISOString() ?? null,
-    createdAt: row.createdAt.toISOString(),
-    count: 1,
-  };
-}

--- a/packages/backend-core/src/control/tokens.controller.ts
+++ b/packages/backend-core/src/control/tokens.controller.ts
@@ -24,6 +24,7 @@ interface TokenDto {
   scopes: string[];
   audiences: string[];
   origin: string | null;
+  iconUrl: string | null;
   endUserId: string | null;
   expiresAt: string | null;
   lastUsedAt: string | null;
@@ -82,6 +83,7 @@ async function listOauthAgents(db: Db | Tx, orgId: string): Promise<TokenDto[]> 
       expiresAt: schema.oauthRefreshToken.expiresAt,
       createdAt: schema.oauthRefreshToken.createdAt,
       clientName: schema.oauthClient.name,
+      clientIcon: schema.oauthClient.icon,
     })
     .from(schema.oauthRefreshToken)
     .leftJoin(
@@ -109,6 +111,7 @@ async function listOauthAgents(db: Db | Tx, orgId: string): Promise<TokenDto[]> 
         scopes: row.scopes,
         audiences: [],
         origin,
+        iconUrl: row.clientIcon ?? null,
         endUserId: null,
         expiresAt: row.expiresAt.toISOString(),
         lastUsedAt: null,
@@ -191,6 +194,7 @@ function toDto(row: typeof schema.tokens.$inferSelect): TokenDto {
     scopes: row.scopes,
     audiences: row.audiences,
     origin: null,
+    iconUrl: null,
     endUserId: row.endUserId,
     expiresAt: row.expiresAt?.toISOString() ?? null,
     lastUsedAt: row.lastUsedAt?.toISOString() ?? null,

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -392,17 +392,16 @@
     "agents": {
       "eyebrow": "Access · Agents",
       "title": "The <em>flock</em>.",
-      "subtitle": "Every OAuth-authorized agent and end-user token issued for this org. Revoke any active token to immediately invalidate further MCP calls.",
+      "subtitle": "Every OAuth-authorized agent connected to this org. Revoke one to immediately cut off its MCP access.",
       "agentsTitleCount": "Agents · {count}",
       "agentsTitle": "Agents",
       "tableToken": "Token",
-      "tableOrigin": "Origin",
       "tableStatus": "Status",
       "tableIssued": "Issued",
       "tableLastUsed": "Last used",
       "tableExpires": "Expires",
       "emptyTitle": "No connected agents yet",
-      "emptyBody": "Add the MCP URL to Claude Desktop, Cursor, or your runtime, then complete consent — issued tokens will appear here.",
+      "emptyBody": "Add the MCP URL to Claude Desktop, Cursor, or your runtime, then complete consent — connected agents will appear here.",
       "noScopes": "no scopes",
       "connections": "{count, plural, one {# connection} other {# connections}}",
       "issued": "Issued {when}",
@@ -412,12 +411,6 @@
         "active": "active",
         "revoked": "revoked",
         "expired": "expired"
-      },
-      "types": {
-        "oauth_access": "OAuth access token",
-        "oauth_refresh": "OAuth refresh token",
-        "delegated_end_user": "End-user token",
-        "guest": "Guest token"
       },
       "revoked": "Token revoked.",
       "errors": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -392,17 +392,16 @@
     "agents": {
       "eyebrow": "Tilgang · Agenter",
       "title": "<em>Flokken</em>.",
-      "subtitle": "Alle OAuth-autoriserte agenter og sluttbruker-tokens utstedt for denne organisasjonen. Tilbakekall et aktivt token for å gjøre videre MCP-kall ugyldige umiddelbart.",
+      "subtitle": "Alle OAuth-autoriserte agenter koblet til denne organisasjonen. Tilbakekall en for å kutte MCP-tilgangen umiddelbart.",
       "agentsTitleCount": "Agenter · {count}",
       "agentsTitle": "Agenter",
       "tableToken": "Token",
-      "tableOrigin": "Opphav",
       "tableStatus": "Status",
       "tableIssued": "Utstedt",
       "tableLastUsed": "Sist brukt",
       "tableExpires": "Utløper",
       "emptyTitle": "Ingen tilkoblede agenter ennå",
-      "emptyBody": "Legg MCP-URL-en inn i Claude Desktop, Cursor eller MCP-klienten din, og fullfør samtykket — utstedte tokens vises her.",
+      "emptyBody": "Legg MCP-URL-en inn i Claude Desktop, Cursor eller MCP-klienten din, og fullfør samtykket — tilkoblede agenter vises her.",
       "noScopes": "ingen scopes",
       "connections": "{count, plural, one {# tilkobling} other {# tilkoblinger}}",
       "issued": "Utstedt {when}",
@@ -412,12 +411,6 @@
         "active": "aktiv",
         "revoked": "tilbakekalt",
         "expired": "utløpt"
-      },
-      "types": {
-        "oauth_access": "OAuth-tilgangstoken",
-        "oauth_refresh": "OAuth-fornyelsestoken",
-        "delegated_end_user": "Sluttbruker-token",
-        "guest": "Gjeste-token"
       },
       "revoked": "Token tilbakekalt.",
       "errors": {

--- a/packages/dashboard-pages/src/pages/agents.tsx
+++ b/packages/dashboard-pages/src/pages/agents.tsx
@@ -18,6 +18,7 @@ interface TokenDto {
   scopes: string[];
   audiences: string[];
   origin: string | null;
+  iconUrl: string | null;
   endUserId: string | null;
   expiresAt: string | null;
   lastUsedAt: string | null;
@@ -99,16 +100,15 @@ export function AgentsPage() {
           <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
         ) : (
           <div className="-mx-6 overflow-x-auto px-6 md:mx-0 md:px-0">
-          <table className="w-full">
+          <table className="w-full table-fixed">
             <thead>
               <tr className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark text-left">
-                <Th>{t('tableToken')}</Th>
-                <Th className="hidden md:table-cell">{t('tableOrigin')}</Th>
-                <Th>{t('tableStatus')}</Th>
-                <Th className="hidden md:table-cell">{t('tableIssued')}</Th>
-                <Th className="hidden md:table-cell">{t('tableLastUsed')}</Th>
-                <Th className="hidden md:table-cell">{t('tableExpires')}</Th>
-                <Th className="text-right" />
+                <Th className="w-[40%]">{t('tableToken')}</Th>
+                <Th className="w-[10%]">{t('tableStatus')}</Th>
+                <Th className="hidden md:table-cell w-[14%]">{t('tableIssued')}</Th>
+                <Th className="hidden md:table-cell w-[14%]">{t('tableLastUsed')}</Th>
+                <Th className="hidden md:table-cell w-[14%]">{t('tableExpires')}</Th>
+                <Th className="text-right w-[8%]" />
               </tr>
             </thead>
             <tbody>
@@ -120,6 +120,7 @@ export function AgentsPage() {
                       ? 'expired'
                       : 'active';
                 const typeLabel = labelForType(token.type, t);
+                const primaryName = token.origin ?? typeLabel;
                 const issued = format.dateTime(new Date(token.createdAt), {
                   month: 'short',
                   day: 'numeric',
@@ -142,23 +143,25 @@ export function AgentsPage() {
                 return (
                   <tr
                     key={token.id}
-                    className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark align-middle"
+                    className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark align-top"
                   >
-                    <td className="py-4 pr-4">
-                      <div className="text-sm font-medium text-ink dark:text-foreground">
-                        {typeLabel}
+                    <td className="py-4 pr-4 align-top">
+                      <div className="flex items-start gap-3">
+                        <ClientGlyph iconUrl={token.iconUrl} name={primaryName} />
+                        <div className="min-w-0">
+                          <div className="text-sm font-medium text-ink dark:text-foreground">
+                            {primaryName}
+                            {(token.count ?? 1) > 1 && (
+                              <span className="ml-1.5 font-normal text-ink-mute">
+                                · {t('connections', { count: token.count! })}
+                              </span>
+                            )}
+                          </div>
+                          <div className="mt-0.5 font-mono text-[11px] leading-relaxed text-ink-mute break-words">
+                            {token.scopes.length > 0 ? token.scopes.join(' ') : t('noScopes')}
+                          </div>
+                        </div>
                       </div>
-                      <div className="font-mono text-[11px] text-ink-mute">
-                        {token.scopes.length > 0 ? token.scopes.join(' ') : t('noScopes')}
-                      </div>
-                    </td>
-                    <td className="hidden md:table-cell py-4 pr-4 font-mono text-xs text-ink-mute">
-                      {token.origin ?? (token.audiences.join(', ') || '—')}
-                      {(token.count ?? 1) > 1 && (
-                        <span className="ml-2 text-ink-mute/70">
-                          · {t('connections', { count: token.count! })}
-                        </span>
-                      )}
                     </td>
                     <td className="py-4 pr-4">
                       <StatusChip status={status} t={t} />
@@ -187,6 +190,26 @@ export function AgentsPage() {
         )}
       </section>
     </>
+  );
+}
+
+function ClientGlyph({ iconUrl, name }: { iconUrl: string | null; name: string }) {
+  const glyph = (name.trim()[0] ?? '?').toUpperCase();
+  return (
+    <span className="flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-md border-[0.5px] border-rule-soft bg-white font-serif text-[13px] leading-none text-ink dark:border-rule-on-dark">
+      {iconUrl ? (
+        <img
+          src={iconUrl}
+          alt=""
+          className="size-5 object-contain"
+          onError={(e) => {
+            e.currentTarget.style.display = 'none';
+          }}
+        />
+      ) : (
+        glyph
+      )}
+    </span>
   );
 }
 

--- a/packages/dashboard-pages/src/pages/agents.tsx
+++ b/packages/dashboard-pages/src/pages/agents.tsx
@@ -145,21 +145,19 @@ export function AgentsPage() {
                     className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark align-top"
                   >
                     <td className="py-4 pr-4 align-top">
-                      <div className="flex items-start gap-3">
+                      <div className="flex items-center gap-2 text-sm font-medium text-ink dark:text-foreground">
                         <ClientGlyph iconUrl={token.iconUrl} name={primaryName} />
-                        <div className="min-w-0">
-                          <div className="text-sm font-medium text-ink dark:text-foreground">
-                            {primaryName}
-                            {(token.count ?? 1) > 1 && (
-                              <span className="ml-1.5 font-normal text-ink-mute">
-                                · {t('connections', { count: token.count! })}
-                              </span>
-                            )}
-                          </div>
-                          <div className="mt-0.5 font-mono text-[11px] leading-relaxed text-ink-mute break-words">
-                            {token.scopes.length > 0 ? token.scopes.join(' ') : t('noScopes')}
-                          </div>
-                        </div>
+                        <span>
+                          {primaryName}
+                          {(token.count ?? 1) > 1 && (
+                            <span className="ml-1.5 font-normal text-ink-mute">
+                              · {t('connections', { count: token.count! })}
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                      <div className="mt-1 font-mono text-[11px] leading-relaxed text-ink-mute break-words">
+                        {token.scopes.length > 0 ? token.scopes.join(' ') : t('noScopes')}
                       </div>
                     </td>
                     <td className="py-4 pr-4">
@@ -195,12 +193,12 @@ export function AgentsPage() {
 function ClientGlyph({ iconUrl, name }: { iconUrl: string | null; name: string }) {
   const glyph = (name.trim()[0] ?? '?').toUpperCase();
   return (
-    <span className="flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-md border-[0.5px] border-rule-soft bg-white font-serif text-[13px] leading-none text-ink dark:border-rule-on-dark">
+    <span className="flex size-[18px] shrink-0 items-center justify-center overflow-hidden rounded-[4px] border-[0.5px] border-rule-soft bg-white font-serif text-[10px] leading-none text-ink dark:border-rule-on-dark">
       {iconUrl ? (
         <img
           src={iconUrl}
           alt=""
-          className="size-5 object-contain"
+          className="size-3 object-contain"
           onError={(e) => {
             e.currentTarget.style.display = 'none';
           }}

--- a/packages/dashboard-pages/src/pages/agents.tsx
+++ b/packages/dashboard-pages/src/pages/agents.tsx
@@ -142,7 +142,7 @@ export function AgentsPage() {
                 return (
                   <tr
                     key={token.id}
-                    className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark align-top"
+                    className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark align-middle"
                   >
                     <td className="py-4 pr-4 align-top">
                       <div className="flex items-center gap-2 text-sm font-medium text-ink dark:text-foreground">

--- a/packages/dashboard-pages/src/pages/agents.tsx
+++ b/packages/dashboard-pages/src/pages/agents.tsx
@@ -119,8 +119,7 @@ export function AgentsPage() {
                     : token.expiresAt !== null && new Date(token.expiresAt) < new Date()
                       ? 'expired'
                       : 'active';
-                const typeLabel = labelForType(token.type, t);
-                const primaryName = token.origin ?? typeLabel;
+                const primaryName = token.origin ?? '—';
                 const issued = format.dateTime(new Date(token.createdAt), {
                   month: 'short',
                   day: 'numeric',
@@ -246,15 +245,4 @@ function StatusChip({
       {label}
     </span>
   );
-}
-
-function labelForType(
-  type: string,
-  t: ReturnType<typeof useTranslations<'dashboard.agents'>>,
-): string {
-  if (type === 'oauth_access') return t('types.oauth_access');
-  if (type === 'oauth_refresh') return t('types.oauth_refresh');
-  if (type === 'delegated_end_user') return t('types.delegated_end_user');
-  if (type === 'guest') return t('types.guest');
-  return type;
 }

--- a/packages/dashboard-pages/src/pages/end-users.tsx
+++ b/packages/dashboard-pages/src/pages/end-users.tsx
@@ -138,14 +138,9 @@ export function EndUsersPage() {
                 <tr key={eu.id} className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
                   <td className="py-4 pr-4">
                     <div className="flex items-center gap-3">
-                      <Avatar name={eu.name} />
-                      <div>
-                        <div className="text-sm font-medium text-ink dark:text-foreground">
-                          {eu.name ?? '—'}
-                        </div>
-                        <div className="font-mono text-[11px] text-ink-mute">
-                          {eu.email ?? eu.phone ?? '—'}
-                        </div>
+                      <Avatar name={eu.name} email={eu.email} />
+                      <div className="text-sm font-medium text-ink dark:text-foreground">
+                        {eu.name ?? eu.email ?? eu.phone ?? '—'}
                       </div>
                     </div>
                   </td>
@@ -189,19 +184,26 @@ function Th({ children, className }: { children?: ReactNode; className?: string 
   );
 }
 
-function Avatar({ name }: { name: string | null }) {
-  const initials =
-    name && name !== '—'
-      ? name
-          .split(/\s+/)
-          .map((s) => s[0])
-          .join('')
-          .slice(0, 2)
-          .toUpperCase()
-      : '?';
+function Avatar({ name, email }: { name: string | null; email: string | null }) {
   return (
     <span className="inline-flex size-9 items-center justify-center rounded-full bg-paper-deep dark:bg-secondary font-mono text-[11px] uppercase text-ink dark:text-foreground">
-      {initials}
+      {avatarInitials(name, email)}
     </span>
   );
+}
+
+function avatarInitials(name: string | null, email: string | null): string {
+  const trimmedName = name?.trim();
+  if (trimmedName) {
+    return trimmedName
+      .split(/\s+/)
+      .map((s) => s[0])
+      .filter(Boolean)
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
+  }
+  const trimmedEmail = email?.trim();
+  if (trimmedEmail) return trimmedEmail[0]!.toUpperCase();
+  return '?';
 }


### PR DESCRIPTION
Polish pass on the Settings → Access pages.

## The flock (Settings → Agents)
- **OAuth-agents-only.** Delegated end-user tokens are no longer merged into `/v1/tokens` — they're managed on the End-users page (which already lists them and revokes per-user), so the flock is now coherently "connected agents."
- **Leads with the client.** Each row shows the OAuth client's name (e.g. **Claude · 3 connections**) + a small client icon/glyph (matching the consent screen), replacing the generic "OAuth refresh token" label.
- **Origin column dropped** (its info moved into the primary label).
- **Fixed table layout** so the scopes list wraps inside the Token column instead of dictating its width and cramming the other columns.
- Removed the now-dead `labelForType` + `types.*` / `tableOrigin` i18n. `GET /v1/tokens` returns only OAuth agents, now with `iconUrl`.

## End-users page
- Single identity line: **name**, else **email**, else **phone**, else **—**.
- Avatar initials from the name (`Ola Nordmann` → `ON`) or the email's first letter (`knut.nordmann@example.no` → `K`); `?` when neither.

## Tests
- Control-plane suite green (108). Updated the delegated-token test: it now asserts delegated tokens are mintable/revocable but **absent** from the OAuth-only flock. Flock test asserts the row carries `iconUrl`.
- Typecheck + lint clean.

Needs a release + cloud bump to land in cloud prod (the `iconUrl` field + flock filtering come from `@getmunin/backend-core`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
