### PR TITLE
fix(oauth): retire the mcp:self_service OAuth scope

### DIFF
--- a/.changeset/drop-mcp-self-service-scope.md
+++ b/.changeset/drop-mcp-self-service-scope.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/core': patch
+---
+
+fix(oauth): retire the `mcp:self_service` OAuth scope
+
+`mcp:self_service` was advertised in the OAuth discovery metadata (`scopes_supported`), so MCP clients like Claude — which request the full advertised set — were granted it on connect, cluttering every agent's scope list. It was inert (an admin-eligible OAuth agent always resolves to the `admin` audience via `deriveMcpAudience`), and nothing server-side ever used it: the self-service audience is granted directly to server-minted delegated end-user tokens (`audiences: ['self_service']`), not through an OAuth scope.
+
+Removed `mcp:self_service` from `SUPPORTED_SCOPES` (so it's no longer advertised or accepted) and dropped its now-orphaned branch in `deriveAudiencesFromScopes`. Existing tokens keep the scope until they reconnect; behavior is unchanged either way.

--- a/packages/backend-core/src/oauth/oauth.constants.ts
+++ b/packages/backend-core/src/oauth/oauth.constants.ts
@@ -4,7 +4,6 @@ export const MCP_RESOURCE_PATH = MCP_INTERNAL_PATH;
 export const SUPPORTED_SCOPES = [
   'mcp:tools',
   'mcp:admin',
-  'mcp:self_service',
   'kb:read',
   'kb:write',
   'conv:read',

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -230,7 +230,6 @@ export function deriveAudiencesFromScopes(scopes: string[]): Audience[] {
   const set = new Set<Audience>();
   for (const scope of scopes) {
     if (scope === 'mcp:admin') set.add('admin');
-    if (scope === 'mcp:self_service') set.add('self_service');
   }
   return Array.from(set);
 }

--- a/packages/core/src/request/derive-audiences.test.ts
+++ b/packages/core/src/request/derive-audiences.test.ts
@@ -7,14 +7,9 @@ describe('deriveAudiencesFromScopes', () => {
     expect(deriveAudiencesFromScopes(['mcp:admin', 'kb:read'])).toEqual(['admin']);
   });
 
-  it('grants self_service only when mcp:self_service is present', () => {
-    expect(deriveAudiencesFromScopes(['mcp:self_service'])).toEqual(['self_service']);
-  });
-
-  it('grants both when both mcp:* scopes are present', () => {
-    expect(deriveAudiencesFromScopes(['mcp:admin', 'mcp:self_service']).sort()).toEqual(
-      ['admin', 'self_service'].sort(),
-    );
+  it('ignores the retired mcp:self_service scope', () => {
+    expect(deriveAudiencesFromScopes(['mcp:self_service'])).toEqual([]);
+    expect(deriveAudiencesFromScopes(['mcp:admin', 'mcp:self_service'])).toEqual(['admin']);
   });
 
   it('returns an empty list for OIDC-only or resource-scope-only tokens', () => {


### PR DESCRIPTION
## Why
Connecting Claude granted `mcp:self_service` (visible in the flock's scope list). Root cause: it was advertised in OAuth discovery `scopes_supported`, and MCP clients request the **full advertised set**, so it got granted on every connect.

It was **inert** — an admin-eligible OAuth agent with `mcp:admin` always resolves to the `admin` audience via `deriveMcpAudience`, so the scope was never exercised — and **unused server-side**: the `self_service` audience is granted directly on server-minted delegated end-user tokens (`POST /v1/tokens/delegated` → `audiences: ['self_service']`, restricted to `SELF_SERVICE_SCOPES`), never through an OAuth scope.

## Change
- Removed `mcp:self_service` from `SUPPORTED_SCOPES` → no longer advertised in `scopes_supported` (both discovery controllers) nor accepted as a valid OAuth scope (`auth-factory`).
- Dropped the now-orphaned `mcp:self_service` branch in `deriveAudiencesFromScopes`; updated its unit test to assert the scope is ignored.

## Impact
- New connections won't request/receive it. Existing tokens keep it until they reconnect — behavior is identical either way (admin agents resolve to `admin`; the `self_service` audience type and delegated-token path are untouched).

## Tests
`deriveAudiencesFromScopes` (4), OAuth discovery metadata (6), audience/guard/skill-loader (27) all green. Typecheck + lint clean. Discovery tests build their expectation from `SUPPORTED_SCOPES` so they track the removal automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)