### PR TITLE
feat(dashboard-pages): export skeleton loading components

### DIFF
--- a/.changeset/export-skeleton-components.md
+++ b/.changeset/export-skeleton-components.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+feat(dashboard-pages): export skeleton loading components
+
+`Skeleton`, `TableSkeleton`, `CardSkeleton`, `CardListSkeleton`, and the `SkeletonColumn` type are now re-exported from the package barrel so downstream consumers can reuse them. Previously they lived in `components/skeleton.tsx` and were only reachable via relative imports inside the package — the `exports` map exposes only `.` and `./server`, so deep imports were blocked too.

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -38,6 +38,13 @@ export {
   type SettingsTopbarProps,
 } from './components/munin-topbar';
 export { PageShell, nativeFieldClass } from './components/page-shell';
+export {
+  Skeleton,
+  TableSkeleton,
+  CardSkeleton,
+  CardListSkeleton,
+  type SkeletonColumn,
+} from './components/skeleton';
 export { NativeSelect } from './components/native-select';
 export {
   AuthShell,


### PR DESCRIPTION
## What

Re-export the skeleton loading components from the `@getmunin/dashboard-pages` barrel so downstream consumers can import them:

- `Skeleton`
- `TableSkeleton`
- `CardSkeleton`
- `CardListSkeleton`
- `SkeletonColumn` (type)

## Why

They live in `components/skeleton.tsx` and were only reachable via relative imports inside the package. The `exports` map declares only `.` and `./server` (no wildcard), so deep imports were blocked too — meaning the components couldn't be reused outside the package.

## Notes

- Patch changeset for `@getmunin/dashboard-pages` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)