### PR TITLE
feat(access): show the authorizing member on each flock row

### DIFF
--- a/.changeset/flock-authorizing-member.md
+++ b/.changeset/flock-authorizing-member.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+feat(access): show the authorizing member on each flock row
+
+The flock (Settings → Agents) groups OAuth connections by client *and* the org member who authorized them, but only the client name was shown — so two members who each connected, say, Claude produced two visually identical rows with no way to tell whose access a revoke would cut off.
+
+`GET /v1/tokens` now joins the authorizing user and returns `user: { name, email }` per row. The Agents page shows that member inline after the client name ("Claude · Kjell Rune Monsø", with the email on hover and as the fallback when no name is set), replacing the "· N connections" count — which only reflected dynamic-client-registration reconnects and wasn't actionable, since a row already represents one member's access to one client and revoke cuts off that whole group.

--- a/packages/backend-core/src/control/tokens.controller.ts
+++ b/packages/backend-core/src/control/tokens.controller.ts
@@ -25,6 +25,7 @@ interface TokenDto {
   audiences: string[];
   origin: string | null;
   iconUrl: string | null;
+  user: { name: string | null; email: string } | null;
   endUserId: string | null;
   expiresAt: string | null;
   lastUsedAt: string | null;
@@ -75,12 +76,15 @@ async function listOauthAgents(db: Db | Tx, orgId: string): Promise<TokenDto[]> 
       createdAt: schema.oauthRefreshToken.createdAt,
       clientName: schema.oauthClient.name,
       clientIcon: schema.oauthClient.icon,
+      userName: schema.users.name,
+      userEmail: schema.users.email,
     })
     .from(schema.oauthRefreshToken)
     .leftJoin(
       schema.oauthClient,
       eq(schema.oauthClient.clientId, schema.oauthRefreshToken.clientId),
     )
+    .leftJoin(schema.users, eq(schema.users.id, schema.oauthRefreshToken.userId))
     .where(
       and(
         eq(schema.oauthRefreshToken.referenceId, orgId),
@@ -103,6 +107,7 @@ async function listOauthAgents(db: Db | Tx, orgId: string): Promise<TokenDto[]> 
         audiences: [],
         origin,
         iconUrl: row.clientIcon ?? null,
+        user: row.userEmail ? { name: row.userName, email: row.userEmail } : null,
         endUserId: null,
         expiresAt: row.expiresAt.toISOString(),
         lastUsedAt: null,

--- a/packages/dashboard-pages/src/pages/agents.tsx
+++ b/packages/dashboard-pages/src/pages/agents.tsx
@@ -19,6 +19,7 @@ interface TokenDto {
   audiences: string[];
   origin: string | null;
   iconUrl: string | null;
+  user?: { name: string | null; email: string } | null;
   endUserId: string | null;
   expiresAt: string | null;
   lastUsedAt: string | null;
@@ -149,9 +150,12 @@ export function AgentsPage() {
                         <ClientGlyph iconUrl={token.iconUrl} name={primaryName} />
                         <span>
                           {primaryName}
-                          {(token.count ?? 1) > 1 && (
-                            <span className="ml-1.5 font-normal text-ink-mute">
-                              · {t('connections', { count: token.count! })}
+                          {token.user && (
+                            <span
+                              className="ml-1.5 font-normal text-ink-mute"
+                              title={token.user.email}
+                            >
+                              · {token.user.name ?? token.user.email}
                             </span>
                           )}
                         </span>


### PR DESCRIPTION
## What

The flock (Settings → Agents) groups OAuth connections by client **and** the org member who authorized them, but only the client name was shown. So two members who each connect, say, Claude produced two visually identical rows — with no way to tell whose access a **Revoke** would cut off.

This surfaces the authorizing member on each row.

## Changes

- **Backend** (`tokens.controller.ts`): `listOauthAgents` left-joins `users` on the refresh token's `userId`; `GET /v1/tokens` now returns `user: { name, email } | null` per row. No new query scope — still org-pinned via `reference_id`.
- **Frontend** (`agents.tsx`): the member is shown inline after the client name — `Claude · Ola Nordmann` — with the email on hover and as the fallback when no name is set. This **replaces** the `· N connections` count, which only reflected dynamic-client-registration reconnects and wasn't actionable (a row already represents one member's access to one client, and revoke cuts off that whole group).

## Notes

- `users` has no RLS (BetterAuth/service-role managed), so the join reads all org members fine.
- `count` is still returned by the API (the control-plane integration test asserts it); it's just no longer rendered.
- The `connections` i18n key is now orphaned — left in place to avoid churn.

## Test plan

- [x] `pnpm -F @getmunin/backend-core -F @getmunin/dashboard-pages typecheck`
- [ ] Manually verified the flock renders the member after the client name (single-member org shows your own name on every row; connect from a second member to see distinct rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
