### PR TITLE
fix(outreach): correct fresh-email subject, unsubscribe domain, and link rendering

### DIFF
--- a/.changeset/outreach-email-fixes.md
+++ b/.changeset/outreach-email-fixes.md
@@ -1,0 +1,9 @@
+---
+"@getmunin/backend-core": patch
+---
+
+fix(outreach): correct fresh-email subject, unsubscribe domain, and link rendering
+
+- Only prepend `Re:` to outbound email subjects when the message is an actual reply (the conversation has prior messages or an `In-Reply-To` header); fresh outreach sends keep their subject verbatim.
+- Build the unsubscribe URL from the API domain (`MUNIN_API_URL`) like other transactional emails, instead of the MCP domain.
+- Render the unsubscribe footer as a markdown link (`[Unsubscribe](…)`) so it shows as an "Unsubscribe" link in the HTML email instead of a full URL.

--- a/packages/backend-core/src/control/outreach-proposals.controller.ts
+++ b/packages/backend-core/src/control/outreach-proposals.controller.ts
@@ -12,6 +12,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { z } from 'zod';
+import { readApiBaseUrl } from '@getmunin/core';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
@@ -92,7 +93,7 @@ export class OutreachProposalsController {
   @Post(':id/approve')
   @HttpCode(200)
   async approve(@Param('id') id: string): Promise<ProposalDto> {
-    const publicBaseUrl = process.env.NEXT_PUBLIC_MCP_URL ?? 'http://localhost:3001';
+    const publicBaseUrl = readApiBaseUrl();
     return translate(() => this.outreach.approveProposal(id, { publicBaseUrl }));
   }
 

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -178,7 +178,9 @@ export class EmailAdapter implements ChannelAdapter {
     const body = quoted ? `${ctx.message.body}\n\n${quoted}` : ctx.message.body;
     const html = ctx.message.bodyHtml ?? renderEmailHtml(ctx.message.body, prior, 3);
 
-    const subject = ensureReSubject(ctx.conversation.subject?.trim() || null);
+    const rawSubject = ctx.conversation.subject?.trim() || null;
+    const isReply = prior.length > 0 || ctx.delivery.inReplyToHeader != null;
+    const subject = isReply ? ensureReSubject(rawSubject) : (rawSubject ?? '(no subject)');
     const trackerUrl = trackerUrlFor(config, ctx, html);
 
     const built: BuiltMessage = buildOutbound({

--- a/packages/backend-core/src/modules/outreach/outreach.service.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.test.ts
@@ -224,7 +224,7 @@ const skipReason = TEST_URL
       const msgRows = await db.execute<{ body: string }>(
         sql`SELECT body FROM conv_messages WHERE id = ${approved.sentMessageId!}`,
       );
-      expect(msgRows[0]!.body).toContain('Unsubscribe: https://test.local/v1/outreach/unsubscribe?token=');
+      expect(msgRows[0]!.body).toContain('[Unsubscribe](https://test.local/v1/outreach/unsubscribe?token=');
 
       // An outbound delivery row was queued (email channel + agent author).
       const delivery = await db.execute<{ count: number }>(

--- a/packages/backend-core/src/modules/outreach/outreach.service.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.ts
@@ -1124,7 +1124,7 @@ function composeOutreachBody(input: {
     body += `\n\n${input.ctaUrl}`;
   }
   if (input.unsubscribeRequired) {
-    body += `\n\n---\nUnsubscribe: ${input.unsubscribeUrl}`;
+    body += `\n\n---\n[Unsubscribe](${input.unsubscribeUrl})`;
   }
   return body;
 }


### PR DESCRIPTION
Three outreach email fixes.

## 1. Spurious `Re:` on fresh outreach emails
`email-adapter.ts` called `ensureReSubject()` unconditionally, so the first send of a fresh conversation got `Re:` prepended even with no prior message. It now only does so when the message is an actual reply (the conversation has prior messages or an `In-Reply-To` header). Replies still get `Re:`; fresh sends keep the subject verbatim.

## 2. Unsubscribe link used the MCP domain
`outreach-proposals.controller.ts` read `NEXT_PUBLIC_MCP_URL` for the unsubscribe base URL. It now uses `readApiBaseUrl()` from `@getmunin/core` (`MUNIN_API_URL`), matching how other transactional links (e.g. CMS delivery) are built.

## 3. Unsubscribe shown as a full URL
`composeOutreachBody` now emits `[Unsubscribe](…)` instead of `Unsubscribe: …`. The email adapter renders the body through `marked`, so the HTML email gets `<a href="…">Unsubscribe</a>`.

Note: the plain-text MIME part keeps the raw markdown, consistent with every other link in the body.

## Testing
- `pnpm typecheck` — all 29 packages green
- `pnpm -F @getmunin/backend-core test` — 859 tests pass (incl. outreach + email integration suites against `munin_test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)