### PR TITLE
feat(conv): reopen on reply across channels + auto-close stale conversations

### DIFF
--- a/.changeset/conv-reopen-and-auto-close.md
+++ b/.changeset/conv-reopen-and-auto-close.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': minor
+---
+
+feat(conv): reopen on reply across channels + auto-close conversations waiting on the user
+
+Inbound replies now reopen a `closed`/`snoozed` conversation on every channel, not just the chat widget. A shared `reopenClosedConversation` helper is wired into the email adapter's threaded-reply path (and the widget path now reuses it), emitting `conversation.status_changed` when a conversation actually transitions back to `open`.
+
+A new deterministic backend sweep (`ConvSchedulerService`, hourly by default) auto-closes non-voice conversations that have been waiting on the end-user: open, last public message from an AI agent or human teammate, and idle past a threshold (default 2 days). Closing reuses the existing `changeStatus` path, so it clears human-attention flags, releases the runner lease, emits the status webhook, and enqueues CRM contact extraction — identical to an operator close. Configurable via `MUNIN_CONV_AUTO_CLOSE_CRON`, `MUNIN_CONV_AUTO_CLOSE_DAYS`, and `MUNIN_CONV_AUTO_CLOSE_DISABLED`.

--- a/packages/backend-core/src/modules/conv/conv-scheduler.service.ts
+++ b/packages/backend-core/src/modules/conv/conv-scheduler.service.ts
@@ -1,0 +1,98 @@
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { CronExpression, SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { schema, type Db } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import {
+  ActorIdentity,
+  RequestContextStore,
+  parseEnvCron,
+  parseEnvDisableFlag,
+  type RequestContext,
+} from '@getmunin/core';
+import { randomUUID } from 'node:crypto';
+import { DB } from '../../common/db/db.module.ts';
+import { withSchedulerLock } from '../../common/scheduler-lock/index.ts';
+import { ConvService } from './conv.service.ts';
+
+const DEFAULT_THRESHOLD_DAYS = 2;
+
+@Injectable()
+export class ConvSchedulerService implements OnModuleInit {
+  private readonly logger = new Logger(ConvSchedulerService.name);
+  private readonly disabled =
+    parseEnvDisableFlag('MUNIN_CONV_AUTO_CLOSE_DISABLED') ||
+    process.env.NODE_ENV === 'test';
+  private readonly thresholdDays = parseThresholdDays();
+
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    private readonly conv: ConvService,
+    private readonly registry: SchedulerRegistry,
+  ) {}
+
+  onModuleInit(): void {
+    if (this.disabled) {
+      this.logger.log('conv auto-close scheduler disabled');
+      return;
+    }
+
+    const cron = parseEnvCron({
+      name: 'MUNIN_CONV_AUTO_CLOSE_CRON',
+      default: CronExpression.EVERY_HOUR,
+    });
+    if (cron === null) {
+      this.logger.log('conv auto-close disabled by env');
+      return;
+    }
+
+    const job = new CronJob(cron, () => {
+      void withSchedulerLock(this.db, 'conv-scheduler:auto-close', () => this.runSweep());
+    });
+    this.registry.addCronJob('conv-auto-close', job);
+    job.start();
+    this.logger.log(
+      `conv auto-close scheduled with "${cron}" (threshold ${this.thresholdDays}d)`,
+    );
+  }
+
+  private async runSweep(): Promise<void> {
+    const orgs = await this.db.select({ id: schema.orgs.id }).from(schema.orgs);
+    if (orgs.length === 0) return;
+
+    for (const org of orgs) {
+      try {
+        await this.closeForOrg(org.id);
+      } catch (err) {
+        this.logger.warn(`conv auto-close failed for org ${org.id}: ${describe(err)}`);
+      }
+    }
+  }
+
+  private async closeForOrg(orgId: string): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
+      await tx.execute(sql`SELECT set_config('app.org_id', ${orgId}, true)`);
+      await tx.execute(sql`SELECT set_config('app.end_user_id', '', true)`);
+      const actor = new ActorIdentity('admin_agent', 'conv-scheduler', orgId, ['*'], ['admin']);
+      const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+      await RequestContextStore.run(ctx, async () => {
+        const closed = await this.conv.autoCloseInactive({ thresholdDays: this.thresholdDays });
+        if (closed > 0) {
+          this.logger.log(`conv auto-close closed ${closed} conversation(s) for org ${orgId}`);
+        }
+      });
+    });
+  }
+}
+
+function parseThresholdDays(): number {
+  const raw = process.env.MUNIN_CONV_AUTO_CLOSE_DAYS;
+  if (!raw) return DEFAULT_THRESHOLD_DAYS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_THRESHOLD_DAYS;
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/backend-core/src/modules/conv/conv-scheduler.test.ts
+++ b/packages/backend-core/src/modules/conv/conv-scheduler.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { ConvSchedulerService } from './conv-scheduler.service.ts';
+
+describe('ConvSchedulerService.onModuleInit', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.MUNIN_CONV_AUTO_CLOSE_DISABLED;
+    delete process.env.MUNIN_CONV_AUTO_CLOSE_CRON;
+  });
+  afterEach(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  function build(): { svc: ConvSchedulerService; registry: SchedulerRegistry } {
+    const registry = new SchedulerRegistry();
+    const db = {} as never;
+    const conv = {} as never;
+    const svc = new ConvSchedulerService(db, conv, registry);
+    return { svc, registry };
+  }
+
+  it('registers the auto-close cron job when not disabled', () => {
+    const { svc, registry } = build();
+    svc.onModuleInit();
+    expect([...registry.getCronJobs().keys()]).toEqual(['conv-auto-close']);
+  });
+
+  it('honors a custom cron expression from env', () => {
+    process.env.MUNIN_CONV_AUTO_CLOSE_CRON = '*/15 * * * *';
+    const { svc, registry } = build();
+    svc.onModuleInit();
+    const job = registry.getCronJob('conv-auto-close');
+    expect(job).toBeDefined();
+    expect(String(job.cronTime.source)).toBe('*/15 * * * *');
+  });
+
+  it('registers nothing when the cron env var is "off"', () => {
+    process.env.MUNIN_CONV_AUTO_CLOSE_CRON = 'off';
+    const { svc, registry } = build();
+    svc.onModuleInit();
+    expect([...registry.getCronJobs().keys()]).toHaveLength(0);
+  });
+
+  it('registers nothing when MUNIN_CONV_AUTO_CLOSE_DISABLED=1', () => {
+    process.env.MUNIN_CONV_AUTO_CLOSE_DISABLED = '1';
+    const { svc, registry } = build();
+    svc.onModuleInit();
+    expect([...registry.getCronJobs().keys()]).toHaveLength(0);
+  });
+
+  it('registers nothing when NODE_ENV=test', () => {
+    process.env.NODE_ENV = 'test';
+    const { svc, registry } = build();
+    svc.onModuleInit();
+    expect([...registry.getCronJobs().keys()]).toHaveLength(0);
+  });
+});

--- a/packages/backend-core/src/modules/conv/conv.auto-close.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.auto-close.integration.test.ts
@@ -1,0 +1,276 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import { ActorIdentity, RequestContextStore, type RequestContext } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { AppModule } from '../../app.module.ts';
+import { ConvService } from './conv.service.ts';
+import { reopenClosedConversation } from './conversation-reopen.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to run conv auto-close integration tests.';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+(skipReason ? describe.skip : describe)('conv auto-close sweep', () => {
+  let app: INestApplication;
+  let db: ReturnType<typeof createDb>;
+  let conv: ConvService;
+  let orgId: string;
+  let chatChannelId: string;
+  let voiceChannelId: string;
+  let euId: string;
+  let contactId: string;
+  let displayCounter = 0;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_BUILTIN_AGENT = '0';
+
+    await runMigrations(TEST_URL!);
+
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db.insert(schema.orgs).values({ name: 'Auto Close Org' }).returning();
+    orgId = org!.id;
+
+    const [chat] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'chat',
+        vendor: 'munin',
+        name: 'ac-chat',
+        config: { provider: 'widget', originAllowlist: [] },
+      })
+      .returning();
+    chatChannelId = chat!.id;
+
+    const [voice] = await db
+      .insert(schema.convChannels)
+      .values({ orgId, type: 'voice', vendor: 'vapi', name: 'ac-voice', config: {} })
+      .returning();
+    voiceChannelId = voice!.id;
+
+    const [eu] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: 'ac-eu', name: 'EU' })
+      .returning();
+    euId = eu!.id;
+
+    const [contact] = await db
+      .insert(schema.convContacts)
+      .values({ orgId, endUserId: euId, name: 'EU' })
+      .returning();
+    contactId = contact!.id;
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.init();
+    conv = app.get(ConvService);
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  async function runInOrg<T>(fn: () => Promise<T>): Promise<T> {
+    return db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
+      await tx.execute(sql`SELECT set_config('app.org_id', ${orgId}, true)`);
+      await tx.execute(sql`SELECT set_config('app.end_user_id', '', true)`);
+      const actor = new ActorIdentity('admin_agent', 'auto-close-test', orgId, ['*'], ['admin']);
+      const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+      return RequestContextStore.run(ctx, fn);
+    });
+  }
+
+  async function mkConv(opts: {
+    channelId?: string;
+    status?: 'open' | 'snoozed' | 'closed' | 'spam';
+    needsHumanAttention?: boolean;
+    endUserId?: string | null;
+    ageDays: number;
+    messages: Array<{
+      authorType: 'user' | 'agent' | 'end_user' | 'system';
+      internal?: boolean;
+      offsetMs: number;
+    }>;
+  }): Promise<string> {
+    displayCounter += 1;
+    const base = Date.now() - opts.ageDays * DAY_MS;
+    const [c] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        channelId: opts.channelId ?? chatChannelId,
+        endUserId: opts.endUserId === undefined ? euId : opts.endUserId,
+        contactId,
+        displayId: displayCounter,
+        status: opts.status ?? 'open',
+        needsHumanAttention: opts.needsHumanAttention ?? false,
+        lastMessageAt: new Date(base),
+      })
+      .returning();
+    for (const m of opts.messages) {
+      await db.insert(schema.convMessages).values({
+        orgId,
+        conversationId: c!.id,
+        authorType: m.authorType,
+        authorId: 'author',
+        body: 'x',
+        internal: m.internal ?? false,
+        createdAt: new Date(base + m.offsetMs),
+      });
+    }
+    return c!.id;
+  }
+
+  async function awaitingIds(): Promise<string[]> {
+    const rows = await runInOrg(() => conv.listConversationsAwaitingUserReply());
+    return rows.map((r) => r.id);
+  }
+
+  it('includes a conversation we (AI agent) replied to last, idle past the threshold', async () => {
+    const id = await mkConv({
+      ageDays: 3,
+      messages: [
+        { authorType: 'end_user', offsetMs: 0 },
+        { authorType: 'agent', offsetMs: 1000 },
+      ],
+    });
+    expect(await awaitingIds()).toContain(id);
+  });
+
+  it('includes a conversation a human teammate replied to last', async () => {
+    const id = await mkConv({
+      ageDays: 3,
+      messages: [
+        { authorType: 'end_user', offsetMs: 0 },
+        { authorType: 'user', offsetMs: 1000 },
+      ],
+    });
+    expect(await awaitingIds()).toContain(id);
+  });
+
+  it('excludes a conversation where the end-user spoke last', async () => {
+    const id = await mkConv({
+      ageDays: 3,
+      messages: [
+        { authorType: 'agent', offsetMs: 0 },
+        { authorType: 'end_user', offsetMs: 1000 },
+      ],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('ignores internal notes when deciding who spoke last', async () => {
+    const id = await mkConv({
+      ageDays: 3,
+      messages: [
+        { authorType: 'agent', offsetMs: 0 },
+        { authorType: 'agent', internal: true, offsetMs: 1000 },
+      ],
+    });
+    expect(await awaitingIds()).toContain(id);
+  });
+
+  it('excludes conversations still within the threshold', async () => {
+    const id = await mkConv({
+      ageDays: 0,
+      messages: [{ authorType: 'agent', offsetMs: 0 }],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('excludes snoozed and closed conversations', async () => {
+    const snoozed = await mkConv({
+      status: 'snoozed',
+      ageDays: 3,
+      messages: [{ authorType: 'agent', offsetMs: 0 }],
+    });
+    const closed = await mkConv({
+      status: 'closed',
+      ageDays: 3,
+      messages: [{ authorType: 'agent', offsetMs: 0 }],
+    });
+    const ids = await awaitingIds();
+    expect(ids).not.toContain(snoozed);
+    expect(ids).not.toContain(closed);
+  });
+
+  it('excludes voice conversations', async () => {
+    const id = await mkConv({
+      channelId: voiceChannelId,
+      ageDays: 3,
+      messages: [{ authorType: 'agent', offsetMs: 0 }],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('excludes conversations flagged as needing human attention', async () => {
+    const id = await mkConv({
+      needsHumanAttention: true,
+      ageDays: 3,
+      messages: [{ authorType: 'agent', offsetMs: 0 }],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('closes qualifying conversations and enqueues CRM extraction', async () => {
+    const id = await mkConv({
+      ageDays: 3,
+      messages: [
+        { authorType: 'end_user', offsetMs: 0 },
+        { authorType: 'agent', offsetMs: 1000 },
+      ],
+    });
+    const closedCount = await runInOrg(() => conv.autoCloseInactive());
+    expect(closedCount).toBeGreaterThanOrEqual(1);
+
+    const [row] = await db
+      .select({ status: schema.convConversations.status })
+      .from(schema.convConversations)
+      .where(sql`id = ${id}`);
+    expect(row!.status).toBe('closed');
+
+    const jobs = await db
+      .select({ id: schema.curatorJobs.id })
+      .from(schema.curatorJobs)
+      .where(sql`dedupe_key = ${`crm-contact-extract:conv:${id}`}`);
+    expect(jobs.length).toBe(1);
+  });
+
+  it('reopenClosedConversation flips closed/snoozed to open exactly once', async () => {
+    const id = await mkConv({
+      status: 'closed',
+      ageDays: 0,
+      messages: [{ authorType: 'agent', offsetMs: 0 }],
+    });
+    expect(await reopenClosedConversation(db, id)).toBe(true);
+
+    const [row] = await db
+      .select({ status: schema.convConversations.status })
+      .from(schema.convConversations)
+      .where(sql`id = ${id}`);
+    expect(row!.status).toBe('open');
+
+    expect(await reopenClosedConversation(db, id)).toBe(false);
+  });
+});

--- a/packages/backend-core/src/modules/conv/conv.module.ts
+++ b/packages/backend-core/src/modules/conv/conv.module.ts
@@ -4,6 +4,7 @@ import { McpModule } from '../../mcp/mcp.module.ts';
 import { RealtimeModule } from '../../realtime/realtime.module.ts';
 import { PublicThrottleModule } from '../../common/rate-limit/public-throttle.module.ts';
 import { ConvService } from './conv.service.ts';
+import { ConvSchedulerService } from './conv-scheduler.service.ts';
 import { ConversationClaimsService } from './conv.claims.service.ts';
 import { ConvAdminTools } from './conv.tools.ts';
 import { ConvSelfServiceTools } from './conv.self-service.tools.ts';
@@ -58,6 +59,7 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
   controllers: [WidgetController, ChannelWebhookController],
   providers: [
     ConvService,
+    ConvSchedulerService,
     ConversationClaimsService,
     ConvAdminTools,
     ConvSelfServiceTools,

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -45,6 +45,7 @@ export type ConversationStatus = (typeof STATUSES)[number];
 export type AgentMode = (typeof AGENT_MODES)[number];
 
 const AWAITING_REPLY_LOOKBACK_MINUTES = 60;
+const AUTO_CLOSE_THRESHOLD_DAYS = 2;
 
 export interface ChannelDto {
   id: string;
@@ -477,6 +478,49 @@ export class ConvService {
       )
       .orderBy(desc(schema.convConversations.lastMessageAt))
       .limit(limit);
+  }
+
+  async listConversationsAwaitingUserReply(input?: {
+    limit?: number;
+    thresholdDays?: number;
+  }): Promise<Array<{ id: string }>> {
+    const ctx = getCurrentContext();
+    const limit = clampLimit(input?.limit, 100, 500);
+    const thresholdDays = input?.thresholdDays ?? AUTO_CLOSE_THRESHOLD_DAYS;
+    return ctx.db
+      .select({ id: schema.convConversations.id })
+      .from(schema.convConversations)
+      .innerJoin(
+        schema.convChannels,
+        eq(schema.convChannels.id, schema.convConversations.channelId),
+      )
+      .where(
+        and(
+          eq(schema.convConversations.status, 'open'),
+          isNotNull(schema.convConversations.endUserId),
+          eq(schema.convConversations.needsHumanAttention, false),
+          sql`${schema.convChannels.type} <> 'voice'`,
+          sql`${schema.convConversations.lastMessageAt} < now() - make_interval(days => ${thresholdDays})`,
+          sql`(
+            SELECT author_type FROM conv_messages
+            WHERE conversation_id = ${schema.convConversations.id}
+              AND internal = false
+            ORDER BY created_at DESC
+            LIMIT 1
+          ) IN ('agent', 'user')`,
+        ),
+      )
+      .orderBy(asc(schema.convConversations.lastMessageAt))
+      .limit(limit);
+  }
+
+  async autoCloseInactive(input?: { thresholdDays?: number }): Promise<number> {
+    const thresholdDays = input?.thresholdDays ?? AUTO_CLOSE_THRESHOLD_DAYS;
+    const stale = await this.listConversationsAwaitingUserReply({ thresholdDays });
+    for (const { id } of stale) {
+      await this.changeStatus({ id, status: 'closed' });
+    }
+    return stale.length;
   }
 
   async getConversation(id: string): Promise<ConversationDetail> {

--- a/packages/backend-core/src/modules/conv/conversation-reopen.ts
+++ b/packages/backend-core/src/modules/conv/conversation-reopen.ts
@@ -1,0 +1,19 @@
+import { schema, type Db, type Tx } from '@getmunin/db';
+import { and, eq, inArray } from 'drizzle-orm';
+
+export async function reopenClosedConversation(
+  tx: Db | Tx,
+  conversationId: string,
+): Promise<boolean> {
+  const reopened = await tx
+    .update(schema.convConversations)
+    .set({ status: 'open', updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.convConversations.id, conversationId),
+        inArray(schema.convConversations.status, ['closed', 'snoozed']),
+      ),
+    )
+    .returning({ id: schema.convConversations.id });
+  return reopened.length > 0;
+}

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -29,6 +29,7 @@ import { smtpTransportOptions } from './email.tools.ts';
 import { buildOutbound, stripMessageIdBrackets, parseMessageIdHeader, type BuiltMessage } from './mime.ts';
 import { renderEmailHtml } from './markdown.ts';
 import { resolveInbound, type ParsedInboundEmail } from './threading.ts';
+import { reopenClosedConversation } from '../conversation-reopen.ts';
 import {
   detectSignatureBlock,
   ensureReSubject,
@@ -374,6 +375,13 @@ export class EmailAdapter implements ChannelAdapter {
           .update(schema.convConversations)
           .set({ lastMessageAt: new Date(), updatedAt: new Date() })
           .where(eq(schema.convConversations.id, conversationId));
+
+        if (resolution && (await reopenClosedConversation(tx, conversationId))) {
+          await this.webhooks.emit({
+            type: 'conversation.status_changed',
+            payload: { conversationId, status: 'open' },
+          });
+        }
 
         await this.webhooks.emit({
           type: 'conversation.message.received',

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -11,6 +11,7 @@ import { WebhookDispatcher, getCurrentContext, verifyHmac } from '@getmunin/core
 import { linkVisitorToEndUser } from '../../analytics/visitor-identity.ts';
 import { CuratorJobsService } from '../../curator/curator-jobs.service.ts';
 import { buildSetTopicAndTitleJob } from '../set-topic-job.ts';
+import { reopenClosedConversation } from '../conversation-reopen.ts';
 import { WidgetChannelConfig } from './widget.types.ts';
 import type {
   WidgetConversationEnvelope,
@@ -661,23 +662,11 @@ export class WidgetIngestService {
         .where(eq(schema.convConversations.id, conv.id));
 
       const hasVisitorMessage = events.some((e) => e.authorType === 'end_user');
-      if (hasVisitorMessage) {
-        const reopened = await tx
-          .update(schema.convConversations)
-          .set({ status: 'open', updatedAt: new Date() })
-          .where(
-            and(
-              eq(schema.convConversations.id, conv.id),
-              inArray(schema.convConversations.status, ['closed', 'snoozed']),
-            ),
-          )
-          .returning({ id: schema.convConversations.id });
-        if (reopened[0]) {
-          await this.webhooks.emit({
-            type: 'conversation.status_changed',
-            payload: { conversationId: conv.id, status: 'open' },
-          });
-        }
+      if (hasVisitorMessage && (await reopenClosedConversation(tx, conv.id))) {
+        await this.webhooks.emit({
+          type: 'conversation.status_changed',
+          payload: { conversationId: conv.id, status: 'open' },
+        });
       }
     }
 


### PR DESCRIPTION
## Summary

Two related gaps in the `conv` module, both addressed here.

### 1. Reopen-on-reply, all channels
Previously only the chat widget reopened a `closed`/`snoozed` conversation when the customer replied — an email reply to a closed thread silently stayed closed, so no agent/runner picked it up.

- New shared helper `conv/conversation-reopen.ts` (`reopenClosedConversation`) — conditionally flips `closed`/`snoozed` → `open`, returns whether a row actually changed.
- Wired into the **email adapter's** threaded-reply path; the **widget** now reuses the same helper. Each emits `conversation.status_changed` only on a real transition.
- SMS/voice (`channel-ingest.service.ts`) is unchanged — it always creates a *new* conversation, so there's nothing to reopen (SMS inbound threading is a noted follow-up).

### 2. Auto-close conversations waiting on the user (2 days)
There was no time-based close anywhere (voice closes on call-end only). New deterministic hourly backend sweep (`ConvSchedulerService`, mirroring `CuratorSchedulerService`):

- Selects **non-voice**, `open` conversations with an end-user where the **last public message was from an AI agent or a human teammate** (`author_type IN ('agent','user')`), `needs_human_attention = false`, and idle past the threshold (default **2 days**).
- Closes each via the existing `changeStatus`, so auto-closes behave **identically to an operator close**: clears attention flags, releases the runner lease, emits the status webhook, and enqueues `skill://crm/extract-contact-from-message`.
- Env-driven: `MUNIN_CONV_AUTO_CLOSE_CRON` (default hourly), `MUNIN_CONV_AUTO_CLOSE_DAYS` (default `2`), `MUNIN_CONV_AUTO_CLOSE_DISABLED`.

No DB migration or RLS change — the sweep runs per-org under the same context pattern as the curator scheduler.

## Testing
- `pnpm typecheck` — all packages pass.
- New `conv-scheduler.test.ts` (cron registration) and `conv.auto-close.integration.test.ts` (every selection condition + close side-effects + reopen helper) — pass.
- Existing email / widget / awaiting-reply integration suites still pass.

## Out of scope / follow-ups
- SMS inbound threading (every inbound SMS currently creates a new conversation; reopen N/A until threading exists).
- A "closing due to inactivity" notification message on auto-close.
- Surfacing the threshold/toggle in the dashboard UI (env-driven for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)