### PR TITLE
feat(conv): wake timed snoozes + dashboard "Last open conversations"

### DIFF
--- a/.changeset/wake-snoozed-conversations.md
+++ b/.changeset/wake-snoozed-conversations.md
@@ -1,0 +1,8 @@
+---
+"@getmunin/backend-core": patch
+"@getmunin/dashboard-pages": patch
+---
+
+Dashboard: replace the single "last conversation" widget with "Last open conversations" — the 20 most recently active open conversations, newest first, with closed/snoozed/spam filtered out.
+
+Conversations: add a snooze-wake worker that reopens snoozed conversations once their `snoozeUntil` elapses, flagging them as needing human attention so they resurface in the inbox. Previously `snoozeUntil` was stored but never honored, so timed snoozes never woke on their own.

--- a/packages/backend-core/src/modules/conv/conv.module.ts
+++ b/packages/backend-core/src/modules/conv/conv.module.ts
@@ -25,6 +25,7 @@ import { ChannelIngestService } from './channels/channel-ingest.service.ts';
 import { ChannelWebhookController } from './channels/channel-webhook.controller.ts';
 import { InboundPollWorker } from './channels/inbound-poll.worker.ts';
 import { OutboundDeliveryWorker } from './channels/outbound-delivery.worker.ts';
+import { SnoozeWakeWorker } from './snooze-wake.worker.ts';
 import { MessageBirdClientService } from './messagebird/messagebird-client.service.ts';
 import { MessageBirdSmsAdapter } from './messagebird/messagebird-sms-adapter.ts';
 import { MessageBirdSmsAdminTools } from './messagebird/messagebird-sms.tools.ts';
@@ -67,6 +68,7 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
     ChannelIngestService,
     InboundPollWorker,
     OutboundDeliveryWorker,
+    SnoozeWakeWorker,
     MessageBirdClientService,
     MessageBirdSmsService,
     MessageBirdSmsAdapter,

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { schema } from '@getmunin/db';
-import { and, asc, desc, eq, ilike, inArray, isNotNull, isNull, notInArray, or, sql, type SQL } from 'drizzle-orm';
+import { and, asc, desc, eq, ilike, inArray, isNotNull, isNull, lte, notInArray, or, sql, type SQL } from 'drizzle-orm';
 import { getCurrentContext, WebhookDispatcher } from '@getmunin/core';
 import { CuratorJobsService } from '../curator/curator-jobs.service.ts';
 import { buildSetTopicAndTitleJob } from './set-topic-job.ts';
@@ -1015,6 +1015,35 @@ export class ConvService {
       });
     }
     return toConversationSummary(result[0]);
+  }
+
+  async wakeDueSnoozedConversations(): Promise<number> {
+    const ctx = getCurrentContext();
+    const now = new Date();
+    const woken = await ctx.db
+      .update(schema.convConversations)
+      .set({
+        status: 'open',
+        snoozeUntil: null,
+        needsHumanAttention: true,
+        needsHumanAttentionAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(schema.convConversations.status, 'snoozed'),
+          isNotNull(schema.convConversations.snoozeUntil),
+          lte(schema.convConversations.snoozeUntil, now),
+        ),
+      )
+      .returning({ id: schema.convConversations.id });
+    for (const row of woken) {
+      await this.webhooks.emit({
+        type: 'conversation.status_changed',
+        payload: { conversationId: row.id, status: 'open' },
+      });
+    }
+    return woken.length;
   }
 
   async tryAcquireConversation(input: {

--- a/packages/backend-core/src/modules/conv/conv.snooze-wake.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.snooze-wake.integration.test.ts
@@ -1,0 +1,128 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplication } from '@nestjs/common';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { eq, sql } from 'drizzle-orm';
+import { AppModule } from '../../app.module.ts';
+import { SnoozeWakeWorker } from './snooze-wake.worker.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to run conv snooze-wake integration tests.';
+
+(skipReason ? describe.skip : describe)('conv snooze wake worker', () => {
+  let app: INestApplication;
+  let db: ReturnType<typeof createDb>;
+  let worker: SnoozeWakeWorker;
+  let orgId: string;
+  let channelId: string;
+  let displayCounter = 0;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_BUILTIN_AGENT = '0';
+
+    await runMigrations(TEST_URL!);
+
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db
+      .insert(schema.orgs)
+      .values({ name: 'Snooze Wake Org' })
+      .returning();
+    orgId = org!.id;
+
+    const [chat] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'chat',
+        vendor: 'munin',
+        name: 'sw-chat',
+        config: { provider: 'widget', originAllowlist: [] },
+      })
+      .returning();
+    channelId = chat!.id;
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    await app.init();
+    worker = app.get(SnoozeWakeWorker);
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+  });
+
+  async function mkConv(opts: {
+    status: 'open' | 'snoozed';
+    snoozeUntil?: Date | null;
+  }): Promise<string> {
+    displayCounter += 1;
+    const [conv] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        channelId,
+        displayId: displayCounter,
+        status: opts.status,
+        snoozeUntil: opts.snoozeUntil ?? null,
+      })
+      .returning();
+    return conv!.id;
+  }
+
+  async function read(id: string) {
+    const [row] = await db
+      .select()
+      .from(schema.convConversations)
+      .where(eq(schema.convConversations.id, id));
+    return row!;
+  }
+
+  it('wakes a snoozed conversation whose snooze_until has elapsed', async () => {
+    const id = await mkConv({
+      status: 'snoozed',
+      snoozeUntil: new Date(Date.now() - 60_000),
+    });
+    const result = await worker.tick();
+    expect(result.woken).toBeGreaterThanOrEqual(1);
+    const row = await read(id);
+    expect(row.status).toBe('open');
+    expect(row.snoozeUntil).toBeNull();
+    expect(row.needsHumanAttention).toBe(true);
+    expect(row.needsHumanAttentionAt).not.toBeNull();
+  });
+
+  it('leaves a conversation snoozed while snooze_until is in the future', async () => {
+    const id = await mkConv({
+      status: 'snoozed',
+      snoozeUntil: new Date(Date.now() + 60 * 60_000),
+    });
+    await worker.tick();
+    const row = await read(id);
+    expect(row.status).toBe('snoozed');
+    expect(row.needsHumanAttention).toBe(false);
+  });
+
+  it('does not touch open conversations', async () => {
+    const id = await mkConv({ status: 'open' });
+    await worker.tick();
+    const row = await read(id);
+    expect(row.status).toBe('open');
+    expect(row.needsHumanAttention).toBe(false);
+  });
+});

--- a/packages/backend-core/src/modules/conv/snooze-wake.worker.ts
+++ b/packages/backend-core/src/modules/conv/snooze-wake.worker.ts
@@ -1,0 +1,100 @@
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { type Db } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import {
+  ActorIdentity,
+  parseEnvDisableFlag,
+  parseEnvInt,
+  withContext,
+  type RequestContext,
+} from '@getmunin/core';
+import { DB } from '../../common/db/db.module.ts';
+import { withSchedulerLock } from '../../common/scheduler-lock/index.ts';
+import { ConvService } from './conv.service.ts';
+
+const DEFAULT_INTERVAL_MS = 60_000;
+
+@Injectable()
+export class SnoozeWakeWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(SnoozeWakeWorker.name);
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private readonly disabled =
+    parseEnvDisableFlag('MUNIN_SNOOZE_WAKE_WORKER_DISABLED') ||
+    process.env.NODE_ENV === 'test';
+  private readonly intervalMs = parseEnvInt({
+    name: 'MUNIN_SNOOZE_WAKE_WORKER_INTERVAL_MS',
+    default: DEFAULT_INTERVAL_MS,
+  });
+
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    private readonly conv: ConvService,
+  ) {}
+
+  onModuleInit(): void {
+    if (this.disabled) return;
+    this.logger.log(`snooze wake worker starting (every ${this.intervalMs}ms)`);
+    this.timer = setInterval(() => {
+      void withSchedulerLock(this.db, 'snooze-wake-worker', () => this.tick());
+    }, this.intervalMs);
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /** Public so tests can drive a single tick directly. */
+  async tick(): Promise<{ woken: number }> {
+    if (this.running) return { woken: 0 };
+    this.running = true;
+    try {
+      let woken = 0;
+      for (const orgId of await this.dueOrgIds()) {
+        try {
+          woken += await this.wakeForOrg(orgId);
+        } catch (err) {
+          this.logger.warn(`wake failed for org ${orgId}: ${describe(err)}`);
+        }
+      }
+      return { woken };
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async dueOrgIds(): Promise<string[]> {
+    const rows = await this.db.execute<{ org_id: string }>(sql`
+      SELECT DISTINCT org_id FROM conv_conversations
+      WHERE status = 'snoozed'
+        AND snooze_until IS NOT NULL
+        AND snooze_until <= now()
+    `);
+    return toArray<{ org_id: string }>(rows).map((r) => r.org_id);
+  }
+
+  private async wakeForOrg(orgId: string): Promise<number> {
+    return await this.db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
+      await tx.execute(sql`SELECT set_config('app.org_id', ${orgId}, true)`);
+      await tx.execute(sql`SELECT set_config('app.end_user_id', '', true)`);
+      const actor = new ActorIdentity('system', 'snooze-wake-worker', orgId, ['*'], ['admin']);
+      const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+      const woken = await withContext(ctx, () => this.conv.wakeDueSnoozedConversations());
+      if (woken > 0) this.logger.log(`woke ${woken} snoozed conversation(s) for org ${orgId}`);
+      return woken;
+    });
+  }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function toArray<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  const rows = (result as { rows?: unknown[] }).rows;
+  return Array.isArray(rows) ? (rows as T[]) : [];
+}

--- a/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
@@ -6,10 +6,7 @@ import { api } from '../../api';
 import { useRelative } from '../../lib/use-relative';
 import type { InboxController } from './inbox-sections';
 
-const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-const MAX_ITEMS = 10;
-const FETCH_LIMIT = 20;
-const EVICT_INTERVAL_MS = 60_000;
+const MAX_ITEMS = 20;
 
 type ConversationStatus = 'open' | 'snoozed' | 'closed' | 'spam';
 
@@ -36,7 +33,6 @@ export function RecentConversationsSection({
 }) {
   const t = useTranslations('dashboard.overview.recentConversations');
   const [items, setItems] = useState<ConversationSummary[]>([]);
-  const [now, setNow] = useState(() => Date.now());
   const fetchedRef = useRef(false);
 
   useEffect(() => {
@@ -45,27 +41,17 @@ export function RecentConversationsSection({
     void (async () => {
       try {
         const page = await api<ConversationListResponse>(
-          `/v1/conversations?limit=${FETCH_LIMIT}`,
+          `/v1/conversations?status=open&limit=${MAX_ITEMS}`,
         );
         setItems(page.items);
       } catch (err) {
-        console.warn('[dashboard] recent conversations fetch failed:', err);
+        console.warn('[dashboard] open conversations fetch failed:', err);
       }
     })();
   }, []);
 
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), EVICT_INTERVAL_MS);
-    return () => clearInterval(id);
-  }, []);
-
   const visible = useMemo(() => {
-    const cutoff = now - WINDOW_MS;
     return items
-      .filter((c) => {
-        const ts = c.lastMessageAt ?? c.updatedAt;
-        return new Date(ts).getTime() >= cutoff;
-      })
       .slice()
       .sort((a, b) => {
         const ta = new Date(a.lastMessageAt ?? a.updatedAt).getTime();
@@ -73,7 +59,7 @@ export function RecentConversationsSection({
         return tb - ta;
       })
       .slice(0, MAX_ITEMS);
-  }, [items, now]);
+  }, [items]);
 
   if (visible.length === 0) return null;
 
@@ -131,8 +117,6 @@ function ConversationRow({
           <span className="text-sm font-medium text-ink dark:text-foreground">{title}</span>
           {preview ? (
             <span className="ml-2 text-sm text-ink-mute"> — {preview}</span>
-          ) : conv.status !== 'open' ? (
-            <span className="ml-2 text-sm text-ink-mute"> — {t(`status.${conv.status}`)}</span>
           ) : null}
         </div>
         <span className="shrink-0 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -367,7 +367,7 @@
         "days": "{n}d"
       },
       "recentConversations": {
-        "eyebrow": "Last conversations",
+        "eyebrow": "Last open conversations",
         "meta": "All channels",
         "untitled": "Conversation #{displayId}",
         "status": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -367,7 +367,7 @@
         "days": "{n}d"
       },
       "recentConversations": {
-        "eyebrow": "Siste samtaler",
+        "eyebrow": "Siste åpne samtaler",
         "meta": "Alle kanaler",
         "untitled": "Samtale #{displayId}",
         "status": {


### PR DESCRIPTION
## Summary

Two related changes around conversation snooze behavior.

### Dashboard — "Last open conversations"
Replaces the old single "last conversation" widget. The dashboard now shows the **20 most recently active open conversations**, newest first, with closed/snoozed/spam filtered out. Filtering is done server-side via `status=open`; the 7-day recency window and per-minute eviction timer (no longer meaningful for an open-only list) were removed.

### Backend — honor timed snoozes
`snoozeUntil` was stored on snooze but **never read** — a conversation snoozed "until next Tuesday" stayed snoozed forever unless the customer messaged back. This adds `SnoozeWakeWorker`, a periodic per-org sweep (mirrors the existing `InboundPollWorker` pattern) that:

- finds snoozed conversations whose `snoozeUntil <= now()`
- flips them back to `open`, clears `snoozeUntil`
- sets `needsHumanAttention` so they resurface at the top of the inbox / dashboard
- emits `conversation.status_changed`

No message is auto-sent — waking only resurfaces the thread for a human to act on, consistent with the platform's propose-first convention. Disable via `MUNIN_SNOOZE_WAKE_WORKER_DISABLED`; interval via `MUNIN_SNOOZE_WAKE_WORKER_INTERVAL_MS` (default 60s).

No schema change — `snooze_until` and `needs_human_attention` columns already exist.

## Testing
- `pnpm -F @getmunin/dashboard-pages typecheck` and `pnpm -F @getmunin/backend-core typecheck` pass.
- New `conv.snooze-wake.integration.test.ts` (3 cases: elapsed snooze wakes + flags attention; future snooze untouched; open conversations untouched) passes, as does the existing `conv.service.test.ts` (32 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)