### PR TITLE
fix(setup): show managed provider name in onboarding summary

### DIFF
--- a/.changeset/onboarding-managed-provider-summary.md
+++ b/.changeset/onboarding-managed-provider-summary.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+fix(setup): show the managed provider name in the onboarding summary
+
+The "Lift-off" summary on the setup wizard always rendered the host of `providerBaseUrl`, so when the workspace was configured to use the managed AI provider it still displayed a stale bring-your-own-key host. The summary now renders the managed provider's name when no API key is set, falling back to the base-URL host for self-configured providers.

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1126,6 +1126,7 @@
       "saveAndContinue": "Save & continue",
       "checklist": {
         "provider": "Provider configured (<code>{url}</code>)",
+        "providerManaged": "Provider configured (<code>{name}</code>)",
         "fast": "Fast model — <code>{model}</code>",
         "smart": "Smart model — <code>{model}</code>"
       },

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1126,6 +1126,7 @@
       "saveAndContinue": "Lagre og fortsett",
       "checklist": {
         "provider": "Leverandør konfigurert (<code>{url}</code>)",
+        "providerManaged": "Leverandør konfigurert (<code>{name}</code>)",
         "fast": "Rask modell — <code>{model}</code>",
         "smart": "Smart modell — <code>{model}</code>"
       },

--- a/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
@@ -169,6 +169,8 @@ export function AgentSetupWizard({
           <Suspense fallback={null}>
             <ReadyCard
               config={config}
+              isManaged={isManaged}
+              managedProviderName={managedPreset?.name}
               importJobId={importJobId}
               importUrl={importUrl}
               onBack={() => setStep(4)}
@@ -182,12 +184,21 @@ export function AgentSetupWizard({
 
 interface ReadyCardProps {
   config: AgentConfigDto;
+  isManaged: boolean;
+  managedProviderName?: string;
   importJobId: string | null;
   importUrl: string | null;
   onBack: () => void;
 }
 
-function ReadyCard({ config, importJobId, importUrl, onBack }: ReadyCardProps) {
+function ReadyCard({
+  config,
+  isManaged,
+  managedProviderName,
+  importJobId,
+  importUrl,
+  onBack,
+}: ReadyCardProps) {
   const t = useTranslations('agentSetup');
   const tCommon = useTranslations('common');
   const searchParams = useSearchParams();
@@ -201,7 +212,9 @@ function ReadyCard({ config, importJobId, importUrl, onBack }: ReadyCardProps) {
     <code className="font-mono text-[13px] text-ink-soft dark:text-foreground/80">{chunks}</code>
   );
   const lines: ReactNode[] = [
-    t.rich('wizard.checklist.provider', { url: shortHost(config.providerBaseUrl), code }),
+    isManaged && managedProviderName
+      ? t.rich('wizard.checklist.providerManaged', { name: managedProviderName, code })
+      : t.rich('wizard.checklist.provider', { url: shortHost(config.providerBaseUrl), code }),
     t.rich('wizard.checklist.fast', { model: config.fastModel, code }),
     t.rich('wizard.checklist.smart', { model: config.smartModel ?? config.fastModel, code }),
   ];


### PR DESCRIPTION
## Problem

On the setup wizard's "Lift-off" summary, the provider line always rendered the host of `config.providerBaseUrl`. When a workspace was configured to use the **managed AI provider** (no API key), this displayed a stale bring-your-own-key host (e.g. `openrouter.ai`) instead of the managed provider's name.

`saveManaged()` only sends `{ providerApiKey: null }` and never clears `providerBaseUrl`, so the previously-selected/default host lingers in config and leaked into the summary.

## Fix

Fixed at the display layer, where the chosen provider is already known authoritatively:

- `agent-setup-wizard.tsx` — pass `isManaged` and `managedProviderName` (from the managed preset) into `ReadyCard`. When managed (no API key set), render the provider's name; otherwise keep the existing base-URL host for self-configured providers.
- Added `wizard.checklist.providerManaged` to `en.json` and `nb.json`.

No backend/contract change — the stored `providerBaseUrl` is left untouched (it's not user-facing for the managed provider, and AI settings already derives the provider from the selected preset).

## Verification

- `@getmunin/dashboard-pages` typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)