### PR TITLE
refactor(mcp): thin tools layer, service layering, consistent metadata

### DIFF
--- a/.changeset/tidy-tools-service-layering.md
+++ b/.changeset/tidy-tools-service-layering.md
@@ -1,0 +1,11 @@
+---
+"@getmunin/backend-core": patch
+---
+
+Tidy the MCP tools layer for consistency. No tool names, input schemas, or output shapes change.
+
+- Analytics: moved tracker CRUD and all reporting queries out of `AnalyticsAdminTools` into `AnalyticsService`, leaving the tool methods as thin delegators (matching every other module). Inline Zod schemas are now named consts inferred with `z.infer`, dropping the hand-maintained arg types.
+- Widget: extracted channel/key logic from `WidgetAdminTools` into a new `WidgetChannelAdminService`; the tool class now delegates.
+- Shared the duplicated API-key minting and origin-allowlist checks (analytics + widget) into `common/` helpers.
+- Renamed the vendor channel-admin files/classes that carried no `@McpTool` from `*.tools.ts`/`*AdminTools` to `*-admin.service.ts`/`*AdminService` (Twilio, MessageBird, Vapi, Threll).
+- Standardized empty-input schemas on the shared `EmptyInput`, set both `readOnlyHint` and `destructiveHint` on every feedback/system-alerts tool, and fixed `system_alerts_*` title casing.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -7370,7 +7370,7 @@
   },
   {
     "name": "system_alerts_list",
-    "title": "System alerts: list",
+    "title": "System alerts: List",
     "description": "List operational alerts for the org. Defaults to open alerts only; pass includeResolved to see history.",
     "audiences": [
       "admin"
@@ -7396,7 +7396,7 @@
   },
   {
     "name": "system_alerts_get",
-    "title": "System alerts: get",
+    "title": "System alerts: Get",
     "description": "Read a single alert by id.",
     "audiences": [
       "admin"
@@ -7420,7 +7420,7 @@
   },
   {
     "name": "system_alerts_acknowledge",
-    "title": "System alerts: acknowledge",
+    "title": "System alerts: Acknowledge",
     "description": "Mark an alert as acknowledged. Does not resolve it; only signals that someone is on it.",
     "audiences": [
       "admin"
@@ -7444,7 +7444,7 @@
   },
   {
     "name": "system_alerts_resolve",
-    "title": "System alerts: resolve",
+    "title": "System alerts: Resolve",
     "description": "Manually resolve the open alert for the given source+subject. Writers normally self-resolve; use this when the underlying state can no longer be observed.",
     "audiences": [
       "admin"

--- a/packages/backend-core/src/common/allowlist.ts
+++ b/packages/backend-core/src/common/allowlist.ts
@@ -1,0 +1,19 @@
+import { BadRequestException } from '@nestjs/common';
+
+function requireAllowlistFlag(envVar: string): boolean {
+  const raw = process.env[envVar]?.trim().toLowerCase();
+  return raw === '1' || raw === 'true';
+}
+
+export function assertOriginAllowlistPopulated(input: {
+  origins: readonly string[];
+  envVar: string;
+  errorCode: string;
+  field: string;
+}): void {
+  if (input.origins.length === 0 && requireAllowlistFlag(input.envVar)) {
+    throw new BadRequestException(
+      `${input.errorCode}: this deployment requires at least one entry in \`${input.field}\` (full origin like \`https://app.example.com\`). Add the production and any preview origins before saving.`,
+    );
+  }
+}

--- a/packages/backend-core/src/common/api-keys/api-key.helpers.ts
+++ b/packages/backend-core/src/common/api-keys/api-key.helpers.ts
@@ -1,0 +1,37 @@
+import { schema, type Db, type Tx } from '@getmunin/db';
+import { buildApiKey, hashSecret, keyPrefix, type KeyKind } from '@getmunin/core';
+
+export interface MintApiKeyInput {
+  orgId: string;
+  type: KeyKind;
+  name: string;
+  scopes: string[];
+  audiences?: string[];
+  trackerId?: string;
+  channelId?: string;
+  createdByUserId?: string | null;
+}
+
+export interface MintedApiKey {
+  id: string;
+  rawKey: string;
+  keyPrefix: string;
+}
+
+export async function mintApiKey(db: Db | Tx, input: MintApiKeyInput): Promise<MintedApiKey> {
+  const rawKey = buildApiKey(input.type);
+  const values: typeof schema.apiKeys.$inferInsert = {
+    orgId: input.orgId,
+    type: input.type,
+    name: input.name,
+    keyHash: hashSecret(rawKey),
+    keyPrefix: keyPrefix(rawKey),
+    scopes: input.scopes,
+    createdByUserId: input.createdByUserId ?? null,
+  };
+  if (input.audiences) values.audiences = input.audiences;
+  if (input.trackerId) values.trackerId = input.trackerId;
+  if (input.channelId) values.channelId = input.channelId;
+  const [row] = await db.insert(schema.apiKeys).values(values).returning();
+  return { id: row!.id, rawKey, keyPrefix: row!.keyPrefix };
+}

--- a/packages/backend-core/src/control/conv-channels.controller.ts
+++ b/packages/backend-core/src/control/conv-channels.controller.ts
@@ -20,10 +20,10 @@ import { RequireRole } from './role.decorator.ts';
 import { ConvService, type ChannelDto } from '../modules/conv/conv.service.ts';
 import { WidgetAdminTools } from '../modules/conv/widget/widget.tools.ts';
 import { EmailAdminTools } from '../modules/conv/email/email.tools.ts';
-import { TwilioSmsAdminTools } from '../modules/conv/twilio/twilio-sms.tools.ts';
-import { MessageBirdSmsAdminTools } from '../modules/conv/messagebird/messagebird-sms.tools.ts';
-import { VapiAdminTools } from '../modules/conv/vapi/vapi.tools.ts';
-import { ThrellAdminTools } from '../modules/conv/threll/threll.tools.ts';
+import { TwilioSmsAdminService } from '../modules/conv/twilio/twilio-sms-admin.service.ts';
+import { MessageBirdSmsAdminService } from '../modules/conv/messagebird/messagebird-sms-admin.service.ts';
+import { VapiAdminService } from '../modules/conv/vapi/vapi-admin.service.ts';
+import { ThrellAdminService } from '../modules/conv/threll/threll-admin.service.ts';
 import { ChannelAdminService } from '../modules/conv/channels/channel-admin.service.ts';
 import {
   CreateWidgetBody,
@@ -57,10 +57,10 @@ export class ConvChannelsController {
     private readonly conv: ConvService,
     private readonly widgetTools: WidgetAdminTools,
     private readonly emailTools: EmailAdminTools,
-    private readonly twilioSmsTools: TwilioSmsAdminTools,
-    private readonly messageBirdSmsTools: MessageBirdSmsAdminTools,
-    private readonly vapiTools: VapiAdminTools,
-    private readonly threllTools: ThrellAdminTools,
+    private readonly twilioSmsTools: TwilioSmsAdminService,
+    private readonly messageBirdSmsTools: MessageBirdSmsAdminService,
+    private readonly vapiTools: VapiAdminService,
+    private readonly threllTools: ThrellAdminService,
     private readonly channelAdmin: ChannelAdminService,
   ) {}
 
@@ -173,7 +173,7 @@ export class ConvChannelsController {
   @HttpCode(200)
   async configureTwilioSms(
     @Body() body: unknown,
-  ): Promise<Awaited<ReturnType<TwilioSmsAdminTools['configure']>>> {
+  ): Promise<Awaited<ReturnType<TwilioSmsAdminService['configure']>>> {
     const parsed = ConfigureTwilioSmsBody.safeParse(body ?? {});
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return this.twilioSmsTools.configure(parsed.data);
@@ -183,7 +183,7 @@ export class ConvChannelsController {
   @HttpCode(200)
   async testTwilioSms(
     @Param('id') id: string,
-  ): Promise<Awaited<ReturnType<TwilioSmsAdminTools['testChannel']>>> {
+  ): Promise<Awaited<ReturnType<TwilioSmsAdminService['testChannel']>>> {
     return this.twilioSmsTools.testChannel({ channelId: id });
   }
 
@@ -192,7 +192,7 @@ export class ConvChannelsController {
   async sendTwilioSmsTest(
     @Param('id') id: string,
     @Body() body: unknown,
-  ): Promise<Awaited<ReturnType<TwilioSmsAdminTools['sendTest']>>> {
+  ): Promise<Awaited<ReturnType<TwilioSmsAdminService['sendTest']>>> {
     const parsed = SendTwilioSmsTestBody.safeParse(body ?? {});
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return this.twilioSmsTools.sendTest({
@@ -206,7 +206,7 @@ export class ConvChannelsController {
   @HttpCode(200)
   async configureMessageBirdSms(
     @Body() body: unknown,
-  ): Promise<Awaited<ReturnType<MessageBirdSmsAdminTools['configure']>>> {
+  ): Promise<Awaited<ReturnType<MessageBirdSmsAdminService['configure']>>> {
     const parsed = ConfigureMessageBirdSmsBody.safeParse(body ?? {});
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return this.messageBirdSmsTools.configure(parsed.data);
@@ -216,7 +216,7 @@ export class ConvChannelsController {
   @HttpCode(200)
   async testMessageBirdSms(
     @Param('id') id: string,
-  ): Promise<Awaited<ReturnType<MessageBirdSmsAdminTools['testChannel']>>> {
+  ): Promise<Awaited<ReturnType<MessageBirdSmsAdminService['testChannel']>>> {
     return this.messageBirdSmsTools.testChannel({ channelId: id });
   }
 
@@ -225,7 +225,7 @@ export class ConvChannelsController {
   async sendMessageBirdSmsTest(
     @Param('id') id: string,
     @Body() body: unknown,
-  ): Promise<Awaited<ReturnType<MessageBirdSmsAdminTools['sendTest']>>> {
+  ): Promise<Awaited<ReturnType<MessageBirdSmsAdminService['sendTest']>>> {
     const parsed = SendMessageBirdSmsTestBody.safeParse(body ?? {});
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return this.messageBirdSmsTools.sendTest({
@@ -239,7 +239,7 @@ export class ConvChannelsController {
   @HttpCode(200)
   async configureVapi(
     @Body() body: unknown,
-  ): Promise<Awaited<ReturnType<VapiAdminTools['configure']>>> {
+  ): Promise<Awaited<ReturnType<VapiAdminService['configure']>>> {
     const parsed = ConfigureVapiBody.safeParse(body ?? {});
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return this.vapiTools.configure(parsed.data);
@@ -249,7 +249,7 @@ export class ConvChannelsController {
   @HttpCode(200)
   async testVapi(
     @Param('id') id: string,
-  ): Promise<Awaited<ReturnType<VapiAdminTools['testChannel']>>> {
+  ): Promise<Awaited<ReturnType<VapiAdminService['testChannel']>>> {
     return this.vapiTools.testChannel({ channelId: id });
   }
 
@@ -258,7 +258,7 @@ export class ConvChannelsController {
   async vapiCall(
     @Param('id') id: string,
     @Body() body: unknown,
-  ): Promise<Awaited<ReturnType<VapiAdminTools['callInitiate']>>> {
+  ): Promise<Awaited<ReturnType<VapiAdminService['callInitiate']>>> {
     const parsed = VapiCallInitiateBody.safeParse(body ?? {});
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return this.vapiTools.callInitiate({
@@ -272,7 +272,7 @@ export class ConvChannelsController {
   @HttpCode(200)
   async configureThrell(
     @Body() body: unknown,
-  ): Promise<Awaited<ReturnType<ThrellAdminTools['configure']>>> {
+  ): Promise<Awaited<ReturnType<ThrellAdminService['configure']>>> {
     const parsed = ConfigureThrellBody.safeParse(body ?? {});
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return this.threllTools.configure(parsed.data);
@@ -300,7 +300,7 @@ export class ConvChannelsController {
   @HttpCode(200)
   async testThrell(
     @Param('id') id: string,
-  ): Promise<Awaited<ReturnType<ThrellAdminTools['testChannel']>>> {
+  ): Promise<Awaited<ReturnType<ThrellAdminService['testChannel']>>> {
     return this.threllTools.testChannel({ channelId: id });
   }
 
@@ -309,7 +309,7 @@ export class ConvChannelsController {
   async threllCall(
     @Param('id') id: string,
     @Body() body: unknown,
-  ): Promise<Awaited<ReturnType<ThrellAdminTools['callInitiate']>>> {
+  ): Promise<Awaited<ReturnType<ThrellAdminService['callInitiate']>>> {
     const parsed = ThrellCallInitiateBody.safeParse(body ?? {});
     if (!parsed.success) throw new BadRequestException(parsed.error.message);
     return this.threllTools.callInitiate({

--- a/packages/backend-core/src/modules/analytics/analytics.service.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.service.ts
@@ -1,8 +1,10 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
-import { and, asc, eq, sql } from 'drizzle-orm';
-import { getCurrentContext } from '@getmunin/core';
+import { and, asc, eq, isNull, sql, type SQL } from 'drizzle-orm';
+import { getCurrentContext, randomToken } from '@getmunin/core';
 import { DB } from '../../common/db/db.module.ts';
+import { mintApiKey } from '../../common/api-keys/api-key.helpers.ts';
+import { assertOriginAllowlistPopulated } from '../../common/allowlist.ts';
 import {
   decodeCursor,
   encodeCursor,
@@ -146,6 +148,43 @@ export interface RecordSearchInput {
   requireVerifiedIdentity?: boolean;
 }
 
+export interface TrackerSummary {
+  id: string;
+  name: string;
+  allowedOrigins: string[];
+  keyPrefix: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  requireVerifiedIdentity: boolean;
+  hasIdentityVerificationSecret: boolean;
+}
+
+export interface CreateTrackerResult extends TrackerSummary {
+  trackerKey: string;
+  identityVerificationSecret: string;
+}
+
+export interface RotateIdentitySecretResult {
+  trackerId: string;
+  identityVerificationSecret: string;
+}
+
+export interface RotateTrackerKeyResult {
+  trackerId: string;
+  trackerKey: string;
+  keyPrefix: string;
+}
+
+export interface FunnelStepArg {
+  label?: string;
+  subjectType?: string;
+  subjectId?: string;
+  pathLike?: string;
+}
+
+type ViewSource = 'pixel' | 'beacon' | 'tracker';
+
 @Injectable()
 export class AnalyticsService {
   private readonly logger = new Logger(AnalyticsService.name);
@@ -223,8 +262,6 @@ export class AnalyticsService {
       return null;
     }
   }
-
-  // ─── Transfer (import / export) ──────────────────────────────────────────
 
   async exportAnalyticsConfig(): Promise<AnalyticsConfigExport> {
     const ctx = getCurrentContext();
@@ -515,6 +552,764 @@ export class AnalyticsService {
 
     return result;
   }
+
+  async createTracker(args: {
+    name: string;
+    allowedOrigins?: string[];
+    requireVerifiedIdentity?: boolean;
+  }): Promise<CreateTrackerResult> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    assertOriginAllowlistPopulated({
+      origins: args.allowedOrigins ?? [],
+      envVar: 'MUNIN_TRACKER_REQUIRE_ALLOWLIST',
+      errorCode: 'allowed_origins_required',
+      field: 'allowedOrigins',
+    });
+    const identityVerificationSecret = randomToken(32);
+    const [tracker] = await ctx.db
+      .insert(schema.analyticsTrackers)
+      .values({
+        orgId: actor.orgId,
+        name: args.name,
+        allowedOrigins: args.allowedOrigins ?? [],
+        identityVerificationSecret,
+        requireVerifiedIdentity: args.requireVerifiedIdentity ?? false,
+      })
+      .returning();
+    const key = await mintApiKey(ctx.db, {
+      orgId: actor.orgId,
+      type: 'track',
+      name: args.name,
+      scopes: ['analytics:track:write'],
+      audiences: ['public'],
+      trackerId: tracker!.id,
+      createdByUserId: actor.userId ?? null,
+    });
+    return {
+      id: tracker!.id,
+      name: tracker!.name,
+      allowedOrigins: tracker!.allowedOrigins,
+      keyPrefix: key.keyPrefix,
+      createdAt: tracker!.createdAt.toISOString(),
+      lastUsedAt: null,
+      revokedAt: null,
+      requireVerifiedIdentity: tracker!.requireVerifiedIdentity,
+      hasIdentityVerificationSecret: true,
+      trackerKey: key.rawKey,
+      identityVerificationSecret,
+    };
+  }
+
+  async listTrackers(args: { includeRevoked?: boolean }): Promise<TrackerSummary[]> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db
+      .select({
+        id: schema.analyticsTrackers.id,
+        name: schema.analyticsTrackers.name,
+        allowedOrigins: schema.analyticsTrackers.allowedOrigins,
+        createdAt: schema.analyticsTrackers.createdAt,
+        requireVerifiedIdentity: schema.analyticsTrackers.requireVerifiedIdentity,
+        identityVerificationSecret: schema.analyticsTrackers.identityVerificationSecret,
+        keyPrefix: schema.apiKeys.keyPrefix,
+        lastUsedAt: schema.apiKeys.lastUsedAt,
+        revokedAt: schema.apiKeys.revokedAt,
+      })
+      .from(schema.analyticsTrackers)
+      .leftJoin(
+        schema.apiKeys,
+        and(
+          eq(schema.apiKeys.trackerId, schema.analyticsTrackers.id),
+          eq(schema.apiKeys.type, 'track'),
+        ),
+      )
+      .where(eq(schema.analyticsTrackers.orgId, actor.orgId));
+    return rows
+      .filter((r) => args.includeRevoked || r.revokedAt === null)
+      .map((r) => ({
+        id: r.id,
+        name: r.name,
+        allowedOrigins: r.allowedOrigins,
+        keyPrefix: r.keyPrefix,
+        createdAt: r.createdAt.toISOString(),
+        lastUsedAt: r.lastUsedAt?.toISOString() ?? null,
+        revokedAt: r.revokedAt?.toISOString() ?? null,
+        requireVerifiedIdentity: r.requireVerifiedIdentity,
+        hasIdentityVerificationSecret: r.identityVerificationSecret !== null,
+      }));
+  }
+
+  async updateTracker(args: {
+    trackerId: string;
+    name?: string;
+    allowedOrigins?: string[];
+    requireVerifiedIdentity?: boolean;
+  }): Promise<TrackerSummary> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const patch: {
+      name?: string;
+      allowedOrigins?: string[];
+      requireVerifiedIdentity?: boolean;
+      updatedAt: Date;
+    } = {
+      updatedAt: new Date(),
+    };
+    if (args.name !== undefined) patch.name = args.name;
+    if (args.allowedOrigins !== undefined) {
+      assertOriginAllowlistPopulated({
+        origins: args.allowedOrigins,
+        envVar: 'MUNIN_TRACKER_REQUIRE_ALLOWLIST',
+        errorCode: 'allowed_origins_required',
+        field: 'allowedOrigins',
+      });
+      patch.allowedOrigins = args.allowedOrigins;
+    }
+    if (args.requireVerifiedIdentity !== undefined)
+      patch.requireVerifiedIdentity = args.requireVerifiedIdentity;
+    const [updated] = await ctx.db
+      .update(schema.analyticsTrackers)
+      .set(patch)
+      .where(
+        and(
+          eq(schema.analyticsTrackers.id, args.trackerId),
+          eq(schema.analyticsTrackers.orgId, actor.orgId),
+        ),
+      )
+      .returning();
+    if (!updated) throw new NotFoundException(`tracker ${args.trackerId} not found`);
+    const [key] = await ctx.db
+      .select({
+        keyPrefix: schema.apiKeys.keyPrefix,
+        lastUsedAt: schema.apiKeys.lastUsedAt,
+        revokedAt: schema.apiKeys.revokedAt,
+      })
+      .from(schema.apiKeys)
+      .where(
+        and(eq(schema.apiKeys.trackerId, args.trackerId), eq(schema.apiKeys.type, 'track')),
+      )
+      .limit(1);
+    return {
+      id: updated.id,
+      name: updated.name,
+      allowedOrigins: updated.allowedOrigins,
+      keyPrefix: key?.keyPrefix ?? null,
+      createdAt: updated.createdAt.toISOString(),
+      lastUsedAt: key?.lastUsedAt?.toISOString() ?? null,
+      revokedAt: key?.revokedAt?.toISOString() ?? null,
+      requireVerifiedIdentity: updated.requireVerifiedIdentity,
+      hasIdentityVerificationSecret: updated.identityVerificationSecret !== null,
+    };
+  }
+
+  async rotateIdentitySecret(args: {
+    trackerId: string;
+  }): Promise<RotateIdentitySecretResult> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const identityVerificationSecret = randomToken(32);
+    const [updated] = await ctx.db
+      .update(schema.analyticsTrackers)
+      .set({ identityVerificationSecret, updatedAt: new Date() })
+      .where(
+        and(
+          eq(schema.analyticsTrackers.id, args.trackerId),
+          eq(schema.analyticsTrackers.orgId, actor.orgId),
+        ),
+      )
+      .returning({ id: schema.analyticsTrackers.id });
+    if (!updated) throw new NotFoundException(`tracker ${args.trackerId} not found`);
+    return { trackerId: updated.id, identityVerificationSecret };
+  }
+
+  async rotateTrackerKey(args: { trackerId: string }): Promise<RotateTrackerKeyResult> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const tracker = await ctx.db
+      .select({ id: schema.analyticsTrackers.id, name: schema.analyticsTrackers.name })
+      .from(schema.analyticsTrackers)
+      .where(
+        and(
+          eq(schema.analyticsTrackers.id, args.trackerId),
+          eq(schema.analyticsTrackers.orgId, actor.orgId),
+        ),
+      )
+      .limit(1);
+    if (!tracker[0]) throw new NotFoundException(`tracker ${args.trackerId} not found`);
+
+    await ctx.db
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(
+          eq(schema.apiKeys.trackerId, args.trackerId),
+          eq(schema.apiKeys.orgId, actor.orgId),
+          eq(schema.apiKeys.type, 'track'),
+          isNull(schema.apiKeys.revokedAt),
+        ),
+      );
+
+    const key = await mintApiKey(ctx.db, {
+      orgId: actor.orgId,
+      type: 'track',
+      name: tracker[0].name,
+      scopes: ['analytics:track:write'],
+      audiences: ['public'],
+      trackerId: args.trackerId,
+      createdByUserId: actor.userId ?? null,
+    });
+    return { trackerId: args.trackerId, trackerKey: key.rawKey, keyPrefix: key.keyPrefix };
+  }
+
+  async revokeTracker(args: { trackerId: string }): Promise<{ revoked: boolean }> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const tracker = await ctx.db
+      .select({ id: schema.analyticsTrackers.id })
+      .from(schema.analyticsTrackers)
+      .where(
+        and(
+          eq(schema.analyticsTrackers.id, args.trackerId),
+          eq(schema.analyticsTrackers.orgId, actor.orgId),
+        ),
+      )
+      .limit(1);
+    if (!tracker[0]) return { revoked: false };
+    const result = await ctx.db
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(
+          eq(schema.apiKeys.trackerId, args.trackerId),
+          eq(schema.apiKeys.orgId, actor.orgId),
+          eq(schema.apiKeys.type, 'track'),
+          isNull(schema.apiKeys.revokedAt),
+        ),
+      )
+      .returning({ id: schema.apiKeys.id });
+    return { revoked: result.length > 0 };
+  }
+
+  async topSubjects(args: {
+    subjectType?: string;
+    sinceDays: number;
+    limit: number;
+    source?: ViewSource;
+    endUserId?: string;
+    contactId?: string;
+  }): Promise<Array<{ subjectType: string; subjectId: string; views: number; visitors: number }>> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const conditions = this.viewWindowConditions(actor.orgId, args);
+    const endUserId = await this.resolveQueryEndUserId(args);
+    if (args.endUserId || args.contactId) {
+      if (!endUserId) return [];
+      conditions.push(sql`end_user_id = ${endUserId}`);
+    }
+    const where = sql.join(conditions, sql` AND `);
+    const rows = await ctx.db.execute<{
+      subject_type: string;
+      subject_id: string;
+      views: number;
+      visitors: number;
+    }>(sql`
+      SELECT subject_type, subject_id,
+             COUNT(*)::int AS views,
+             COUNT(DISTINCT visitor_id)::int AS visitors
+      FROM analytics_view_events
+      WHERE ${where}
+      GROUP BY subject_type, subject_id
+      ORDER BY views DESC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      subjectType: r.subject_type,
+      subjectId: r.subject_id,
+      views: r.views,
+      visitors: r.visitors,
+    }));
+  }
+
+  async topCountries(args: {
+    subjectType?: string;
+    sinceDays: number;
+    limit: number;
+    source?: ViewSource;
+  }): Promise<Array<{ country: string | null; views: number; visitors: number }>> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const where = sql.join(this.viewWindowConditions(actor.orgId, args), sql` AND `);
+    const rows = await ctx.db.execute<{
+      country: string | null;
+      views: number;
+      visitors: number;
+    }>(sql`
+      SELECT country,
+             COUNT(*)::int AS views,
+             COUNT(DISTINCT visitor_id)::int AS visitors
+      FROM analytics_view_events
+      WHERE ${where}
+      GROUP BY country
+      ORDER BY views DESC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      country: r.country,
+      views: r.views,
+      visitors: r.visitors,
+    }));
+  }
+
+  async trafficBySource(args: {
+    subjectType?: string;
+    sinceDays: number;
+    limit: number;
+    source?: ViewSource;
+  }): Promise<
+    Array<{
+      utmSource: string | null;
+      utmMedium: string | null;
+      utmCampaign: string | null;
+      views: number;
+      visitors: number;
+    }>
+  > {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const where = sql.join(this.viewWindowConditions(actor.orgId, args), sql` AND `);
+    const rows = await ctx.db.execute<{
+      utm_source: string | null;
+      utm_medium: string | null;
+      utm_campaign: string | null;
+      views: number;
+      visitors: number;
+    }>(sql`
+      SELECT utm_source, utm_medium, utm_campaign,
+             COUNT(*)::int AS views,
+             COUNT(DISTINCT visitor_id)::int AS visitors
+      FROM analytics_view_events
+      WHERE ${where}
+      GROUP BY utm_source, utm_medium, utm_campaign
+      ORDER BY views DESC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      utmSource: r.utm_source,
+      utmMedium: r.utm_medium,
+      utmCampaign: r.utm_campaign,
+      views: r.views,
+      visitors: r.visitors,
+    }));
+  }
+
+  async referrerHosts(args: {
+    subjectType?: string;
+    excludeHost?: string;
+    sinceDays: number;
+    limit: number;
+    source?: ViewSource;
+  }): Promise<Array<{ host: string | null; views: number; visitors: number }>> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const where = sql.join(this.viewWindowConditions(actor.orgId, args), sql` AND `);
+    const hostExpr = sql`NULLIF(substring(referrer FROM '^[a-zA-Z]+://([^/?#]+)'), '')`;
+    const exclude = args.excludeHost
+      ? sql`AND (${hostExpr} IS NULL OR ${hostExpr} <> ${args.excludeHost})`
+      : sql``;
+    const rows = await ctx.db.execute<{
+      host: string | null;
+      views: number;
+      visitors: number;
+    }>(sql`
+      SELECT ${hostExpr} AS host,
+             COUNT(*)::int AS views,
+             COUNT(DISTINCT visitor_id)::int AS visitors
+      FROM analytics_view_events
+      WHERE ${where} ${exclude}
+      GROUP BY host
+      ORDER BY views DESC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      host: r.host,
+      views: r.views,
+      visitors: r.visitors,
+    }));
+  }
+
+  async viewsOverTime(args: {
+    subjectType?: string;
+    subjectId?: string;
+    sinceDays: number;
+    source?: ViewSource;
+    endUserId?: string;
+    contactId?: string;
+  }): Promise<Array<{ day: string; views: number; visitors: number }>> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const eventConditions = this.viewWindowConditions(actor.orgId, args);
+    const endUserId = await this.resolveQueryEndUserId(args);
+    if (args.endUserId || args.contactId) {
+      if (!endUserId) {
+        return Array.from({ length: args.sinceDays }, (_, i) => {
+          const d = new Date(Date.now() - (args.sinceDays - 1 - i) * 86400000);
+          return { day: d.toISOString().slice(0, 10), views: 0, visitors: 0 };
+        });
+      }
+      eventConditions.push(sql`end_user_id = ${endUserId}`);
+    }
+    const eventWhere = sql.join(eventConditions, sql` AND `);
+    const rows = await ctx.db.execute<{
+      day: Date | string;
+      views: number;
+      visitors: number;
+    }>(sql`
+      WITH days AS (
+        SELECT generate_series(
+          date_trunc('day', NOW()) - ((${args.sinceDays} - 1) || ' days')::interval,
+          date_trunc('day', NOW()),
+          '1 day'::interval
+        )::date AS day
+      ),
+      counts AS (
+        SELECT date_trunc('day', created_at)::date AS day,
+               COUNT(*)::int AS views,
+               COUNT(DISTINCT visitor_id)::int AS visitors
+        FROM analytics_view_events
+        WHERE ${eventWhere}
+        GROUP BY 1
+      )
+      SELECT d.day, COALESCE(c.views, 0)::int AS views, COALESCE(c.visitors, 0)::int AS visitors
+      FROM days d
+      LEFT JOIN counts c ON c.day = d.day
+      ORDER BY d.day ASC
+    `);
+    return rows.map((r) => ({
+      day: typeof r.day === 'string' ? r.day : r.day.toISOString().slice(0, 10),
+      views: r.views,
+      visitors: r.visitors,
+    }));
+  }
+
+  async subjectEngagement(args: {
+    subjectType: string;
+    subjectId: string;
+    sinceDays: number;
+    endUserId?: string;
+    contactId?: string;
+  }): Promise<{
+    views: number;
+    visitors: number;
+    avgDwellMs: number | null;
+    avgReadDepth: number | null;
+    lastViewAt: string | null;
+  }> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const conditions = [
+      sql`org_id = ${actor.orgId}`,
+      sql`subject_type = ${args.subjectType}`,
+      sql`subject_id = ${args.subjectId}`,
+      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
+    ];
+    const endUserId = await this.resolveQueryEndUserId(args);
+    if (args.endUserId || args.contactId) {
+      if (!endUserId) {
+        return {
+          views: 0,
+          visitors: 0,
+          avgDwellMs: null,
+          avgReadDepth: null,
+          lastViewAt: null,
+        };
+      }
+      conditions.push(sql`end_user_id = ${endUserId}`);
+    }
+    const where = sql.join(conditions, sql` AND `);
+    const rows = await ctx.db.execute<{
+      views: number;
+      visitors: number;
+      avg_dwell_ms: number | null;
+      avg_read_depth: number | null;
+      last_view_at: Date | string | null;
+    }>(sql`
+      SELECT COUNT(*)::int AS views,
+             COUNT(DISTINCT visitor_id)::int AS visitors,
+             AVG(dwell_ms) FILTER (WHERE dwell_ms IS NOT NULL) AS avg_dwell_ms,
+             AVG(read_depth) FILTER (WHERE read_depth IS NOT NULL) AS avg_read_depth,
+             MAX(created_at) AS last_view_at
+      FROM analytics_view_events
+      WHERE ${where}
+    `);
+    const r = rows[0]!;
+    return {
+      views: r.views,
+      visitors: r.visitors,
+      avgDwellMs: r.avg_dwell_ms !== null ? Math.round(Number(r.avg_dwell_ms)) : null,
+      avgReadDepth: r.avg_read_depth !== null ? Math.round(Number(r.avg_read_depth)) : null,
+      lastViewAt: r.last_view_at ? new Date(r.last_view_at).toISOString() : null,
+    };
+  }
+
+  async funnel(args: {
+    steps: FunnelStepArg[];
+    sinceDays: number;
+    stepWindowHours?: number;
+    source?: ViewSource;
+  }): Promise<{
+    sinceDays: number;
+    steps: Array<{
+      index: number;
+      label: string;
+      actors: number;
+      conversionFromPrev: number | null;
+      dropFromPrev: number | null;
+      conversionFromStart: number;
+    }>;
+    overallConversion: number;
+  }> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const steps = args.steps;
+
+    const prefilter = sql.join(
+      steps.map((s) => sql`(${funnelStepPredicate(s, sql.raw('ev'))})`),
+      sql` OR `,
+    );
+    const sourceCond = args.source ? sql` AND ev.source = ${args.source}` : sql``;
+
+    const ctes: SQL[] = [
+      sql`base AS (
+        SELECT COALESCE(vi.end_user_id, ev.visitor_id) AS actor,
+               ev.created_at AS created_at,
+               ev.subject_type AS subject_type,
+               ev.subject_id AS subject_id,
+               ev.path AS path
+        FROM analytics_view_events ev
+        LEFT JOIN analytics_visitor_identities vi
+          ON vi.org_id = ev.org_id AND vi.visitor_id = ev.visitor_id
+        WHERE ev.org_id = ${actor.orgId}
+          AND ev.created_at > NOW() - (${args.sinceDays} || ' days')::interval${sourceCond}
+          AND COALESCE(vi.end_user_id, ev.visitor_id) IS NOT NULL
+          AND (${prefilter})
+      )`,
+    ];
+
+    steps.forEach((step, i) => {
+      const name = sql.raw(`s${i}`);
+      const pred = funnelStepPredicate(step, sql.raw('b'));
+      if (i === 0) {
+        ctes.push(sql`${name} AS (
+          SELECT b.actor AS actor, MIN(b.created_at) AS t
+          FROM base b
+          WHERE ${pred}
+          GROUP BY b.actor
+        )`);
+      } else {
+        const prev = sql.raw(`s${i - 1}`);
+        const windowCond = args.stepWindowHours
+          ? sql` AND b.created_at <= ${prev}.t + (${args.stepWindowHours} || ' hours')::interval`
+          : sql``;
+        ctes.push(sql`${name} AS (
+          SELECT b.actor AS actor, MIN(b.created_at) AS t
+          FROM base b
+          JOIN ${prev} ON ${prev}.actor = b.actor
+          WHERE (${pred}) AND b.created_at > ${prev}.t${windowCond}
+          GROUP BY b.actor
+        )`);
+      }
+    });
+
+    const selectCols = steps.map(
+      (_, i) => sql`(SELECT COUNT(*)::int FROM ${sql.raw(`s${i}`)}) AS ${sql.raw(`step_${i}`)}`,
+    );
+    const rows = await ctx.db.execute<Record<string, number>>(
+      sql`WITH ${sql.join(ctes, sql`, `)} SELECT ${sql.join(selectCols, sql`, `)}`,
+    );
+    const counts = steps.map((_, i) => Number(rows[0]?.[`step_${i}`] ?? 0));
+    const first = counts[0] ?? 0;
+
+    return {
+      sinceDays: args.sinceDays,
+      steps: steps.map((step, i) => {
+        const actors = counts[i] ?? 0;
+        const prevCount = i > 0 ? counts[i - 1] ?? 0 : null;
+        return {
+          index: i + 1,
+          label: funnelStepLabel(step, i),
+          actors,
+          conversionFromPrev:
+            prevCount === null ? null : prevCount > 0 ? roundRate(actors / prevCount) : 0,
+          dropFromPrev:
+            prevCount === null ? null : prevCount > 0 ? roundRate(1 - actors / prevCount) : 0,
+          conversionFromStart: first > 0 ? roundRate(actors / first) : 0,
+        };
+      }),
+      overallConversion: first > 0 ? roundRate((counts[counts.length - 1] ?? 0) / first) : 0,
+    };
+  }
+
+  async contactJourney(args: {
+    endUserId?: string;
+    contactId?: string;
+    sinceDays: number;
+    limit: number;
+  }): Promise<
+    Array<{
+      kind: 'view' | 'search';
+      at: string;
+      subjectType: string | null;
+      subjectId: string | null;
+      path: string | null;
+      query: string | null;
+      resultCount: number | null;
+    }>
+  > {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const endUserId = await this.resolveQueryEndUserId(args);
+    if (!endUserId) return [];
+    const matchActor = sql`(end_user_id = ${endUserId} OR visitor_id IN (
+      SELECT visitor_id FROM analytics_visitor_identities
+      WHERE org_id = ${actor.orgId} AND end_user_id = ${endUserId}
+    ))`;
+    const rows = await ctx.db.execute<{
+      kind: 'view' | 'search';
+      at: Date | string;
+      subject_type: string | null;
+      subject_id: string | null;
+      path: string | null;
+      query: string | null;
+      result_count: number | null;
+    }>(sql`
+      SELECT 'view'::text AS kind,
+             created_at AS at,
+             subject_type,
+             subject_id,
+             path,
+             NULL::text AS query,
+             NULL::int AS result_count
+      FROM analytics_view_events
+      WHERE org_id = ${actor.orgId}
+        AND ${matchActor}
+        AND created_at > NOW() - (${args.sinceDays} || ' days')::interval
+      UNION ALL
+      SELECT 'search'::text AS kind,
+             created_at AS at,
+             subject_type,
+             NULL::text AS subject_id,
+             NULL::text AS path,
+             query,
+             result_count
+      FROM analytics_search_events
+      WHERE org_id = ${actor.orgId}
+        AND ${matchActor}
+        AND created_at > NOW() - (${args.sinceDays} || ' days')::interval
+      ORDER BY at ASC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      kind: r.kind,
+      at: new Date(r.at).toISOString(),
+      subjectType: r.subject_type,
+      subjectId: r.subject_id,
+      path: r.path,
+      query: r.query,
+      resultCount: r.result_count,
+    }));
+  }
+
+  async zeroResultSearches(args: {
+    subjectType?: string;
+    sinceDays: number;
+    limit: number;
+  }): Promise<Array<{ query: string; occurrences: number; lastSeenAt: string }>> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const conditions = [
+      sql`org_id = ${actor.orgId}`,
+      sql`result_count = 0`,
+      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
+    ];
+    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
+    const where = sql.join(conditions, sql` AND `);
+    const rows = await ctx.db.execute<{
+      query: string;
+      occurrences: number;
+      last_seen_at: Date | string;
+    }>(sql`
+      SELECT query,
+             COUNT(*)::int AS occurrences,
+             MAX(created_at) AS last_seen_at
+      FROM analytics_search_events
+      WHERE ${where}
+      GROUP BY query
+      ORDER BY occurrences DESC, last_seen_at DESC
+      LIMIT ${args.limit}
+    `);
+    return rows.map((r) => ({
+      query: r.query,
+      occurrences: r.occurrences,
+      lastSeenAt: new Date(r.last_seen_at).toISOString(),
+    }));
+  }
+
+  private viewWindowConditions(
+    orgId: string,
+    args: { sinceDays: number; subjectType?: string; subjectId?: string; source?: ViewSource },
+  ): SQL[] {
+    const conditions: SQL[] = [
+      sql`org_id = ${orgId}`,
+      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
+    ];
+    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
+    if (args.subjectId) conditions.push(sql`subject_id = ${args.subjectId}`);
+    if (args.source) conditions.push(sql`source = ${args.source}`);
+    return conditions;
+  }
+
+  private async resolveQueryEndUserId(args: {
+    endUserId?: string;
+    contactId?: string;
+  }): Promise<string | null> {
+    if (args.endUserId) return args.endUserId;
+    if (!args.contactId) return null;
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const rows = await ctx.db
+      .select({ endUserId: schema.crmContacts.endUserId })
+      .from(schema.crmContacts)
+      .where(
+        and(
+          eq(schema.crmContacts.id, args.contactId),
+          eq(schema.crmContacts.orgId, actor.orgId),
+        ),
+      )
+      .limit(1);
+    return rows[0]?.endUserId ?? null;
+  }
+}
+
+function funnelStepPredicate(step: FunnelStepArg, alias: SQL): SQL {
+  const conds: SQL[] = [];
+  if (step.subjectType) conds.push(sql`${alias}.subject_type = ${step.subjectType}`);
+  if (step.subjectId) conds.push(sql`${alias}.subject_id = ${step.subjectId}`);
+  if (step.pathLike) conds.push(sql`${alias}.path LIKE ${step.pathLike}`);
+  return sql.join(conds, sql` AND `);
+}
+
+function funnelStepLabel(step: FunnelStepArg, index: number): string {
+  if (step.label) return step.label;
+  const parts: string[] = [];
+  if (step.subjectType) parts.push(step.subjectType);
+  if (step.subjectId) parts.push(step.subjectId);
+  if (step.pathLike) parts.push(`path~${step.pathLike}`);
+  return parts.join(':') || `step ${index + 1}`;
+}
+
+function roundRate(n: number): number {
+  return Number(n.toFixed(4));
 }
 
 function truncate(value: string | null | undefined, max: number): string | null {

--- a/packages/backend-core/src/modules/analytics/analytics.tools.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.tools.ts
@@ -1,15 +1,6 @@
-import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
-import { schema } from '@getmunin/db';
-import { and, eq, isNull, sql, type SQL } from 'drizzle-orm';
-import {
-  buildApiKey,
-  getCurrentContext,
-  hashSecret,
-  keyPrefix,
-  randomToken,
-} from '@getmunin/core';
 import { AnalyticsService } from './analytics.service.ts';
 import { CursorInputSchema, IdMapSchema } from '../../common/transfer/transfer.types.ts';
 
@@ -75,18 +66,9 @@ const AnalyticsImportInput = z.object({
   idMap: IdMapSchema.optional(),
 });
 
-function requireTrackerAllowlist(): boolean {
-  const raw = process.env.MUNIN_TRACKER_REQUIRE_ALLOWLIST?.trim().toLowerCase();
-  return raw === '1' || raw === 'true';
-}
+const EmptyInput = z.object({});
 
-function assertTrackerAllowlistPopulated(allowedOrigins: readonly string[]): void {
-  if (allowedOrigins.length === 0 && requireTrackerAllowlist()) {
-    throw new BadRequestException(
-      'allowed_origins_required: this deployment requires at least one entry in `allowedOrigins` (full origin like `https://app.example.com`). Add the production and any preview origins before saving.',
-    );
-  }
-}
+const ViewSourceSchema = z.enum(['pixel', 'beacon', 'tracker']);
 
 const CreateTrackerInput = z.object({
   name: z.string().min(1).max(120),
@@ -113,6 +95,64 @@ const RotateTrackerKeyInput = z.object({
   trackerId: z.string(),
 });
 
+const ListTrackersInput = z.object({
+  includeRevoked: z.boolean().optional(),
+});
+
+const TopSubjectsInput = z.object({
+  subjectType: z.string().max(32).optional(),
+  sinceDays: z.number().int().min(1).max(365).default(30),
+  limit: z.number().int().min(1).max(200).default(20),
+  source: ViewSourceSchema.optional(),
+  endUserId: z.string().optional(),
+  contactId: z.string().optional(),
+});
+
+const TopCountriesInput = z.object({
+  subjectType: z.string().max(32).optional(),
+  sinceDays: z.number().int().min(1).max(365).default(30),
+  limit: z.number().int().min(1).max(200).default(50),
+  source: ViewSourceSchema.optional(),
+});
+
+const TrafficBySourceInput = z.object({
+  subjectType: z.string().max(32).optional(),
+  sinceDays: z.number().int().min(1).max(365).default(30),
+  limit: z.number().int().min(1).max(200).default(50),
+  source: ViewSourceSchema.optional(),
+});
+
+const ReferrerHostsInput = z.object({
+  subjectType: z.string().max(32).optional(),
+  excludeHost: z.string().max(255).optional(),
+  sinceDays: z.number().int().min(1).max(365).default(30),
+  limit: z.number().int().min(1).max(200).default(50),
+  source: ViewSourceSchema.optional(),
+});
+
+const ViewsOverTimeInput = z.object({
+  subjectType: z.string().max(32).optional(),
+  subjectId: z.string().optional(),
+  sinceDays: z.number().int().min(1).max(365).default(30),
+  source: ViewSourceSchema.optional(),
+  endUserId: z.string().optional(),
+  contactId: z.string().optional(),
+});
+
+const SubjectEngagementInput = z.object({
+  subjectType: z.string().max(32),
+  subjectId: z.string(),
+  sinceDays: z.number().int().min(1).max(365).default(90),
+  endUserId: z.string().optional(),
+  contactId: z.string().optional(),
+});
+
+const ZeroResultSearchesInput = z.object({
+  subjectType: z.string().max(32).optional(),
+  sinceDays: z.number().int().min(1).max(365).default(30),
+  limit: z.number().int().min(1).max(200).default(50),
+});
+
 const ContactJourneyInput = z.object({
   contactId: z.string().optional(),
   endUserId: z.string().optional(),
@@ -135,65 +175,12 @@ const FunnelInput = z.object({
   steps: z.array(FunnelStepSchema).min(2).max(8),
   sinceDays: z.number().int().min(1).max(365).default(30),
   stepWindowHours: z.number().int().min(1).max(24 * 365).optional(),
-  source: z.enum(['pixel', 'beacon', 'tracker']).optional(),
+  source: ViewSourceSchema.optional(),
 });
-
-type FunnelStep = z.infer<typeof FunnelStepSchema>;
-
-function funnelStepPredicate(step: FunnelStep, alias: SQL): SQL {
-  const conds: SQL[] = [];
-  if (step.subjectType) conds.push(sql`${alias}.subject_type = ${step.subjectType}`);
-  if (step.subjectId) conds.push(sql`${alias}.subject_id = ${step.subjectId}`);
-  if (step.pathLike) conds.push(sql`${alias}.path LIKE ${step.pathLike}`);
-  return sql.join(conds, sql` AND `);
-}
-
-function funnelStepLabel(step: FunnelStep, index: number): string {
-  if (step.label) return step.label;
-  const parts: string[] = [];
-  if (step.subjectType) parts.push(step.subjectType);
-  if (step.subjectId) parts.push(step.subjectId);
-  if (step.pathLike) parts.push(`path~${step.pathLike}`);
-  return parts.join(':') || `step ${index + 1}`;
-}
-
-function roundRate(n: number): number {
-  return Number(n.toFixed(4));
-}
-
-interface TrackerSummary {
-  id: string;
-  name: string;
-  allowedOrigins: string[];
-  keyPrefix: string | null;
-  createdAt: string;
-  lastUsedAt: string | null;
-  revokedAt: string | null;
-  requireVerifiedIdentity: boolean;
-  hasIdentityVerificationSecret: boolean;
-}
-
-interface CreateTrackerResult extends TrackerSummary {
-  trackerKey: string;
-  identityVerificationSecret: string;
-}
-
-interface RotateIdentitySecretResult {
-  trackerId: string;
-  identityVerificationSecret: string;
-}
-
-interface RotateTrackerKeyResult {
-  trackerId: string;
-  trackerKey: string;
-  keyPrefix: string;
-}
 
 @Injectable()
 export class AnalyticsAdminTools {
-  constructor(
-    @Inject(AnalyticsService) private readonly analytics: AnalyticsService,
-  ) {}
+  constructor(@Inject(AnalyticsService) private readonly analytics: AnalyticsService) {}
 
   @McpTool({
     name: 'analytics_export_config',
@@ -202,7 +189,7 @@ export class AnalyticsAdminTools {
       'Export this org\'s analytics configuration — trackers and visitor-identity links — as a portable JSON payload. Low-volume, returned in one shot. Tracker identity-verification secrets are redacted (the ciphertext is useless on another server); the operator re-enters them after import. Pair with `analytics_export_events` (paginated) and feed both into `analytics_import` on another Munin server.',
     audiences: ['admin'],
     scopes: ['analytics:read'],
-    input: z.object({}),
+    input: EmptyInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
@@ -254,49 +241,8 @@ export class AnalyticsAdminTools {
     readOnlyHint: false,
     destructiveHint: true,
   })
-  async createTracker(args: z.infer<typeof CreateTrackerInput>): Promise<CreateTrackerResult> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    assertTrackerAllowlistPopulated(args.allowedOrigins ?? []);
-    const identityVerificationSecret = randomToken(32);
-    const [tracker] = await ctx.db
-      .insert(schema.analyticsTrackers)
-      .values({
-        orgId: actor.orgId,
-        name: args.name,
-        allowedOrigins: args.allowedOrigins ?? [],
-        identityVerificationSecret,
-        requireVerifiedIdentity: args.requireVerifiedIdentity ?? false,
-      })
-      .returning();
-    const rawKey = buildApiKey('track');
-    const [key] = await ctx.db
-      .insert(schema.apiKeys)
-      .values({
-        orgId: actor.orgId,
-        type: 'track',
-        name: args.name,
-        keyHash: hashSecret(rawKey),
-        keyPrefix: keyPrefix(rawKey),
-        scopes: ['analytics:track:write'],
-        audiences: ['public'],
-        trackerId: tracker!.id,
-        createdByUserId: actor.userId ?? null,
-      })
-      .returning();
-    return {
-      id: tracker!.id,
-      name: tracker!.name,
-      allowedOrigins: tracker!.allowedOrigins,
-      keyPrefix: key!.keyPrefix,
-      createdAt: tracker!.createdAt.toISOString(),
-      lastUsedAt: null,
-      revokedAt: null,
-      requireVerifiedIdentity: tracker!.requireVerifiedIdentity,
-      hasIdentityVerificationSecret: true,
-      trackerKey: rawKey,
-      identityVerificationSecret,
-    };
+  createTracker(args: z.infer<typeof CreateTrackerInput>) {
+    return this.analytics.createTracker(args);
   }
 
   @McpTool({
@@ -306,47 +252,12 @@ export class AnalyticsAdminTools {
       'List analytics trackers for the current org with their key prefix, allowed origins, and revocation state. Plaintext keys are never returned; rotate via `analytics_revoke_tracker` + `analytics_create_tracker`.',
     audiences: ['admin'],
     scopes: ['analytics:read'],
-    input: z.object({ includeRevoked: z.boolean().optional() }),
+    input: ListTrackersInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async listTrackers(args: { includeRevoked?: boolean }): Promise<TrackerSummary[]> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const rows = await ctx.db
-      .select({
-        id: schema.analyticsTrackers.id,
-        name: schema.analyticsTrackers.name,
-        allowedOrigins: schema.analyticsTrackers.allowedOrigins,
-        createdAt: schema.analyticsTrackers.createdAt,
-        requireVerifiedIdentity: schema.analyticsTrackers.requireVerifiedIdentity,
-        identityVerificationSecret: schema.analyticsTrackers.identityVerificationSecret,
-        keyPrefix: schema.apiKeys.keyPrefix,
-        lastUsedAt: schema.apiKeys.lastUsedAt,
-        revokedAt: schema.apiKeys.revokedAt,
-      })
-      .from(schema.analyticsTrackers)
-      .leftJoin(
-        schema.apiKeys,
-        and(
-          eq(schema.apiKeys.trackerId, schema.analyticsTrackers.id),
-          eq(schema.apiKeys.type, 'track'),
-        ),
-      )
-      .where(eq(schema.analyticsTrackers.orgId, actor.orgId));
-    return rows
-      .filter((r) => args.includeRevoked || r.revokedAt === null)
-      .map((r) => ({
-        id: r.id,
-        name: r.name,
-        allowedOrigins: r.allowedOrigins,
-        keyPrefix: r.keyPrefix,
-        createdAt: r.createdAt.toISOString(),
-        lastUsedAt: r.lastUsedAt?.toISOString() ?? null,
-        revokedAt: r.revokedAt?.toISOString() ?? null,
-        requireVerifiedIdentity: r.requireVerifiedIdentity,
-        hasIdentityVerificationSecret: r.identityVerificationSecret !== null,
-      }));
+  listTrackers(args: z.infer<typeof ListTrackersInput>) {
+    return this.analytics.listTrackers(args);
   }
 
   @McpTool({
@@ -360,57 +271,8 @@ export class AnalyticsAdminTools {
     readOnlyHint: false,
     destructiveHint: true,
   })
-  async updateTracker(args: z.infer<typeof UpdateTrackerInput>): Promise<TrackerSummary> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const patch: {
-      name?: string;
-      allowedOrigins?: string[];
-      requireVerifiedIdentity?: boolean;
-      updatedAt: Date;
-    } = {
-      updatedAt: new Date(),
-    };
-    if (args.name !== undefined) patch.name = args.name;
-    if (args.allowedOrigins !== undefined) {
-      assertTrackerAllowlistPopulated(args.allowedOrigins);
-      patch.allowedOrigins = args.allowedOrigins;
-    }
-    if (args.requireVerifiedIdentity !== undefined)
-      patch.requireVerifiedIdentity = args.requireVerifiedIdentity;
-    const [updated] = await ctx.db
-      .update(schema.analyticsTrackers)
-      .set(patch)
-      .where(
-        and(
-          eq(schema.analyticsTrackers.id, args.trackerId),
-          eq(schema.analyticsTrackers.orgId, actor.orgId),
-        ),
-      )
-      .returning();
-    if (!updated) throw new NotFoundException(`tracker ${args.trackerId} not found`);
-    const [key] = await ctx.db
-      .select({
-        keyPrefix: schema.apiKeys.keyPrefix,
-        lastUsedAt: schema.apiKeys.lastUsedAt,
-        revokedAt: schema.apiKeys.revokedAt,
-      })
-      .from(schema.apiKeys)
-      .where(
-        and(eq(schema.apiKeys.trackerId, args.trackerId), eq(schema.apiKeys.type, 'track')),
-      )
-      .limit(1);
-    return {
-      id: updated.id,
-      name: updated.name,
-      allowedOrigins: updated.allowedOrigins,
-      keyPrefix: key?.keyPrefix ?? null,
-      createdAt: updated.createdAt.toISOString(),
-      lastUsedAt: key?.lastUsedAt?.toISOString() ?? null,
-      revokedAt: key?.revokedAt?.toISOString() ?? null,
-      requireVerifiedIdentity: updated.requireVerifiedIdentity,
-      hasIdentityVerificationSecret: updated.identityVerificationSecret !== null,
-    };
+  updateTracker(args: z.infer<typeof UpdateTrackerInput>) {
+    return this.analytics.updateTracker(args);
   }
 
   @McpTool({
@@ -424,24 +286,8 @@ export class AnalyticsAdminTools {
     readOnlyHint: false,
     destructiveHint: true,
   })
-  async rotateIdentitySecret(
-    args: z.infer<typeof RotateIdentitySecretInput>,
-  ): Promise<RotateIdentitySecretResult> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const identityVerificationSecret = randomToken(32);
-    const [updated] = await ctx.db
-      .update(schema.analyticsTrackers)
-      .set({ identityVerificationSecret, updatedAt: new Date() })
-      .where(
-        and(
-          eq(schema.analyticsTrackers.id, args.trackerId),
-          eq(schema.analyticsTrackers.orgId, actor.orgId),
-        ),
-      )
-      .returning({ id: schema.analyticsTrackers.id });
-    if (!updated) throw new NotFoundException(`tracker ${args.trackerId} not found`);
-    return { trackerId: updated.id, identityVerificationSecret };
+  rotateIdentitySecret(args: z.infer<typeof RotateIdentitySecretInput>) {
+    return this.analytics.rotateIdentitySecret(args);
   }
 
   @McpTool({
@@ -455,51 +301,8 @@ export class AnalyticsAdminTools {
     readOnlyHint: false,
     destructiveHint: true,
   })
-  async rotateTrackerKey(
-    args: z.infer<typeof RotateTrackerKeyInput>,
-  ): Promise<RotateTrackerKeyResult> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const tracker = await ctx.db
-      .select({ id: schema.analyticsTrackers.id, name: schema.analyticsTrackers.name })
-      .from(schema.analyticsTrackers)
-      .where(
-        and(
-          eq(schema.analyticsTrackers.id, args.trackerId),
-          eq(schema.analyticsTrackers.orgId, actor.orgId),
-        ),
-      )
-      .limit(1);
-    if (!tracker[0]) throw new NotFoundException(`tracker ${args.trackerId} not found`);
-
-    await ctx.db
-      .update(schema.apiKeys)
-      .set({ revokedAt: new Date() })
-      .where(
-        and(
-          eq(schema.apiKeys.trackerId, args.trackerId),
-          eq(schema.apiKeys.orgId, actor.orgId),
-          eq(schema.apiKeys.type, 'track'),
-          isNull(schema.apiKeys.revokedAt),
-        ),
-      );
-
-    const rawKey = buildApiKey('track');
-    const [key] = await ctx.db
-      .insert(schema.apiKeys)
-      .values({
-        orgId: actor.orgId,
-        type: 'track',
-        name: tracker[0].name,
-        keyHash: hashSecret(rawKey),
-        keyPrefix: keyPrefix(rawKey),
-        scopes: ['analytics:track:write'],
-        audiences: ['public'],
-        trackerId: args.trackerId,
-        createdByUserId: actor.userId ?? null,
-      })
-      .returning();
-    return { trackerId: args.trackerId, trackerKey: rawKey, keyPrefix: key!.keyPrefix };
+  rotateTrackerKey(args: z.infer<typeof RotateTrackerKeyInput>) {
+    return this.analytics.rotateTrackerKey(args);
   }
 
   @McpTool({
@@ -509,62 +312,12 @@ export class AnalyticsAdminTools {
       'List the most-viewed subjects (CMS entries, landing pages, etc.) over a recent window. Use this to see what content is actually getting traffic. Filter by `subjectType` to scope to one surface (e.g. `cms_entry`). Pass `endUserId` or `contactId` to restrict the ranking to one identified visitor — useful for "what has this lead been reading?".',
     audiences: ['admin'],
     scopes: ['analytics:read'],
-    input: z.object({
-      subjectType: z.string().max(32).optional(),
-      sinceDays: z.number().int().min(1).max(365).default(30),
-      limit: z.number().int().min(1).max(200).default(20),
-      source: z.enum(['pixel', 'beacon', 'tracker']).optional(),
-      endUserId: z.string().optional(),
-      contactId: z.string().optional(),
-    }),
+    input: TopSubjectsInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async topSubjects(args: {
-    subjectType?: string;
-    sinceDays: number;
-    limit: number;
-    source?: 'pixel' | 'beacon' | 'tracker';
-    endUserId?: string;
-    contactId?: string;
-  }): Promise<
-    Array<{ subjectType: string; subjectId: string; views: number; visitors: number }>
-  > {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const conditions = [
-      sql`org_id = ${actor.orgId}`,
-      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
-    ];
-    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
-    if (args.source) conditions.push(sql`source = ${args.source}`);
-    const endUserId = await this.resolveEndUserId(args);
-    if (args.endUserId || args.contactId) {
-      if (!endUserId) return [];
-      conditions.push(sql`end_user_id = ${endUserId}`);
-    }
-    const where = sql.join(conditions, sql` AND `);
-    const rows = await ctx.db.execute<{
-      subject_type: string;
-      subject_id: string;
-      views: number;
-      visitors: number;
-    }>(sql`
-      SELECT subject_type, subject_id,
-             COUNT(*)::int AS views,
-             COUNT(DISTINCT visitor_id)::int AS visitors
-      FROM analytics_view_events
-      WHERE ${where}
-      GROUP BY subject_type, subject_id
-      ORDER BY views DESC
-      LIMIT ${args.limit}
-    `);
-    return rows.map((r) => ({
-      subjectType: r.subject_type,
-      subjectId: r.subject_id,
-      views: r.views,
-      visitors: r.visitors,
-    }));
+  topSubjects(args: z.infer<typeof TopSubjectsInput>) {
+    return this.analytics.topSubjects(args);
   }
 
   @McpTool({
@@ -574,49 +327,12 @@ export class AnalyticsAdminTools {
       'Visitor and view counts grouped by ISO 3166-1 alpha-2 country code over a recent window. Requires the backend to have `MUNIN_GEOIP_DB_PATH` configured; rows recorded without a GeoIP DB carry `country = NULL` and roll up into an "unknown" bucket. Filter by `subjectType` (e.g. `page`, `cms_entry`) or `source` to scope.',
     audiences: ['admin'],
     scopes: ['analytics:read'],
-    input: z.object({
-      subjectType: z.string().max(32).optional(),
-      sinceDays: z.number().int().min(1).max(365).default(30),
-      limit: z.number().int().min(1).max(200).default(50),
-      source: z.enum(['pixel', 'beacon', 'tracker']).optional(),
-    }),
+    input: TopCountriesInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async topCountries(args: {
-    subjectType?: string;
-    sinceDays: number;
-    limit: number;
-    source?: 'pixel' | 'beacon' | 'tracker';
-  }): Promise<Array<{ country: string | null; views: number; visitors: number }>> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const conditions = [
-      sql`org_id = ${actor.orgId}`,
-      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
-    ];
-    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
-    if (args.source) conditions.push(sql`source = ${args.source}`);
-    const where = sql.join(conditions, sql` AND `);
-    const rows = await ctx.db.execute<{
-      country: string | null;
-      views: number;
-      visitors: number;
-    }>(sql`
-      SELECT country,
-             COUNT(*)::int AS views,
-             COUNT(DISTINCT visitor_id)::int AS visitors
-      FROM analytics_view_events
-      WHERE ${where}
-      GROUP BY country
-      ORDER BY views DESC
-      LIMIT ${args.limit}
-    `);
-    return rows.map((r) => ({
-      country: r.country,
-      views: r.views,
-      visitors: r.visitors,
-    }));
+  topCountries(args: z.infer<typeof TopCountriesInput>) {
+    return this.analytics.topCountries(args);
   }
 
   @McpTool({
@@ -626,61 +342,12 @@ export class AnalyticsAdminTools {
       'Views and unique visitors grouped by `utm_source` (with `utm_medium` / `utm_campaign` breakdown). Use this to compare campaign attribution: which channels actually drive engaged traffic vs. just clicks. Rows where `utm_source` is NULL (no campaign params on the URL) roll into a single "direct/organic" bucket.',
     audiences: ['admin'],
     scopes: ['analytics:read'],
-    input: z.object({
-      subjectType: z.string().max(32).optional(),
-      sinceDays: z.number().int().min(1).max(365).default(30),
-      limit: z.number().int().min(1).max(200).default(50),
-      source: z.enum(['pixel', 'beacon', 'tracker']).optional(),
-    }),
+    input: TrafficBySourceInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async trafficBySource(args: {
-    subjectType?: string;
-    sinceDays: number;
-    limit: number;
-    source?: 'pixel' | 'beacon' | 'tracker';
-  }): Promise<
-    Array<{
-      utmSource: string | null;
-      utmMedium: string | null;
-      utmCampaign: string | null;
-      views: number;
-      visitors: number;
-    }>
-  > {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const conditions = [
-      sql`org_id = ${actor.orgId}`,
-      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
-    ];
-    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
-    if (args.source) conditions.push(sql`source = ${args.source}`);
-    const where = sql.join(conditions, sql` AND `);
-    const rows = await ctx.db.execute<{
-      utm_source: string | null;
-      utm_medium: string | null;
-      utm_campaign: string | null;
-      views: number;
-      visitors: number;
-    }>(sql`
-      SELECT utm_source, utm_medium, utm_campaign,
-             COUNT(*)::int AS views,
-             COUNT(DISTINCT visitor_id)::int AS visitors
-      FROM analytics_view_events
-      WHERE ${where}
-      GROUP BY utm_source, utm_medium, utm_campaign
-      ORDER BY views DESC
-      LIMIT ${args.limit}
-    `);
-    return rows.map((r) => ({
-      utmSource: r.utm_source,
-      utmMedium: r.utm_medium,
-      utmCampaign: r.utm_campaign,
-      views: r.views,
-      visitors: r.visitors,
-    }));
+  trafficBySource(args: z.infer<typeof TrafficBySourceInput>) {
+    return this.analytics.trafficBySource(args);
   }
 
   @McpTool({
@@ -690,58 +357,12 @@ export class AnalyticsAdminTools {
       'External traffic sources grouped by the host portion of `referrer`. Use this to see which sites are linking to you (HN, Reddit, partner blogs). Same-origin referrers are excluded server-side via the `excludeHost` argument (typically your own production host); pass it to keep internal navigations from drowning out external referrals. Rows with NULL referrer (direct navigation, bookmarks, link-with-`rel=noreferrer`) roll into a single "direct" bucket.',
     audiences: ['admin'],
     scopes: ['analytics:read'],
-    input: z.object({
-      subjectType: z.string().max(32).optional(),
-      excludeHost: z.string().max(255).optional(),
-      sinceDays: z.number().int().min(1).max(365).default(30),
-      limit: z.number().int().min(1).max(200).default(50),
-      source: z.enum(['pixel', 'beacon', 'tracker']).optional(),
-    }),
+    input: ReferrerHostsInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async referrerHosts(args: {
-    subjectType?: string;
-    excludeHost?: string;
-    sinceDays: number;
-    limit: number;
-    source?: 'pixel' | 'beacon' | 'tracker';
-  }): Promise<Array<{ host: string | null; views: number; visitors: number }>> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const conditions = [
-      sql`org_id = ${actor.orgId}`,
-      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
-    ];
-    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
-    if (args.source) conditions.push(sql`source = ${args.source}`);
-    const where = sql.join(conditions, sql` AND `);
-    // Extract host from `scheme://host[:port]/...`. Captures everything
-    // between `://` and the next `/`, `?`, `#`, or end-of-string. NULL
-    // referrers (direct navigation) stay NULL and form the "direct" bucket.
-    const hostExpr = sql`NULLIF(substring(referrer FROM '^[a-zA-Z]+://([^/?#]+)'), '')`;
-    const exclude = args.excludeHost
-      ? sql`AND (${hostExpr} IS NULL OR ${hostExpr} <> ${args.excludeHost})`
-      : sql``;
-    const rows = await ctx.db.execute<{
-      host: string | null;
-      views: number;
-      visitors: number;
-    }>(sql`
-      SELECT ${hostExpr} AS host,
-             COUNT(*)::int AS views,
-             COUNT(DISTINCT visitor_id)::int AS visitors
-      FROM analytics_view_events
-      WHERE ${where} ${exclude}
-      GROUP BY host
-      ORDER BY views DESC
-      LIMIT ${args.limit}
-    `);
-    return rows.map((r) => ({
-      host: r.host,
-      views: r.views,
-      visitors: r.visitors,
-    }));
+  referrerHosts(args: z.infer<typeof ReferrerHostsInput>) {
+    return this.analytics.referrerHosts(args);
   }
 
   @McpTool({
@@ -751,75 +372,12 @@ export class AnalyticsAdminTools {
       'Daily view + unique-visitor counts over a recent window. Returns one row per UTC day, ordered oldest → newest, with zero-filled gaps so days with no traffic appear as `views: 0`. Use this to spot trends, weekly patterns, and the impact of campaigns or content launches.',
     audiences: ['admin'],
     scopes: ['analytics:read'],
-    input: z.object({
-      subjectType: z.string().max(32).optional(),
-      subjectId: z.string().optional(),
-      sinceDays: z.number().int().min(1).max(365).default(30),
-      source: z.enum(['pixel', 'beacon', 'tracker']).optional(),
-      endUserId: z.string().optional(),
-      contactId: z.string().optional(),
-    }),
+    input: ViewsOverTimeInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async viewsOverTime(args: {
-    subjectType?: string;
-    subjectId?: string;
-    sinceDays: number;
-    source?: 'pixel' | 'beacon' | 'tracker';
-    endUserId?: string;
-    contactId?: string;
-  }): Promise<Array<{ day: string; views: number; visitors: number }>> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const eventConditions = [
-      sql`org_id = ${actor.orgId}`,
-      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
-    ];
-    if (args.subjectType) eventConditions.push(sql`subject_type = ${args.subjectType}`);
-    if (args.subjectId) eventConditions.push(sql`subject_id = ${args.subjectId}`);
-    if (args.source) eventConditions.push(sql`source = ${args.source}`);
-    const endUserId = await this.resolveEndUserId(args);
-    if (args.endUserId || args.contactId) {
-      if (!endUserId) {
-        return Array.from({ length: args.sinceDays }, (_, i) => {
-          const d = new Date(Date.now() - (args.sinceDays - 1 - i) * 86400000);
-          return { day: d.toISOString().slice(0, 10), views: 0, visitors: 0 };
-        });
-      }
-      eventConditions.push(sql`end_user_id = ${endUserId}`);
-    }
-    const eventWhere = sql.join(eventConditions, sql` AND `);
-    const rows = await ctx.db.execute<{
-      day: Date | string;
-      views: number;
-      visitors: number;
-    }>(sql`
-      WITH days AS (
-        SELECT generate_series(
-          date_trunc('day', NOW()) - ((${args.sinceDays} - 1) || ' days')::interval,
-          date_trunc('day', NOW()),
-          '1 day'::interval
-        )::date AS day
-      ),
-      counts AS (
-        SELECT date_trunc('day', created_at)::date AS day,
-               COUNT(*)::int AS views,
-               COUNT(DISTINCT visitor_id)::int AS visitors
-        FROM analytics_view_events
-        WHERE ${eventWhere}
-        GROUP BY 1
-      )
-      SELECT d.day, COALESCE(c.views, 0)::int AS views, COALESCE(c.visitors, 0)::int AS visitors
-      FROM days d
-      LEFT JOIN counts c ON c.day = d.day
-      ORDER BY d.day ASC
-    `);
-    return rows.map((r) => ({
-      day: typeof r.day === 'string' ? r.day : r.day.toISOString().slice(0, 10),
-      views: r.views,
-      visitors: r.visitors,
-    }));
+  viewsOverTime(args: z.infer<typeof ViewsOverTimeInput>) {
+    return this.analytics.viewsOverTime(args);
   }
 
   @McpTool({
@@ -829,77 +387,12 @@ export class AnalyticsAdminTools {
       'View counts, unique visitors, and average dwell/read-depth for one subject (e.g. one CMS entry) over a recent window. Use this when judging whether a stale entry should be refreshed or archived.',
     audiences: ['admin'],
     scopes: ['analytics:read'],
-    input: z.object({
-      subjectType: z.string().max(32),
-      subjectId: z.string(),
-      sinceDays: z.number().int().min(1).max(365).default(90),
-      endUserId: z.string().optional(),
-      contactId: z.string().optional(),
-    }),
+    input: SubjectEngagementInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async subjectEngagement(args: {
-    subjectType: string;
-    subjectId: string;
-    sinceDays: number;
-    endUserId?: string;
-    contactId?: string;
-  }): Promise<{
-    views: number;
-    visitors: number;
-    avgDwellMs: number | null;
-    avgReadDepth: number | null;
-    lastViewAt: string | null;
-  }> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const conditions = [
-      sql`org_id = ${actor.orgId}`,
-      sql`subject_type = ${args.subjectType}`,
-      sql`subject_id = ${args.subjectId}`,
-      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
-    ];
-    const endUserId = await this.resolveEndUserId(args);
-    if (args.endUserId || args.contactId) {
-      if (!endUserId) {
-        return {
-          views: 0,
-          visitors: 0,
-          avgDwellMs: null,
-          avgReadDepth: null,
-          lastViewAt: null,
-        };
-      }
-      conditions.push(sql`end_user_id = ${endUserId}`);
-    }
-    const where = sql.join(conditions, sql` AND `);
-    const rows = await ctx.db.execute<{
-      views: number;
-      visitors: number;
-      avg_dwell_ms: number | null;
-      avg_read_depth: number | null;
-      // postgres-js returns aggregate timestamp columns as ISO strings when
-      // reached via raw `db.execute(sql\`…\`)`. Coerce via `new Date(...)`
-      // below — it accepts both strings and Date objects.
-      last_view_at: Date | string | null;
-    }>(sql`
-      SELECT COUNT(*)::int AS views,
-             COUNT(DISTINCT visitor_id)::int AS visitors,
-             AVG(dwell_ms) FILTER (WHERE dwell_ms IS NOT NULL) AS avg_dwell_ms,
-             AVG(read_depth) FILTER (WHERE read_depth IS NOT NULL) AS avg_read_depth,
-             MAX(created_at) AS last_view_at
-      FROM analytics_view_events
-      WHERE ${where}
-    `);
-    const r = rows[0]!;
-    return {
-      views: r.views,
-      visitors: r.visitors,
-      avgDwellMs: r.avg_dwell_ms !== null ? Math.round(Number(r.avg_dwell_ms)) : null,
-      avgReadDepth: r.avg_read_depth !== null ? Math.round(Number(r.avg_read_depth)) : null,
-      lastViewAt: r.last_view_at ? new Date(r.last_view_at).toISOString() : null,
-    };
+  subjectEngagement(args: z.infer<typeof SubjectEngagementInput>) {
+    return this.analytics.subjectEngagement(args);
   }
 
   @McpTool({
@@ -913,97 +406,8 @@ export class AnalyticsAdminTools {
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async funnel(args: z.infer<typeof FunnelInput>): Promise<{
-    sinceDays: number;
-    steps: Array<{
-      index: number;
-      label: string;
-      actors: number;
-      conversionFromPrev: number | null;
-      dropFromPrev: number | null;
-      conversionFromStart: number;
-    }>;
-    overallConversion: number;
-  }> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const steps = args.steps;
-
-    const prefilter = sql.join(
-      steps.map((s) => sql`(${funnelStepPredicate(s, sql.raw('ev'))})`),
-      sql` OR `,
-    );
-    const sourceCond = args.source ? sql` AND ev.source = ${args.source}` : sql``;
-
-    const ctes: SQL[] = [
-      sql`base AS (
-        SELECT COALESCE(vi.end_user_id, ev.visitor_id) AS actor,
-               ev.created_at AS created_at,
-               ev.subject_type AS subject_type,
-               ev.subject_id AS subject_id,
-               ev.path AS path
-        FROM analytics_view_events ev
-        LEFT JOIN analytics_visitor_identities vi
-          ON vi.org_id = ev.org_id AND vi.visitor_id = ev.visitor_id
-        WHERE ev.org_id = ${actor.orgId}
-          AND ev.created_at > NOW() - (${args.sinceDays} || ' days')::interval${sourceCond}
-          AND COALESCE(vi.end_user_id, ev.visitor_id) IS NOT NULL
-          AND (${prefilter})
-      )`,
-    ];
-
-    steps.forEach((step, i) => {
-      const name = sql.raw(`s${i}`);
-      const pred = funnelStepPredicate(step, sql.raw('b'));
-      if (i === 0) {
-        ctes.push(sql`${name} AS (
-          SELECT b.actor AS actor, MIN(b.created_at) AS t
-          FROM base b
-          WHERE ${pred}
-          GROUP BY b.actor
-        )`);
-      } else {
-        const prev = sql.raw(`s${i - 1}`);
-        const windowCond = args.stepWindowHours
-          ? sql` AND b.created_at <= ${prev}.t + (${args.stepWindowHours} || ' hours')::interval`
-          : sql``;
-        ctes.push(sql`${name} AS (
-          SELECT b.actor AS actor, MIN(b.created_at) AS t
-          FROM base b
-          JOIN ${prev} ON ${prev}.actor = b.actor
-          WHERE (${pred}) AND b.created_at > ${prev}.t${windowCond}
-          GROUP BY b.actor
-        )`);
-      }
-    });
-
-    const selectCols = steps.map(
-      (_, i) => sql`(SELECT COUNT(*)::int FROM ${sql.raw(`s${i}`)}) AS ${sql.raw(`step_${i}`)}`,
-    );
-    const rows = await ctx.db.execute<Record<string, number>>(
-      sql`WITH ${sql.join(ctes, sql`, `)} SELECT ${sql.join(selectCols, sql`, `)}`,
-    );
-    const counts = steps.map((_, i) => Number(rows[0]?.[`step_${i}`] ?? 0));
-    const first = counts[0] ?? 0;
-
-    return {
-      sinceDays: args.sinceDays,
-      steps: steps.map((step, i) => {
-        const actors = counts[i] ?? 0;
-        const prevCount = i > 0 ? counts[i - 1] ?? 0 : null;
-        return {
-          index: i + 1,
-          label: funnelStepLabel(step, i),
-          actors,
-          conversionFromPrev:
-            prevCount === null ? null : prevCount > 0 ? roundRate(actors / prevCount) : 0,
-          dropFromPrev:
-            prevCount === null ? null : prevCount > 0 ? roundRate(1 - actors / prevCount) : 0,
-          conversionFromStart: first > 0 ? roundRate(actors / first) : 0,
-        };
-      }),
-      overallConversion: first > 0 ? roundRate((counts[counts.length - 1] ?? 0) / first) : 0,
-    };
+  funnel(args: z.infer<typeof FunnelInput>) {
+    return this.analytics.funnel(args);
   }
 
   @McpTool({
@@ -1017,90 +421,8 @@ export class AnalyticsAdminTools {
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async contactJourney(args: z.infer<typeof ContactJourneyInput>): Promise<
-    Array<{
-      kind: 'view' | 'search';
-      at: string;
-      subjectType: string | null;
-      subjectId: string | null;
-      path: string | null;
-      query: string | null;
-      resultCount: number | null;
-    }>
-  > {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const endUserId = await this.resolveEndUserId(args);
-    if (!endUserId) return [];
-    const matchActor = sql`(end_user_id = ${endUserId} OR visitor_id IN (
-      SELECT visitor_id FROM analytics_visitor_identities
-      WHERE org_id = ${actor.orgId} AND end_user_id = ${endUserId}
-    ))`;
-    const rows = await ctx.db.execute<{
-      kind: 'view' | 'search';
-      at: Date | string;
-      subject_type: string | null;
-      subject_id: string | null;
-      path: string | null;
-      query: string | null;
-      result_count: number | null;
-    }>(sql`
-      SELECT 'view'::text AS kind,
-             created_at AS at,
-             subject_type,
-             subject_id,
-             path,
-             NULL::text AS query,
-             NULL::int AS result_count
-      FROM analytics_view_events
-      WHERE org_id = ${actor.orgId}
-        AND ${matchActor}
-        AND created_at > NOW() - (${args.sinceDays} || ' days')::interval
-      UNION ALL
-      SELECT 'search'::text AS kind,
-             created_at AS at,
-             subject_type,
-             NULL::text AS subject_id,
-             NULL::text AS path,
-             query,
-             result_count
-      FROM analytics_search_events
-      WHERE org_id = ${actor.orgId}
-        AND ${matchActor}
-        AND created_at > NOW() - (${args.sinceDays} || ' days')::interval
-      ORDER BY at ASC
-      LIMIT ${args.limit}
-    `);
-    return rows.map((r) => ({
-      kind: r.kind,
-      at: new Date(r.at).toISOString(),
-      subjectType: r.subject_type,
-      subjectId: r.subject_id,
-      path: r.path,
-      query: r.query,
-      resultCount: r.result_count,
-    }));
-  }
-
-  private async resolveEndUserId(args: {
-    endUserId?: string;
-    contactId?: string;
-  }): Promise<string | null> {
-    if (args.endUserId) return args.endUserId;
-    if (!args.contactId) return null;
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const rows = await ctx.db
-      .select({ endUserId: schema.crmContacts.endUserId })
-      .from(schema.crmContacts)
-      .where(
-        and(
-          eq(schema.crmContacts.id, args.contactId),
-          eq(schema.crmContacts.orgId, actor.orgId),
-        ),
-      )
-      .limit(1);
-    return rows[0]?.endUserId ?? null;
+  contactJourney(args: z.infer<typeof ContactJourneyInput>) {
+    return this.analytics.contactJourney(args);
   }
 
   @McpTool({
@@ -1110,49 +432,12 @@ export class AnalyticsAdminTools {
       'List recent public search queries that returned zero results. The single best input for "what should we write about next" — readers are asking but Munin has no answer.',
     audiences: ['admin'],
     scopes: ['analytics:read'],
-    input: z.object({
-      subjectType: z.string().max(32).optional(),
-      sinceDays: z.number().int().min(1).max(365).default(30),
-      limit: z.number().int().min(1).max(200).default(50),
-    }),
+    input: ZeroResultSearchesInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  async zeroResultSearches(args: {
-    subjectType?: string;
-    sinceDays: number;
-    limit: number;
-  }): Promise<Array<{ query: string; occurrences: number; lastSeenAt: string }>> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const conditions = [
-      sql`org_id = ${actor.orgId}`,
-      sql`result_count = 0`,
-      sql`created_at > NOW() - (${args.sinceDays} || ' days')::interval`,
-    ];
-    if (args.subjectType) conditions.push(sql`subject_type = ${args.subjectType}`);
-    const where = sql.join(conditions, sql` AND `);
-    const rows = await ctx.db.execute<{
-      query: string;
-      occurrences: number;
-      // See `analytics_get_subject_engagement` — raw `db.execute` returns
-      // aggregate timestamp columns as ISO strings; coerce below.
-      last_seen_at: Date | string;
-    }>(sql`
-      SELECT query,
-             COUNT(*)::int AS occurrences,
-             MAX(created_at) AS last_seen_at
-      FROM analytics_search_events
-      WHERE ${where}
-      GROUP BY query
-      ORDER BY occurrences DESC, last_seen_at DESC
-      LIMIT ${args.limit}
-    `);
-    return rows.map((r) => ({
-      query: r.query,
-      occurrences: r.occurrences,
-      lastSeenAt: new Date(r.last_seen_at).toISOString(),
-    }));
+  zeroResultSearches(args: z.infer<typeof ZeroResultSearchesInput>) {
+    return this.analytics.zeroResultSearches(args);
   }
 
   @McpTool({
@@ -1166,32 +451,7 @@ export class AnalyticsAdminTools {
     readOnlyHint: false,
     destructiveHint: true,
   })
-  async revokeTracker(args: z.infer<typeof RevokeTrackerInput>): Promise<{ revoked: boolean }> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const tracker = await ctx.db
-      .select({ id: schema.analyticsTrackers.id })
-      .from(schema.analyticsTrackers)
-      .where(
-        and(
-          eq(schema.analyticsTrackers.id, args.trackerId),
-          eq(schema.analyticsTrackers.orgId, actor.orgId),
-        ),
-      )
-      .limit(1);
-    if (!tracker[0]) return { revoked: false };
-    const result = await ctx.db
-      .update(schema.apiKeys)
-      .set({ revokedAt: new Date() })
-      .where(
-        and(
-          eq(schema.apiKeys.trackerId, args.trackerId),
-          eq(schema.apiKeys.orgId, actor.orgId),
-          eq(schema.apiKeys.type, 'track'),
-          isNull(schema.apiKeys.revokedAt),
-        ),
-      )
-      .returning({ id: schema.apiKeys.id });
-    return { revoked: result.length > 0 };
+  revokeTracker(args: z.infer<typeof RevokeTrackerInput>) {
+    return this.analytics.revokeTracker(args);
   }
 }

--- a/packages/backend-core/src/modules/conv/channels/channel-admin.tools.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-admin.tools.ts
@@ -41,7 +41,7 @@ const SendTestInput = z.object({
   body: z.string().min(1).max(1600).optional(),
 });
 
-const ListVendorsInput = z.object({});
+const EmptyInput = z.object({});
 
 const ListOptionsInput = z
   .object({
@@ -79,11 +79,11 @@ export class ChannelAdminTools {
       'List the voice/SMS channel vendors you can configure, with each vendor’s `kind`, capabilities (call/sendTest), and config fields (name, required, secret, description). Use this to discover what to pass to conv_configure_channel.',
     audiences: ['admin'],
     scopes: ['conv:read'],
-    input: ListVendorsInput,
+    input: EmptyInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  listVendors(_args: z.infer<typeof ListVendorsInput>) {
+  listVendors() {
     return { vendors: this.svc.listVendors() };
   }
 

--- a/packages/backend-core/src/modules/conv/conv.module.ts
+++ b/packages/backend-core/src/modules/conv/conv.module.ts
@@ -29,29 +29,30 @@ import { OutboundDeliveryWorker } from './channels/outbound-delivery.worker.ts';
 import { SnoozeWakeWorker } from './snooze-wake.worker.ts';
 import { MessageBirdClientService } from './messagebird/messagebird-client.service.ts';
 import { MessageBirdSmsAdapter } from './messagebird/messagebird-sms-adapter.ts';
-import { MessageBirdSmsAdminTools } from './messagebird/messagebird-sms.tools.ts';
+import { MessageBirdSmsAdminService } from './messagebird/messagebird-sms-admin.service.ts';
 import { MessageBirdSmsService } from './messagebird/messagebird-sms.service.ts';
 import { VapiClientService } from './vapi/vapi-client.service.ts';
 import { VapiAdapter } from './vapi/vapi-adapter.ts';
-import { VapiAdminTools } from './vapi/vapi.tools.ts';
+import { VapiAdminService } from './vapi/vapi-admin.service.ts';
 import { VapiService } from './vapi/vapi.service.ts';
 import { VapiToolBridge } from './vapi/vapi-tool-bridge.ts';
 import { ThrellClientService } from './threll/threll-client.service.ts';
 import { ThrellAdapter } from './threll/threll-adapter.ts';
-import { ThrellAdminTools } from './threll/threll.tools.ts';
+import { ThrellAdminService } from './threll/threll-admin.service.ts';
 import { ThrellService } from './threll/threll.service.ts';
 import { ThrellToolBridge } from './threll/threll-tool-bridge.ts';
 import { VoiceCallbackService } from './voice-callback.service.ts';
 import { VoiceCallbackTools } from './voice-callback.tools.ts';
 import { TwilioClientService } from './twilio/twilio-client.service.ts';
 import { TwilioSmsAdapter } from './twilio/twilio-sms-adapter.ts';
-import { TwilioSmsAdminTools } from './twilio/twilio-sms.tools.ts';
+import { TwilioSmsAdminService } from './twilio/twilio-sms-admin.service.ts';
 import { TwilioSmsService } from './twilio/twilio-sms.service.ts';
 import { WidgetAdapter } from './widget/widget-adapter.ts';
 import { WidgetIngestService } from './widget/widget-ingest.service.ts';
 import { WidgetVoiceService } from './widget/widget-voice.service.ts';
 import { WidgetController } from './widget/widget.controller.ts';
 import { WidgetEmailFallbackWorker } from './widget/widget-email-fallback.worker.ts';
+import { WidgetChannelAdminService } from './widget/widget-channel-admin.service.ts';
 import { WidgetAdminTools } from './widget/widget.tools.ts';
 import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
 
@@ -74,20 +75,20 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
     MessageBirdClientService,
     MessageBirdSmsService,
     MessageBirdSmsAdapter,
-    MessageBirdSmsAdminTools,
+    MessageBirdSmsAdminService,
     TwilioClientService,
     TwilioSmsService,
     TwilioSmsAdapter,
-    TwilioSmsAdminTools,
+    TwilioSmsAdminService,
     VapiClientService,
     VapiService,
     VapiAdapter,
-    VapiAdminTools,
+    VapiAdminService,
     VapiToolBridge,
     ThrellClientService,
     ThrellService,
     ThrellAdapter,
-    ThrellAdminTools,
+    ThrellAdminService,
     ThrellToolBridge,
     VoiceCallbackService,
     VoiceCallbackTools,
@@ -95,6 +96,7 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
     WidgetEmailFallbackWorker,
     WidgetIngestService,
     WidgetVoiceService,
+    WidgetChannelAdminService,
     WidgetAdminTools,
     WidgetThrottlerGuard,
     {
@@ -147,19 +149,19 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
     MessageBirdClientService,
     MessageBirdSmsService,
     MessageBirdSmsAdapter,
-    MessageBirdSmsAdminTools,
+    MessageBirdSmsAdminService,
     TwilioClientService,
     TwilioSmsService,
     TwilioSmsAdapter,
-    TwilioSmsAdminTools,
+    TwilioSmsAdminService,
     VapiClientService,
     VapiService,
     VapiAdapter,
-    VapiAdminTools,
+    VapiAdminService,
     ThrellClientService,
     ThrellService,
     ThrellAdapter,
-    ThrellAdminTools,
+    ThrellAdminService,
     ChannelAdminService,
     ChannelAdminTools,
     VoiceCallbackService,

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-admin.provider.ts
@@ -5,7 +5,7 @@ import type {
   ChannelAdminProvider,
   ConfigureChannelInput,
 } from '../channels/channel-admin.ts';
-import { ConfigureInput, MessageBirdSmsAdminTools } from './messagebird-sms.tools.ts';
+import { ConfigureInput, MessageBirdSmsAdminService } from './messagebird-sms-admin.service.ts';
 
 const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
 
@@ -18,7 +18,7 @@ export class MessageBirdSmsAdminProvider implements ChannelAdminProvider {
   readonly configFields = describeConfigFields(ConfigSchema);
   readonly capabilities = { call: false, sendTest: true };
 
-  constructor(@Inject(MessageBirdSmsAdminTools) private readonly tools: MessageBirdSmsAdminTools) {}
+  constructor(@Inject(MessageBirdSmsAdminService) private readonly tools: MessageBirdSmsAdminService) {}
 
   configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
     const config = ConfigSchema.parse(input.config);

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-admin.service.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-admin.service.ts
@@ -48,7 +48,7 @@ export const ConfigureInput = z.object({
 });
 
 @Injectable()
-export class MessageBirdSmsAdminTools {
+export class MessageBirdSmsAdminService {
   constructor(
     @Inject(MessageBirdSmsService) private readonly svc: MessageBirdSmsService,
     @Inject(MessageBirdClientService) private readonly client: MessageBirdClientService,

--- a/packages/backend-core/src/modules/conv/threll/threll-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-admin.provider.ts
@@ -8,7 +8,7 @@ import type {
   ConfigureChannelInput,
   ListChannelOptionsInput,
 } from '../channels/channel-admin.ts';
-import { ConfigureInput, ThrellAdminTools, type ThrellListWorkersResult } from './threll.tools.ts';
+import { ConfigureInput, ThrellAdminService, type ThrellListWorkersResult } from './threll-admin.service.ts';
 
 const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
 
@@ -26,7 +26,7 @@ export class ThrellAdminProvider implements ChannelAdminProvider {
   readonly configFields = describeConfigFields(ConfigSchema);
   readonly capabilities = { call: true, sendTest: false };
 
-  constructor(@Inject(ThrellAdminTools) private readonly tools: ThrellAdminTools) {}
+  constructor(@Inject(ThrellAdminService) private readonly tools: ThrellAdminService) {}
 
   configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
     const config = ConfigSchema.parse(input.config);

--- a/packages/backend-core/src/modules/conv/threll/threll-admin.service.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-admin.service.ts
@@ -53,7 +53,7 @@ export const ConfigureInput = z.object({
 });
 
 @Injectable()
-export class ThrellAdminTools {
+export class ThrellAdminService {
   constructor(
     @Inject(ThrellService) private readonly svc: ThrellService,
     @Inject(ThrellClientService) private readonly client: ThrellClientService,

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms-admin.provider.ts
@@ -5,7 +5,7 @@ import type {
   ChannelAdminProvider,
   ConfigureChannelInput,
 } from '../channels/channel-admin.ts';
-import { ConfigureInput, TwilioSmsAdminTools } from './twilio-sms.tools.ts';
+import { ConfigureInput, TwilioSmsAdminService } from './twilio-sms-admin.service.ts';
 
 const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
 
@@ -18,7 +18,7 @@ export class TwilioSmsAdminProvider implements ChannelAdminProvider {
   readonly configFields = describeConfigFields(ConfigSchema);
   readonly capabilities = { call: false, sendTest: true };
 
-  constructor(@Inject(TwilioSmsAdminTools) private readonly tools: TwilioSmsAdminTools) {}
+  constructor(@Inject(TwilioSmsAdminService) private readonly tools: TwilioSmsAdminService) {}
 
   configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
     const config = ConfigSchema.parse(input.config);

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms-admin.service.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms-admin.service.ts
@@ -49,7 +49,7 @@ export const ConfigureInput = z.object({
 });
 
 @Injectable()
-export class TwilioSmsAdminTools {
+export class TwilioSmsAdminService {
   constructor(
     @Inject(TwilioSmsService) private readonly svc: TwilioSmsService,
     @Inject(TwilioClientService) private readonly client: TwilioClientService,

--- a/packages/backend-core/src/modules/conv/vapi/vapi-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-admin.provider.ts
@@ -8,7 +8,7 @@ import type {
   ConfigureChannelInput,
   ListChannelOptionsInput,
 } from '../channels/channel-admin.ts';
-import { ConfigureInput, VapiAdminTools, type VapiListAssistantsResult } from './vapi.tools.ts';
+import { ConfigureInput, VapiAdminService, type VapiListAssistantsResult } from './vapi-admin.service.ts';
 
 const ConfigSchema = ConfigureInput.omit({ channelId: true, name: true });
 
@@ -23,7 +23,7 @@ export class VapiAdminProvider implements ChannelAdminProvider {
   readonly configFields = describeConfigFields(ConfigSchema);
   readonly capabilities = { call: true, sendTest: false };
 
-  constructor(@Inject(VapiAdminTools) private readonly tools: VapiAdminTools) {}
+  constructor(@Inject(VapiAdminService) private readonly tools: VapiAdminService) {}
 
   configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
     const config = ConfigSchema.parse(input.config);

--- a/packages/backend-core/src/modules/conv/vapi/vapi-admin.service.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-admin.service.ts
@@ -66,7 +66,7 @@ export const ConfigureInput = z.object({
 });
 
 @Injectable()
-export class VapiAdminTools {
+export class VapiAdminService {
   constructor(
     @Inject(VapiService) private readonly svc: VapiService,
     @Inject(VapiClientService) private readonly client: VapiClientService,

--- a/packages/backend-core/src/modules/conv/widget/widget-channel-admin.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-channel-admin.service.ts
@@ -1,0 +1,229 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { z } from 'zod';
+import { schema } from '@getmunin/db';
+import { and, eq } from 'drizzle-orm';
+import { getCurrentContext, randomToken } from '@getmunin/core';
+import { mintApiKey } from '../../../common/api-keys/api-key.helpers.ts';
+import { assertOriginAllowlistPopulated } from '../../../common/allowlist.ts';
+import { WidgetChannelConfig } from './widget.types.ts';
+
+type WidgetConfig = z.infer<typeof WidgetChannelConfig>;
+
+export type SanitizedWidgetConfig = Omit<WidgetConfig, 'identityVerificationSecret'> & {
+  hasIdentityVerificationSecret: boolean;
+};
+
+export interface WidgetChannelDto {
+  id: string;
+  name: string;
+  type: 'chat';
+  active: boolean;
+  config: SanitizedWidgetConfig;
+}
+
+export interface CreateWidgetChannelResult extends WidgetChannelDto {
+  widgetKey: string;
+  identityVerificationSecret: string;
+}
+
+export interface RotateWidgetIdentitySecretResult {
+  channelId: string;
+  identityVerificationSecret: string;
+}
+
+export interface CreateWidgetChannelInput {
+  name: string;
+  originAllowlist: string[];
+  webhookOnEscalation?: string;
+  requireVerifiedIdentity?: boolean;
+}
+
+export interface UpdateWidgetChannelInput {
+  channelId: string;
+  originAllowlist?: string[];
+  webhookOnEscalation?: string | null;
+  requireVerifiedIdentity?: boolean;
+}
+
+function assertAllowlistPopulated(originAllowlist: readonly string[]): void {
+  assertOriginAllowlistPopulated({
+    origins: originAllowlist,
+    envVar: 'MUNIN_WIDGET_REQUIRE_ALLOWLIST',
+    errorCode: 'origin_allowlist_required',
+    field: 'originAllowlist',
+  });
+}
+
+function sanitizeConfig(config: WidgetConfig): SanitizedWidgetConfig {
+  const { identityVerificationSecret, ...rest } = config;
+  return { ...rest, hasIdentityVerificationSecret: !!identityVerificationSecret };
+}
+
+@Injectable()
+export class WidgetChannelAdminService {
+  async createChannel(args: CreateWidgetChannelInput): Promise<CreateWidgetChannelResult> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+
+    assertAllowlistPopulated(args.originAllowlist);
+
+    const identityVerificationSecret = randomToken(32);
+    const config = WidgetChannelConfig.parse({
+      provider: 'widget',
+      originAllowlist: args.originAllowlist,
+      webhookOnEscalation: args.webhookOnEscalation,
+      identityVerificationSecret,
+      requireVerifiedIdentity: args.requireVerifiedIdentity ?? false,
+    });
+
+    const [channel] = await ctx.db
+      .insert(schema.convChannels)
+      .values({
+        orgId: actor.orgId,
+        type: 'chat',
+        vendor: 'munin',
+        name: args.name,
+        config: config,
+      })
+      .returning();
+
+    const key = await mintApiKey(ctx.db, {
+      orgId: actor.orgId,
+      type: 'widget',
+      name: `${args.name} widget key`,
+      scopes: ['conv:widget:write'],
+      channelId: channel!.id,
+      createdByUserId: actor.userId ?? null,
+    });
+
+    return {
+      id: channel!.id,
+      name: channel!.name,
+      type: 'chat',
+      active: channel!.active,
+      config: sanitizeConfig(config),
+      widgetKey: key.rawKey,
+      identityVerificationSecret,
+    };
+  }
+
+  async updateChannel(args: UpdateWidgetChannelInput): Promise<WidgetChannelDto> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+
+    const rows = await ctx.db
+      .select()
+      .from(schema.convChannels)
+      .where(
+        and(
+          eq(schema.convChannels.id, args.channelId),
+          eq(schema.convChannels.orgId, actor.orgId),
+        ),
+      )
+      .limit(1);
+    const existing = rows[0];
+    if (!existing) throw new NotFoundException(`channel ${args.channelId} not found`);
+    const prev = WidgetChannelConfig.parse(existing.config);
+
+    if (args.originAllowlist !== undefined) {
+      assertAllowlistPopulated(args.originAllowlist);
+    }
+
+    const next = WidgetChannelConfig.parse({
+      provider: 'widget',
+      originAllowlist: args.originAllowlist ?? prev.originAllowlist,
+      webhookOnEscalation:
+        args.webhookOnEscalation === null
+          ? undefined
+          : (args.webhookOnEscalation ?? prev.webhookOnEscalation),
+      identityVerificationSecret: prev.identityVerificationSecret,
+      requireVerifiedIdentity: args.requireVerifiedIdentity ?? prev.requireVerifiedIdentity,
+    });
+
+    const [updated] = await ctx.db
+      .update(schema.convChannels)
+      .set({ config: next, updatedAt: new Date() })
+      .where(eq(schema.convChannels.id, args.channelId))
+      .returning();
+
+    return {
+      id: updated!.id,
+      name: updated!.name,
+      type: 'chat',
+      active: updated!.active,
+      config: sanitizeConfig(next),
+    };
+  }
+
+  async rotateKey(args: { channelId: string }): Promise<{ widgetKey: string }> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+
+    const channel = await ctx.db
+      .select({ id: schema.convChannels.id, name: schema.convChannels.name })
+      .from(schema.convChannels)
+      .where(
+        and(
+          eq(schema.convChannels.id, args.channelId),
+          eq(schema.convChannels.orgId, actor.orgId),
+        ),
+      )
+      .limit(1);
+    if (!channel[0]) throw new NotFoundException(`channel ${args.channelId} not found`);
+
+    await ctx.db
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(
+          eq(schema.apiKeys.channelId, args.channelId),
+          eq(schema.apiKeys.type, 'widget'),
+        ),
+      );
+
+    const key = await mintApiKey(ctx.db, {
+      orgId: actor.orgId,
+      type: 'widget',
+      name: `${channel[0].name} widget key`,
+      scopes: ['conv:widget:write'],
+      channelId: args.channelId,
+      createdByUserId: actor.userId ?? null,
+    });
+
+    return { widgetKey: key.rawKey };
+  }
+
+  async rotateIdentitySecret(args: {
+    channelId: string;
+  }): Promise<RotateWidgetIdentitySecretResult> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+
+    const rows = await ctx.db
+      .select()
+      .from(schema.convChannels)
+      .where(
+        and(
+          eq(schema.convChannels.id, args.channelId),
+          eq(schema.convChannels.orgId, actor.orgId),
+        ),
+      )
+      .limit(1);
+    const existing = rows[0];
+    if (!existing) throw new NotFoundException(`channel ${args.channelId} not found`);
+    const prev = WidgetChannelConfig.parse(existing.config);
+
+    const identityVerificationSecret = randomToken(32);
+    const next = WidgetChannelConfig.parse({
+      ...prev,
+      identityVerificationSecret,
+    });
+
+    await ctx.db
+      .update(schema.convChannels)
+      .set({ config: next, updatedAt: new Date() })
+      .where(eq(schema.convChannels.id, args.channelId));
+
+    return { channelId: args.channelId, identityVerificationSecret };
+  }
+}

--- a/packages/backend-core/src/modules/conv/widget/widget.tools.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.tools.ts
@@ -1,23 +1,7 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
-import { schema } from '@getmunin/db';
-import { and, eq } from 'drizzle-orm';
-import { buildApiKey, getCurrentContext, hashSecret, keyPrefix, randomToken } from '@getmunin/core';
-import { WidgetChannelConfig } from './widget.types.ts';
-
-function requireWidgetAllowlist(): boolean {
-  const raw = process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST?.trim().toLowerCase();
-  return raw === '1' || raw === 'true';
-}
-
-function assertAllowlistPopulated(originAllowlist: readonly string[]): void {
-  if (originAllowlist.length === 0 && requireWidgetAllowlist()) {
-    throw new BadRequestException(
-      'origin_allowlist_required: this deployment requires at least one entry in `originAllowlist` (full origin like `https://app.example.com`). Add the production and any preview origins before saving.',
-    );
-  }
-}
+import { WidgetChannelAdminService } from './widget-channel-admin.service.ts';
 
 const CreateInput = z.object({
   name: z.string().min(1).max(120),
@@ -35,40 +19,12 @@ const UpdateInput = z.object({
 
 const RotateInput = z.object({ channelId: z.string() });
 
-type WidgetConfig = z.infer<typeof WidgetChannelConfig>;
-type SanitizedWidgetConfig = Omit<WidgetConfig, 'identityVerificationSecret'> & {
-  /** Whether an identity verification secret is currently configured. The
-   *  plaintext is only ever surfaced from `conv_widget_create_channel` and
-   *  `conv_widget_rotate_identity_secret`. */
-  hasIdentityVerificationSecret: boolean;
-};
-
-function sanitizeConfig(config: WidgetConfig): SanitizedWidgetConfig {
-  const { identityVerificationSecret, ...rest } = config;
-  return { ...rest, hasIdentityVerificationSecret: !!identityVerificationSecret };
-}
-
-interface ChannelDto {
-  id: string;
-  name: string;
-  type: 'chat';
-  active: boolean;
-  config: SanitizedWidgetConfig;
-}
-
-interface CreateResult extends ChannelDto {
-  widgetKey: string;
-  /** HMAC secret for browser-side identity verification. Surfaced once. */
-  identityVerificationSecret: string;
-}
-
-interface RotateIdentitySecretResult {
-  channelId: string;
-  identityVerificationSecret: string;
-}
-
 @Injectable()
 export class WidgetAdminTools {
+  constructor(
+    @Inject(WidgetChannelAdminService) private readonly widget: WidgetChannelAdminService,
+  ) {}
+
   @McpTool({
     name: 'conv_widget_create_channel',
     title: 'Conv: Create chat-widget channel',
@@ -80,53 +36,8 @@ export class WidgetAdminTools {
     readOnlyHint: false,
     destructiveHint: true,
   })
-  async createChannel(args: z.infer<typeof CreateInput>): Promise<CreateResult> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-
-    assertAllowlistPopulated(args.originAllowlist);
-
-    const identityVerificationSecret = randomToken(32);
-    const config = WidgetChannelConfig.parse({
-      provider: 'widget',
-      originAllowlist: args.originAllowlist,
-      webhookOnEscalation: args.webhookOnEscalation,
-      identityVerificationSecret,
-      requireVerifiedIdentity: args.requireVerifiedIdentity ?? false,
-    });
-
-    const [channel] = await ctx.db
-      .insert(schema.convChannels)
-      .values({
-        orgId: actor.orgId,
-        type: 'chat',
-        vendor: 'munin',
-        name: args.name,
-        config: config,
-      })
-      .returning();
-
-    const rawKey = buildApiKey('widget');
-    await ctx.db.insert(schema.apiKeys).values({
-      orgId: actor.orgId,
-      type: 'widget',
-      name: `${args.name} widget key`,
-      keyHash: hashSecret(rawKey),
-      keyPrefix: keyPrefix(rawKey),
-      scopes: ['conv:widget:write'],
-      channelId: channel!.id,
-      createdByUserId: actor.userId ?? null,
-    });
-
-    return {
-      id: channel!.id,
-      name: channel!.name,
-      type: 'chat',
-      active: channel!.active,
-      config: sanitizeConfig(config),
-      widgetKey: rawKey,
-      identityVerificationSecret,
-    };
+  createChannel(args: z.infer<typeof CreateInput>) {
+    return this.widget.createChannel(args);
   }
 
   @McpTool({
@@ -140,52 +51,8 @@ export class WidgetAdminTools {
     readOnlyHint: false,
     destructiveHint: true,
   })
-  async updateChannel(args: z.infer<typeof UpdateInput>): Promise<ChannelDto> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-
-    const rows = await ctx.db
-      .select()
-      .from(schema.convChannels)
-      .where(
-        and(
-          eq(schema.convChannels.id, args.channelId),
-          eq(schema.convChannels.orgId, actor.orgId),
-        ),
-      )
-      .limit(1);
-    const existing = rows[0];
-    if (!existing) throw new NotFoundException(`channel ${args.channelId} not found`);
-    const prev = WidgetChannelConfig.parse(existing.config);
-
-    if (args.originAllowlist !== undefined) {
-      assertAllowlistPopulated(args.originAllowlist);
-    }
-
-    const next = WidgetChannelConfig.parse({
-      provider: 'widget',
-      originAllowlist: args.originAllowlist ?? prev.originAllowlist,
-      webhookOnEscalation:
-        args.webhookOnEscalation === null
-          ? undefined
-          : (args.webhookOnEscalation ?? prev.webhookOnEscalation),
-      identityVerificationSecret: prev.identityVerificationSecret,
-      requireVerifiedIdentity: args.requireVerifiedIdentity ?? prev.requireVerifiedIdentity,
-    });
-
-    const [updated] = await ctx.db
-      .update(schema.convChannels)
-      .set({ config: next, updatedAt: new Date() })
-      .where(eq(schema.convChannels.id, args.channelId))
-      .returning();
-
-    return {
-      id: updated!.id,
-      name: updated!.name,
-      type: 'chat',
-      active: updated!.active,
-      config: sanitizeConfig(next),
-    };
+  updateChannel(args: z.infer<typeof UpdateInput>) {
+    return this.widget.updateChannel(args);
   }
 
   @McpTool({
@@ -199,45 +66,8 @@ export class WidgetAdminTools {
     readOnlyHint: false,
     destructiveHint: true,
   })
-  async rotateKey(args: z.infer<typeof RotateInput>): Promise<{ widgetKey: string }> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-
-    const channel = await ctx.db
-      .select({ id: schema.convChannels.id, name: schema.convChannels.name })
-      .from(schema.convChannels)
-      .where(
-        and(
-          eq(schema.convChannels.id, args.channelId),
-          eq(schema.convChannels.orgId, actor.orgId),
-        ),
-      )
-      .limit(1);
-    if (!channel[0]) throw new NotFoundException(`channel ${args.channelId} not found`);
-
-    await ctx.db
-      .update(schema.apiKeys)
-      .set({ revokedAt: new Date() })
-      .where(
-        and(
-          eq(schema.apiKeys.channelId, args.channelId),
-          eq(schema.apiKeys.type, 'widget'),
-        ),
-      );
-
-    const rawKey = buildApiKey('widget');
-    await ctx.db.insert(schema.apiKeys).values({
-      orgId: actor.orgId,
-      type: 'widget',
-      name: `${channel[0].name} widget key`,
-      keyHash: hashSecret(rawKey),
-      keyPrefix: keyPrefix(rawKey),
-      scopes: ['conv:widget:write'],
-      channelId: args.channelId,
-      createdByUserId: actor.userId ?? null,
-    });
-
-    return { widgetKey: rawKey };
+  rotateKey(args: z.infer<typeof RotateInput>) {
+    return this.widget.rotateKey(args);
   }
 
   @McpTool({
@@ -251,37 +81,7 @@ export class WidgetAdminTools {
     readOnlyHint: false,
     destructiveHint: true,
   })
-  async rotateIdentitySecret(
-    args: z.infer<typeof RotateInput>,
-  ): Promise<RotateIdentitySecretResult> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-
-    const rows = await ctx.db
-      .select()
-      .from(schema.convChannels)
-      .where(
-        and(
-          eq(schema.convChannels.id, args.channelId),
-          eq(schema.convChannels.orgId, actor.orgId),
-        ),
-      )
-      .limit(1);
-    const existing = rows[0];
-    if (!existing) throw new NotFoundException(`channel ${args.channelId} not found`);
-    const prev = WidgetChannelConfig.parse(existing.config);
-
-    const identityVerificationSecret = randomToken(32);
-    const next = WidgetChannelConfig.parse({
-      ...prev,
-      identityVerificationSecret,
-    });
-
-    await ctx.db
-      .update(schema.convChannels)
-      .set({ config: next, updatedAt: new Date() })
-      .where(eq(schema.convChannels.id, args.channelId));
-
-    return { channelId: args.channelId, identityVerificationSecret };
+  rotateIdentitySecret(args: z.infer<typeof RotateInput>) {
+    return this.widget.rotateIdentitySecret(args);
   }
 }

--- a/packages/backend-core/src/modules/crm/crm.tools.ts
+++ b/packages/backend-core/src/modules/crm/crm.tools.ts
@@ -645,7 +645,7 @@ export class CrmAdminTools {
       'List saved contact segments. A segment is a named CRM filter — used as the audience for outreach campaigns and other targeting workflows. Returns each segment with its filter definition.',
     audiences: ['admin'],
     scopes: ['crm:read'],
-    input: z.object({}),
+    input: EmptyInput,
     readOnlyHint: true,
     destructiveHint: false,
   })

--- a/packages/backend-core/src/modules/feedback/feedback.tools.ts
+++ b/packages/backend-core/src/modules/feedback/feedback.tools.ts
@@ -60,6 +60,7 @@ export class FeedbackTools {
     scopes: [],
     input: EmptyInput,
     readOnlyHint: true,
+    destructiveHint: false,
   })
   async list() {
     return { items: await this.service.listPending() };
@@ -73,6 +74,7 @@ export class FeedbackTools {
     scopes: [],
     input: IdInput,
     readOnlyHint: true,
+    destructiveHint: false,
   })
   get(args: z.infer<typeof IdInput>) {
     return this.service.get(args.id);
@@ -101,6 +103,7 @@ export class FeedbackTools {
     audiences: ['admin'],
     scopes: [],
     input: IdInput,
+    readOnlyHint: false,
     destructiveHint: true,
   })
   async dismiss(args: z.infer<typeof IdInput>) {
@@ -117,6 +120,7 @@ export class FeedbackTools {
     scopes: [],
     input: SearchInput,
     readOnlyHint: true,
+    destructiveHint: false,
   })
   async search(args: z.infer<typeof SearchInput>) {
     return { items: await this.service.search(args) };

--- a/packages/backend-core/src/modules/system-alerts/system-alerts.tools.ts
+++ b/packages/backend-core/src/modules/system-alerts/system-alerts.tools.ts
@@ -21,13 +21,14 @@ export class SystemAlertsTools {
 
   @McpTool({
     name: 'system_alerts_list',
-    title: 'System alerts: list',
+    title: 'System alerts: List',
     description:
       'List operational alerts for the org. Defaults to open alerts only; pass includeResolved to see history.',
     audiences: ['admin'],
     scopes: [],
     input: ListInput,
     readOnlyHint: true,
+    destructiveHint: false,
   })
   async list(args: z.infer<typeof ListInput>) {
     return { items: await this.service.list(args) };
@@ -35,12 +36,13 @@ export class SystemAlertsTools {
 
   @McpTool({
     name: 'system_alerts_get',
-    title: 'System alerts: get',
+    title: 'System alerts: Get',
     description: 'Read a single alert by id.',
     audiences: ['admin'],
     scopes: [],
     input: IdInput,
     readOnlyHint: true,
+    destructiveHint: false,
   })
   get(args: z.infer<typeof IdInput>) {
     return this.service.get(args.id);
@@ -48,7 +50,7 @@ export class SystemAlertsTools {
 
   @McpTool({
     name: 'system_alerts_acknowledge',
-    title: 'System alerts: acknowledge',
+    title: 'System alerts: Acknowledge',
     description: 'Mark an alert as acknowledged. Does not resolve it; only signals that someone is on it.',
     audiences: ['admin'],
     scopes: [],
@@ -62,7 +64,7 @@ export class SystemAlertsTools {
 
   @McpTool({
     name: 'system_alerts_resolve',
-    title: 'System alerts: resolve',
+    title: 'System alerts: Resolve',
     description:
       'Manually resolve the open alert for the given source+subject. Writers normally self-resolve; use this when the underlying state can no longer be observed.',
     audiences: ['admin'],


### PR DESCRIPTION
Tools-layer consistency cleanup surfaced while reviewing the MCP tools/services. **No tool names, input schemas, or output shapes change** — the only externally visible diff is four cosmetic `system_alerts_*` title casings (docs-fixtures confirms this).

> Stacked on `feat/analytics-funnel` (#563) because the analytics changes build on the funnel code from that branch. Base auto-retargets to `main` once #563 merges.

## What & why

**Layering — tools should be thin (the #1 issue)**
- `analytics.tools.ts` and `widget.tools.ts` held raw SQL, key-minting, and DB writes directly in the `@McpTool` classes; every other module keeps the tool method a one-line delegation to a service. Moved all analytics tracker-CRUD + reporting queries into `AnalyticsService`, and the widget channel/key logic into a new `WidgetChannelAdminService`. Tool methods now delegate.
- Collapsed the `org_id + time-window + subjectType/source` filter builder (copy-pasted 5×) into one private helper.

**Shared helpers**
- Extracted the duplicated API-key minting → `common/api-keys/api-key.helpers.ts` and the env-driven origin-allowlist check → `common/allowlist.ts`, used by both analytics and widget.

**Misleading names**
- The Twilio/MessageBird/Vapi/Threll `*.tools.ts` files (classes `*AdminTools`) contain **zero** `@McpTool`s — they're channel-admin services behind the generic `conv_configure_channel` tool. Renamed to `*-admin.service.ts` / `*AdminService` and updated the providers, `conv.module.ts`, and the `/v1` controller.

**Smaller consistency fixes**
- Analytics inputs: named Zod consts + `z.infer` instead of inline schemas paired with hand-written arg types (single source of truth).
- Standardized empty inputs on the shared `EmptyInput`.
- Always set both `readOnlyHint` and `destructiveHint` on feedback/system-alerts tools.
- Fixed `system_alerts_*` title casing (`"…: list"` → `"…: List"`).

Not addressed (explicitly out of scope): minor naming nits (injected-field names, `WebhookAdminTools` singular, `FeedbackTools`/`SystemAlertsTools` dropping the `Admin` suffix).

## Verification
- `pnpm typecheck` (workspace) ✅
- `eslint` on all changed/new files ✅
- `docs:generate` → fixture diff is exactly the 4 title-casing lines ✅
- Integration + unit suites for analytics (trackers + transfer), widget channel, all four vendor channels, feedback, system-alerts, channel rate-limit — ~111 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)