### PR TITLE
fix(mcp): return actionable errors instead of 500s for constraint violations

### DIFF
--- a/.changeset/mcp-tools-actionable-errors.md
+++ b/.changeset/mcp-tools-actionable-errors.md
@@ -1,0 +1,15 @@
+---
+"@getmunin/backend-core": patch
+"@getmunin/mcp-toolkit": patch
+---
+
+Fix MCP tools that returned a bare `500 Internal server error` or an invalid result on otherwise-valid input. Database constraint violations are now caught before they fire and surface as actionable tool errors:
+
+- `crm_create_segment` — duplicate segment name now returns `crm_conflict` instead of a 500.
+- `conv_create_topic` — duplicate slug now returns `conv_topic_slug_conflict` instead of a 500.
+- `cms_create_locale` — duplicate locale code now returns `cms_locale_conflict` instead of a 500.
+- `crm_delete_segment` — deleting a segment referenced by an outreach campaign now explains the conflict (and how to resolve it) instead of a 500.
+- `conv_assign_conversation` — assigning to a user who is not a member of the org now returns a clear `conv_invalid` error instead of a 500.
+- `webhooks_delete` — now returns `{ deleted, id }` instead of nothing; a void return serialized to `undefined` content and tripped the MCP `CallToolResult` schema (`-32602`).
+
+The MCP dispatch layer also coalesces a void tool return to a valid `null` text result so a future void-returning tool can't produce a transport-level error.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,19 @@ Each module typically has `<mod>.module.ts`, `<mod>.service.ts`, `<mod>.tools.ts
 - Tool + skill enforcement lives in `packages/mcp-toolkit/src/server.ts`. Scopes are intersected against `actor.scopes` at call time.
 - The same `/mcp` serves admin agents (OAuth-authorized) and end-user agents (delegated tokens minted via `delegated-token.controller.ts`).
 
+### Adding a new MCP tool — checklist
+
+Tools are a public product surface and are reviewed for the Anthropic Software Directory (reviewers call every tool with valid params and scan its metadata). Keep new tools correct *and* compliant:
+
+- **Pre-check DB constraints — don't rely on `try/catch`.** A handler runs inside the request's outer tenant transaction, so a unique/FK violation poisons that transaction and the *commit* fails **after** your handler returns — past any in-handler catch — surfacing as a bare `500`. Guard *before* the failing statement: `SELECT` for an existing row (unique), check referencing rows before a delete (FK `restrict`), confirm an FK target exists before insert/update — then `throw new ConflictException('<module>_conflict: …')` / `BadRequestException(...)`. Pattern: `crm_create_pipeline` (unique), `crm_delete_segment` (FK), `conv_assign_conversation` (FK target). Never return a generic 500 — reviewers reject them.
+- **Never return `void`/`undefined` from a handler.** `JSON.stringify(undefined)` is `undefined`, which fails the MCP `CallToolResult` schema (`-32602`). Return a small object, e.g. `{ deleted: true, id }`. (Dispatch coalesces void → `null` as a backstop, but return something meaningful.)
+- **Annotations are required:** `title` plus exactly one hint — `readOnlyHint: true` for reads, `destructiveHint: true` for anything that writes/updates/deletes (read-only tools auto-run; destructive tools always prompt). Tool `name` ≤ 64 chars.
+- **Split read and write.** No tool that both reads and mutates, and no catch-all `method`-style param; keep `create` / `update` / `delete` as separate tools.
+- **Description = what it does and when to use it**, matching actual behavior. Don't tell Claude how to behave, don't direct it to call other tools, no hidden/encoded instructions — those are auto-rejected as prompt-injection.
+- **Zod input schema** for every input (drives validation + the published JSON schema); set `audiences` (admin vs end-user) and `scopes` (`<module>:read` / `<module>:write`).
+- **DB touch?** migration + RLS policy + per-module SQL (see Conventions).
+- **Test the conflict/validation paths, not just the happy path** (`*.test.ts` / `*.integration.test.ts`). To exercise the whole surface locally, drive `/mcp` with an admin key (`mn_admin_*`) over JSON-RPC and assert no `500`/`-32602`.
+
 ## Persistence
 
 - Postgres + pgvector. Schema in `packages/db/src/schema.ts`, migrations in `packages/db/drizzle/`. RLS policies in `packages/db/src/sql/rls.sql` (one policy per table, gated by the `app.org_id` and `app.bypass_rls` GUCs that `TenancyInterceptor` sets per request).

--- a/packages/backend-core/src/modules/cms/cms.integration.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.integration.test.ts
@@ -570,6 +570,18 @@ const skipReason = TEST_URL
       );
     });
   }, 30_000);
+
+  it('createLocale returns an actionable conflict on a duplicate code (not a 500)', async () => {
+    await withClient(adminKey, async (c) => {
+      await c.callTool({ name: 'cms_create_locale', arguments: { code: 'nl', name: 'Dutch' } });
+      const dup = (await c.callTool({
+        name: 'cms_create_locale',
+        arguments: { code: 'nl', name: 'Dutch (dup)' },
+      })) as { isError?: boolean; content?: Array<{ text?: string }> };
+      expect(dup.isError).toBe(true);
+      expect(dup.content?.[0]?.text).toContain('cms_locale_conflict');
+    });
+  }, 30_000);
 });
 
 function retarget(url: string, baseUrl: string): string {

--- a/packages/backend-core/src/modules/cms/cms.service.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.ts
@@ -901,6 +901,9 @@ export class CmsService {
       .from(schema.cmsLocales)
       .where(eq(schema.cmsLocales.orgId, actor.orgId))
       .orderBy(desc(schema.cmsLocales.position));
+    if (existing.some((l) => l.code === input.code)) {
+      throw new ConflictException(`cms_locale_conflict: ${input.code}`);
+    }
     const position = existing[0] ? existing[0].position + 1 : 0;
     const isDefault = input.isDefault ?? existing.length === 0;
     if (isDefault) {

--- a/packages/backend-core/src/modules/conv/conv.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.integration.test.ts
@@ -502,6 +502,49 @@ const skipReason = TEST_URL
       expect(detail.needsHumanAttentionAt).toBeNull();
     });
   }, 30_000);
+
+  it('createTopic returns an actionable conflict on a duplicate slug (not a 500)', async () => {
+    await withClient(adminKey, async (c) => {
+      await c.callTool({
+        name: 'conv_create_topic',
+        arguments: { name: 'Billing', slug: 'billing' },
+      });
+      const dup = (await c.callTool({
+        name: 'conv_create_topic',
+        arguments: { name: 'Billing 2', slug: 'billing' },
+      })) as { isError?: boolean; content?: Array<{ text?: string }> };
+      expect(dup.isError).toBe(true);
+      expect(dup.content?.[0]?.text).toContain('conv_topic_slug_conflict');
+    });
+  }, 30_000);
+
+  it('assignConversation rejects a non-member assignee with an actionable error (not a 500)', async () => {
+    await withClient(adminKey, async (c) => {
+      const importId = `it-${Date.now()}`;
+      await c.callTool({
+        name: 'conv_import',
+        arguments: {
+          records: {
+            channels: [{ id: importId, type: 'email', vendor: 'smtp', name: 'Imported', active: true }],
+            conversations: [
+              { id: `${importId}-c`, channelId: importId, subject: 'Hi', status: 'open', topicSlug: null, agentMode: 'auto' },
+            ],
+            messages: [],
+          },
+        },
+      });
+      const list = parseToolResult<Array<{ id: string }>>(
+        await c.callTool({ name: 'conv_list_conversations', arguments: {} }),
+      );
+      const conversationId = list[0]!.id;
+      const assigned = (await c.callTool({
+        name: 'conv_assign_conversation',
+        arguments: { id: conversationId, assigneeUserId: 'user_does_not_exist' },
+      })) as { isError?: boolean; content?: Array<{ text?: string }> };
+      expect(assigned.isError).toBe(true);
+      expect(assigned.content?.[0]?.text).toMatch(/not a member/i);
+    });
+  }, 30_000);
 });
 
 function parseToolResult<T>(result: unknown): T {

--- a/packages/backend-core/src/modules/conv/conv.service.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.test.ts
@@ -8,7 +8,7 @@ import {
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { eq, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ConvService, ConvInvalidError } from './conv.service.ts';
 import { ConversationClaimsService } from './conv.claims.service.ts';
 import { AlertsService } from '../system-alerts/system-alerts.service.ts';
@@ -44,6 +44,7 @@ const skipReason = TEST_URL
       .values({ email: `conv-svc-test-${ts}@example.com`, name: 'Test User' })
       .returning();
     userId = user!.id;
+    await db.insert(schema.orgMembers).values({ orgId, userId });
     actor = new ActorIdentity('admin_agent', 'agt_conv_test', orgId, ['*'], ['admin']);
 
     const dispatcher = new WebhookDispatcher();
@@ -453,6 +454,13 @@ const skipReason = TEST_URL
       await expect(
         run(() => svc.assignConversation({ id: randomUUID(), assigneeUserId: null })),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('assignConversation rejects a non-member assignee (no constraint 500)', async () => {
+      const conv = await seedConv();
+      await expect(
+        run(() => svc.assignConversation({ id: conv.id, assigneeUserId: 'user_not_a_member' })),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('changeStatus open/closed/spam transitions emit webhook', async () => {

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -1,4 +1,11 @@
-import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { schema } from '@getmunin/db';
 import { and, asc, desc, eq, ilike, inArray, isNotNull, isNull, lte, notInArray, or, sql, type SQL } from 'drizzle-orm';
 import { getCurrentContext, WebhookDispatcher } from '@getmunin/core';
@@ -288,6 +295,14 @@ export class ConvService {
     const actor = ctx.actor!;
     if (!isValidSlug(input.slug)) {
       throw new ConvInvalidError('slug must be lowercase letters, digits and hyphens (1-64 chars)');
+    }
+    const existing = await ctx.db
+      .select({ id: schema.convTopics.id })
+      .from(schema.convTopics)
+      .where(and(eq(schema.convTopics.orgId, actor.orgId), eq(schema.convTopics.slug, input.slug)))
+      .limit(1);
+    if (existing[0]) {
+      throw new ConflictException(`conv_topic_slug_conflict: ${input.slug}`);
     }
     const [row] = await ctx.db
       .insert(schema.convTopics)
@@ -979,6 +994,24 @@ export class ConvService {
     assigneeUserId: string | null;
   }): Promise<ConversationSummary> {
     const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    if (input.assigneeUserId !== null) {
+      const member = await ctx.db
+        .select({ userId: schema.orgMembers.userId })
+        .from(schema.orgMembers)
+        .where(
+          and(
+            eq(schema.orgMembers.orgId, actor.orgId),
+            eq(schema.orgMembers.userId, input.assigneeUserId),
+          ),
+        )
+        .limit(1);
+      if (!member[0]) {
+        throw new BadRequestException(
+          `conv_invalid: user ${input.assigneeUserId} is not a member of this org`,
+        );
+      }
+    }
     const result = await ctx.db
       .update(schema.convConversations)
       .set({ assigneeUserId: input.assigneeUserId, updatedAt: new Date() })

--- a/packages/backend-core/src/modules/crm/crm.integration.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.integration.test.ts
@@ -265,6 +265,48 @@ const skipReason = TEST_URL
       expect(text).not.toMatch(/Alice/);
     });
   }, 30_000);
+
+  it('createSegment returns an actionable conflict on a duplicate name (not a 500)', async () => {
+    await withClient(adminKey, async (c) => {
+      await c.callTool({
+        name: 'crm_create_segment',
+        arguments: { name: 'Duplicate Segment', filter: { tagsAny: ['vip'] } },
+      });
+      const dup = (await c.callTool({
+        name: 'crm_create_segment',
+        arguments: { name: 'Duplicate Segment', filter: { tagsAny: ['vip'] } },
+      })) as { isError?: boolean; content?: Array<{ text?: string }> };
+      expect(dup.isError).toBe(true);
+      expect(dup.content?.[0]?.text).toContain('crm_conflict');
+    });
+  }, 30_000);
+
+  it('deleteSegment returns an actionable conflict when referenced by a campaign (not a 500)', async () => {
+    await withClient(adminKey, async (c) => {
+      const seg = parseToolResult<{ id: string }>(
+        await c.callTool({
+          name: 'crm_create_segment',
+          arguments: { name: 'Referenced Segment', filter: { tagsAny: ['x'] } },
+        }),
+      );
+      const channel = parseToolResult<{ id: string }>(
+        await c.callTool({
+          name: 'conv_create_channel',
+          arguments: { type: 'email', vendor: 'smtp', name: 'Outreach Channel' },
+        }),
+      );
+      await c.callTool({
+        name: 'outreach_create_campaign',
+        arguments: { name: 'Spring Push', brief: 'Hello', segmentId: seg.id, channelId: channel.id },
+      });
+      const del = (await c.callTool({
+        name: 'crm_delete_segment',
+        arguments: { id: seg.id },
+      })) as { isError?: boolean; content?: Array<{ text?: string }> };
+      expect(del.isError).toBe(true);
+      expect(del.content?.[0]?.text).toMatch(/referenced by .*campaign/i);
+    });
+  }, 30_000);
 });
 
 function parseToolResult<T>(result: unknown): T {

--- a/packages/backend-core/src/modules/crm/crm.service.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.ts
@@ -555,6 +555,14 @@ export class CrmService {
     const actor = ctx.actor!;
     if (!input.name.trim()) throw new CrmInvalidError('segment name must be non-empty');
     const filter = normaliseFilter(input.filter);
+    const existing = await ctx.db
+      .select({ id: schema.crmSegments.id })
+      .from(schema.crmSegments)
+      .where(and(eq(schema.crmSegments.orgId, actor.orgId), eq(schema.crmSegments.name, input.name)))
+      .limit(1);
+    if (existing[0]) {
+      throw new ConflictException(`crm_conflict: segment with name "${input.name}" already exists`);
+    }
     try {
       const [row] = await ctx.db
         .insert(schema.crmSegments)
@@ -596,6 +604,15 @@ export class CrmService {
 
   async deleteSegment(id: string): Promise<{ deleted: true }> {
     const ctx = getCurrentContext();
+    const referencingCampaigns = await ctx.db
+      .select({ id: schema.outreachCampaigns.id })
+      .from(schema.outreachCampaigns)
+      .where(eq(schema.outreachCampaigns.segmentId, id));
+    if (referencingCampaigns.length > 0) {
+      throw new ConflictException(
+        `crm_conflict: segment ${id} is referenced by ${referencingCampaigns.length} outreach campaign(s); delete or repoint those campaigns first`,
+      );
+    }
     const result = await ctx.db
       .delete(schema.crmSegments)
       .where(eq(schema.crmSegments.id, id))

--- a/packages/backend-core/src/modules/webhooks/webhooks.service.test.ts
+++ b/packages/backend-core/src/modules/webhooks/webhooks.service.test.ts
@@ -93,9 +93,12 @@ const skipReason = TEST_URL
     );
   });
 
-  it('delete removes the row; second delete is 404', async () => {
+  it('delete removes the row, returns a serializable result; second delete is 404', async () => {
     const created = await run(() => svc.create({ url: 'https://hooks.example.com/h' }));
-    await run(() => svc.delete(created.id));
+    // Must return a value (not void): a void return serializes to undefined content
+    // and trips the MCP CallToolResult schema (-32602).
+    const result = await run(() => svc.delete(created.id));
+    expect(result).toEqual({ deleted: true, id: created.id });
     expect(await run(() => svc.list())).toHaveLength(0);
     await expect(run(() => svc.delete(created.id))).rejects.toThrow(NotFoundException);
   });

--- a/packages/backend-core/src/modules/webhooks/webhooks.service.ts
+++ b/packages/backend-core/src/modules/webhooks/webhooks.service.ts
@@ -145,7 +145,7 @@ export class WebhooksService {
     return toDto(result[0]);
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string): Promise<{ deleted: true; id: string }> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
     const result = await ctx.db
@@ -153,6 +153,7 @@ export class WebhooksService {
       .where(and(eq(schema.webhooks.id, id), eq(schema.webhooks.orgId, actor.orgId)))
       .returning({ id: schema.webhooks.id });
     if (result.length === 0) throw new NotFoundException(`webhook ${id} not found`);
+    return { deleted: true, id };
   }
 
   async rotateSecret(id: string): Promise<WebhookDto> {

--- a/packages/mcp-toolkit/src/dispatch.ts
+++ b/packages/mcp-toolkit/src/dispatch.ts
@@ -202,7 +202,10 @@ export async function callTool(
     content: [
       {
         type: 'text' as const,
-        text: typeof value === 'string' ? value : JSON.stringify(value),
+        // JSON.stringify(undefined) returns undefined (not a string), which fails
+        // the MCP CallToolResult schema. Coalesce so a void-returning tool still
+        // yields a valid result instead of a transport-level -32602 error.
+        text: typeof value === 'string' ? value : JSON.stringify(value ?? null),
       },
     ],
   };

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -65,6 +65,16 @@ function buildRegistry(): McpToolRegistry {
       throw new Error('handler exploded');
     },
   );
+  r.register(
+    {
+      name: 'void_tool',
+      description: 'returns undefined',
+      audiences: ['admin'],
+      scopes: [],
+      input: z.object({}),
+    },
+    () => undefined,
+  );
   return r;
 }
 
@@ -97,6 +107,21 @@ describe('openInProcessMcpClient', () => {
     expect(fakeAudit.record).toHaveBeenCalledWith(
       expect.objectContaining({ tool: 'echo', result: 'ok' }),
     );
+  });
+
+  it('callTool coerces a void return into a valid text result (never undefined)', async () => {
+    // Regression: JSON.stringify(undefined) === undefined, which fails the MCP
+    // CallToolResult schema and surfaces as a transport-level -32602 error.
+    const client = openInProcessMcpClient({
+      registry: buildRegistry(),
+      actor: adminActor(),
+      audience: 'admin',
+      audit: fakeAudit,
+    });
+    const out = await runInCtx(adminActor(), () => client.callTool('void_tool', {}));
+    expect(out.isError).toBeUndefined();
+    expect(out.content[0]).toEqual({ type: 'text', text: 'null' });
+    expect(typeof out.content[0]?.text).toBe('string');
   });
 
   it('callTool rejects an unknown tool with a denied audit row', async () => {


### PR DESCRIPTION
## Why

Verifying every MCP tool against a local backend (all 153 tools, full functional sweep) for the Anthropic Software Directory submission surfaced **6 tools that returned a bare `500 Internal server error` or an invalid result on otherwise-valid input**. The pre-submission checklist explicitly rejects generic 500s and requires every tool to return a valid response with valid params, so these are submission blockers.

## Root cause

The MCP dispatch layer runs each tool inside the request's **outer tenant transaction** (`TenancyInterceptor`). When a DB constraint fires, that transaction is poisoned and the **commit** fails *after* the handler returns — past any per-tool `try/catch`. `crm_create_segment` already had a catch-and-translate and still 500'd, which confirmed it. The transaction-safe fix is to **pre-check before the failing statement** (the pattern `crm_create_pipeline` already uses).

## Fixes

| Tool | Before | After |
|---|---|---|
| `crm_create_segment` | 500 on duplicate name | `crm_conflict` |
| `conv_create_topic` | 500 on duplicate slug | `conv_topic_slug_conflict` |
| `cms_create_locale` | 500 on duplicate code | `cms_locale_conflict` |
| `crm_delete_segment` | 500 when referenced by a campaign | explains the conflict + how to resolve |
| `conv_assign_conversation` | 500 on non-member assignee | `conv_invalid` |
| `webhooks_delete` | `-32602` invalid result (returned void) | `{ deleted, id }` |

`webhooks_delete` returned `void`, which serialized to `undefined` content and tripped the MCP `CallToolResult` schema. The dispatch layer now also coalesces a void return to a valid `null` text result so a future void-returning tool can't produce a transport-level error.

## Tests

- New service/integration cases for each of the 6 tools (assert an actionable error / valid result, never a 500 / `-32602`).
- `mcp-toolkit`: dispatch unit test for the void-return coalescing.
- Updated the existing `assignConversation` service test to seed a real org member (the new membership check correctly rejected the previously-fake assignee).

Full suites green: **backend-core 886 passed**, **mcp-toolkit 65 passed**. Re-ran the 153-tool sweep against a local backend on `munin_test` — no 500s or `-32602` remain; the 6 tools now behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)