### PR TITLE
fix(dashboard): sync recent conversations list with realtime events

### DIFF
--- a/.changeset/recent-conversations-realtime-sync.md
+++ b/.changeset/recent-conversations-realtime-sync.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/dashboard-pages": patch
+---
+
+Keep the dashboard's recent open conversations list in sync with realtime conversation events, so closing a conversation removes it from the list without a page reload.

--- a/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { api } from '../../api';
+import { useRealtime } from '../../realtime';
 import { useRelative } from '../../lib/use-relative';
 import type { InboxController } from './inbox-sections';
 
@@ -33,22 +34,25 @@ export function RecentConversationsSection({
 }) {
   const t = useTranslations('dashboard.overview.recentConversations');
   const [items, setItems] = useState<ConversationSummary[]>([]);
-  const fetchedRef = useRef(false);
+
+  const load = useCallback(async () => {
+    try {
+      const page = await api<ConversationListResponse>(
+        `/v1/conversations?status=open&limit=${MAX_ITEMS}`,
+      );
+      setItems(page.items);
+    } catch (err) {
+      console.warn('[dashboard] open conversations fetch failed:', err);
+    }
+  }, []);
 
   useEffect(() => {
-    if (fetchedRef.current) return;
-    fetchedRef.current = true;
-    void (async () => {
-      try {
-        const page = await api<ConversationListResponse>(
-          `/v1/conversations?status=open&limit=${MAX_ITEMS}`,
-        );
-        setItems(page.items);
-      } catch (err) {
-        console.warn('[dashboard] open conversations fetch failed:', err);
-      }
-    })();
-  }, []);
+    void load();
+  }, [load]);
+
+  useRealtime([{ channel: 'org' }], (event) => {
+    if (event.type.startsWith('conversation.')) void load();
+  });
 
   const visible = useMemo(() => {
     return items


### PR DESCRIPTION
## Problem

Closing a conversation did not remove it from the dashboard's **last open conversations** list — it stayed there until a full page reload.

## Cause

`RecentConversationsSection` fetched `/v1/conversations?status=open` **once on mount** behind a permanent `fetchedRef` guard, then never re-synced. Every other live list in the dashboard (inbox live/queue sections in `inbox-data.ts`, usage KPIs in `overview.tsx`) stays current by subscribing to realtime `conversation.*` events and refetching — this section was the odd one out.

## Fix

- Extracted the fetch into a reusable `load` callback (dropped the one-shot `fetchedRef` guard).
- Subscribe to the org realtime channel and re-run `load()` on any `conversation.*` event.

Now closing a conversation (from the drawer, another tab, or the agent) emits a `conversation.*` event; the section refetches and the now-closed conversation drops off, since the query filters `status=open`.

## Notes

This opens a section-scoped websocket subscription, consistent with how `overview.tsx` and `inbox-data.ts` each subscribe independently today. A follow-up PR consolidates these onto a single dashboard connection.

## Test plan

- [x] `pnpm turbo run typecheck --filter=@getmunin/dashboard-pages`
- [ ] Manual: open dashboard, close a conversation from the drawer, confirm it disappears from the recent list without reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)