### PR TITLE
refactor(dashboard): share one realtime WebSocket across consumers

### DIFF
--- a/.changeset/single-realtime-connection.md
+++ b/.changeset/single-realtime-connection.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/dashboard-pages": patch
+---
+
+Share a single realtime WebSocket connection across all `useRealtime` callers instead of opening one socket per component. The dashboard previously held several concurrent connections (inbox, usage summary, recent conversations, system alerts, activity rail); they now multiplex over one connection, with each `event` frame routed to only the listeners subscribed to its channel. The `useRealtime` API is unchanged.

--- a/packages/dashboard-pages/src/realtime.ts
+++ b/packages/dashboard-pages/src/realtime.ts
@@ -32,117 +32,220 @@ function subKey(sub: SubscriptionChannel): string {
   return 'id' in sub ? `${sub.channel}:${sub.id}` : sub.channel;
 }
 
+interface Listener {
+  channels: Set<string>;
+  onEvent: (event: RealtimeEventRow) => void;
+}
+
+class RealtimeClient {
+  private ws: WebSocket | null = null;
+  private status: RealtimeStatus = 'connecting';
+  private readonly listeners = new Set<Listener>();
+  private readonly statusListeners = new Set<(status: RealtimeStatus) => void>();
+  private readonly refcounts = new Map<string, number>();
+  private readonly activeSubs = new Set<string>();
+  private backoffMs = 500;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private pingInterval: ReturnType<typeof setInterval> | null = null;
+
+  getStatus(): RealtimeStatus {
+    return this.status;
+  }
+
+  subscribeStatus(cb: (status: RealtimeStatus) => void): () => void {
+    this.statusListeners.add(cb);
+    return () => this.statusListeners.delete(cb);
+  }
+
+  addListener(listener: Listener): void {
+    this.listeners.add(listener);
+    for (const key of listener.channels) this.retain(key);
+    this.ensureConnection();
+  }
+
+  removeListener(listener: Listener): void {
+    if (!this.listeners.delete(listener)) return;
+    for (const key of listener.channels) this.release(key);
+    if (this.listeners.size === 0) this.teardown();
+  }
+
+  setListenerChannels(listener: Listener, subscriptions: readonly SubscriptionChannel[]): void {
+    const next = new Set(subscriptions.map(subKey));
+    for (const key of listener.channels) {
+      if (!next.has(key)) this.release(key);
+    }
+    for (const key of next) {
+      if (!listener.channels.has(key)) this.retain(key);
+    }
+    listener.channels = next;
+  }
+
+  private retain(key: string): void {
+    const count = (this.refcounts.get(key) ?? 0) + 1;
+    this.refcounts.set(key, count);
+    if (count === 1) this.send({ type: 'subscribe', ...decodeKey(key) }, key, true);
+  }
+
+  private release(key: string): void {
+    const count = (this.refcounts.get(key) ?? 0) - 1;
+    if (count <= 0) {
+      this.refcounts.delete(key);
+      this.send({ type: 'unsubscribe', ...decodeKey(key) }, key, false);
+    } else {
+      this.refcounts.set(key, count);
+    }
+  }
+
+  private send(payload: object, key: string, active: boolean): void {
+    const ws = this.ws;
+    if (ws && ws.readyState === ws.OPEN) {
+      ws.send(JSON.stringify(payload));
+      if (active) this.activeSubs.add(key);
+      else this.activeSubs.delete(key);
+    }
+  }
+
+  private setStatus(status: RealtimeStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    for (const cb of this.statusListeners) cb(status);
+  }
+
+  private ensureConnection(): void {
+    if (this.ws || typeof WebSocket === 'undefined') return;
+    this.connect();
+  }
+
+  private connect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.setStatus('connecting');
+    const url = API_URL.replace(/^http/, 'ws') + '/v1/realtime';
+    const ws = new WebSocket(url);
+    this.ws = ws;
+
+    ws.onopen = () => {
+      if (this.ws !== ws) return;
+      this.backoffMs = 500;
+      this.setStatus('connected');
+      this.activeSubs.clear();
+      for (const key of this.refcounts.keys()) {
+        ws.send(JSON.stringify({ type: 'subscribe', ...decodeKey(key) }));
+        this.activeSubs.add(key);
+      }
+      this.pingInterval = setInterval(() => {
+        if (ws.readyState === ws.OPEN) ws.send(JSON.stringify({ type: 'ping' }));
+      }, 30_000);
+    };
+
+    ws.onmessage = (msg) => {
+      let frame: IncomingFrame | null = null;
+      try {
+        frame = JSON.parse(msg.data as string) as IncomingFrame;
+      } catch (err) {
+        console.debug('[munin/realtime] dropped malformed frame', err);
+        return;
+      }
+      if (frame.type === 'event' && frame.event) this.dispatch(frame.channel, frame.event);
+    };
+
+    ws.onerror = () => undefined;
+
+    ws.onclose = () => {
+      if (this.ws !== ws) return;
+      this.clearTimers();
+      this.ws = null;
+      this.activeSubs.clear();
+      if (this.listeners.size === 0) return;
+      this.setStatus('offline');
+      const delay = this.backoffMs;
+      this.backoffMs = Math.min(this.backoffMs * 2, 30_000);
+      this.reconnectTimer = setTimeout(() => this.connect(), delay);
+    };
+  }
+
+  private dispatch(channel: string | undefined, event: RealtimeEventRow): void {
+    for (const listener of this.listeners) {
+      if (channel === undefined || listener.channels.has(channel)) listener.onEvent(event);
+    }
+  }
+
+  private clearTimers(): void {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private teardown(): void {
+    this.clearTimers();
+    this.activeSubs.clear();
+    this.refcounts.clear();
+    const ws = this.ws;
+    this.ws = null;
+    if (!ws) return;
+    ws.onopen = null;
+    ws.onmessage = null;
+    ws.onerror = null;
+    ws.onclose = null;
+    try {
+      ws.close();
+    } catch (err) {
+      console.warn('[munin/realtime] ws.close() failed during teardown', err);
+    }
+  }
+}
+
+function decodeKey(key: string): SubscriptionChannel {
+  const sep = key.indexOf(':');
+  if (sep < 0) return { channel: 'org' };
+  const channel = key.slice(0, sep) as 'conversation' | 'contact';
+  return { channel, id: key.slice(sep + 1) };
+}
+
+const client = new RealtimeClient();
+
 export function useRealtime(
   subscriptions: readonly SubscriptionChannel[],
   onEvent: (event: RealtimeEventRow) => void,
 ): { connected: boolean; status: RealtimeStatus } {
-  const [status, setStatus] = useState<RealtimeStatus>('connecting');
+  const [status, setStatus] = useState<RealtimeStatus>(() => client.getStatus());
   const connected = status === 'connected';
+
   const onEventRef = useRef(onEvent);
   onEventRef.current = onEvent;
 
-  const wsRef = useRef<WebSocket | null>(null);
-  const activeSubsRef = useRef<Map<string, SubscriptionChannel>>(new Map());
+  const subsRef = useRef<readonly SubscriptionChannel[]>(subscriptions);
+  subsRef.current = subscriptions;
 
-  const subsKey = subscriptions.map(subKey).sort().join(',');
-  const desiredSubsRef = useRef<readonly SubscriptionChannel[]>(subscriptions);
-  desiredSubsRef.current = subscriptions;
+  const listenerRef = useRef<Listener | null>(null);
 
   useEffect(() => {
-    let backoffMs = 500;
-    let cancelled = false;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-    let pingInterval: ReturnType<typeof setInterval> | null = null;
-
-    const url = API_URL.replace(/^http/, 'ws') + '/v1/realtime';
-
-    const connect = () => {
-      if (cancelled) return;
-      setStatus('connecting');
-      const ws = new WebSocket(url);
-      wsRef.current = ws;
-      ws.onopen = () => {
-        if (cancelled || wsRef.current !== ws) return;
-        backoffMs = 500;
-        setStatus('connected');
-        activeSubsRef.current = new Map();
-        for (const sub of desiredSubsRef.current) {
-          const key = subKey(sub);
-          ws.send(JSON.stringify({ type: 'subscribe', ...sub }));
-          activeSubsRef.current.set(key, sub);
-        }
-        pingInterval = setInterval(() => {
-          if (ws.readyState === ws.OPEN) ws.send(JSON.stringify({ type: 'ping' }));
-        }, 30_000);
-      };
-      ws.onmessage = (msg) => {
-        let frame: IncomingFrame | null = null;
-        try {
-          frame = JSON.parse(msg.data as string) as IncomingFrame;
-        } catch (err) {
-          console.debug('[munin/realtime] dropped malformed frame', err);
-          return;
-        }
-        if (frame.type === 'event' && frame.event) {
-          onEventRef.current(frame.event);
-        }
-      };
-      ws.onerror = () => undefined;
-      ws.onclose = () => {
-        if (pingInterval) clearInterval(pingInterval);
-        pingInterval = null;
-        if (cancelled) return;
-        wsRef.current = null;
-        activeSubsRef.current = new Map();
-        setStatus('offline');
-        const delay = backoffMs;
-        backoffMs = Math.min(backoffMs * 2, 30_000);
-        reconnectTimer = setTimeout(connect, delay);
-      };
+    const listener: Listener = {
+      channels: new Set(subsRef.current.map(subKey)),
+      onEvent: (event) => onEventRef.current(event),
     };
-
-    connect();
-
+    listenerRef.current = listener;
+    const unsubscribeStatus = client.subscribeStatus(setStatus);
+    setStatus(client.getStatus());
+    client.addListener(listener);
     return () => {
-      cancelled = true;
-      if (reconnectTimer) clearTimeout(reconnectTimer);
-      if (pingInterval) clearInterval(pingInterval);
-      const ws = wsRef.current;
-      wsRef.current = null;
-      activeSubsRef.current = new Map();
-      if (ws) {
-        ws.onopen = null;
-        ws.onmessage = null;
-        ws.onerror = null;
-        ws.onclose = null;
-        try {
-          ws.close();
-        } catch (err) {
-          console.warn('[munin/realtime] ws.close() failed during cleanup', err);
-          return;
-        }
-      }
+      client.removeListener(listener);
+      listenerRef.current = null;
+      unsubscribeStatus();
     };
   }, []);
 
+  const subsKey = subscriptions.map(subKey).sort().join(',');
   useEffect(() => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== ws.OPEN) return;
-    const desired = new Map<string, SubscriptionChannel>();
-    for (const sub of desiredSubsRef.current) desired.set(subKey(sub), sub);
-    const active = activeSubsRef.current;
-    for (const [key, sub] of active) {
-      if (!desired.has(key)) {
-        ws.send(JSON.stringify({ type: 'unsubscribe', ...sub }));
-        active.delete(key);
-      }
-    }
-    for (const [key, sub] of desired) {
-      if (!active.has(key)) {
-        ws.send(JSON.stringify({ type: 'subscribe', ...sub }));
-        active.set(key, sub);
-      }
-    }
+    const listener = listenerRef.current;
+    if (listener) client.setListenerChannels(listener, subsRef.current);
   }, [subsKey]);
 
   return { connected, status };


### PR DESCRIPTION
## Motivation

Every `useRealtime` call opened its **own** WebSocket to `/v1/realtime`. On the dashboard that meant several concurrent connections at once — inbox (`inbox-data.ts`), usage summary (`overview.tsx`), recent conversations, the system-alerts banner, and the inbox activity rail — all largely subscribed to the same `org` firehose.

Follow-up to #567, which noted this consolidation as a separate change.

## Approach

`useRealtime`'s public API is unchanged; only its internals move to a module-level `RealtimeClient` singleton that all callers share:

- **One socket, union of channels.** The client refcounts subscription keys and sends `subscribe`/`unsubscribe` deltas, so the socket holds exactly the union of every mounted listener's channels.
- **Per-listener routing.** The server already tags each delivered `event` frame with the `channel` it matched (`org`, `conversation:<id>`, `contact:<id>`). The client fans each frame out **only** to listeners subscribed to that channel — reproducing today's per-component behavior exactly (e.g. an `org`-only listener never sees another component's `conversation:<id>` frames).
- **Shared lifecycle.** Reconnect/backoff and ping run once. The connection opens when the first listener mounts and closes when the last unmounts. Status (`connecting`/`connected`/`offline`) is broadcast to all hooks, so existing offline→connected refetch logic in `inbox-data.ts` still fires.

No call sites changed.

## Behavior preservation notes

- A hook subscribing to both `org` and `conversation:<id>` (inbox-data) still receives matching events on both channels, exactly as the old single-socket-with-two-subs did; its handlers are idempotent.
- The activity page appends every `org` event (deduped by id) — unchanged, since it still receives every `org`-tagged frame and nothing else.

## Test plan

- [x] `pnpm turbo run typecheck --filter=@getmunin/dashboard-pages`
- [x] `eslint src/realtime.ts`
- [ ] Manual: load dashboard, confirm a **single** `/v1/realtime` connection in devtools; close/reply to conversations and confirm inbox, recent list, activity rail, and usage KPIs all still update live; drop network and confirm reconnect + refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)