### PR TITLE
docs(readme): restructure modules, surface agent runner, tidy flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,19 @@
 > Open-source, headless HubSpot alternative.
 
 <p align="left">
-  <a href="https://github.com/getmunin/munin/blob/main/LICENSE"><img src="https://img.shields.io/github/license/getmunin/munin?color=3D424A&labelColor=0F1419" alt="MIT License"></a>
-  <a href="https://github.com/getmunin/munin/commits/main"><img src="https://img.shields.io/github/last-commit/getmunin/munin?color=3D424A&labelColor=0F1419" alt="Last commit"></a>
+  <a href="https://github.com/getmunin/munin/blob/main/LICENSE"><img src="https://img.shields.io/github/license/getmunin/munin?color=3fb950&labelColor=0F1419" alt="MIT License"></a>
+  <a href="https://github.com/getmunin/munin/commits/main"><img src="https://img.shields.io/github/last-commit/getmunin/munin?color=3fb950&labelColor=0F1419" alt="Last commit"></a>
   <a href="https://registry.modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP%20Registry-com.getmunin%2Fmunin-0066FF?labelColor=0F1419" alt="Listed in the MCP Registry"></a>
 </p>
 
 <p align="left">
   <a href="https://www.getmunin.com"><b>Website</b></a> ·
+  <a href="https://vimeo.com/1204180225?autoplay=0&utm_source=github&utm_medium=readme&utm_campaign=demo-video"><b>See it in action</b></a> ·
   <a href="https://www.getmunin.com/en/docs/"><b>Documentation</b></a> ·
   <a href="https://registry.modelcontextprotocol.io"><b>MCP Registry</b></a>
 </p>
 
-CRM, conversations, outreach, CMS, knowledge base, and analytics on one Postgres schema — exposed as tools your agents drive, not screens you click through. Headless the way a headless CMS is: there's a thin dashboard for settings, auth, and human-in-the-loop review, but the apps themselves have no admin UI. Every action runs through MCP tools, callable from any MCP-compatible client (Claude, Cursor, ChatGPT, custom runners) — same tools, same permissions, same audit log, whether a human or an agent is driving.
+CRM, conversations, outreach, CMS, knowledge base, and analytics on one Postgres schema — exposed as tools your agents drive, not screens you click through. Headless the way a headless CMS is: there's a thin dashboard for settings, auth, and human-in-the-loop review, but the apps themselves have no admin UI. Every action runs through MCP tools, callable from any MCP-compatible client (Claude, Cursor, ChatGPT, custom runners) — same tools, same permissions, same audit log, whether a human or an agent is driving. Munin even ships its own: an in-process, per-org agent runner that answers live conversations and works the curation queue against an LLM provider you configure — so the platform runs out of the box, with external MCP clients optional.
 
 <p align="center">
   <img src=".github/assets/dashboard.png" alt="The Munin dashboard — a thin shell over the MCP tool surface" width="100%"><br>
@@ -45,6 +46,68 @@ These six modules aren't separate products — they share one Postgres schema, o
   </a>
 </p>
 
+## Core modules
+
+#### Knowledge Base
+- Markdown articles organized into spaces, each scoped to the audiences allowed to see it.
+- Hybrid search that blends keyword matching with meaning-based results.
+- Website import — crawl a public site and turn each page into an article in the background, automatically dropping articles when their source page disappears.
+- Full version history with restore, plus a review queue for proposed edits.
+
+#### Conversations
+- One inbox across email, chat widget, voice (Threll.ai / Vapi), and SMS (Twilio / MessageBird).
+- Inbound *and* outbound — agents answer conversations and can place outbound calls.
+- Assignable, organized by topic, and searchable across every message.
+- Built-in handoff to a human, with notifications to your own systems as conversations change.
+
+#### CRM
+- Contacts, companies, deals, activities, pipelines, and segments.
+- AI-written summaries and suggested next actions, kept separate from what people edit by hand.
+- Consent tracking — the lawful basis and source for each contact, required before they can be added to any outreach.
+- Automatic duplicate detection that proposes merges for review, plus bulk contact import.
+
+#### CMS
+- Content collections with structured fields, and entries you can publish in multiple languages.
+- Scheduled publishing and a media library for images and files.
+- Full version history with restore, search, and cross-references between entries.
+- A public content API serves your site or app, with engagement tracking built into every entry.
+
+#### Outreach
+- Propose-only outbound email — campaigns, segments, and drafts for both first touches and replies.
+- Recipients are drawn only from contacts who have recorded consent (see CRM).
+- Every message waits for human approval; nothing is ever sent automatically.
+
+#### Analytics
+- Captures page views and on-site searches across anything you want to measure.
+- CMS pages are tracked automatically; for any other page, you add a small tracking snippet.
+- Conversion funnels and per-visitor journeys — once someone is identified, their visits link to a CRM contact, including the anonymous ones from before.
+- Breakdowns by traffic source, referrer, and country, plus "what to write next" signals (popular topics, engagement, and searches that came back empty).
+
+## Automation
+
+#### Conversation loop
+An in-process, per-org agent runner answers live conversations on every channel (chat widget, email, SMS, voice) against the LLM provider you configure — drafting and sending replies, and handing off to a human when needed.
+
+#### Curator loop
+The in-process agent runner also works a durable background job queue: scheduled KB curation, CRM hygiene, contact extraction, stale-content review, and outreach drafts, with retry and dead-letter handling.
+
+#### Playbooks & skills
+Packaged markdown procedures (`skill://module/<verb-object>`) for multi-step, cross-module workflows, surfaced over MCP — followed both by Munin's own runner and by any external AI agent operating on the platform.
+
+## Platform
+
+#### Data portability
+Symmetric `*_export` / `*_import` MCP tools (and `/v1/<module>/export|import` REST endpoints) per module, so an agent can move an org's data between a self-hosted server and the cloud in either direction. See `skill://playbooks/data-migration`.
+
+#### Audit & webhooks
+Every action is written to an audit log, and webhooks fan those events out to your own endpoints with signed, replayable deliveries.
+
+#### Alerts & feedback
+Operational issues surface as system alerts the agent can list, acknowledge, and resolve. An in-product feedback channel lets you file feature requests and vote on Munin's public roadmap.
+
+#### Auth & access
+Sign-in and access control run on BetterAuth, with OAuth 2.1 dynamic-client registration and team invites.
+
 ## See it in action
 
 > Lovable builds your frontend. Munin spins up your operations. One prompt, one MCP endpoint — and the agents do the rest.
@@ -56,19 +119,6 @@ Watch Lovable build a real website from a single prompt while Munin stands up ev
     <img src=".github/assets/demo-thumbnail.png" alt="Watch: Lovable builds the frontend while Munin stands up everything behind it" width="100%">
   </a>
 </p>
-
-## What's in the box
-
-- **Knowledge Base** — markdown documents, hybrid search (BM25 + pgvector embeddings), per-document audience scoping.
-- **Conversations** — multi-channel threads (email, voice via Threll.ai or Vapi, SMS via Twilio or MessageBird, chat widget) routed to end-users, assignable, agent-resolvable, with handover state and webhook fan-out.
-- **CRM** — contacts, companies, deals, activities, pipelines, segments, plus a merge-proposal queue the `clean-contact-data` curator runs against.
-- **CMS** — agent-authored content collections with field schemas, localized entries, scheduled publishing, an asset library backed by S3-compatible storage, and a public delivery API that ships a `_tracking` block on every entry for built-in engagement signal.
-- **Outreach** — propose-only outbound emails: campaigns + segments + drafts queued for human approval; never auto-sends.
-- **Analytics** — polymorphic page-view + search-query ingestion. CMS delivery wires in for free; arbitrary pages drop in a `<script src="…/tracker.js" data-key="mn_track_…">` tag. Read tools (`analytics_list_top_subjects`, `analytics_get_subject_engagement`, `analytics_list_zero_result_searches`) feed the "what should we write next" loop into curator skills like `cms/review-stale-entries`.
-- **Curator** — durable background job queue running skills (KB curation, CRM hygiene, contact extraction, stale-content review, outreach drafts) on a schedule with retry + dead-letter.
-- **Playbooks + skills** — packaged markdown procedures (`skill://module/<verb-object>`) the agent reads via MCP resources to follow multi-step flows.
-- **Data portability** — symmetric `*_export` / `*_import` MCP tools (and `/v1/<module>/export|import` REST) per module, so an agent can move an org's data between a self-hosted server and the cloud in either direction. See `skill://playbooks/data-migration`.
-- **Cross-cutting** — audit log, webhooks, team invites, OAuth 2.1 dynamic-client registration, BetterAuth-backed sign-in.
 
 ## Two ways to run
 
@@ -91,7 +141,7 @@ After `docker compose up`, the backend listens on `:3001` and the dashboard on `
 
 1. Open `http://localhost:3000` and register the first user — they become the singleton org admin.
 2. In the dashboard, go to **Settings → API keys** and mint an admin key (`mn_admin_…`). Shown once; treat like a password.
-3. Pick one of:
+3. Poke at the API and tools:
 
 ```sh
 # REST control plane — direct, no OAuth
@@ -102,15 +152,6 @@ curl -s http://localhost:3001/v1/kb/spaces \
 npx @modelcontextprotocol/inspector
 # In its UI: URL = http://localhost:3001/mcp, Auth = Bearer mn_admin_...
 
-# Claude Code (CLI)
-claude mcp add munin-local http://localhost:3001/mcp
-# Then `claude` → OAuth flow opens in browser → tools available
-
-# Claude Desktop — claude_desktop_config.json
-# {
-#   "mcpServers": { "munin": { "url": "http://localhost:3001/mcp" } }
-# }
-
 # Raw curl over Streamable HTTP — useful for sanity-checking the transport
 curl -N -X POST http://localhost:3001/mcp \
   -H "Authorization: Bearer mn_admin_..." \
@@ -119,13 +160,19 @@ curl -N -X POST http://localhost:3001/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
-The OpenAPI spec for the REST control plane is at `packages/backend-core/openapi.json`.
+The OpenAPI spec for the REST control plane is at `packages/backend-core/openapi.json`. To wire an MCP client like Claude or Cursor, see [Connect your AI agent](#connect-your-ai-agent) below.
 
 ## Connect your AI agent
 
-Once you've signed up (hosted) or run `docker compose up` (self-host), point your MCP client at the URL.
+Once you've signed up (hosted) or run `docker compose up` (self-host), point your MCP client at the URL — `http://localhost:3001/mcp` for self-host, or `https://mcp.getmunin.com` for hosted.
 
-**Claude Desktop / Code** — add to your MCP config:
+**Claude Code (CLI):**
+
+```sh
+claude mcp add munin http://localhost:3001/mcp
+```
+
+**Claude Desktop** — add to your MCP config:
 
 ```json
 {
@@ -137,7 +184,7 @@ Once you've signed up (hosted) or run `docker compose up` (self-host), point you
 }
 ```
 
-(For the hosted version, swap in `https://mcp.getmunin.com`.) The first call triggers an OAuth consent screen in your browser, then your agent has the full tool surface — Knowledge Base, Conversations, CRM, CMS, Outreach, Analytics.
+The first call triggers an OAuth consent screen in your browser, then your agent has the full tool surface — Knowledge Base, Conversations, CRM, CMS, Outreach, Analytics.
 
 ## Two trust contexts, one MCP endpoint
 
@@ -147,20 +194,6 @@ The same `/mcp` endpoint serves two distinct callers, audience-aware:
 - **End-user agents** (your voice AI, web chatbot, mobile app helper) — short-lived delegated tokens minted server-side from your backend, scoped to one of your end-users. Only self-service tools (read your own contact, send a message in your own conversation).
 
 See `packages/backend-core/src/control/delegated-token.controller.ts` for the token-mint API. The `@getmunin/sdk` Node client wraps it.
-
-## Architecture sketch
-
-- `apps/backend` — thin NestJS entry composing `@getmunin/backend-core` modules with single-tenant `AuthModule`. Exposes the MCP server (Streamable HTTP), OAuth 2.1 + OIDC discovery, and the control-plane REST API on port 3001.
-- `apps/web` — Next.js dashboard + landing on port 3000.
-- `apps/chat-widget` — embeddable browser widget that consumes a `mn_widget_*` key and the widget ingest API.
-- `apps/analytics-tracker` — embeddable browser tracker, served at `/tracker.js`, that consumes a public `mn_track_*` key and writes page-view events.
-- `packages/backend-core` — every shared NestJS module (KB, Conversations, CRM, CMS, Outreach, Analytics, Curator, Web, Playbooks, MCP, control plane, audit, tenancy, RLS, mailer, storage, webhooks, rate limit, quotas, OAuth) plus `createApp` and the `createAuthController` helper. Cloud composes the same modules with multi-tenant auth.
-- `packages/dashboard-pages` — dashboard page components shared between OSS and cloud webs.
-- `packages/ui` — design-system primitives (shadcn-style).
-- `packages/{core, db, types, sdk, mcp-toolkit}` — non-Nest building blocks: actor identity + tenancy GUCs, Drizzle schema + migrations, shared types, Node client SDK, MCP `@McpTool` / `@SkillRegistry` decorators.
-- `packages/{agent-host, agent-runtime}` — durable per-org agent runner that picks curator jobs off the queue and executes them against the configured LLM provider.
-- `packages/widget-voice` — vendor-agnostic browser voice SDK for the chat widget (Threll.ai WebRTC + Vapi) behind a common `VoiceSession` interface.
-- All `@getmunin/*` packages are published to GitHub Packages.
 
 ## Stack
 


### PR DESCRIPTION
## What

A README pass focused on the module overview, the agent runner, and section flow. README-only — no code changes.

### Module overview
- Renamed **What's in the box → Core modules**; reformatted into per-module `####` subheadings with short, plain-language bullets (Chatwoot-style).
- Removed code-level jargon from the product overview (the `<script…tracker.js…>` tag, `BM25`/`pgvector`, `S3-compatible`, the `_tracking` block, `clean-contact-data`, "polymorphic ingestion", "webhook fan-out"). The technical specifics still live in **Stack**.
- Surfaced capabilities that weren't documented anywhere: KB website import + version history, Conversations outbound calling + topics, CRM AI summaries + consent tracking, CMS version history + cross-references, Analytics conversion funnels + read-time contact journeys + acquisition breakdowns.

### Agent runner + new topics
- Split **Automation** and **Platform** into their own top-level topics, each with subheadings.
- Documented the in-process, per-org **agent runner** (conversation loop + curator loop) that handles chat and curation out of the box — previously only hinted at. Intro now says Munin ships its own runner, with external MCP clients optional.
- Noted **Playbooks & skills** are read by external AI agents too, not just the built-in runner.
- Kept the three system modules (feedback, system-alerts, webhooks) out of "Modules at a glance" — they live in **Platform** prose as plumbing.

### Flow + polish
- Moved **See it in action** below the feature sections (payoff before setup) and added it to the top nav.
- Deduped **Try it locally** vs **Connect your AI agent** (the duplicated Claude config now lives only in the latter, which gains the `claude mcp add` CLI option).
- Removed the **Architecture sketch** section (the package-by-package layout is already in `CLAUDE.md` / `CONTRIBUTING.md`).
- Recoloured the license + last-commit badges green.

## Preview
Rendered locally with grip throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)