### PR TITLE
feat(cms): cms_search reference expansion

### DIFF
--- a/.changeset/cms-search-include.md
+++ b/.changeset/cms-search-include.md
@@ -1,0 +1,5 @@
+---
+"@getmunin/backend-core": minor
+---
+
+CMS: `cms_search` reference expansion. Pass `include: ["references"]` to `cms_search` (or `?include=references` on the public delivery search endpoint) to resolve `reference` fields and inline `ref://` tokens on search hits — reference fields expand in place to `{ id, slug, collection, locale, data }` and inline tokens are surfaced in a `_refs` sidecar, matching the behavior of `cms_get_entry` / `cms_list_entries` and the entry delivery endpoints. Default search behavior (raw ids, no `_refs`) is unchanged.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -2209,6 +2209,16 @@
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 50
+        },
+        "include": {
+          "description": "Set to [\"references\"] to expand reference fields into the referenced entries.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "references"
+            ]
+          }
         }
       },
       "required": [

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -1248,6 +1248,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/packages/backend-core/src/control/cms-delivery.controller.ts
+++ b/packages/backend-core/src/control/cms-delivery.controller.ts
@@ -78,6 +78,7 @@ export class CmsDeliveryController {
     @Query('locale') locale?: string,
     @Query('limit') limit?: string,
     @Query('visitor_id') visitorId?: string,
+    @Query('include') include?: string,
   ) {
     if (!q || !q.trim()) return [];
     const org = await this.resolveOrg(orgId);
@@ -88,6 +89,7 @@ export class CmsDeliveryController {
         locale,
         limit: limit ? Number.parseInt(limit, 10) : undefined,
         publishedOnly: true,
+        ...(includeReferences(include) ? { include: ['references'] } : {}),
       },
       { orgId: org.id },
     );
@@ -225,8 +227,6 @@ export class CmsDeliveryController {
       ...(trackingEnabled(tracking) ? { _tracking: buildTracking(org.id, row.id) } : {}),
     };
   }
-
-  // ─── helpers ─────────────────────────────────────────────────────────
 
   private async fetchAssets(
     orgId: string,

--- a/packages/backend-core/src/modules/cms/cms.integration.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.integration.test.ts
@@ -952,6 +952,77 @@ const skipReason = TEST_URL
     const noIncJson = (await noInc.json()) as { _refs?: unknown };
     expect(noIncJson._refs).toBeUndefined();
   }, 30_000);
+
+  it('cms_search with include:["references"] expands reference fields and inline ref:// tokens', async () => {
+    let targetId = '';
+    await withClient(adminKey, async (c) => {
+      await c.callTool({
+        name: 'cms_create_collection',
+        arguments: {
+          name: 'Docs',
+          slug: 'docs',
+          fields: [
+            { name: 'title', type: 'text', required: true },
+            { name: 'slug', type: 'text', required: true },
+            { name: 'body', type: 'markdown' },
+            { name: 'related', type: 'reference', options: { targetCollection: 'docs' } },
+          ],
+        },
+      });
+      const target = parseToolResult<{ id: string }>(
+        await c.callTool({
+          name: 'cms_create_entry',
+          arguments: {
+            collection: 'docs',
+            slug: 'target-doc',
+            data: { title: 'Target Doc', slug: 'target-doc', body: 'target' },
+            status: 'published',
+          },
+        }),
+      );
+      targetId = target.id;
+      await c.callTool({
+        name: 'cms_create_entry',
+        arguments: {
+          collection: 'docs',
+          slug: 'searchabledoc',
+          data: {
+            title: 'Searchabledoc unique',
+            slug: 'searchabledoc',
+            body: `see [target](ref://${target.id})`,
+            related: target.id,
+          },
+          status: 'published',
+        },
+      });
+    });
+
+    await withClient(adminKey, async (c) => {
+      const hits = parseToolResult<
+        Array<{
+          slug: string;
+          data: { related: unknown };
+          refs?: Record<string, { slug: string }>;
+        }>
+      >(
+        await c.callTool({
+          name: 'cms_search',
+          arguments: { query: 'Searchabledoc', include: ['references'] },
+        }),
+      );
+      const hit = hits.find((h) => h.slug === 'searchabledoc');
+      expect(hit).toBeTruthy();
+      expect(hit!.data.related).toMatchObject({ id: targetId, collection: 'docs' });
+      expect(hit!.refs?.[targetId]).toMatchObject({ slug: 'target-doc' });
+
+      const plain = parseToolResult<Array<{ slug: string; data: { related: unknown }; refs?: unknown }>>(
+        await c.callTool({ name: 'cms_search', arguments: { query: 'Searchabledoc' } }),
+      );
+      const plainHit = plain.find((h) => h.slug === 'searchabledoc');
+      expect(plainHit!.data.related).toBe(targetId);
+      expect(plainHit!.refs).toBeUndefined();
+    });
+  }, 30_000);
 });
 
 function retarget(url: string, baseUrl: string): string {

--- a/packages/backend-core/src/modules/cms/cms.search.ts
+++ b/packages/backend-core/src/modules/cms/cms.search.ts
@@ -9,13 +9,19 @@ import { CmsService, type EntryStatus } from './cms.service.ts';
 import type { FieldDef } from './cms.fields.ts';
 import {
   applyAssetExpansion,
+  applyReferenceExpansion,
   buildInlineAssetSidecar,
+  buildReferenceSidecar,
   collectAssetIds,
+  collectInlineReferenceIds,
+  collectReferenceIds,
   projectData,
   rewriteInlineAssets,
   type AssetSummary,
+  type ExpandedEntry,
 } from './cms.fields.ts';
 import { loadAssetMap } from './cms.asset-loader.ts';
+import { loadEntryMap } from './cms.entry-loader.ts';
 
 export interface SearchHit {
   entryId: string;
@@ -26,6 +32,7 @@ export interface SearchHit {
   status: EntryStatus;
   data: Record<string, unknown>;
   assets?: Record<string, AssetSummary>;
+  refs?: Record<string, ExpandedEntry>;
   excerpt: string;
   score: number;
   source: 'fts' | 'vector' | 'both';
@@ -36,9 +43,9 @@ export interface SearchInput {
   collection?: string;
   status?: EntryStatus;
   locale?: string;
-  /** Public-only filter (delivery API). Admin search includes drafts + scheduled. */
   publishedOnly?: boolean;
   limit?: number;
+  include?: string[];
 }
 
 const DEFAULT_LIMIT = 10;
@@ -98,8 +105,6 @@ export class CmsSearchService {
     const trimmed = input.query.trim();
     if (!trimmed) return [];
 
-    // Public path uses the service-role DB (no request context); admin path
-    // uses the tenant-bound transaction Db from the request context.
     const db: Db | Tx = opts?.orgId ? this.serviceDb : getCurrentContext().db;
 
     const filters: SQL[] = [];
@@ -196,9 +201,29 @@ export class CmsSearchService {
       const fields = fieldsByEntryId.get(hit.entryId);
       if (!fields) continue;
       const expanded = applyAssetExpansion(fields, hit.data, assets);
-      const sidecar = buildInlineAssetSidecar(fields, expanded, assets);
+      const assetSidecar = buildInlineAssetSidecar(fields, expanded, assets);
       hit.data = rewriteInlineAssets(fields, expanded, assets);
-      if (Object.keys(sidecar).length > 0) hit.assets = sidecar;
+      if (Object.keys(assetSidecar).length > 0) hit.assets = assetSidecar;
+    }
+
+    if (input.include?.includes('references') || input.include?.includes('*')) {
+      const refIds = new Set<string>();
+      for (const hit of fused) {
+        const fields = fieldsByEntryId.get(hit.entryId);
+        if (!fields) continue;
+        for (const id of collectReferenceIds(fields, hit.data)) refIds.add(id);
+        for (const id of collectInlineReferenceIds(fields, hit.data)) refIds.add(id);
+      }
+      const entryMap = await loadEntryMap(db, orgId, refIds, {
+        publishedOnly: !!input.publishedOnly,
+      });
+      for (const hit of fused) {
+        const fields = fieldsByEntryId.get(hit.entryId);
+        if (!fields) continue;
+        const refSidecar = buildReferenceSidecar(fields, hit.data, entryMap);
+        hit.data = applyReferenceExpansion(fields, hit.data, entryMap);
+        if (Object.keys(refSidecar).length > 0) hit.refs = refSidecar;
+      }
     }
     return fused;
   }

--- a/packages/backend-core/src/modules/cms/cms.tools.ts
+++ b/packages/backend-core/src/modules/cms/cms.tools.ts
@@ -167,6 +167,7 @@ const SearchInput = z.object({
   status: z.enum(ENTRY_STATUSES).optional(),
   locale: z.string().optional(),
   limit: z.number().int().positive().max(50).optional(),
+  include: IncludeInput,
 });
 
 const EmptyInput = z.object({});
@@ -225,8 +226,6 @@ export class CmsAdminTools {
     @Inject(CmsService) private readonly cms: CmsService,
     @Inject(CmsSearchService) private readonly search: CmsSearchService,
   ) {}
-
-  // Collections ─────────────────────────────────────────────────────────
 
   @McpTool({
     name: 'cms_list_collections',
@@ -300,8 +299,6 @@ export class CmsAdminTools {
   deleteCollection(args: z.infer<typeof DeleteCollectionInput>) {
     return this.cms.deleteCollection(args.idOrSlug);
   }
-
-  // Entries ─────────────────────────────────────────────────────────────
 
   @McpTool({
     name: 'cms_list_entries',
@@ -448,8 +445,6 @@ export class CmsAdminTools {
     return this.cms.restoreVersion(args);
   }
 
-  // Assets ──────────────────────────────────────────────────────────────
-
   @McpTool({
     name: 'cms_list_assets',
     title: 'CMS: List assets',
@@ -538,8 +533,6 @@ export class CmsAdminTools {
     return this.cms.deleteAsset(args);
   }
 
-  // Locales ─────────────────────────────────────────────────────────────
-
   @McpTool({
     name: 'cms_list_locales',
     title: 'CMS: List locales',
@@ -582,8 +575,6 @@ export class CmsAdminTools {
     return this.cms.setDefaultLocale(args);
   }
 
-  // References ──────────────────────────────────────────────────────────
-
   @McpTool({
     name: 'cms_list_inbound_references',
     title: 'CMS: List inbound references',
@@ -614,8 +605,6 @@ export class CmsAdminTools {
     return this.cms.listAssetUsage(args.assetId);
   }
 
-  // Search ──────────────────────────────────────────────────────────────
-
   @McpTool({
     name: 'cms_search',
     title: 'CMS: Search entries',
@@ -630,8 +619,6 @@ export class CmsAdminTools {
   searchEntries(args: z.infer<typeof SearchInput>) {
     return this.search.search(args);
   }
-
-  // Transfer ────────────────────────────────────────────────────────────
 
   @McpTool({
     name: 'cms_export',


### PR DESCRIPTION
> **Stacked on #574** (`feat/cms-inline-entry-refs`), itself on #573 → #572. Merge bottom-up; bases retarget as each lands. Diff here is search-only.

## Context

Closes the one gap left across the blocks/reference-expansion stack: `cms_search` resolved assets (incl. inside blocks) but not references. This brings search to parity with `cms_get_entry` / `cms_list_entries` and the entry delivery endpoints.

## What changed

- `cms_search` accepts `include: ["references"]`; the public delivery search endpoint accepts `?include=references`.
- When requested, each search hit:
  - expands `reference` fields (top-level and inside blocks) **in place** to `{ id, slug, collection, locale, data }`, and
  - surfaces inline `ref://` tokens (left in the prose) via a **`_refs`** sidecar.
- One level deep; **published-only** targets on the public path, all statuses for admin. Default search (raw ids, no `_refs`) is unchanged.
- Reuses the existing plumbing — `loadEntryMap`, `applyReferenceExpansion`, `buildReferenceSidecar`, `collect{,Inline}ReferenceIds`. Read-path asset var renamed to `assetSidecar` for consistency.

## Housekeeping

Stripped inline `//` comments (section dividers, etc.) and one-line doc comments from the touched CMS files, per review feedback. Kept the two multi-line JSDoc blocks documenting the public-delivery security invariants.

## Testing

- `pnpm typecheck` (29/29), lint clean
- Integration (real Postgres): `cms_search` with `include:["references"]` expands a reference field and surfaces an inline `ref://` target in `_refs`; plain search returns raw ids and no `_refs`. Full CMS suite **19/19**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)