### PR TITLE
fix(db): correct migration 0048 journal timestamp so it applies on existing DBs

### DIFF
--- a/.changeset/fix-migration-0048-journal-order.md
+++ b/.changeset/fix-migration-0048-journal-order.md
@@ -1,0 +1,16 @@
+---
+"@getmunin/db": patch
+---
+
+Fix the `cms_asset_references` migration (0048) being silently skipped on
+existing databases. Its journal `when` timestamp was lower than the preceding
+migration's, and drizzle only applies migrations whose timestamp is newer than
+the latest one already recorded — so on any database already past 0047 the
+table was never created, and the follow-up RLS step failed with
+`relation "cms_asset_references" does not exist`. Fresh databases (CI) applied
+everything in order, which is why it passed review.
+
+The timestamp is corrected, the migration is made idempotent (so a database
+that already applied the broken version re-runs it as a no-op), and a new test
+asserts journal `when` timestamps strictly increase with idx to catch this
+class of bug before release.

--- a/packages/db/drizzle/0048_cms_asset_references.sql
+++ b/packages/db/drizzle/0048_cms_asset_references.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "cms_asset_references" (
+CREATE TABLE IF NOT EXISTS "cms_asset_references" (
 	"id" text PRIMARY KEY NOT NULL,
 	"org_id" text NOT NULL,
 	"from_entry_id" text NOT NULL,
@@ -6,63 +6,65 @@ CREATE TABLE "cms_asset_references" (
 	"field_name" varchar(64) NOT NULL,
 	"kind" varchar(16) NOT NULL,
 	"position" integer DEFAULT 0 NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "cms_asset_references_org_id_orgs_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."orgs"("id") ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "cms_asset_references_from_entry_id_cms_entries_id_fk" FOREIGN KEY ("from_entry_id") REFERENCES "public"."cms_entries"("id") ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "cms_asset_references_asset_id_cms_assets_id_fk" FOREIGN KEY ("asset_id") REFERENCES "public"."cms_assets"("id") ON DELETE cascade ON UPDATE no action
 );
 --> statement-breakpoint
-ALTER TABLE "cms_asset_references" ADD CONSTRAINT "cms_asset_references_org_id_orgs_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."orgs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "cms_asset_references" ADD CONSTRAINT "cms_asset_references_from_entry_id_cms_entries_id_fk" FOREIGN KEY ("from_entry_id") REFERENCES "public"."cms_entries"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "cms_asset_references" ADD CONSTRAINT "cms_asset_references_asset_id_cms_assets_id_fk" FOREIGN KEY ("asset_id") REFERENCES "public"."cms_assets"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "cms_asset_references_from_idx" ON "cms_asset_references" USING btree ("from_entry_id");--> statement-breakpoint
-CREATE INDEX "cms_asset_references_asset_idx" ON "cms_asset_references" USING btree ("asset_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "cms_asset_references_from_idx" ON "cms_asset_references" USING btree ("from_entry_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "cms_asset_references_asset_idx" ON "cms_asset_references" USING btree ("asset_id");--> statement-breakpoint
 DO $$
 BEGIN
   PERFORM set_config('app.bypass_rls', 'on', true);
 
-  INSERT INTO cms_asset_references (id, org_id, from_entry_id, asset_id, field_name, kind, position)
-  SELECT
-    'cmar_' || encode(gen_random_bytes(12), 'hex'),
-    e.org_id,
-    e.id,
-    e.data ->> f.field_name,
-    f.field_name,
-    'field',
-    0
-  FROM cms_entries e
-  JOIN cms_collections c ON c.id = e.collection_id
-  CROSS JOIN LATERAL jsonb_array_elements(c.fields) AS fld
-  CROSS JOIN LATERAL (
-    SELECT fld ->> 'name' AS field_name, fld ->> 'type' AS field_type
-  ) f
-  WHERE f.field_type = 'asset'
-    AND jsonb_typeof(e.data -> f.field_name) = 'string'
-    AND length(e.data ->> f.field_name) > 0
-    AND EXISTS (SELECT 1 FROM cms_assets a WHERE a.id = e.data ->> f.field_name);
-
-  INSERT INTO cms_asset_references (id, org_id, from_entry_id, asset_id, field_name, kind, position)
-  SELECT
-    'cmar_' || encode(gen_random_bytes(12), 'hex'),
-    e.org_id,
-    e.id,
-    elem.value #>> '{}',
-    f.field_name,
-    'field',
-    (elem.ordinality - 1)::int
-  FROM cms_entries e
-  JOIN cms_collections c ON c.id = e.collection_id
-  CROSS JOIN LATERAL jsonb_array_elements(c.fields) AS fld
-  CROSS JOIN LATERAL (
+  IF NOT EXISTS (SELECT 1 FROM cms_asset_references LIMIT 1) THEN
+    INSERT INTO cms_asset_references (id, org_id, from_entry_id, asset_id, field_name, kind, position)
     SELECT
-      fld ->> 'name' AS field_name,
-      fld ->> 'type' AS field_type,
-      fld -> 'options' -> 'items' ->> 'type' AS item_type
-  ) f
-  CROSS JOIN LATERAL jsonb_array_elements(
-    CASE WHEN jsonb_typeof(e.data -> f.field_name) = 'array'
-      THEN e.data -> f.field_name ELSE '[]'::jsonb END
-  ) WITH ORDINALITY AS elem(value, ordinality)
-  WHERE f.field_type = 'array'
-    AND f.item_type = 'asset'
-    AND jsonb_typeof(elem.value) = 'string'
-    AND length(elem.value #>> '{}') > 0
-    AND EXISTS (SELECT 1 FROM cms_assets a WHERE a.id = elem.value #>> '{}');
+      'cmar_' || encode(gen_random_bytes(12), 'hex'),
+      e.org_id,
+      e.id,
+      e.data ->> f.field_name,
+      f.field_name,
+      'field',
+      0
+    FROM cms_entries e
+    JOIN cms_collections c ON c.id = e.collection_id
+    CROSS JOIN LATERAL jsonb_array_elements(c.fields) AS fld
+    CROSS JOIN LATERAL (
+      SELECT fld ->> 'name' AS field_name, fld ->> 'type' AS field_type
+    ) f
+    WHERE f.field_type = 'asset'
+      AND jsonb_typeof(e.data -> f.field_name) = 'string'
+      AND length(e.data ->> f.field_name) > 0
+      AND EXISTS (SELECT 1 FROM cms_assets a WHERE a.id = e.data ->> f.field_name);
+
+    INSERT INTO cms_asset_references (id, org_id, from_entry_id, asset_id, field_name, kind, position)
+    SELECT
+      'cmar_' || encode(gen_random_bytes(12), 'hex'),
+      e.org_id,
+      e.id,
+      elem.value #>> '{}',
+      f.field_name,
+      'field',
+      (elem.ordinality - 1)::int
+    FROM cms_entries e
+    JOIN cms_collections c ON c.id = e.collection_id
+    CROSS JOIN LATERAL jsonb_array_elements(c.fields) AS fld
+    CROSS JOIN LATERAL (
+      SELECT
+        fld ->> 'name' AS field_name,
+        fld ->> 'type' AS field_type,
+        fld -> 'options' -> 'items' ->> 'type' AS item_type
+    ) f
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE WHEN jsonb_typeof(e.data -> f.field_name) = 'array'
+        THEN e.data -> f.field_name ELSE '[]'::jsonb END
+    ) WITH ORDINALITY AS elem(value, ordinality)
+    WHERE f.field_type = 'array'
+      AND f.item_type = 'asset'
+      AND jsonb_typeof(elem.value) = 'string'
+      AND length(elem.value #>> '{}') > 0
+      AND EXISTS (SELECT 1 FROM cms_assets a WHERE a.id = elem.value #>> '{}');
+  END IF;
 END $$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -341,7 +341,7 @@
     {
       "idx": 48,
       "version": "7",
-      "when": 1782678545672,
+      "when": 1782800200000,
       "tag": "0048_cms_asset_references",
       "breakpoints": true
     }

--- a/packages/db/src/migrations-journal.test.ts
+++ b/packages/db/src/migrations-journal.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync, readdirSync } from 'node:fs';
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = resolve(here, '..', 'drizzle');
+const journalPath = resolve(drizzleDir, 'meta', '_journal.json');
+
+const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as { entries: JournalEntry[] };
+const entries = [...journal.entries].sort((a, b) => a.idx - b.idx);
+
+describe('drizzle migration journal', () => {
+  it('has entries', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it('idx values are contiguous from 0', () => {
+    entries.forEach((e, i) => {
+      expect(e.idx, `journal entry "${e.tag}" has idx ${e.idx}, expected ${i}`).toBe(i);
+    });
+  });
+
+  // The bug this guards against: drizzle's migrator applies a migration only when
+  // its `when` is greater than the newest timestamp already recorded in the target
+  // database. A migration whose `when` is *lower* than an earlier one is therefore
+  // silently skipped on any DB that is already past that earlier timestamp — while
+  // a fresh DB (CI) applies everything in idx order and looks fine. So an out-of-order
+  // timestamp only breaks real, already-migrated deployments. Keep `when` strictly
+  // increasing with idx and CI catches it before release.
+  it('`when` timestamps are strictly increasing with idx', () => {
+    for (let i = 1; i < entries.length; i++) {
+      const prev = entries[i - 1]!;
+      const cur = entries[i]!;
+      expect(
+        cur.when,
+        `Migration "${cur.tag}" (idx ${cur.idx}, when=${cur.when}) must have a later \`when\` than ` +
+          `"${prev.tag}" (idx ${prev.idx}, when=${prev.when}). Out-of-order timestamps are silently ` +
+          `skipped by drizzle on databases already past the earlier timestamp.`,
+      ).toBeGreaterThan(prev.when);
+    }
+  });
+
+  it('every journal entry maps 1:1 to a migration .sql file', () => {
+    const sqlFiles = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+    const tagged = entries.map((e) => `${e.tag}.sql`).sort();
+    expect(sqlFiles).toEqual(tagged);
+  });
+});


### PR DESCRIPTION
## Problem

Deploying `4.62.0` to an **existing** database fails at the migrate step:

```
PostgresError: relation "cms_asset_references" does not exist
```

Migration `0048_cms_asset_references` has a journal `when` timestamp (`1782678545672`) **lower than the preceding `0047`** (`1782800100000`):

| idx | when | tag |
|----|------|-----|
| 47 | 1782800100000 | 0047_analytics_view_visitor_idx |
| 48 | 1782678545672 ⬅ earlier | 0048_cms_asset_references |

Drizzle applies a migration only when its `when` is greater than the newest timestamp already recorded in the target DB. On any database already past `0047`, `0048` looks like it's in the past and is **silently skipped** — the table is never created, and the per-module RLS step (`cms.sql`) then fails referencing the missing table. A **fresh** DB (CI / OSS integration tests) applies everything in idx order, which is why this passed review and only bit real deployments (cloud dev surfaced it).

## Fix

- **Correct the timestamp** — bump `0048`'s `when` to `1782800200000` (just after `0047`) so it applies on existing deployments.
- **Make `0048` idempotent** — `CREATE TABLE/INDEX IF NOT EXISTS`, inline FK constraints, and run the backfill only when the table is empty. The corrected timestamp would otherwise make drizzle *re-apply* `0048` on a DB that ran the broken version fresh-on-`4.62.0`; the guards make that a no-op (no `already exists`, no duplicate backfill rows).
- **Failsafe** — new `migrations-journal.test.ts` asserts journal `when` timestamps strictly increase with idx (and journal↔file 1:1), so CI catches this class of bug before release even on a fresh DB.

## Verification

- New journal test fails on the bug, passes after the timestamp fix.
- Smoke-tested end-to-end against a local DB in the **exact** bugged state (at `0047`, table missing): migrations apply cleanly, `cms_asset_references` is created (3 FKs, 3 indexes, RLS forced), and the `cms.sql` RLS step succeeds.
- Re-applying `0048` on the populated table is a clean no-op (only benign `IF NOT EXISTS` skips; row count unchanged).
- `pnpm -F @getmunin/db typecheck` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)