### PR TITLE
feat(conv): show contact identity in conversation drawer

### DIFF
--- a/.changeset/conv-show-contact-identity.md
+++ b/.changeset/conv-show-contact-identity.md
@@ -1,0 +1,15 @@
+---
+"@getmunin/backend-core": minor
+"@getmunin/dashboard-pages": minor
+---
+
+Show who a conversation is with in the inbox drawer instead of a bare end-user id.
+
+`GET /v1/conversations/:id` (and the `ConversationDetail` it returns) now carries
+the resolved counterpart identity — `contactEmail`, `contactName`, `contactPhone`
+— preferring the linked `conv_contacts` row and falling back to the `end_users`
+row. Both the full and simplified conversation drawers render the email (then
+name) in the header rather than the raw end-user id.
+
+Also tightens the queue row layout so long titles truncate and the row actions
+swap in on hover without overlapping the timestamp.

--- a/packages/backend-core/src/modules/conv/conv.service.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.test.ts
@@ -322,6 +322,51 @@ const skipReason = TEST_URL
       const detail = await run(() => svc.getConversation(conv.id));
       expect(detail.messages.map((m) => m.body)).toEqual(['first', 'second']);
     });
+
+    it('getConversation resolves counterpart identity, preferring the contact over the end user', async () => {
+      const ch = await seedChannel();
+      const [endUser] = await db
+        .insert(schema.endUsers)
+        .values({ orgId, email: 'eu@example.com', name: 'End User' })
+        .returning();
+      const [contact] = await db
+        .insert(schema.convContacts)
+        .values({ orgId, endUserId: endUser!.id, email: 'contact@example.com', name: 'Contact' })
+        .returning();
+      const conv = await run(() =>
+        svc.createConversation({
+          channelId: ch.id,
+          body: 'hi',
+          authorType: 'agent',
+          authorId: actor.id,
+          endUserId: endUser!.id,
+          contactId: contact!.id,
+        }),
+      );
+      const detail = await run(() => svc.getConversation(conv.id));
+      expect(detail.contactEmail).toBe('contact@example.com');
+      expect(detail.contactName).toBe('Contact');
+    });
+
+    it('getConversation falls back to the end user when no contact is linked', async () => {
+      const ch = await seedChannel();
+      const [endUser] = await db
+        .insert(schema.endUsers)
+        .values({ orgId, email: 'lonely@example.com', name: 'Lonely' })
+        .returning();
+      const conv = await run(() =>
+        svc.createConversation({
+          channelId: ch.id,
+          body: 'hi',
+          authorType: 'agent',
+          authorId: actor.id,
+          endUserId: endUser!.id,
+        }),
+      );
+      const detail = await run(() => svc.getConversation(conv.id));
+      expect(detail.contactEmail).toBe('lonely@example.com');
+      expect(detail.contactName).toBe('Lonely');
+    });
   });
 
   // ─── Messaging ───────────────────────────────────────────────────────

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -133,6 +133,9 @@ export interface ConversationDetail extends ConversationSummary {
    */
   assistantName: string | null;
   endUserLocale: string | null;
+  contactEmail: string | null;
+  contactName: string | null;
+  contactPhone: string | null;
 }
 
 export interface ConvChannelExport {
@@ -546,11 +549,18 @@ export class ConvService {
         channelType: schema.convChannels.type,
         assistantName: schema.assistants.name,
         endUserLocale: sql<string | null>`(${schema.endUsers.metadata}->>'locale')`.as('end_user_locale'),
+        endUserEmail: schema.endUsers.email,
+        endUserName: schema.endUsers.name,
+        endUserPhone: schema.endUsers.phone,
+        contactEmail: schema.convContacts.email,
+        contactName: schema.convContacts.name,
+        contactPhone: schema.convContacts.phone,
       })
       .from(schema.convConversations)
       .innerJoin(schema.convChannels, eq(schema.convChannels.id, schema.convConversations.channelId))
       .leftJoin(schema.assistants, eq(schema.assistants.orgId, schema.convConversations.orgId))
       .leftJoin(schema.endUsers, eq(schema.endUsers.id, schema.convConversations.endUserId))
+      .leftJoin(schema.convContacts, eq(schema.convContacts.id, schema.convConversations.contactId))
       .where(eq(schema.convConversations.id, id))
       .limit(1);
     const row = conversations[0];
@@ -583,6 +593,9 @@ export class ConvService {
       messages: rows.map((r) => toMessageDto(r.msg, authorNames, r.seenAt)),
       assistantName: row.assistantName ?? null,
       endUserLocale: row.endUserLocale ?? null,
+      contactEmail: row.contactEmail ?? row.endUserEmail ?? null,
+      contactName: row.contactName ?? row.endUserName ?? null,
+      contactPhone: row.contactPhone ?? row.endUserPhone ?? null,
     };
   }
 

--- a/packages/dashboard-pages/src/components/dashboard/inbox-conv-drawers.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-conv-drawers.tsx
@@ -144,7 +144,11 @@ export function SimplifiedConvDrawer({
   const draftBody = draftEdit ?? draft?.body ?? '';
   const isEditing = draftEdit !== null || !draft;
   const waiting = detail.needsHumanAttentionAt ? age(detail.needsHumanAttentionAt) : '';
-  const who = detail.endUserId ?? t('conversationFallback', { id: detail.displayId });
+  const who =
+    detail.contactEmail ??
+    detail.contactName ??
+    detail.endUserId ??
+    t('conversationFallback', { id: detail.displayId });
 
   useCmdEnter(() => {
     if (draftBody.trim() && !pending) onSendDraft(draftBody);
@@ -270,7 +274,8 @@ export function FullConvDrawer({
 }) {
   const t = useTranslations('dashboard.overview.drawer');
   const claimed = detail.claim !== null;
-  const endUserLabel = detail.endUserId ?? t('endUserFallback');
+  const endUserLabel =
+    detail.contactEmail ?? detail.contactName ?? detail.endUserId ?? t('endUserFallback');
 
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const lastMessageId = detail.messages[detail.messages.length - 1]?.id;

--- a/packages/dashboard-pages/src/components/dashboard/inbox-helpers.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-helpers.ts
@@ -21,6 +21,9 @@ export function liveToStubDetail(c: LiveSummary): ConversationDetail {
   return {
     ...c,
     claim: c.claim,
+    contactEmail: null,
+    contactName: null,
+    contactPhone: null,
     messages: latest
       ? [
           {

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -358,7 +358,7 @@ function QueueRow({
   return (
     <li className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
       <div
-        className="group/qrow relative flex items-center gap-4 px-4 py-3 transition-colors duration-fast ease-munin hover:bg-paper-deep cursor-pointer dark:hover:bg-secondary"
+        className="group/qrow flex items-center gap-4 px-4 py-3 transition-colors duration-fast ease-munin hover:bg-paper-deep cursor-pointer dark:hover:bg-secondary"
         onClick={onOpen}
         role="button"
         tabIndex={0}
@@ -372,15 +372,15 @@ function QueueRow({
         <span className="shrink-0">
           <Pill tone={tone}>{t(labelKey)}</Pill>
         </span>
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 truncate">
           <span className="text-sm font-medium text-ink dark:text-foreground">{item.title}</span>
           <span className="ml-2 text-sm text-ink-mute"> — {item.snippet}</span>
         </div>
-        <span className="shrink-0 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute opacity-100 transition-opacity duration-fast ease-munin group-hover/qrow:opacity-0">
+        <span className="shrink-0 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute group-hover/qrow:hidden">
           {age(item.createdAt)}
         </span>
         <div
-          className="absolute inset-y-0 right-3 flex items-center gap-2 opacity-0 transition-opacity duration-fast ease-munin group-hover/qrow:opacity-100 focus-within:opacity-100"
+          className="hidden shrink-0 items-center gap-2 group-hover/qrow:flex focus-within:flex"
           onClick={(e) => e.stopPropagation()}
         >
           <Button variant="accent" size="sm" onClick={onApprove} disabled={pending}>

--- a/packages/dashboard-pages/src/components/dashboard/inbox-types.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-types.ts
@@ -50,6 +50,9 @@ export interface MessageDto {
 export interface ConversationDetail extends ConversationSummary {
   messages: MessageDto[];
   claim: { holderType: 'user' | 'agent'; holderId: string; expiresAt: string } | null;
+  contactEmail: string | null;
+  contactName: string | null;
+  contactPhone: string | null;
 }
 
 export interface ActivityDto {


### PR DESCRIPTION
## What

The inbox conversation drawer showed the counterpart as a raw end-user id (or a `—` fallback) — never the email of the person you're talking to, even when we had it. This surfaces the contact's identity instead.

## Changes

- **Backend** (`conv.service.ts`): `getConversation` now `leftJoin`s `conv_contacts` (it already joined `end_users`) and resolves `contactEmail` / `contactName` / `contactPhone` onto the `ConversationDetail` DTO, **preferring the conversation-scoped `conv_contacts` row and falling back to the linked `end_users` row**. `GET /v1/conversations/:id` carries the fields automatically (the controller spreads `...detail`).
- **Drawers** (`inbox-conv-drawers.tsx`): both `FullConvDrawer` and `SimplifiedConvDrawer` headers render `contactEmail ?? contactName ?? endUserId ?? fallback`.
- **Types/stub** (`inbox-types.ts`, `inbox-helpers.ts`): mirror the three fields client-side; the pre-load live stub sets them to `null`.
- **Queue row** (`inbox-sections.tsx`): truncate long titles and swap row actions in on hover without overlapping the timestamp.

## Tests

- Added two `getConversation` cases: contact identity wins over the end user, and falls back to the end user when no contact is linked.
- `pnpm -F @getmunin/backend-core test` — 921 passed.
- `pnpm typecheck` clean for `@getmunin/backend-core` and `@getmunin/dashboard-pages`.

## Notes

- Scope is the **detail drawer** only; the inbox list summaries still carry just `endUserId` (surfacing email there would need joins at the list query sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)