### PR TITLE
fix(dashboard): stabilize queue row height and center pill text

### DIFF
--- a/.changeset/dashboard-row-heights-pill-centering.md
+++ b/.changeset/dashboard-row-heights-pill-centering.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/dashboard-pages': patch
+'@getmunin/ui': patch
+---
+
+Fix dashboard overview row heights and pill text centering. Queue rows no longer grow taller on hover — the right-hand slot now always reserves the action buttons' height (`h-7`) whether it shows the timestamp or the hover-revealed approve/dismiss buttons. The "open conversations" rows now reserve the same height, so both sections line up at a consistent row height. Pills (e.g. the `CMS` badge) get `leading-none` so their uppercase text is vertically centered within the badge instead of floating high.

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -376,7 +376,7 @@ function QueueRow({
           <span className="text-sm font-medium text-ink dark:text-foreground">{item.title}</span>
           <span className="ml-2 text-sm text-ink-mute"> — {item.snippet}</span>
         </div>
-        <span className="shrink-0 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute group-hover/qrow:hidden">
+        <span className="flex h-7 shrink-0 items-center font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute group-hover/qrow:hidden">
           {age(item.createdAt)}
         </span>
         <div

--- a/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
@@ -123,7 +123,7 @@ function ConversationRow({
             <span className="ml-2 text-sm text-ink-mute"> — {preview}</span>
           ) : null}
         </div>
-        <span className="shrink-0 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+        <span className="flex h-7 shrink-0 items-center font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
           {age(ts)}
         </span>
       </div>

--- a/packages/ui/src/components/pill.tsx
+++ b/packages/ui/src/components/pill.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../cn';
 
 const pillVariants = cva(
-  "inline-flex items-center gap-1.5 px-1.5 py-[3px] font-mono text-[9px] uppercase tracking-eyebrow font-medium shadow-[inset_0_0_0_0.5px_currentColor] whitespace-nowrap before:content-[''] before:size-[5px] before:rounded-full before:bg-current",
+  "inline-flex items-center gap-1.5 px-1.5 py-[3px] font-mono text-[9px] leading-none uppercase tracking-eyebrow font-medium shadow-[inset_0_0_0_0.5px_currentColor] whitespace-nowrap before:content-[''] before:size-[5px] before:rounded-full before:bg-current",
   {
     variants: {
       tone: {


### PR DESCRIPTION
## What

Three small dashboard-overview UI fixes:

1. **Queue rows no longer grow on hover.** Each row used `items-center` + `py-3`, so its height was set by its tallest child. On hover the tiny `text-[10px]` timestamp was swapped for `size="sm"` (`h-7`, 28px) action buttons, pushing the row ~8px taller. The timestamp slot now reserves the same `h-7` height, so the row height is identical hovered or not.
2. **Open-conversations rows match the queue rows.** They shared the queue's `py-3` but their tallest content was only `text-sm` (~20px), so they sat ~8px shorter. They now reserve the same `h-7` slot, lining both sections up at one consistent row height.
3. **Pill text is vertically centered.** The shared `Pill` had no `leading`, so it inherited a tall line-height; with all-caps text (no descenders) the glyphs floated above the dot/box center. Added `leading-none` so the caps center within the badge (e.g. the `CMS` badge).

## Notes

- Touches `@getmunin/dashboard-pages` and `@getmunin/ui` (both published) — changeset included (patch/patch).
- Visual-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)