### PR TITLE
fix(compose): make `docker compose up` work out of the box

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,10 @@ BACKEND_PORT=3001
 # split-host setups (separate api.* and mcp.* subdomains) point this at
 # the API host specifically.
 MUNIN_API_URL=http://localhost:3001
+# Secrets below (auth secret, key pepper, encryption key, storage secret):
+# left at these "replace-me-*" placeholders, `docker compose up` generates a
+# strong value on first boot and persists it in the munin-data volume. Set
+# them explicitly for shared/production deployments.
 # Generate with: openssl rand -base64 48
 MUNIN_AUTH_SECRET=replace-me-with-strong-random-secret
 # Used to pepper API-key hashes; rotate it and you invalidate every key.

--- a/README.md
+++ b/README.md
@@ -128,9 +128,11 @@ Watch Lovable build a real website from a single prompt while Munin stands up ev
 ```bash
 git clone https://github.com/getmunin/munin.git
 cd munin
-cp .env.example .env  # edit MUNIN_AUTH_SECRET + MUNIN_KEY_PEPPER + MUNIN_ENCRYPTION_KEY
+cp .env.example .env
 docker compose up
 ```
+
+Secrets left at their `.env.example` placeholders are auto-generated on first boot and persisted in the `munin-data` volume — fine for local self-hosting. For shared or production deployments, set strong `MUNIN_AUTH_SECRET` + `MUNIN_KEY_PEPPER` + `MUNIN_ENCRYPTION_KEY` values (`openssl rand -base64 48`) in `.env` instead.
 
 The first user to sign up becomes the org admin; subsequent users need an invitation token or an email whose domain is in `MUNIN_ALLOWED_EMAIL_DOMAINS`.
 

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -29,5 +29,8 @@ COPY --from=build /deploy/package.json ./
 COPY --from=build /deploy/node_modules ./node_modules
 COPY --from=build /repo/apps/backend/dist ./dist
 COPY --from=build /repo/apps/backend/public ./public
+COPY apps/backend/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 EXPOSE 3001
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "dist/main.js"]

--- a/apps/backend/docker-entrypoint.sh
+++ b/apps/backend/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+# In production the backend rejects placeholder secrets (see
+# assertProductionAuthSecret). To keep `docker compose up` a true one-command
+# start, generate any unset/placeholder secret here and persist it under a
+# volume so it stays stable across restarts — a rotating MUNIN_ENCRYPTION_KEY
+# would make previously-stored secrets unrecoverable.
+SECRET_DIR="${MUNIN_SECRET_DIR:-/var/munin/secrets}"
+mkdir -p "$SECRET_DIR"
+
+is_placeholder() {
+  case "$1" in
+    "" | replace-me* | replace_me* | dev-secret* | dev_secret* | test-secret* | changeme* | do-not-use* | do_not_use*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+ensure_secret() {
+  name="$1"
+  file="$SECRET_DIR/$name"
+  eval "val=\${$name:-}"
+  if is_placeholder "$val"; then
+    if [ ! -s "$file" ]; then
+      head -c 48 /dev/urandom | base64 | tr -d '\n' >"$file"
+      echo "munin: generated $name (persisted in $SECRET_DIR — set it explicitly for shared/production deployments)"
+    fi
+    export "$name=$(cat "$file")"
+  fi
+}
+
+ensure_secret MUNIN_AUTH_SECRET
+ensure_secret MUNIN_KEY_PEPPER
+ensure_secret MUNIN_ENCRYPTION_KEY
+ensure_secret MUNIN_STORAGE_LOCAL_SECRET
+
+exec "$@"

--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,12 @@
 #   docker compose up
 #
 # Brings up: Postgres + pgvector, Munin backend, Munin web.
+#
+# The placeholder secrets in .env.example are auto-generated on first boot
+# and persisted in the munin-data volume — fine for local/single-host
+# self-hosting. For shared or production deployments, set strong
+# MUNIN_AUTH_SECRET / MUNIN_KEY_PEPPER / MUNIN_ENCRYPTION_KEY values in .env
+# (`openssl rand -base64 48`) instead of relying on the generated ones.
 
 services:
   postgres:
@@ -40,6 +46,8 @@ services:
       MUNIN_MIGRATE_URL: postgres://${POSTGRES_USER:-munin}:${POSTGRES_PASSWORD:-munin}@postgres:5432/${POSTGRES_DB:-munin}
       DATABASE_URL: postgres://munin_app:munin_app@postgres:5432/${POSTGRES_DB:-munin}
     command: ["sh", "-c", "node dist/migrate.js && node dist/main.js"]
+    volumes:
+      - munin-data:/var/munin
     ports:
       - "${BACKEND_PORT:-3001}:3001"
 
@@ -59,3 +67,4 @@ services:
 
 volumes:
   munin-pg:
+  munin-data:


### PR DESCRIPTION
## Problem

`docker compose up` did **not** work out of the box. The backend sets `NODE_ENV=production`, where `assertProductionAuthSecret` (`packages/backend-core/src/auth-controller-factory.ts`) rejects placeholder secrets. The shipped `.env.example` sets `MUNIN_AUTH_SECRET=replace-me-with-strong-random-secret`, so following the documented `cp .env.example .env && docker compose up` made the backend throw at boot and crashloop under `restart: unless-stopped` — it never served traffic. (Postgres, migrations, and web were all fine; only the backend crashed.)

The `compose.yml` header advertised a 2-step run with no secret editing, which was misleading. `pnpm dev` never tripped this because the guard only fires when `NODE_ENV=production`.

## Fix

1. **Auto-generate secrets** — new `apps/backend/docker-entrypoint.sh` (wired in via the Dockerfile `ENTRYPOINT`) detects empty/placeholder values for `MUNIN_AUTH_SECRET`, `MUNIN_KEY_PEPPER`, `MUNIN_ENCRYPTION_KEY`, `MUNIN_STORAGE_LOCAL_SECRET`, generates strong ones, and persists them to the new `munin-data` volume at `/var/munin/secrets` so they're **stable across restarts** (a rotating encryption key would orphan stored secrets). Real secrets in `.env` are left untouched. The same volume also covers the default local asset path (`/var/munin/assets`).
2. **Docs corrected** — `compose.yml` header, `README.md`, and `.env.example` now describe the real behavior: runs out of the box with auto-generated + persisted secrets; set strong values explicitly for shared/production deploys.

## Verification

Built and ran the full stack with the **unmodified** `.env.example` (placeholders intact):

- Backend boots clean: **0 restarts**, `Nest application successfully started`, `listening on :3001`.
- Entrypoint generates all 4 secrets on **first boot only**.
- Endpoints respond: `/v1/kb/spaces` → 401 (auth required), `/.well-known/oauth-authorization-server` → 200, `/mcp` route mapped.
- **Persistence held**: after a restart, no regeneration and the `MUNIN_ENCRYPTION_KEY` SHA-256 was identical before/after.
- Postgres healthy + migrations run; web serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)