### PR TITLE
fix(cms): format date fields in read-only entry drawer

### DIFF
--- a/.changeset/cms-drawer-date-formatting.md
+++ b/.changeset/cms-drawer-date-formatting.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Format `date` and `datetime` fields in the read-only CMS entry drawer using the viewer's locale instead of printing the raw stored ISO string (e.g. `Jun 29, 2026, 12:00 PM` rather than `2026-06-29T12:00:00.000Z`), matching how the edit-mode date picker displays them.

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms.tsx
@@ -633,12 +633,14 @@ function FieldViewer({
       return <ArrayViewer field={field} value={value} aspectLabel={aspectLabel} />;
     case 'boolean':
       return <ValueBox>{value === true ? 'true' : 'false'}</ValueBox>;
+    case 'date':
+      return <ValueBox>{formatDateValue(value, false) || '—'}</ValueBox>;
+    case 'datetime':
+      return <ValueBox>{formatDateValue(value, true) || '—'}</ValueBox>;
     case 'text':
     case 'select':
     case 'integer':
     case 'number':
-    case 'date':
-    case 'datetime':
       return <ValueBox>{asString(value) || '—'}</ValueBox>;
     default:
       return (
@@ -1219,6 +1221,16 @@ function AssetDropZone({
 
 function asString(value: unknown): string {
   return typeof value === 'string' ? value : '';
+}
+
+function formatDateValue(value: unknown, withTime: boolean): string {
+  const raw = asString(value);
+  if (!raw) return '';
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw;
+  return withTime
+    ? d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+    : d.toLocaleDateString(undefined, { dateStyle: 'medium' });
 }
 
 function scalarText(value: unknown): string {


### PR DESCRIPTION
## Summary

The read-only CMS entry drawer (`FieldViewer`) rendered `date`/`datetime` fields by falling through to the plain-text branch, which printed the raw stored ISO string (`2026-06-29T12:00:00.000Z`). Edit mode, by contrast, shows a locale-formatted date picker (`29/06/2026, 12:00`).

This splits `date`/`datetime` out of the text branch and formats them via a new `formatDateValue` helper using the viewer's locale — `datetime` shows date + short time, `date` shows date only. Invalid/empty values fall back to the raw string or `—`.

## Test plan

- [x] `pnpm -F @getmunin/dashboard-pages typecheck`
- [ ] Open a CMS entry with a date/datetime field in the drawer; confirm read-only view matches the edit-mode picker's formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)