### PR TITLE
fix(channels): stop email dialog button label flashing on cancel

### DIFF
--- a/.changeset/email-dialog-button-flash.md
+++ b/.changeset/email-dialog-button-flash.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+fix(channels): stop the email channel dialog button label flashing on cancel
+
+The "Edit email channel" dialog derived its edit/create state live from the
+`editChannel` prop. Cancelling cleared that prop before the dialog's close
+animation finished, briefly re-rendering the still-mounted dialog in create
+mode (the footer button flashed from "Save changes" to "Create"). The edit
+state is now frozen while the dialog is open.

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -1191,7 +1191,7 @@ function EmailChannelDialog({
   onSaved: () => void;
   editChannel: EmailChannelDto | null;
 }) {
-  const isEdit = editChannel !== null;
+  const [isEdit, setIsEdit] = useState(editChannel !== null);
   const t = useTranslations('dashboard.channels');
   const tCommon = useTranslations('common');
   const translate = useTranslateError();
@@ -1228,6 +1228,7 @@ function EmailChannelDialog({
 
   useEffect(() => {
     if (!open) return;
+    setIsEdit(editChannel !== null);
     const cfg = editChannel?.config;
     setName(editChannel?.name ?? '');
     setDefaultAgentMode(editChannel?.defaultAgentMode ?? 'auto');


### PR DESCRIPTION
## Problem

When you open the **Edit email channel** dialog and press **Cancel**, the footer button text briefly changes ("Save changes" → "Create") just before the dialog closes. The dialog title and description flip too, but the button is the most visible.

## Cause

The dialog derived its mode live:

```ts
const isEdit = editChannel !== null;
```

Cancelling calls `onOpenChange(false)`, which clears `editEmail` in the parent **immediately**. But the Radix dialog keeps its content mounted through the close animation, so for that brief window `editChannel` is already `null` → `isEdit` flips to `false` → every `isEdit`-driven label re-renders in create mode before unmounting.

## Fix

Capture `isEdit` into state inside the existing open-reset effect (which already early-returns while the dialog is closed). The value now stays frozen through the closing animation, so the labels no longer flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)