### PR TITLE
fix(crm): coerce timestamp fields when applying a merge proposal

### DIFF
--- a/.changeset/crm-merge-proposal-timestamp-patch.md
+++ b/.changeset/crm-merge-proposal-timestamp-patch.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Fix `crm_apply_merge_proposal` crashing with a bare 500 when the proposal's `recommendedPatch` carries a timestamp field (e.g. `consentGivenAt`) as an ISO string. Drizzle's timestamp encoder calls `value.toISOString()` during query build, which throws on a string. The patch is now normalized before the keeper update: values for timestamp columns are coerced from ISO strings (or epoch numbers) to `Date`, and keys that aren't real, patchable contact columns are dropped instead of being passed through to `.set()`.

--- a/packages/backend-core/src/modules/crm/crm.service.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.test.ts
@@ -514,6 +514,33 @@ const skipReason = TEST_URL
       expect(refreshedDup.doNotContact).toBe(true);
     });
 
+    it('applyMergeProposal coerces ISO-string timestamps in the patch and drops unknown keys', async () => {
+      const keeper = await run(() => svc.createContact({ name: 'Keeper', email: 'k@y' }));
+      const dup = await run(() => svc.createContact({ name: 'Dup', email: 'k@y' }));
+      const givenAt = '2026-06-26T12:17:03.653Z';
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: keeper.id,
+          contactBId: dup.id,
+          confidence: 'high',
+          evidence: { sameEmail: 'k@y' },
+          recommendedKeeperId: keeper.id,
+          recommendedPatch: {
+            consentLawfulBasis: 'consent',
+            consentGivenAt: givenAt,
+            consentSource: 'self-test-outreach-flow',
+            notARealColumn: 'should be dropped',
+          },
+        }),
+      );
+      const applied = await run(() => svc.applyMergeProposal({ id: proposal.id }));
+      expect(applied.status).toBe('applied');
+      const refreshedKeeper = await run(() => svc.getContact(keeper.id));
+      expect(refreshedKeeper.consentGivenAt).toBe(givenAt);
+      expect(refreshedKeeper.consentLawfulBasis).toBe('consent');
+      expect(refreshedKeeper.consentSource).toBe('self-test-outreach-flow');
+    });
+
     it('applyMergeProposal reassigns activities, deals, and contact-typed relationships from duplicate to keeper', async () => {
       const keeper = await run(() => svc.createContact({ name: 'Keeper', email: 'k@y' }));
       const dup = await run(() => svc.createContact({ name: 'Dup', email: 'k@y' }));

--- a/packages/backend-core/src/modules/crm/crm.service.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.ts
@@ -1149,10 +1149,10 @@ export class CrmService {
     }
 
     const patch = proposal.recommendedPatch ?? {};
-    const keeperUpdates: Record<string, unknown> = { updatedAt: new Date() };
-    for (const [k, v] of Object.entries(patch)) {
-      if (v !== undefined) keeperUpdates[k] = v;
-    }
+    const keeperUpdates: Record<string, unknown> = {
+      updatedAt: new Date(),
+      ...normalizeMergePatch(patch),
+    };
     if (!keeperRow.endUserId && duplicateRow.endUserId) {
       keeperUpdates['endUserId'] = duplicateRow.endUserId;
     }
@@ -1898,6 +1898,54 @@ function toMergeProposalDto(
 
 function canonicalizePair(a: string, b: string): [string, string] {
   return a < b ? [a, b] : [b, a];
+}
+
+const MERGE_PATCH_TIMESTAMP_FIELDS = new Set([
+  'consentGivenAt',
+  'lastContactedAt',
+  'unsubscribedAt',
+  'aiSummaryAt',
+  'lastAiTouchAt',
+]);
+
+const MERGE_PATCH_ALLOWED_FIELDS = new Set([
+  'name',
+  'email',
+  'phone',
+  'title',
+  'address',
+  'companyId',
+  'ownerUserId',
+  'tags',
+  'customFields',
+  'aiSummary',
+  'aiNextAction',
+  'engagementScore',
+  'doNotContact',
+  'consentLawfulBasis',
+  'consentSource',
+  'consentEvidence',
+  ...MERGE_PATCH_TIMESTAMP_FIELDS,
+]);
+
+function normalizeMergePatch(patch: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) continue;
+    if (!MERGE_PATCH_ALLOWED_FIELDS.has(k)) continue;
+    if (MERGE_PATCH_TIMESTAMP_FIELDS.has(k)) {
+      if (v === null) {
+        out[k] = null;
+        continue;
+      }
+      const d = v instanceof Date ? v : new Date(v as string | number);
+      if (Number.isNaN(d.getTime())) continue;
+      out[k] = d;
+      continue;
+    }
+    out[k] = v;
+  }
+  return out;
 }
 
 function archiveMonth(d: Date): string {


### PR DESCRIPTION
## Problem

`crm_apply_merge_proposal` fails with a bare **500** in prod. The logged stack points at drizzle's query-build phase (`SQL.buildQueryFromSourceParams` → `Array.map`), not execution.

Inspecting the stuck prod proposal, its `recommendedPatch` was:

```json
{ "tags": [...], "consentSource": "...", "consentGivenAt": "2026-06-26T12:17:03.653Z", "consentLawfulBasis": "consent" }
```

`applyMergeProposal` spread that patch straight into a `.set()` on `crm_contacts`. `consent_given_at` is a `timestamp` column, and drizzle's `PgTimestamp.mapToDriverValue = (v) => v.toISOString()` runs **during query build**. The patch stored an ISO **string**, so `"…".toISOString()` throws `TypeError: value.toISOString is not a function` → 500. `crm_propose_merge` accepts `recommendedPatch` as `z.record(z.string(), z.unknown())`, so the proposing agent put a string where a `Date` was expected.

## Fix

Added `normalizeMergePatch()` in `crm.service.ts`, applied before building the keeper update:

- Keeps only real, patchable `crm_contacts` columns (drops anything else — e.g. stray keys — instead of passing them to `.set()`).
- Coerces the timestamp columns (`consentGivenAt`, `lastContactedAt`, `unsubscribedAt`, `aiSummaryAt`, `lastAiTouchAt`) from ISO string / epoch number to `Date`, dropping invalid dates.

This unblocks the already-stored proposal via apply-time coercion — **no data migration needed** — and hardens against future bad patches.

## Testing

- New regression test mirroring the exact prod payload (ISO-string timestamp + an unknown key). Without the fix it reproduces the `toISOString` crash.
- All 6 `applyMergeProposal` tests pass against local `munin_test`; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)