### PR TITLE
fix(widget): stop iCloud Passwords popover on message composer

### DIFF
--- a/.changeset/widget-composer-icloud-passwords.md
+++ b/.changeset/widget-composer-icloud-passwords.md
@@ -1,0 +1,7 @@
+---
+"@getmunin/chat-widget": patch
+---
+
+fix(widget): stop iCloud Passwords popover from opening on the message composer
+
+The composer textarea had no `autocomplete` attribute, so browsers defaulted it to `on` and the iCloud Passwords extension classified the widget as a login form (helped by the save-thread email field), offering credential autofill when typing a message. Set `autocomplete="off"` (and `autocorrect="off"`) on the composer to opt it out.

--- a/apps/chat-widget/src/ui.ts
+++ b/apps/chat-widget/src/ui.ts
@@ -947,7 +947,7 @@ function renderPanel(config: WidgetConfig, strings: Strings): PanelHandles {
     </button>
     <div class="messages"></div>
     <form class="composer">
-      <textarea rows="1" placeholder="${escapeAttr(strings.composerPlaceholder)}" aria-label="${escapeAttr(strings.messageAriaLabel)}"></textarea>
+      <textarea rows="1" autocomplete="off" autocorrect="off" placeholder="${escapeAttr(strings.composerPlaceholder)}" aria-label="${escapeAttr(strings.messageAriaLabel)}"></textarea>
       <div class="composer-row">
         <button type="submit" class="send" aria-label="${escapeAttr(strings.sendAriaLabel)}" disabled>
           <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## What

Set `autocomplete="off"` and `autocorrect="off"` on the chat widget's message composer textarea.

## Why

The composer textarea (`apps/chat-widget/src/ui.ts`) had no `autocomplete` attribute, so browsers defaulted it to `on`. The iCloud Passwords Chrome extension on macOS then classified the widget as a login form — reinforced by the save-thread email field elsewhere in the same shadow DOM — and popped up a credential autofill suggestion the moment a user focused the message box.

Explicitly opting the field out with `autocomplete="off"` suppresses the popover. `autocorrect="off"` is included so mobile browsers don't autocorrect chat messages. The save-thread email input keeps `autocomplete="email"` (legitimate credential-adjacent field).

## Testing

Manual: rebuild the widget bundle, open in Chrome on macOS with iCloud Passwords enabled, focus the composer — the iCloud Passwords popover no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)