### PR TITLE
feat(mcp): serve ui:// MCP App resources + inspector spike (#385)

### DIFF
--- a/.changeset/mcp-apps-inspector-plumbing.md
+++ b/.changeset/mcp-apps-inspector-plumbing.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/mcp-toolkit': minor
+'@getmunin/backend-core': minor
+---
+
+Serve `ui://` MCP App resources (SEP-1865): tools can declare `_meta.ui.resourceUri` pointing at an app-audience HTML resource rendered inline by supporting hosts, with resource-level `_meta` (CSP) passed through `resources/list` / `resources/read`. App resources are kept separate from the `skill://` catalog. Includes the `inspector_hello` spike tool + `ui://inspector/hello` panel, verified end-to-end against claude.ai including the widget-initiated `callServerTool` round trip.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -22,6 +22,23 @@
     }
   },
   {
+    "name": "inspector_hello",
+    "title": "Inspector: Hello Munin",
+    "description": "Returns a small greeting payload rendered by the Hello Munin MCP App panel. A plumbing spike for interactive MCP Apps panels.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "analytics_export_config",
     "title": "Analytics: Export trackers + visitor identities",
     "description": "Export this org's analytics configuration — trackers and visitor-identity links — as a portable JSON payload. Low-volume, returned in one shot. Tracker identity-verification secrets are redacted (the ciphertext is useless on another server); the operator re-enters them after import. Pair with `analytics_export_events` (paginated) and feed both into `analytics_import` on another Munin server.",

--- a/packages/backend-core/src/mcp/inspector.resource.ts
+++ b/packages/backend-core/src/mcp/inspector.resource.ts
@@ -57,7 +57,7 @@ const INSPECTOR_HELLO_HTML = `<!DOCTYPE html>
       <button id="refresh" disabled>Refresh from server</button>
     </main>
     <script type="module">
-      import { App } from 'https://esm.sh/@modelcontextprotocol/ext-apps@1.7.4';
+      import { App } from 'https://cdn.jsdelivr.net/npm/@modelcontextprotocol/ext-apps@1.7.4/+esm';
 
       const statusEl = document.getElementById('status');
       const payloadEl = document.getElementById('payload');
@@ -109,8 +109,8 @@ export function inspectorHelloResource(): RegisteredSkill {
     meta: {
       ui: {
         csp: {
-          resourceDomains: ['https://esm.sh'],
-          connectDomains: ['https://esm.sh'],
+          resourceDomains: ['https://cdn.jsdelivr.net'],
+          connectDomains: ['https://cdn.jsdelivr.net'],
         },
       },
     },

--- a/packages/backend-core/src/mcp/inspector.resource.ts
+++ b/packages/backend-core/src/mcp/inspector.resource.ts
@@ -1,0 +1,118 @@
+import { APP_RESOURCE_MIME_TYPE, type RegisteredSkill } from '@getmunin/mcp-toolkit';
+
+export const INSPECTOR_HELLO_URI = 'ui://inspector/hello';
+
+const INSPECTOR_HELLO_HTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Munin Inspector — Hello</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 1.25rem;
+        line-height: 1.5;
+      }
+      h1 {
+        font-size: 1.1rem;
+        margin: 0 0 0.5rem;
+      }
+      #status {
+        font-size: 0.85rem;
+        opacity: 0.7;
+        margin: 0 0 0.75rem;
+      }
+      pre {
+        background: rgba(127, 127, 127, 0.12);
+        border-radius: 8px;
+        padding: 0.75rem;
+        font-size: 0.8rem;
+        overflow: auto;
+        margin: 0 0 0.75rem;
+      }
+      button {
+        font: inherit;
+        padding: 0.4rem 0.9rem;
+        border-radius: 8px;
+        border: 1px solid rgba(127, 127, 127, 0.4);
+        background: transparent;
+        cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Hello from Munin 👋</h1>
+      <p id="status">Connecting to host…</p>
+      <pre id="payload">—</pre>
+      <button id="refresh" disabled>Refresh from server</button>
+    </main>
+    <script type="module">
+      import { App } from 'https://esm.sh/@modelcontextprotocol/ext-apps@1.7.4';
+
+      const statusEl = document.getElementById('status');
+      const payloadEl = document.getElementById('payload');
+      const refreshBtn = document.getElementById('refresh');
+
+      function render(result) {
+        const text = result?.content?.find((c) => c.type === 'text')?.text;
+        payloadEl.textContent = text ?? JSON.stringify(result ?? {}, null, 2);
+      }
+
+      const app = new App({ name: 'Munin Inspector', version: '0.1.0' });
+
+      app.ontoolresult = (params) => {
+        statusEl.textContent = 'Tool result pushed by host.';
+        render(params);
+      };
+
+      await app.connect();
+      statusEl.textContent = 'Connected — served by Munin over ui://inspector/hello.';
+      refreshBtn.disabled = false;
+
+      refreshBtn.addEventListener('click', async () => {
+        refreshBtn.disabled = true;
+        statusEl.textContent = 'Calling inspector_hello…';
+        try {
+          const result = await app.callServerTool({ name: 'inspector_hello', arguments: {} });
+          statusEl.textContent = 'Refreshed via tools/call round trip.';
+          render(result);
+        } catch (err) {
+          statusEl.textContent = 'Tool call failed: ' + (err?.message ?? err);
+        } finally {
+          refreshBtn.disabled = false;
+        }
+      });
+    </script>
+  </body>
+</html>
+`;
+
+export function inspectorHelloResource(): RegisteredSkill {
+  return {
+    uri: INSPECTOR_HELLO_URI,
+    name: 'Inspector: Hello Munin',
+    description: 'Spike panel validating the MCP Apps round trip (issue #385).',
+    audiences: ['admin'],
+    mimeType: APP_RESOURCE_MIME_TYPE,
+    content: INSPECTOR_HELLO_HTML,
+    public: false,
+    meta: {
+      ui: {
+        csp: {
+          resourceDomains: ['https://esm.sh'],
+          connectDomains: ['https://esm.sh'],
+        },
+      },
+    },
+  };
+}

--- a/packages/backend-core/src/mcp/inspector.tool.ts
+++ b/packages/backend-core/src/mcp/inspector.tool.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpTool } from '@getmunin/mcp-toolkit';
+import { getCurrentContext } from '@getmunin/core';
+import { INSPECTOR_HELLO_URI } from './inspector.resource.ts';
+
+const InspectorHelloInput = z.object({});
+
+@Injectable()
+export class InspectorMcpTool {
+  @McpTool({
+    name: 'inspector_hello',
+    title: 'Inspector: Hello Munin',
+    description:
+      'Returns a small greeting payload rendered by the Hello Munin MCP App panel. A plumbing spike for interactive MCP Apps panels.',
+    audiences: ['admin'],
+    scopes: [],
+    input: InspectorHelloInput,
+    readOnlyHint: true,
+    destructiveHint: false,
+    _meta: { ui: { resourceUri: INSPECTOR_HELLO_URI }, 'ui/resourceUri': INSPECTOR_HELLO_URI },
+  })
+  hello() {
+    const ctx = getCurrentContext();
+    return {
+      greeting: 'Hello from Munin 👋',
+      orgId: ctx.actor?.orgId,
+      actorType: ctx.actor?.type,
+      now: new Date().toISOString(),
+    };
+  }
+}

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -219,6 +219,32 @@ const skipReason = TEST_URL
     });
   });
 
+  it('exposes the inspector MCP App: tool _meta.ui.resourceUri + ui:// resource', async () => {
+    await withClient(adminKey, async (c) => {
+      const { tools } = await c.listTools();
+      const inspector = tools.find((t) => t.name === 'inspector_hello');
+      expect(inspector, 'inspector_hello tool missing').toBeDefined();
+      expect((inspector as { _meta?: { ui?: { resourceUri?: string } } })._meta?.ui?.resourceUri).toBe(
+        'ui://inspector/hello',
+      );
+
+      const { resources } = await c.listResources();
+      const panel = resources.find((r) => r.uri === 'ui://inspector/hello');
+      expect(panel, 'ui://inspector/hello not in resources/list').toBeDefined();
+      expect(panel!.mimeType).toBe('text/html;profile=mcp-app');
+
+      const read = await c.readResource({ uri: 'ui://inspector/hello' });
+      const first = read.contents[0];
+      expect(first?.mimeType).toBe('text/html;profile=mcp-app');
+      const html = first && 'text' in first ? first.text : '';
+      expect(html).toContain('Hello from Munin');
+      expect((first as { _meta?: { ui?: { csp?: unknown } } })._meta?.ui?.csp).toBeDefined();
+
+      const called = await c.callTool({ name: 'inspector_hello', arguments: {} });
+      expect(JSON.stringify(called)).toContain('Hello from Munin');
+    });
+  });
+
   it('end-user agent does not see admin-only skills', async () => {
     await withClient(endUserToken, async (c) => {
       const { resources } = await c.listResources();

--- a/packages/backend-core/src/mcp/mcp.module.ts
+++ b/packages/backend-core/src/mcp/mcp.module.ts
@@ -5,11 +5,12 @@ import { McpRegistryService } from './mcp.registry.ts';
 import { McpSkillRegistryService } from './mcp.skill-registry.service.ts';
 import { McpBurstGuard } from './mcp-burst.guard.ts';
 import { PingMcpTool } from './ping.tool.ts';
+import { InspectorMcpTool } from './inspector.tool.ts';
 
 @Module({
   imports: [DiscoveryModule],
   controllers: [McpController],
-  providers: [McpRegistryService, McpSkillRegistryService, McpBurstGuard, PingMcpTool],
+  providers: [McpRegistryService, McpSkillRegistryService, McpBurstGuard, PingMcpTool, InspectorMcpTool],
   exports: [McpRegistryService, McpSkillRegistryService],
 })
 export class McpModule {}

--- a/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
+++ b/packages/backend-core/src/mcp/mcp.skill-registry.service.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { SkillRegistry } from '@getmunin/mcp-toolkit';
 import type { Audience } from '@getmunin/core';
 import { loadSkills, type SkillSource } from './skill-loader.ts';
+import { inspectorHelloResource } from './inspector.resource.ts';
 import { mcpResourceOrigin } from '../oauth/oauth.constants.ts';
 
 @Injectable()
@@ -17,6 +18,7 @@ export class McpSkillRegistryService extends SkillRegistry implements OnModuleIn
     for (const skill of loadSkills(sources)) {
       this.register(skill);
     }
+    this.register(inspectorHelloResource());
     this.cachedInstructions = buildInstructions(
       this.list('admin').filter((s) => s.uri.startsWith('skill://')),
       mcpResourceOrigin(),

--- a/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
+++ b/packages/backend-core/src/mcp/tools-smoke.integration.test.ts
@@ -111,7 +111,7 @@ const MIN_EXPECTED_PER_MODULE: Record<string, number> = {
     it('every tool name follows the <module>_<verb> convention or is a known utility', async () => {
       const tools = await admin.listTools();
       const KNOWN_PREFIXES = Object.values(EXPECTED_BY_MODULE);
-      const UTILITY_TOOLS = new Set(['ping', 'skills_list', 'skills_read']);
+      const UTILITY_TOOLS = new Set(['ping', 'inspector_hello', 'skills_list', 'skills_read']);
       for (const t of tools) {
         if (UTILITY_TOOLS.has(t.name)) continue;
         const matchesAny = KNOWN_PREFIXES.some((re) => re.test(t.name));

--- a/packages/mcp-toolkit/src/dispatch.ts
+++ b/packages/mcp-toolkit/src/dispatch.ts
@@ -53,12 +53,14 @@ export interface ResourceListing {
   name: string;
   description: string;
   mimeType: string;
+  _meta?: Record<string, unknown>;
 }
 
 export interface ResourceContent {
   uri: string;
   mimeType: string;
   text: string;
+  _meta?: Record<string, unknown>;
 }
 
 function skillToolListings(): ToolListing[] {
@@ -280,6 +282,20 @@ export function listResources(ctx: DispatchContext): ResourceListing[] {
     }));
 }
 
+export function listAppResources(ctx: DispatchContext): ResourceListing[] {
+  if (!ctx.skills) return [];
+  return ctx.skills
+    .list(ctx.audience)
+    .filter((s) => s.uri.startsWith('ui://'))
+    .map((s) => ({
+      uri: s.uri,
+      name: s.name,
+      description: s.description,
+      mimeType: s.mimeType,
+      ...(s.meta ? { _meta: s.meta } : {}),
+    }));
+}
+
 export function readResource(ctx: DispatchContext, uri: string): ResourceContent {
   if (!ctx.skills) throw new Error(`Unknown resource: ${uri}`);
   const skill: RegisteredSkill | undefined = ctx.skills.get(uri);
@@ -291,6 +307,7 @@ export function readResource(ctx: DispatchContext, uri: string): ResourceContent
     uri: skill.uri,
     mimeType: skill.mimeType,
     text: renderSkill(ctx, skill),
+    ...(skill.meta ? { _meta: skill.meta } : {}),
   };
 }
 

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -552,7 +552,7 @@ describe('ui:// MCP App resources (SEP-1865)', () => {
   });
 
   it('hides admin-only ui:// panels from a self-service caller', () => {
-    const selfActor = new ActorIdentity('end_user', 'eu:1', 'org_test', [], ['self_service']);
+    const selfActor = new ActorIdentity('end_user_agent', 'eu:1', 'org_test', [], ['self_service']);
     expect(listAppResources(ctx(selfActor, 'self_service'))).toEqual([]);
     expect(() => readResource(ctx(selfActor, 'self_service'), 'ui://inspector/hello')).toThrow(
       /not available/,

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -2,9 +2,16 @@ import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
 import { ActorIdentity, RequestContextStore, type RequestContext } from '@getmunin/core';
 import { McpToolRegistry } from './registry.ts';
-import { SkillRegistry } from './skill-registry.ts';
+import { SkillRegistry, APP_RESOURCE_MIME_TYPE } from './skill-registry.ts';
 import { openInProcessMcpClient } from './in-process-client.ts';
-import type { CaptureExceptionContext, CaptureExceptionFn } from './dispatch.ts';
+import {
+  listAppResources,
+  listResources,
+  readResource,
+  type CaptureExceptionContext,
+  type CaptureExceptionFn,
+  type DispatchContext,
+} from './dispatch.ts';
 
 const fakeAudit = { record: vi.fn(() => Promise.resolve()) };
 
@@ -486,5 +493,69 @@ describe('openInProcessMcpClient', () => {
       mimeType: 'text/markdown',
       text: '# go',
     });
+  });
+});
+
+describe('ui:// MCP App resources (SEP-1865)', () => {
+  function mixedRegistry(): SkillRegistry {
+    const skills = new SkillRegistry();
+    skills.register({
+      uri: 'skill://playbooks/frontend-integration',
+      name: 'Frontend integration',
+      description: 'markdown guide',
+      audiences: ['admin'],
+      mimeType: 'text/markdown',
+      content: '# guide',
+      public: true,
+    });
+    skills.register({
+      uri: 'ui://inspector/hello',
+      name: 'Inspector: Hello Munin',
+      description: 'spike panel',
+      audiences: ['admin'],
+      mimeType: APP_RESOURCE_MIME_TYPE,
+      content: '<!DOCTYPE html><body>hello</body>',
+      public: false,
+      meta: { ui: { csp: { resourceDomains: ['https://esm.sh'] } } },
+    });
+    return skills;
+  }
+
+  function ctx(actor: ActorIdentity, audience: 'admin' | 'self_service'): DispatchContext {
+    return { registry: buildRegistry(), audience, actor, audit: fakeAudit, skills: mixedRegistry() };
+  }
+
+  it('listResources stays skill:// only so skills_list never leaks ui:// panels', () => {
+    const uris = listResources(ctx(adminActor(), 'admin')).map((r) => r.uri);
+    expect(uris).toContain('skill://playbooks/frontend-integration');
+    expect(uris).not.toContain('ui://inspector/hello');
+  });
+
+  it('listAppResources returns ui:// panels with the App mime type and resource _meta', () => {
+    const listed = listAppResources(ctx(adminActor(), 'admin'));
+    expect(listed).toEqual([
+      {
+        uri: 'ui://inspector/hello',
+        name: 'Inspector: Hello Munin',
+        description: 'spike panel',
+        mimeType: 'text/html;profile=mcp-app',
+        _meta: { ui: { csp: { resourceDomains: ['https://esm.sh'] } } },
+      },
+    ]);
+  });
+
+  it('readResource serves the panel HTML with its _meta passthrough', () => {
+    const out = readResource(ctx(adminActor(), 'admin'), 'ui://inspector/hello');
+    expect(out.mimeType).toBe(APP_RESOURCE_MIME_TYPE);
+    expect(out.text).toContain('hello');
+    expect(out._meta).toEqual({ ui: { csp: { resourceDomains: ['https://esm.sh'] } } });
+  });
+
+  it('hides admin-only ui:// panels from a self-service caller', () => {
+    const selfActor = new ActorIdentity('end_user', 'eu:1', 'org_test', [], ['self_service']);
+    expect(listAppResources(ctx(selfActor, 'self_service'))).toEqual([]);
+    expect(() => readResource(ctx(selfActor, 'self_service'), 'ui://inspector/hello')).toThrow(
+      /not available/,
+    );
   });
 });

--- a/packages/mcp-toolkit/src/index.ts
+++ b/packages/mcp-toolkit/src/index.ts
@@ -1,6 +1,6 @@
 export { McpTool, getMcpToolMeta, MCP_TOOL_META, type McpToolMeta } from './decorator.ts';
 export { McpToolRegistry, type RegisteredMcpTool } from './registry.ts';
-export { SkillRegistry, type RegisteredSkill } from './skill-registry.ts';
+export { SkillRegistry, APP_RESOURCE_MIME_TYPE, type RegisteredSkill } from './skill-registry.ts';
 export { createMcpServer, type CreateMcpServerOptions } from './server.ts';
 export {
   openInProcessMcpClient,

--- a/packages/mcp-toolkit/src/server.ts
+++ b/packages/mcp-toolkit/src/server.ts
@@ -10,6 +10,7 @@ import type { McpToolRegistry } from './registry.ts';
 import type { SkillRegistry } from './skill-registry.ts';
 import {
   callTool,
+  listAppResources,
   listResources,
   listTools,
   readResource,
@@ -59,10 +60,13 @@ export function createMcpServer(opts: CreateMcpServerOptions): Server {
 
   if (opts.skills) {
     server.setRequestHandler(ListResourcesRequestSchema, () => ({
-      resources: listResources(dispatch).map((r) => ({
-        ...r,
-        annotations: { audience: ['assistant'] as const, priority: 0.9 },
-      })),
+      resources: [
+        ...listResources(dispatch).map((r) => ({
+          ...r,
+          annotations: { audience: ['assistant'] as const, priority: 0.9 },
+        })),
+        ...listAppResources(dispatch),
+      ],
     }));
     server.setRequestHandler(ReadResourceRequestSchema, (req) => ({
       contents: [readResource(dispatch, req.params.uri)],

--- a/packages/mcp-toolkit/src/skill-registry.ts
+++ b/packages/mcp-toolkit/src/skill-registry.ts
@@ -1,5 +1,7 @@
 import type { Audience } from '@getmunin/core';
 
+export const APP_RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app';
+
 export interface RegisteredSkill {
   uri: string;
   name: string;
@@ -8,6 +10,7 @@ export interface RegisteredSkill {
   mimeType: string;
   content: string;
   public: boolean;
+  meta?: Record<string, unknown>;
 }
 
 export class SkillRegistry {


### PR DESCRIPTION
Plumbing spike for **MCP Apps** (SEP-1865), the first step of #385: let an MCP tool declare `_meta.ui.resourceUri` pointing at a `ui://` HTML resource that a supporting host (Claude, Claude Desktop, …) renders inline in the chat, with the bidirectional `ui/*` channel back to tools.

## What's here

**`@getmunin/mcp-toolkit` (the reusable plumbing)**
- `RegisteredSkill` gains optional resource-level `meta` (the `ui.csp` / permissions block); `ResourceContent` / `ResourceListing` carry `_meta`.
- `APP_RESOURCE_MIME_TYPE` = `text/html;profile=mcp-app`.
- `listAppResources()` serves `ui://` resources, kept **separate** from `listResources()` so `skills_list` / `skills_read` and the public skill catalog stay `skill://`-only (no leak).
- `server.ts` merges app resources into `resources/list`; `readResource` passes `_meta` through.

**`@getmunin/backend-core` (round-trip proof)**
- `ui://inspector/hello` resource — a self-contained "Hello Munin" panel using the official `@modelcontextprotocol/ext-apps` `App` client (loaded from jsdelivr, declared in `_meta.ui.csp`; the eventual `packages/inspector-app` React bundle will bundle it instead).
- `inspector_hello` tool wired via `_meta.ui.resourceUri` (both nested `ui.resourceUri` and the legacy flat `ui/resourceUri` key for host compatibility). Admin-only, read-only.

## Verification

Verified end-to-end at the protocol level (unit + integration): `tools/list` carries `_meta.ui.resourceUri`, `resources/list` + `resources/read` return the panel with the App mime type and CSP `_meta`, audience-gated to admin.

**Verified visually against production claude.ai** (custom connector over a tunnel, full OAuth DCR/authorize/token): the panel renders inline, the host pushes the tool result into it (`ontoolresult`), and the widget-initiated `app.callServerTool` round trip works — the complete SEP-1865 loop.

One real bug found and fixed along the way: the panel originally imported the ext-apps SDK from **esm.sh**, whose `zod/v4` shim exports only `{ default, z }` while the esm.sh-compiled MCP SDK calls `t.custom(...)` on the module namespace. The SDK threw at import time inside the host iframe (`TypeError: t.custom is not a function`), `App.connect()` never ran, and claude.ai kept the unconnected iframe invisible while still telling the model the widget rendered. This is indistinguishable from a host-side render gap from the outside and is likely what ext-apps#671 reporters are hitting. jsdelivr's `+esm` build links zod correctly; `esm.sh?bundle` does not help. The proper fix remains bundling the SDK into the `packages/inspector-app` build (follow-up below).

Practical notes for iterating on `ui://` panels against claude.ai: the host caches resources per URI (bump a version suffix to force a refetch), and an app that never completes `App.connect()` renders nothing, silently.

## Not in this spike (follow-ups from #385)
- The real `packages/inspector-app` React bundle on `@getmunin/ui`, replacing the inline stub (and removing the CDN dependency entirely).
- The first approval-flow route (outreach proposal review) and reporting views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
