### PR TITLE
fix(analytics): correct identity-hash formula in tracker tool description

### DIFF
--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -526,7 +526,7 @@
   {
     "name": "analytics_rotate_tracker_identity_secret",
     "title": "Analytics: Rotate tracker identity verification secret",
-    "description": "Mint a fresh HMAC secret for verifying visitor-identity claims sent to `/v1/a/identify`. Returns the plaintext secret once; store it server-side and use it to compute `userHash = HMAC_SHA256(externalId, secret)` before calling `window.mn.identify(externalId, userHash)` from the browser. The previous secret is replaced immediately — any in-flight identify calls signed with it will fail.",
+    "description": "Mint a fresh HMAC secret for verifying visitor-identity claims sent to `/v1/a/identify`. Returns the plaintext secret once; store it server-side and use it to compute `userHash = HMAC_SHA256('${externalId}:${visitorId}', secret)` — the hash binds the visitor, so read `visitorId` from `window.mn.getVisitorId()` first — before calling `window.mn.identify(externalId, userHash)` from the browser. The previous secret is replaced immediately — any in-flight identify calls signed with it will fail.",
     "audiences": [
       "admin"
     ],

--- a/packages/backend-core/src/modules/analytics/analytics.tools.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.tools.ts
@@ -279,7 +279,7 @@ export class AnalyticsAdminTools {
     name: 'analytics_rotate_tracker_identity_secret',
     title: 'Analytics: Rotate tracker identity verification secret',
     description:
-      "Mint a fresh HMAC secret for verifying visitor-identity claims sent to `/v1/a/identify`. Returns the plaintext secret once; store it server-side and use it to compute `userHash = HMAC_SHA256(externalId, secret)` before calling `window.mn.identify(externalId, userHash)` from the browser. The previous secret is replaced immediately — any in-flight identify calls signed with it will fail.",
+      "Mint a fresh HMAC secret for verifying visitor-identity claims sent to `/v1/a/identify`. Returns the plaintext secret once; store it server-side and use it to compute `userHash = HMAC_SHA256('${externalId}:${visitorId}', secret)` — the hash binds the visitor, so read `visitorId` from `window.mn.getVisitorId()` first — before calling `window.mn.identify(externalId, userHash)` from the browser. The previous secret is replaced immediately — any in-flight identify calls signed with it will fail.",
     audiences: ['admin'],
     scopes: ['analytics:write'],
     input: RotateIdentitySecretInput,


### PR DESCRIPTION
## Bug

`analytics_rotate_tracker_identity_secret`'s tool description instructed integrators to compute:

```
userHash = HMAC_SHA256(externalId, secret)
```

But the `/v1/a/identify` controller verifies the **visitor-bound** form:

```js
// analytics-tracker.controller.ts
verifyHmac(`${body.externalId}:${body.visitorId}`, secret, body.userHash.toLowerCase())
```

That binding was added by the #595 security fix ("bind analytics identify hashes to the visitor id"), which updated the controller and the `identify-visitors` skill but **not** this tool description. An integrator following the tool text computes `HMAC(externalId)` — which never validates against the controller's `HMAC(externalId:visitorId)`, so every identify call silently drops.

(This is exactly what recently misled a coding agent into thinking the widget and analytics surfaces verify identity the same way.)

## Fix

Update the description to the visitor-bound formula and note that `visitorId` comes from `window.mn.getVisitorId()`. Now consistent with the controller and the `skill://analytics/identify-visitors` skill. Regenerated `docs-fixtures/mcp-tools.json`.

The `analytics_get_contact_journey` mention of `window.mn.identify(externalId, userHash)` is left as-is — that's the correct *browser call signature* (the tracker adds `visitorId` itself); only the server-side hash-computation instruction was wrong.

Tool-surface/behavioral doc only — no code path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)