### PR TITLE
feat(inspector): localize panel from MCP App host locale

### DIFF
--- a/.changeset/inspector-host-locale.md
+++ b/.changeset/inspector-host-locale.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/inspector-app': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Localize the inspector panel from the MCP App host locale.
+
+- The panel reads `getHostContext()?.locale` after connect (falling back to `navigator.language`, then `en`) and re-renders on `onhostcontextchanged`, so it follows the user's Claude language setting rather than the iframe's browser default.
+- Strings live in a new `inspector.*` namespace in `@getmunin/dashboard-pages`' message catalogs (English + Norwegian), now exposed via a `./messages/*.json` export; the panel bundles only that namespace (~1 kB per locale) through a small `t(key, params)` helper.
+- Ages in the proposal ledger format through `Intl.RelativeTimeFormat` with the host locale instead of hardcoded English abbreviations.
+
+Server-originated strings (tool error messages) remain English.

--- a/packages/dashboard-pages/package.json
+++ b/packages/dashboard-pages/package.json
@@ -17,7 +17,8 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./server": "./src/server.ts"
+    "./server": "./src/server.ts",
+    "./messages/*.json": "./src/messages/*.json"
   },
   "files": [
     "src"

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1339,6 +1339,55 @@
       "signUp": "Sign up with GitHub"
     }
   },
+  "inspector": {
+    "chrome": {
+      "contextInspector": "Inspector",
+      "contextOutreach": "Outreach"
+    },
+    "connect": {
+      "connecting": "Connecting to host…",
+      "failed": "Could not connect to the host: {error}"
+    },
+    "fallback": {
+      "title": "Munin Inspector",
+      "waiting": "Connected — waiting for a tool result from the host.",
+      "raw": "Connected — showing the raw tool result."
+    },
+    "proposals": {
+      "eyebrow": "Pending proposals",
+      "title": "Outreach proposals",
+      "sublineEmpty": "Nothing waiting — the queue is clear.",
+      "sublinePending": "{count} waiting for review — approving sends the email.",
+      "refresh": "Refresh",
+      "refreshing": "Refreshing…",
+      "noSubject": "(no subject)",
+      "evidenceShow": "Evidence +",
+      "evidenceHide": "Evidence −",
+      "approve": "Approve & send",
+      "approving": "Sending…",
+      "dismiss": "Dismiss",
+      "dismissing": "Dismissing…",
+      "sentNow": "Sent just now.",
+      "sent": "Sent.",
+      "approved": "Approved.",
+      "dismissed": "Dismissed — nothing was sent.",
+      "dismissedReason": "Dismissed — {reason}",
+      "failed": "Failed.",
+      "failedReason": "Failed — {reason}",
+      "showMore": "Show {count} more ({hidden} hidden)",
+      "footClear": "Queue clear",
+      "footPending": "{count} pending · approve sends immediately",
+      "footShowing": "showing {visible} of {total}",
+      "ageNow": "now",
+      "status": {
+        "pending": "pending",
+        "approved": "approved",
+        "sent": "sent",
+        "dismissed": "dismissed",
+        "failed": "failed"
+      }
+    }
+  },
   "legal": {
     "privacy": {
       "title": "Privacy Policy — Munin",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1339,6 +1339,55 @@
       "signUp": "Opprett konto med GitHub"
     }
   },
+  "inspector": {
+    "chrome": {
+      "contextInspector": "Inspektør",
+      "contextOutreach": "Utgående"
+    },
+    "connect": {
+      "connecting": "Kobler til verten…",
+      "failed": "Kunne ikke koble til verten: {error}"
+    },
+    "fallback": {
+      "title": "Munin Inspector",
+      "waiting": "Tilkoblet — venter på et verktøyresultat fra verten.",
+      "raw": "Tilkoblet — viser det rå verktøyresultatet."
+    },
+    "proposals": {
+      "eyebrow": "Ventende forslag",
+      "title": "Utgående forslag",
+      "sublineEmpty": "Ingenting venter — køen er tom.",
+      "sublinePending": "{count} venter på gjennomgang — godkjenning sender e-posten.",
+      "refresh": "Oppdater",
+      "refreshing": "Oppdaterer…",
+      "noSubject": "(uten emne)",
+      "evidenceShow": "Grunnlag +",
+      "evidenceHide": "Grunnlag −",
+      "approve": "Godkjenn & send",
+      "approving": "Sender…",
+      "dismiss": "Avvis",
+      "dismissing": "Avviser…",
+      "sentNow": "Sendt akkurat nå.",
+      "sent": "Sendt.",
+      "approved": "Godkjent.",
+      "dismissed": "Avvist — ingenting ble sendt.",
+      "dismissedReason": "Avvist — {reason}",
+      "failed": "Mislyktes.",
+      "failedReason": "Mislyktes — {reason}",
+      "showMore": "Vis {count} til ({hidden} skjult)",
+      "footClear": "Køen er tom",
+      "footPending": "{count} ventende · godkjenning sender umiddelbart",
+      "footShowing": "viser {visible} av {total}",
+      "ageNow": "nå",
+      "status": {
+        "pending": "ventende",
+        "approved": "godkjent",
+        "sent": "sendt",
+        "dismissed": "avvist",
+        "failed": "mislyktes"
+      }
+    }
+  },
   "legal": {
     "privacy": {
       "title": "Personvernerklæring — Munin",

--- a/packages/inspector-app/package.json
+++ b/packages/inspector-app/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@getmunin/dashboard-pages": "workspace:*",
     "@getmunin/ui": "workspace:*",
     "@modelcontextprotocol/ext-apps": "^1.7.4",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/inspector-app/src/app.tsx
+++ b/packages/inspector-app/src/app.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { App as McpApp } from '@modelcontextprotocol/ext-apps';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { isProposalList, parseToolResult } from './types';
 import { Chrome } from './chrome';
+import { createT, resolveLocale, I18nProvider } from './i18n';
 import { ProposalsView } from './views/proposals';
 
 const mcpApp = new McpApp({ name: 'Munin Inspector', version: '0.2.0' });
@@ -13,6 +14,7 @@ export function InspectorApp() {
   const [connection, setConnection] = useState<Connection>('connecting');
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [payload, setPayload] = useState<unknown>(null);
+  const [locale, setLocale] = useState(() => resolveLocale(undefined));
 
   useEffect(() => {
     mcpApp.ontoolresult = (result: CallToolResult) => {
@@ -20,12 +22,15 @@ export function InspectorApp() {
     };
     mcpApp.onhostcontextchanged = (params) => {
       console.log('[Munin Inspector] host context changed:', params);
+      if (params.locale) setLocale(resolveLocale(params.locale));
     };
     mcpApp
       .connect()
       .then(() => {
         setConnection('connected');
-        console.log('[Munin Inspector] host context:', mcpApp.getHostContext());
+        const context = mcpApp.getHostContext();
+        console.log('[Munin Inspector] host context:', context);
+        if (context?.locale) setLocale(resolveLocale(context.locale));
       })
       .catch((err: unknown) => {
         setConnection('failed');
@@ -33,41 +38,34 @@ export function InspectorApp() {
       });
   }, []);
 
-  if (connection === 'failed') {
-    return (
-      <Chrome context="Inspector" tool="—">
-        <div className="plain">
-          <p className="line line-error">Could not connect to the host: {connectionError}</p>
-        </div>
-      </Chrome>
-    );
-  }
-
-  if (connection === 'connecting') {
-    return (
-      <Chrome context="Inspector" tool="—">
-        <div className="plain">
-          <p className="status">Connecting to host…</p>
-        </div>
-      </Chrome>
-    );
-  }
-
-  if (isProposalList(payload)) {
-    return <ProposalsView app={mcpApp} initial={payload} />;
-  }
+  const i18n = useMemo(() => ({ locale, t: createT(locale) }), [locale]);
+  const { t } = i18n;
 
   return (
-    <Chrome context="Inspector" tool="—">
-      <div className="plain">
-        <h1>Munin Inspector</h1>
-        <p className="status">
-          {payload === null
-            ? 'Connected — waiting for a tool result from the host.'
-            : 'Connected — showing the raw tool result.'}
-        </p>
-        {payload !== null && <pre className="payload">{JSON.stringify(payload, null, 2)}</pre>}
-      </div>
-    </Chrome>
+    <I18nProvider value={i18n}>
+      {connection === 'failed' ? (
+        <Chrome context={t('chrome.contextInspector')} tool="—">
+          <div className="plain">
+            <p className="line line-error">{t('connect.failed', { error: connectionError ?? '' })}</p>
+          </div>
+        </Chrome>
+      ) : connection === 'connecting' ? (
+        <Chrome context={t('chrome.contextInspector')} tool="—">
+          <div className="plain">
+            <p className="status">{t('connect.connecting')}</p>
+          </div>
+        </Chrome>
+      ) : isProposalList(payload) ? (
+        <ProposalsView app={mcpApp} initial={payload} />
+      ) : (
+        <Chrome context={t('chrome.contextInspector')} tool="—">
+          <div className="plain">
+            <h1>{t('fallback.title')}</h1>
+            <p className="status">{payload === null ? t('fallback.waiting') : t('fallback.raw')}</p>
+            {payload !== null && <pre className="payload">{JSON.stringify(payload, null, 2)}</pre>}
+          </div>
+        </Chrome>
+      )}
+    </I18nProvider>
   );
 }

--- a/packages/inspector-app/src/i18n.ts
+++ b/packages/inspector-app/src/i18n.ts
@@ -1,0 +1,44 @@
+import { createContext, useContext } from 'react';
+import { inspector as en } from '@getmunin/dashboard-pages/messages/en.json';
+import { inspector as nb } from '@getmunin/dashboard-pages/messages/nb.json';
+
+const CATALOGS: Record<string, unknown> = { en, nb };
+
+export const DEFAULT_LOCALE = 'en';
+
+export function resolveLocale(hostLocale: string | undefined): string {
+  const candidate = hostLocale || (typeof navigator === 'undefined' ? '' : navigator.language);
+  try {
+    return Intl.getCanonicalLocales(candidate)[0] ?? DEFAULT_LOCALE;
+  } catch {
+    return DEFAULT_LOCALE;
+  }
+}
+
+export type Translator = (key: string, params?: Record<string, string | number>) => string;
+
+export function createT(locale: string): Translator {
+  const base = locale.toLowerCase().split('-')[0] ?? DEFAULT_LOCALE;
+  const catalog = CATALOGS[base] ?? CATALOGS[DEFAULT_LOCALE];
+  return (key, params) => {
+    let node: unknown = catalog;
+    for (const part of key.split('.')) {
+      node = typeof node === 'object' && node !== null ? (node as Record<string, unknown>)[part] : undefined;
+    }
+    if (typeof node !== 'string') return key;
+    return node.replace(/\{(\w+)\}/g, (match, name: string) =>
+      params && name in params ? String(params[name]) : match,
+    );
+  };
+}
+
+const I18nContext = createContext<{ locale: string; t: Translator }>({
+  locale: DEFAULT_LOCALE,
+  t: createT(DEFAULT_LOCALE),
+});
+
+export const I18nProvider = I18nContext.Provider;
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/packages/inspector-app/src/i18n.ts
+++ b/packages/inspector-app/src/i18n.ts
@@ -2,7 +2,9 @@ import { createContext, useContext } from 'react';
 import { inspector as en } from '@getmunin/dashboard-pages/messages/en.json';
 import { inspector as nb } from '@getmunin/dashboard-pages/messages/nb.json';
 
-const CATALOGS: Record<string, unknown> = { en, nb };
+/* Browsers commonly report plain 'no' (Norwegian macrolanguage); route it
+   and nynorsk to the bokmål catalog. */
+const CATALOGS: Record<string, unknown> = { en, nb, no: nb, nn: nb };
 
 export const DEFAULT_LOCALE = 'en';
 

--- a/packages/inspector-app/src/i18n.ts
+++ b/packages/inspector-app/src/i18n.ts
@@ -2,8 +2,6 @@ import { createContext, useContext } from 'react';
 import { inspector as en } from '@getmunin/dashboard-pages/messages/en.json';
 import { inspector as nb } from '@getmunin/dashboard-pages/messages/nb.json';
 
-/* Browsers commonly report plain 'no' (Norwegian macrolanguage); route it
-   and nynorsk to the bokmål catalog. */
 const CATALOGS: Record<string, unknown> = { en, nb, no: nb, nn: nb };
 
 export const DEFAULT_LOCALE = 'en';

--- a/packages/inspector-app/src/views/proposals.tsx
+++ b/packages/inspector-app/src/views/proposals.tsx
@@ -8,6 +8,7 @@ import {
   type Proposal,
 } from '../types';
 import { Chrome } from '../chrome';
+import { useI18n, type Translator } from '../i18n';
 
 type CardState = {
   busy: 'approve' | 'dismiss' | null;
@@ -21,6 +22,7 @@ const DISPLAY_PAGE = 25;
 const REFRESH_LIMIT = 100;
 
 export function ProposalsView({ app, initial }: { app: McpApp; initial: Proposal[] }) {
+  const { t } = useI18n();
   const [proposals, setProposals] = useState<Proposal[]>(initial);
   const [openId, setOpenId] = useState<string | null>(initial[0]?.id ?? null);
   const [evidenceOpen, setEvidenceOpen] = useState<Record<string, boolean>>({});
@@ -94,20 +96,32 @@ export function ProposalsView({ app, initial }: { app: McpApp; initial: Proposal
     }
   }
 
+  const foot =
+    pendingCount === 0
+      ? t('proposals.footClear')
+      : [
+          hiddenCount > 0
+            ? t('proposals.footShowing', { visible: visible.length, total: proposals.length })
+            : null,
+          t('proposals.footPending', { count: pendingCount }),
+        ]
+          .filter(Boolean)
+          .join(' · ');
+
   return (
-    <Chrome context="Outreach" tool="outreach_list_proposals">
+    <Chrome context={t('chrome.contextOutreach')} tool="outreach_list_proposals">
       <div className="ledger-head">
         <div>
-          <div className="eyebrow eyebrow-accent">Pending proposals</div>
-          <h1 className="ledger-title">Outreach proposals</h1>
+          <div className="eyebrow eyebrow-accent">{t('proposals.eyebrow')}</div>
+          <h1 className="ledger-title">{t('proposals.title')}</h1>
           <p className="subline">
             {pendingCount === 0
-              ? 'Nothing waiting — the queue is clear.'
-              : `${pendingCount} waiting for review — approving sends the email.`}
+              ? t('proposals.sublineEmpty')
+              : t('proposals.sublinePending', { count: pendingCount })}
           </p>
         </div>
         <button className="chip-btn" disabled={refreshing} onClick={() => void refresh()}>
-          {refreshing ? 'Refreshing…' : 'Refresh'}
+          {refreshing ? t('proposals.refreshing') : t('proposals.refresh')}
         </button>
       </div>
       {listError && <p className="list-error">{listError}</p>}
@@ -131,16 +145,13 @@ export function ProposalsView({ app, initial }: { app: McpApp; initial: Proposal
           className="more-row"
           onClick={() => setVisibleCount((n) => n + DISPLAY_PAGE)}
         >
-          Show {Math.min(DISPLAY_PAGE, hiddenCount)} more ({hiddenCount} hidden)
+          {t('proposals.showMore', {
+            count: Math.min(DISPLAY_PAGE, hiddenCount),
+            hidden: hiddenCount,
+          })}
         </button>
       )}
-      <div className="ledger-foot">
-        {pendingCount === 0
-          ? 'Queue clear'
-          : `${
-              hiddenCount > 0 ? `showing ${visible.length} of ${proposals.length} · ` : ''
-            }${pendingCount} pending · approve sends immediately`}
-      </div>
+      <div className="ledger-foot">{foot}</div>
     </Chrome>
   );
 }
@@ -164,11 +175,12 @@ function ProposalRow({
   onApprove: () => void;
   onDismiss: () => void;
 }) {
+  const { locale, t } = useI18n();
   const contact = proposal.contact;
   const name = contact?.name || contact?.email || proposal.contactId;
   const campaignMeta = `${proposal.campaign?.name ?? proposal.campaignId} · ${proposal.kind}`;
   const hasEvidence = Object.keys(proposal.evidence ?? {}).length > 0;
-  const line = decidedLine(proposal, state.decidedNow);
+  const line = decidedLine(proposal, state.decidedNow, t);
 
   return (
     <div className="row">
@@ -186,16 +198,16 @@ function ProposalRow({
       >
         <span className={`pill pill-${proposal.status}`}>
           <span className="pill-dot" />
-          {proposal.status}
+          {t(`proposals.status.${proposal.status}`)}
         </span>
         <div className="row-main">
           <div className="row-who">
             <b>{name}</b>
             {contact?.email && contact.name && <span className="mute"> · {contact.email}</span>}
           </div>
-          <div className="row-subject">{proposal.draftSubject ?? '(no subject)'}</div>
+          <div className="row-subject">{proposal.draftSubject ?? t('proposals.noSubject')}</div>
         </div>
-        <span className="row-age">{age(proposal.createdAt)}</span>
+        <span className="row-age">{age(proposal.createdAt, locale, t)}</span>
         <span className="row-caret">{open ? '−' : '+'}</span>
       </div>
       {open && (
@@ -208,7 +220,7 @@ function ProposalRow({
           </div>
           {hasEvidence && (
             <button className="ev-toggle" onClick={onToggleEvidence}>
-              {evidenceOpen ? 'Evidence −' : 'Evidence +'}
+              {evidenceOpen ? t('proposals.evidenceHide') : t('proposals.evidenceShow')}
             </button>
           )}
           {hasEvidence && evidenceOpen && (
@@ -222,10 +234,10 @@ function ProposalRow({
                 disabled={state.busy !== null}
                 onClick={onApprove}
               >
-                {state.busy === 'approve' ? 'Sending…' : 'Approve & send'}
+                {state.busy === 'approve' ? t('proposals.approving') : t('proposals.approve')}
               </button>
               <button className="chip-btn" disabled={state.busy !== null} onClick={onDismiss}>
-                {state.busy === 'dismiss' ? 'Dismissing…' : 'Dismiss'}
+                {state.busy === 'dismiss' ? t('proposals.dismissing') : t('proposals.dismiss')}
               </button>
             </div>
           ) : (
@@ -240,22 +252,28 @@ function ProposalRow({
 function decidedLine(
   proposal: Proposal,
   decidedNow: boolean,
+  t: Translator,
 ): { text: string; className: string } | null {
   switch (proposal.status) {
     case 'sent':
-      return { text: decidedNow ? 'Sent just now.' : 'Sent.', className: 'line-accent' };
+      return {
+        text: decidedNow ? t('proposals.sentNow') : t('proposals.sent'),
+        className: 'line-accent',
+      };
     case 'approved':
-      return { text: 'Approved.', className: 'line-accent' };
+      return { text: t('proposals.approved'), className: 'line-accent' };
     case 'dismissed':
       return {
         text: proposal.dismissReason
-          ? `Dismissed — ${proposal.dismissReason}`
-          : 'Dismissed — nothing was sent.',
+          ? t('proposals.dismissedReason', { reason: proposal.dismissReason })
+          : t('proposals.dismissed'),
         className: 'line-mute',
       };
     case 'failed':
       return {
-        text: proposal.failureReason ? `Failed — ${proposal.failureReason}` : 'Failed.',
+        text: proposal.failureReason
+          ? t('proposals.failedReason', { reason: proposal.failureReason })
+          : t('proposals.failed'),
         className: 'line-error',
       };
     default:
@@ -263,13 +281,14 @@ function decidedLine(
   }
 }
 
-function age(iso: string): string {
+function age(iso: string, locale: string, t: Translator): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return '';
   const mins = Math.max(0, Math.floor((Date.now() - then) / 60_000));
-  if (mins < 1) return 'now';
-  if (mins < 60) return `${mins}m`;
+  if (mins < 1) return t('proposals.ageNow');
+  const rtf = new Intl.RelativeTimeFormat(locale, { style: 'short' });
+  if (mins < 60) return rtf.format(-mins, 'minute');
   const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h`;
-  return `${Math.floor(hours / 24)}d`;
+  if (hours < 24) return rtf.format(-hours, 'hour');
+  return rtf.format(-Math.floor(hours / 24), 'day');
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,9 @@ importers:
 
   packages/inspector-app:
     dependencies:
+      '@getmunin/dashboard-pages':
+        specifier: workspace:*
+        version: link:../dashboard-pages
       '@getmunin/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## What

The inspector panel was hardcoded English, and `age()` silently formatted with the iframe's browser locale — the browser preference, not the user's Claude language setting. Three layers, per the plan:

**Signal** — after `connect()` the panel reads `getHostContext()?.locale` (BCP 47), falls back to `navigator.language` → `en`, and live-switches on `onhostcontextchanged` (the SDK types `locale?: string` on both the context and the change notification). Locale tags are sanitized through `Intl.getCanonicalLocales` so a malformed host value can't throw. The existing host-context console logs stay. **Confirmed in devtools**: claude.ai populates `hostContext.locale` for custom connectors (e.g. `en-US` — the Claude app language, not the browser language) and fires `onhostcontextchanged`; the fallback chain covers hosts that omit it. Plain `no` (Norwegian macrolanguage, what browsers typically report) is aliased to the `nb` catalog.

**Strings** — new `inspector.*` namespace in `@getmunin/dashboard-pages`' `en.json`/`nb.json` (translations live in one place for both surfaces), exposed via a new `./messages/*.json` package export. The panel uses a ~20-line `t(key, params)` helper with a React context carrying `{locale, t}`. Named JSON imports let Rollup tree-shake the catalogs: the bundle contains only the `inspector` subtree — verified no dashboard strings (`Audit log`, `Hendelseslogg`, …) in `dist/index.html`.

**Formats** — proposal ages go through `Intl.RelativeTimeFormat(locale, { style: 'short' })` (`5 min. ago` / `for 5 min siden`). `narrow` was rejected: Norwegian CLDR falls back to a bare `-5 min`, which reads as a negative number.

Server-originated strings (tool error messages, campaign/kind meta) stay English — that's the backend item.

## Verification

- typecheck, lint, build green for inspector-app; dashboard-pages typecheck + 32 tests pass.
- Runtime smoke test: nb resolution (`nb-NO` → Norwegian strings), unsupported-locale fallback (`de-DE` → English), missing-key returns the key, interpolation, and Intl output for both locales.
- Bundle: both locale catalogs together add ~2 kB; no other namespaces leak in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
