### PR TITLE
fix(outreach): hydrate contact and campaign on proposal mutation results

### DIFF
--- a/.changeset/outreach-decision-hydration.md
+++ b/.changeset/outreach-decision-hydration.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Outreach proposal mutations (`outreach_approve_proposal`, `outreach_dismiss_proposal`, propose/update) now return the same joined `contact` and `campaign` summaries as `outreach_list_proposals`. Previously they returned `contact: null`, which made the inspector panel's row title fall back to the raw contact id after a decision.

--- a/packages/backend-core/src/modules/outreach/outreach.service.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.test.ts
@@ -201,6 +201,8 @@ const skipReason = TEST_URL
       );
       expect(p.status).toBe('pending');
       expect(p.kind).toBe('initial');
+      expect(p.contact?.email).toBe('jane@acme.com');
+      expect(p.campaign?.name).toBe('launch');
 
       const pending = await run(() => svc.listProposals({ status: 'pending' }));
       expect(pending).toHaveLength(1);
@@ -213,6 +215,8 @@ const skipReason = TEST_URL
       expect(approved.status).toBe('sent');
       expect(approved.conversationId).toBeTruthy();
       expect(approved.sentMessageId).toBeTruthy();
+      expect(approved.contact?.email).toBe('jane@acme.com');
+      expect(approved.campaign?.name).toBe('launch');
 
       // Conversation has the campaign id stamped.
       const convRows = await db.execute<{ outreach_campaign_id: string | null }>(
@@ -452,6 +456,8 @@ const skipReason = TEST_URL
       );
       expect(dismissed.status).toBe('dismissed');
       expect(dismissed.dismissReason).toBe('tone is off');
+      expect(dismissed.contact?.id).toBe(contactId);
+      expect(dismissed.campaign?.name).toBe('d');
     });
   });
 

--- a/packages/backend-core/src/modules/outreach/outreach.service.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.ts
@@ -380,7 +380,11 @@ export class OutreachService {
           kind: row!.kind,
         },
       });
-      return toProposalDto(row!);
+      return toProposalDto(
+        row!,
+        { id: contact.id, name: contact.name, email: contact.email, companyId: contact.companyId },
+        { id: campaign.id, name: campaign.name },
+      );
     } catch (err) {
       if (isUniqueViolation(err, 'outreach_proposals_pending_pair_uq')) {
         throw new ConflictException(
@@ -462,7 +466,16 @@ export class OutreachService {
           kind: row!.kind,
         },
       });
-      return toProposalDto(row!);
+      return toProposalDto(
+        row!,
+        {
+          id: crmContact.id,
+          name: crmContact.name,
+          email: crmContact.email,
+          companyId: crmContact.companyId,
+        },
+        { id: replyCampaign.id, name: replyCampaign.name },
+      );
     } catch (err) {
       if (isUniqueViolation(err, 'outreach_proposals_pending_pair_uq')) {
         throw new ConflictException(
@@ -583,7 +596,7 @@ export class OutreachService {
       },
     });
 
-    return toProposalDto(updated!);
+    return toProposalDto(updated!, proposal.contact, proposal.campaign);
   }
 
   private async approveInitialVoice(
@@ -672,7 +685,7 @@ export class OutreachService {
       },
     });
 
-    return toProposalDto(updated!);
+    return toProposalDto(updated!, proposal.contact, proposal.campaign);
   }
 
   private async createVoiceStubConversation(args: {
@@ -814,7 +827,7 @@ export class OutreachService {
       },
     });
 
-    return toProposalDto(updated!);
+    return toProposalDto(updated!, proposal.contact, proposal.campaign);
   }
 
   async updateProposal(input: {
@@ -846,7 +859,7 @@ export class OutreachService {
         contactId: proposal.contactId,
       },
     });
-    return toProposalDto(updated!);
+    return toProposalDto(updated!, proposal.contact, proposal.campaign);
   }
 
   async dismissProposal(input: { id: string; reason?: string }): Promise<ProposalDto> {
@@ -877,7 +890,7 @@ export class OutreachService {
         reason: input.reason ?? null,
       },
     });
-    return toProposalDto(updated!);
+    return toProposalDto(updated!, proposal.contact, proposal.campaign);
   }
 
   // ─── Internal helpers ───────────────────────────────────────────────────


### PR DESCRIPTION
## What

`outreach_list_proposals` returns proposals with joined `contact` (`{id, name, email, companyId}`) and `campaign` (`{id, name}`) summaries, but every mutation — `outreach_approve_proposal`, `outreach_dismiss_proposal`, `outreach_propose_initial`, `outreach_propose_reply`, `outreach_update_proposal` — returned the bare row with `contact: null`/`campaign: null`.

The inspector panel replaces the listed proposal with the decision result in place, so approving a row made its title degrade from the contact's name to the raw `cct_…` id (screenshot in the report). Any MCP client doing the same swap hits it.

All seven return sites now pass the contact/campaign summaries that are already in scope (the decision paths load the hydrated proposal up front; the propose paths already fetched the CRM contact and campaign for validation) — no extra queries.

## Testing

Extended the existing service tests: propose/approve/dismiss results now assert `contact` and `campaign` are populated. All 3 outreach suites (28 tests) pass against a local Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)