### PR TITLE
fix(auth): resume pending OAuth authorize instead of dropping it at login

### DIFF
--- a/.changeset/oauth-login-resume.md
+++ b/.changeset/oauth-login-resume.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Resume a pending OAuth authorize instead of dropping it at the login page. When better-auth bounced `/auth/oauth2/authorize` to `/login` and the user already had a session, `redirectIfAuthenticated` ignored the OAuth query and redirected to `/dashboard`, stranding the connector mid-flow. It now detects authorize params (`response_type=code` + `client_id`) and redirects back to the authorize endpoint. The consent page's unauthenticated and switch-account bounces now carry the OAuth query to `/login` (the previous `?next=` param was never read, and its absolute URL would have been rejected anyway), so the existing post-sign-in resume logic completes the flow.

--- a/apps/web/app/[locale]/(auth)/login/page.tsx
+++ b/apps/web/app/[locale]/(auth)/login/page.tsx
@@ -11,10 +11,10 @@ export default async function LoginPage({
   searchParams,
 }: {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<{ redirect?: string | string[] }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const [{ locale }, sp] = await Promise.all([params, searchParams]);
-  await redirectIfAuthenticated({ locale, redirectParam: sp.redirect });
+  await redirectIfAuthenticated({ locale, redirectParam: sp.redirect, searchParams: sp });
   const providers = await fetchAuthProviders();
   return (
     <Suspense fallback={null}>

--- a/apps/web/app/[locale]/(auth)/signup/page.tsx
+++ b/apps/web/app/[locale]/(auth)/signup/page.tsx
@@ -11,10 +11,10 @@ export default async function SignupPage({
   searchParams,
 }: {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<{ redirect?: string | string[] }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const [{ locale }, sp] = await Promise.all([params, searchParams]);
-  await redirectIfAuthenticated({ locale, redirectParam: sp.redirect });
+  await redirectIfAuthenticated({ locale, redirectParam: sp.redirect, searchParams: sp });
   const providers = await fetchAuthProviders();
   return (
     <Suspense fallback={null}>

--- a/packages/dashboard-pages/src/auth/post-signin-redirect.test.ts
+++ b/packages/dashboard-pages/src/auth/post-signin-redirect.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  oauthResumeFromSearchParams,
+  resumeOauthAuthorizeUrl,
+  safeRedirect,
+} from './post-signin-redirect';
+
+const AUTHORIZE_SP = {
+  response_type: 'code',
+  client_id: 'client-123',
+  redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+  scope: 'kb:read crm:write',
+  state: 'xyz',
+};
+
+describe('oauthResumeFromSearchParams', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com';
+  });
+
+  it('builds the authorize resume URL from page search params', () => {
+    const url = oauthResumeFromSearchParams(AUTHORIZE_SP);
+    expect(url).toBe(
+      `https://api.example.com/auth/oauth2/authorize?${new URLSearchParams(AUTHORIZE_SP).toString()}`,
+    );
+  });
+
+  it('returns null without response_type=code', () => {
+    expect(oauthResumeFromSearchParams({ client_id: 'client-123' })).toBeNull();
+    expect(oauthResumeFromSearchParams({ redirect: '/dashboard' })).toBeNull();
+    expect(oauthResumeFromSearchParams({})).toBeNull();
+  });
+
+  it('returns null without client_id', () => {
+    expect(oauthResumeFromSearchParams({ response_type: 'code' })).toBeNull();
+  });
+
+  it('uses the first value of repeated params', () => {
+    const url = oauthResumeFromSearchParams({
+      ...AUTHORIZE_SP,
+      client_id: ['client-123', 'client-456'],
+    });
+    expect(url).toContain('client_id=client-123');
+  });
+});
+
+describe('resumeOauthAuthorizeUrl', () => {
+  it('preserves the full oauth query verbatim', () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com/';
+    const params = new URLSearchParams(AUTHORIZE_SP);
+    const url = resumeOauthAuthorizeUrl(params);
+    expect(url).toBe(`https://api.example.com/auth/oauth2/authorize?${params.toString()}`);
+  });
+});
+
+describe('safeRedirect', () => {
+  it('accepts app-relative paths', () => {
+    expect(safeRedirect('/dashboard/settings')).toBe('/dashboard/settings');
+  });
+
+  it('rejects absolute and protocol-relative URLs', () => {
+    expect(safeRedirect('https://evil.example.com')).toBe('/dashboard');
+    expect(safeRedirect('//evil.example.com')).toBe('/dashboard');
+    expect(safeRedirect(null)).toBe('/dashboard');
+  });
+});

--- a/packages/dashboard-pages/src/auth/post-signin-redirect.ts
+++ b/packages/dashboard-pages/src/auth/post-signin-redirect.ts
@@ -9,6 +9,21 @@ export function absoluteCallbackUrl(path: string): string {
   return new URL(path, window.location.origin).toString();
 }
 
+export function oauthResumeFromSearchParams(
+  sp: Record<string, string | string[] | undefined>,
+): string | null {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(sp)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(key, item);
+    } else {
+      params.append(key, value);
+    }
+  }
+  return resumeOauthAuthorizeUrl(params);
+}
+
 export function resumeOauthAuthorizeUrl(params: URLSearchParams): string | null {
   if (params.get('response_type') !== 'code') return null;
   if (!params.get('client_id')) return null;

--- a/packages/dashboard-pages/src/auth/server-session.ts
+++ b/packages/dashboard-pages/src/auth/server-session.ts
@@ -1,7 +1,8 @@
 import 'server-only';
 import { cookies } from 'next/headers';
+import { redirect as externalRedirect } from 'next/navigation';
 import { redirect } from '../i18n-navigation';
-import { safeRedirect } from './post-signin-redirect';
+import { oauthResumeFromSearchParams, safeRedirect } from './post-signin-redirect';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
@@ -60,9 +61,12 @@ export async function getServerSession(): Promise<ServerSession | null> {
 export async function redirectIfAuthenticated(opts: {
   locale: string;
   redirectParam?: string | string[] | null;
+  searchParams?: Record<string, string | string[] | undefined>;
 }): Promise<void> {
   const session = await getServerSession();
   if (!session) return;
+  const resume = opts.searchParams ? oauthResumeFromSearchParams(opts.searchParams) : null;
+  if (resume) externalRedirect(resume);
   const raw = Array.isArray(opts.redirectParam) ? opts.redirectParam[0] : opts.redirectParam;
   redirect({ href: safeRedirect(raw ?? null), locale: opts.locale });
 }

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -109,10 +109,9 @@ export function OAuthConsentPage({ clientInfo }: OAuthConsentPageProps) {
 
   useEffect(() => {
     if (!isPending && !session) {
-      const next = encodeURIComponent(window.location.href);
-      window.location.assign(`/login?next=${next}`);
+      window.location.assign(oauthQuery ? `/login?${oauthQuery}` : '/login');
     }
-  }, [isPending, session]);
+  }, [isPending, session, oauthQuery]);
 
   if (isPending || !session) {
     return <PageSpinner className="min-h-screen bg-background" />;
@@ -174,9 +173,8 @@ export function OAuthConsentPage({ clientInfo }: OAuthConsentPageProps) {
               onSubmit={(accept) => void submit(accept)}
               onSwitchAccount={() => {
                 void (async () => {
-                  const next = encodeURIComponent(window.location.href);
                   await authClient.signOut();
-                  window.location.assign(`/login?next=${next}`);
+                  window.location.assign(oauthQuery ? `/login?${oauthQuery}` : '/login');
                 })();
               }}
             />


### PR DESCRIPTION
## What

Reported while reconnecting the Claude connector: the OAuth flow landed on the Munin dashboard instead of returning to claude.ai. Root cause is the already-authenticated shortcut on the login page:

- better-auth bounces `/auth/oauth2/authorize` to `/login?<oauth-query>` when it wants a login; the client `LoginForm` has resume logic (`resumeOauthAuthorizeUrl`) for after sign-in.
- But `redirectIfAuthenticated` (server component, runs first when a session exists) read only `?redirect=`, ignored the pending OAuth query, and `safeRedirect(null)` defaulted to `/dashboard` — flow dead, user stranded.
- Separately, the consent page's unauthenticated and switch-account bounces sent `/login?next=<absolute url>` — a param the login page never reads, carrying a URL `safeRedirect` would reject anyway.

## Fix

- `redirectIfAuthenticated` accepts the page's `searchParams`; when they carry authorize params (`response_type=code` + `client_id`), it redirects to the resumed authorize URL (new `oauthResumeFromSearchParams` helper) instead of `/dashboard`. Login and signup pages pass their params through.
- The consent page's `/login` bounces now forward the OAuth query itself, so the existing `LoginForm` resume path completes the flow after sign-in (including the switch-account case, which re-enters authorize and re-prompts consent for the new user).

Consent-skip-on-existing-grant behavior is unchanged — that part is standard OAuth and was working; only the login-page detour lost the flow.

## Testing

- New `post-signin-redirect.test.ts`: resume-URL construction from searchParams, null without `response_type`/`client_id`, repeated-param handling, `safeRedirect` open-redirect rejections. 39/39 dashboard-pages tests pass.
- typecheck + lint green for dashboard-pages and web.
- Manually exercised the reconnect flow against the local tunnel rig.

## Cloud follow-up

`web-cloud`'s login/signup pages need the same one-line `searchParams` pass-through on the next `@getmunin` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)