### PR TITLE
fix(inspector): round panel corners to the host clip radius

### DIFF
--- a/.changeset/inspector-host-corner-radius.md
+++ b/.changeset/inspector-host-corner-radius.md
@@ -2,4 +2,4 @@
 '@getmunin/inspector-app': patch
 ---
 
-Adopt the host's corner radius so the panel border follows the iframe clip. MCP App hosts (claude.ai mobile in particular) clip the embed with rounded corners, which sliced the panel's square 1px border off at the corners. The panel now applies the host's style variables and rounds itself with `--border-radius-lg`, falling back to square corners on hosts that don't send style tokens.
+Stop MCP App hosts' rounded iframe clipping from slicing the panel border. The panel applies the host's style variables and rounds itself with `--border-radius-lg` where available; on `platform: 'mobile'` hosts (which draw their own rounded card around the embed) it drops its outer border entirely and lets the host frame it. Hosts that send no style tokens keep the square Munin look.

--- a/.changeset/inspector-host-corner-radius.md
+++ b/.changeset/inspector-host-corner-radius.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/inspector-app': patch
+---
+
+Adopt the host's corner radius so the panel border follows the iframe clip. MCP App hosts (claude.ai mobile in particular) clip the embed with rounded corners, which sliced the panel's square 1px border off at the corners. The panel now applies the host's style variables and rounds itself with `--border-radius-lg`, falling back to square corners on hosts that don't send style tokens.

--- a/packages/inspector-app/src/app.tsx
+++ b/packages/inspector-app/src/app.tsx
@@ -24,6 +24,9 @@ export function InspectorApp() {
       console.log('[Munin Inspector] host context changed:', params);
       if (params.locale) setLocale(resolveLocale(params.locale));
       if (params.styles?.variables) applyHostStyleVariables(params.styles.variables);
+      if (params.platform) {
+        document.body.classList.toggle('host-mobile', params.platform === 'mobile');
+      }
     };
     mcpApp
       .connect()
@@ -33,6 +36,7 @@ export function InspectorApp() {
         console.log('[Munin Inspector] host context:', context);
         if (context?.locale) setLocale(resolveLocale(context.locale));
         if (context?.styles?.variables) applyHostStyleVariables(context.styles.variables);
+        document.body.classList.toggle('host-mobile', context?.platform === 'mobile');
       })
       .catch((err: unknown) => {
         setConnection('failed');

--- a/packages/inspector-app/src/app.tsx
+++ b/packages/inspector-app/src/app.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { App as McpApp } from '@modelcontextprotocol/ext-apps';
+import { App as McpApp, applyHostStyleVariables } from '@modelcontextprotocol/ext-apps';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { isProposalList, parseToolResult } from './types';
 import { Chrome } from './chrome';
@@ -23,6 +23,7 @@ export function InspectorApp() {
     mcpApp.onhostcontextchanged = (params) => {
       console.log('[Munin Inspector] host context changed:', params);
       if (params.locale) setLocale(resolveLocale(params.locale));
+      if (params.styles?.variables) applyHostStyleVariables(params.styles.variables);
     };
     mcpApp
       .connect()
@@ -31,6 +32,7 @@ export function InspectorApp() {
         const context = mcpApp.getHostContext();
         console.log('[Munin Inspector] host context:', context);
         if (context?.locale) setLocale(resolveLocale(context.locale));
+        if (context?.styles?.variables) applyHostStyleVariables(context.styles.variables);
       })
       .catch((err: unknown) => {
         setConnection('failed');

--- a/packages/inspector-app/src/styles.css
+++ b/packages/inspector-app/src/styles.css
@@ -271,6 +271,10 @@ body.host-mobile .panel {
   .row-detail {
     padding-left: 24px;
   }
+
+  .row-age {
+    display: none;
+  }
 }
 
 .draft {

--- a/packages/inspector-app/src/styles.css
+++ b/packages/inspector-app/src/styles.css
@@ -34,6 +34,11 @@ button {
 .panel {
   background: var(--paper);
   border: 1px solid var(--ink);
+  /* Hosts clip the iframe with their own corner radius (claude.ai mobile
+     ~12px), slicing a square border off at the corners. Adopt the host's
+     radius token so the border follows the clip; 0 elsewhere. */
+  border-radius: var(--border-radius-lg, 0);
+  overflow: hidden;
 }
 
 .chrome {

--- a/packages/inspector-app/src/styles.css
+++ b/packages/inspector-app/src/styles.css
@@ -34,11 +34,13 @@ button {
 .panel {
   background: var(--paper);
   border: 1px solid var(--ink);
-  /* Hosts clip the iframe with their own corner radius (claude.ai mobile
-     ~12px), slicing a square border off at the corners. Adopt the host's
-     radius token so the border follows the clip; 0 elsewhere. */
   border-radius: var(--border-radius-lg, 0);
   overflow: hidden;
+}
+
+body.host-mobile .panel {
+  border: none;
+  border-radius: 0;
 }
 
 .chrome {


### PR DESCRIPTION
Hosts clip the MCP App iframe with their own rounded corners — claude.ai mobile visibly slices the panel's square 1px border off at each corner. Mobile hosts draw their own rounded card around the embed; drop the panel's outer border there and let the host frame it. Desktop keeps the ink border and token-based radius. Also hides the age cell on narrow layouts.

Reopened against `main` (original #610 was based on the now-merged `feat/inspector-host-locale` branch, so it never got CI and was auto-closed when that branch was deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)