### PR TITLE
fix(crm): dismiss pending outreach proposals on contact merge

### DIFF
--- a/.changeset/merge-dismiss-outreach-proposals.md
+++ b/.changeset/merge-dismiss-outreach-proposals.md
@@ -1,0 +1,7 @@
+---
+"@getmunin/backend-core": patch
+---
+
+fix(crm): dismiss pending outreach proposals when a contact is merged
+
+Applying a merge proposal archives the duplicate contact with `doNotContact: true` but previously left its pending outreach proposals bound to the now-suppressed tombstone. Approving one of those orphaned proposals then failed at the eligibility gate with `outreach_invalid: contact … is no longer eligible (suppression or consent withdrawn)`. The merge now dismisses the duplicate's pending proposals (with a `contact merged into <keeperId>` reason) and emits `outreach.proposal.dismissed` for each.

--- a/packages/backend-core/src/modules/crm/crm.service.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.test.ts
@@ -51,6 +51,10 @@ const skipReason = TEST_URL
 
   beforeEach(async () => {
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    await db.execute(sql`DELETE FROM outreach_proposals WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM outreach_campaigns WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM conv_channels WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM crm_segments WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM crm_merge_proposals WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM crm_activities WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM crm_deals WHERE org_id = ${orgId}`);
@@ -616,6 +620,82 @@ const skipReason = TEST_URL
           (r.toType === 'contact' && r.toId === dup.id),
       );
       expect(stillOnDup).toHaveLength(0);
+    });
+
+    it('applyMergeProposal dismisses pending outreach proposals bound to the duplicate', async () => {
+      const keeper = await run(() => svc.createContact({ name: 'Keeper', email: 'k@y' }));
+      const dup = await run(() => svc.createContact({ name: 'Dup', email: 'k@y' }));
+      const other = await run(() => svc.createContact({ name: 'Other', email: 'o@y' }));
+
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      const [segment] = await db
+        .insert(schema.crmSegments)
+        .values({
+          orgId,
+          name: `seg-${Date.now()}`,
+          filterDefinition: {},
+          createdByActorType: 'agent',
+          createdByActorId: actor.id,
+        })
+        .returning();
+      const [channel] = await db
+        .insert(schema.convChannels)
+        .values({ orgId, type: 'email', vendor: 'smtp', name: `ch-${Date.now()}` })
+        .returning();
+      const [campaign] = await db
+        .insert(schema.outreachCampaigns)
+        .values({
+          orgId,
+          name: `camp-${Date.now()}`,
+          brief: 'b',
+          segmentId: segment!.id,
+          channelId: channel!.id,
+          createdByActorType: 'agent',
+          createdByActorId: actor.id,
+        })
+        .returning();
+      const proposalRow = {
+        orgId,
+        campaignId: campaign!.id,
+        kind: 'initial',
+        draftBody: 'hi',
+        proposedByActorType: 'agent',
+        proposedByActorId: actor.id,
+      };
+      const [dupProposal] = await db
+        .insert(schema.outreachProposals)
+        .values({ ...proposalRow, contactId: dup.id })
+        .returning();
+      const [otherProposal] = await db
+        .insert(schema.outreachProposals)
+        .values({ ...proposalRow, contactId: other.id })
+        .returning();
+      const [dupSent] = await db
+        .insert(schema.outreachProposals)
+        .values({ ...proposalRow, contactId: dup.id, kind: 'reply', status: 'sent' })
+        .returning();
+
+      const proposal = await run(() =>
+        svc.proposeMerge({
+          contactAId: keeper.id,
+          contactBId: dup.id,
+          confidence: 'high',
+          evidence: {},
+          recommendedKeeperId: keeper.id,
+        }),
+      );
+      await run(() => svc.applyMergeProposal({ id: proposal.id }));
+
+      const rows = await db
+        .select()
+        .from(schema.outreachProposals)
+        .where(eq(schema.outreachProposals.orgId, orgId));
+      const byId = (pid: string) => rows.find((r) => r.id === pid)!;
+      expect(byId(dupProposal!.id).status).toBe('dismissed');
+      expect(byId(dupProposal!.id).dismissReason).toBe(`contact merged into ${keeper.id}`);
+      expect(byId(dupProposal!.id).contactId).toBe(dup.id);
+      expect(byId(otherProposal!.id).status).toBe('pending');
+      expect(byId(dupSent!.id).status).toBe('sent');
     });
 
     it('applyMergeProposal transfers endUserId to keeper when keeper has none and clears duplicate', async () => {

--- a/packages/backend-core/src/modules/crm/crm.service.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.ts
@@ -1200,6 +1200,39 @@ export class CrmService {
         ),
       );
 
+    const dismissReason = `contact merged into ${keeperId}`;
+    const dismissedProposals = await ctx.db
+      .update(schema.outreachProposals)
+      .set({
+        status: 'dismissed',
+        dismissReason,
+        decidedByActorType: actor.type === 'user' ? 'user' : 'agent',
+        decidedByActorId: actor.id,
+        decidedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(schema.outreachProposals.contactId, duplicateId),
+          eq(schema.outreachProposals.status, 'pending'),
+        ),
+      )
+      .returning({
+        id: schema.outreachProposals.id,
+        campaignId: schema.outreachProposals.campaignId,
+      });
+    for (const dismissed of dismissedProposals) {
+      await this.webhooks.emit({
+        type: 'outreach.proposal.dismissed',
+        payload: {
+          proposalId: dismissed.id,
+          campaignId: dismissed.campaignId,
+          contactId: duplicateId,
+          reason: dismissReason,
+        },
+      });
+    }
+
     const archiveTag = `dedup-archived-${archiveMonth(new Date())}`;
     const dupTags = duplicateRow.tags.includes(archiveTag)
       ? duplicateRow.tags


### PR DESCRIPTION
## Problem

Approving an outreach proposal was failing with:

```
outreach_invalid: contact <id> is no longer eligible (suppression or consent withdrawn)
```

This looked like a consent/suppression issue but was actually a gap in the contact-merge path. `CrmService.applyMergeProposal` repoints activities, deals, and relationships from the duplicate to the keeper, then archives the duplicate with `doNotContact: true` + `mergedInto`/`mergedAt` + a `dedup-archived-*` tag — but did **nothing** with the duplicate's pending outreach proposals. Proposals bind to a fixed `contactId`, so they stayed pointed at the now-suppressed tombstone. At approve-time, `OutreachService.approveInitial` re-checks the contact, sees `doNotContact`, and throws.

## Fix

When a merge is applied, the duplicate's **pending** outreach proposals are now dismissed (`status: 'dismissed'`, `dismissReason: "contact merged into <keeperId>"`, decided-by set to the merging actor), and an `outreach.proposal.dismissed` webhook fires for each.

Dismiss rather than repoint-to-keeper is deliberate:
- Repointing could collide with the `(campaignId, contactId, kind)` pending-unique index → poisoned transaction → bare 500 (the failure mode `CLAUDE.md` warns about).
- It matches the intended semantics: the tombstone stays suppressed; reaching the survivor means filing a fresh proposal against it.

Only `pending` proposals are touched — already-`sent`/`dismissed` ones are left alone.

## Testing

- `pnpm -F @getmunin/backend-core typecheck` — clean.
- New test asserts the duplicate's pending proposal flips to `dismissed` with the reason, an unrelated contact's proposal stays `pending`, and a `sent` proposal is untouched. Full CRM suite (50/50) passes against a local Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)