### PR TITLE
fix(security): close widget session leak, gate mcp:admin by role, harden webhook endpoint

### DIFF
--- a/.changeset/widget-session-and-mcp-admin-scope.md
+++ b/.changeset/widget-session-and-mcp-admin-scope.md
@@ -1,0 +1,12 @@
+---
+"@getmunin/core": minor
+"@getmunin/backend-core": minor
+"@getmunin/chat-widget": minor
+---
+
+Security hardening from a follow-up audit.
+
+- **Widget session credential moved out of the URL (BREAKING):** the widget read endpoints (`GET /v1/widget/messages`, `GET /v1/widget/conversations`, `GET /v1/widget/voice/available`) no longer accept the session credential in the query string. `sessionId`, `sessionIds`, `verifiedExternalId`, and `userHash` must now be sent as the `x-munin-session-id`, `x-munin-session-ids`, `x-munin-verified-external-id`, and `x-munin-user-hash` request headers. This keeps the session token — which grants read/write on a visitor's conversation — out of server, proxy, and CDN access logs. The bundled chat widget is updated; any custom integration that called these GET endpoints must move the fields from the query string to headers.
+- **Widget origin allowlist is required by default (BREAKING):** a widget channel with an empty `originAllowlist` now rejects all traffic, and creating one without an allowlist fails, unless `MUNIN_WIDGET_REQUIRE_ALLOWLIST` is explicitly set to `0`/`false`. Previously the allowlist was only enforced when the flag was opted in. Existing widget channels without an allowlist stop accepting requests until their origins are configured (or the flag is disabled). This inverts the default to fail-closed.
+- **OAuth `mcp:admin` scope is gated by org role (BREAKING):** OAuth access tokens (opaque and JWT) issued to users whose org membership role is not `owner` or `admin` no longer carry the `mcp:admin` scope or the admin MCP audience — they resolve to the self-service surface. Previously any member who consented to an `mcp:admin` scope grant reached every admin MCP tool. Admin API keys (`mn_admin_*`) are unaffected.
+- **Channel webhook endpoint hardened:** `POST /v1/conversations/channels/:channelId/webhook` is now rate-limited (per-IP, like the other public endpoints) and returns a uniform `401` for both unknown-channel and signature-verification failures to prevent channel-id enumeration. Note: an unknown channel now returns `401` instead of `404`.

--- a/apps/chat-widget/src/api.test.ts
+++ b/apps/chat-widget/src/api.test.ts
@@ -25,6 +25,10 @@ function mockFetch(
   return { fetchImpl, calls };
 }
 
+function headerOf(call: CapturedCall, name: string): string | undefined {
+  return (call.init.headers as Record<string, string> | undefined)?.[name];
+}
+
 describe('api: postMessage', () => {
   it('POSTs to /v1/widget/messages with channelId, sessionId, end_user role', async () => {
     const { fetchImpl, calls } = mockFetch(() => ({
@@ -168,8 +172,9 @@ describe('api: backfillSince', () => {
     expect(res.messages).toHaveLength(1);
     expect(res.hasMore).toBe(false);
     expect(calls[0]!.url).toContain('channelId=cnv_chan');
-    expect(calls[0]!.url).toContain('sessionId=sess_1');
+    expect(calls[0]!.url).not.toContain('sessionId');
     expect(calls[0]!.url).not.toContain('since=');
+    expect(headerOf(calls[0]!, 'x-munin-session-id')).toBe('sess_1');
     expect(calls[0]!.init.method).toBe('GET');
   });
 
@@ -190,7 +195,7 @@ describe('api: backfillSince', () => {
     expect(calls[0]!.url).toContain('since=2026-05-09T11%3A00%3A00.123Z');
   });
 
-  it('threads identity attrs as query params', async () => {
+  it('threads identity attrs as request headers', async () => {
     const { fetchImpl, calls } = mockFetch(() => ({
       status: 200,
       body: { messages: [], hasMore: false },
@@ -204,8 +209,10 @@ describe('api: backfillSince', () => {
       fetchImpl,
     });
     await client.backfillSince(undefined);
-    expect(calls[0]!.url).toContain('verifiedExternalId=user_42');
-    expect(calls[0]!.url).toContain(`userHash=${'b'.repeat(64)}`);
+    expect(calls[0]!.url).not.toContain('verifiedExternalId');
+    expect(calls[0]!.url).not.toContain('userHash');
+    expect(headerOf(calls[0]!, 'x-munin-verified-external-id')).toBe('user_42');
+    expect(headerOf(calls[0]!, 'x-munin-user-hash')).toBe('b'.repeat(64));
   });
 
   it('throws WidgetApiError on non-2xx response', async () => {

--- a/apps/chat-widget/src/api.ts
+++ b/apps/chat-widget/src/api.ts
@@ -140,6 +140,21 @@ export function createApiClient(deps: ApiClientDeps): ApiClient {
     };
   }
 
+  function sessionGetHeaders(opts?: { sessionIds?: string[] }): Record<string, string> {
+    const headers: Record<string, string> = { Authorization: `Bearer ${deps.widgetKey}` };
+    if (opts?.sessionIds) {
+      if (opts.sessionIds.length > 0) headers['x-munin-session-ids'] = opts.sessionIds.join(',');
+    } else {
+      headers['x-munin-session-id'] = sessionId;
+    }
+    const identity = deps.getIdentity?.();
+    if (identity) {
+      headers['x-munin-verified-external-id'] = identity.externalId;
+      headers['x-munin-user-hash'] = identity.userHash;
+    }
+    return headers;
+  }
+
   function ingestPayload(text: string): Record<string, unknown> {
     const payload: Record<string, unknown> = {
       channelId: deps.channelId,
@@ -174,16 +189,10 @@ export function createApiClient(deps: ApiClientDeps): ApiClient {
     async backfillSince(since) {
       const url = new URL(messagesUrl);
       url.searchParams.set('channelId', deps.channelId);
-      url.searchParams.set('sessionId', sessionId);
       if (since) url.searchParams.set('since', since.toISOString());
-      const identity = deps.getIdentity?.();
-      if (identity) {
-        url.searchParams.set('verifiedExternalId', identity.externalId);
-        url.searchParams.set('userHash', identity.userHash);
-      }
       const res = await fetchImpl(url.toString(), {
         method: 'GET',
-        headers: { Authorization: `Bearer ${deps.widgetKey}` },
+        headers: sessionGetHeaders(),
       });
       if (!res.ok) throw new WidgetApiError(res.status, await safeJson(res));
       return (await res.json()) as BackfillResult;
@@ -192,17 +201,9 @@ export function createApiClient(deps: ApiClientDeps): ApiClient {
     async listConversations(sessionIds) {
       const url = new URL(conversationsUrl);
       url.searchParams.set('channelId', deps.channelId);
-      if (sessionIds.length > 0) {
-        url.searchParams.set('sessionIds', sessionIds.join(','));
-      }
-      const identity = deps.getIdentity?.();
-      if (identity) {
-        url.searchParams.set('verifiedExternalId', identity.externalId);
-        url.searchParams.set('userHash', identity.userHash);
-      }
       const res = await fetchImpl(url.toString(), {
         method: 'GET',
-        headers: { Authorization: `Bearer ${deps.widgetKey}` },
+        headers: sessionGetHeaders({ sessionIds }),
       });
       if (!res.ok) throw new WidgetApiError(res.status, await safeJson(res));
       const body = (await res.json()) as { conversations: ConversationSummary[] };
@@ -255,15 +256,9 @@ export function createApiClient(deps: ApiClientDeps): ApiClient {
       const url = new URL(`${base}/voice/available`);
       url.searchParams.set('channelId', deps.channelId);
       url.searchParams.set('conversationId', conversationId);
-      url.searchParams.set('sessionId', sessionId);
-      const identity = deps.getIdentity?.();
-      if (identity) {
-        url.searchParams.set('verifiedExternalId', identity.externalId);
-        url.searchParams.set('userHash', identity.userHash);
-      }
       const res = await fetchImpl(url.toString(), {
         method: 'GET',
-        headers: { Authorization: `Bearer ${deps.widgetKey}` },
+        headers: sessionGetHeaders(),
       });
       if (!res.ok) throw new WidgetApiError(res.status, await safeJson(res));
       return (await res.json()) as VoiceAvailabilityResult;

--- a/packages/backend-core/src/common/allowlist.ts
+++ b/packages/backend-core/src/common/allowlist.ts
@@ -1,12 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
-
-function requireAllowlistFlag(envVar: string, defaultRequire: boolean): boolean {
-  const raw = process.env[envVar]?.trim().toLowerCase();
-  if (raw === undefined || raw === '') return defaultRequire;
-  if (raw === '1' || raw === 'true') return true;
-  if (raw === '0' || raw === 'false' || raw === 'off' || raw === 'no') return false;
-  return defaultRequire;
-}
+import { parseEnvBool } from '@getmunin/core';
 
 export function assertOriginAllowlistPopulated(input: {
   origins: readonly string[];
@@ -17,7 +10,7 @@ export function assertOriginAllowlistPopulated(input: {
 }): void {
   if (
     input.origins.length === 0 &&
-    requireAllowlistFlag(input.envVar, input.defaultRequire ?? false)
+    parseEnvBool({ name: input.envVar, default: input.defaultRequire ?? false })
   ) {
     throw new BadRequestException(
       `${input.errorCode}: this deployment requires at least one entry in \`${input.field}\` (full origin like \`https://app.example.com\`). Add the production and any preview origins before saving.`,

--- a/packages/backend-core/src/common/allowlist.ts
+++ b/packages/backend-core/src/common/allowlist.ts
@@ -1,8 +1,11 @@
 import { BadRequestException } from '@nestjs/common';
 
-function requireAllowlistFlag(envVar: string): boolean {
+function requireAllowlistFlag(envVar: string, defaultRequire: boolean): boolean {
   const raw = process.env[envVar]?.trim().toLowerCase();
-  return raw === '1' || raw === 'true';
+  if (raw === undefined || raw === '') return defaultRequire;
+  if (raw === '1' || raw === 'true') return true;
+  if (raw === '0' || raw === 'false' || raw === 'off' || raw === 'no') return false;
+  return defaultRequire;
 }
 
 export function assertOriginAllowlistPopulated(input: {
@@ -10,8 +13,12 @@ export function assertOriginAllowlistPopulated(input: {
   envVar: string;
   errorCode: string;
   field: string;
+  defaultRequire?: boolean;
 }): void {
-  if (input.origins.length === 0 && requireAllowlistFlag(input.envVar)) {
+  if (
+    input.origins.length === 0 &&
+    requireAllowlistFlag(input.envVar, input.defaultRequire ?? false)
+  ) {
     throw new BadRequestException(
       `${input.errorCode}: this deployment requires at least one entry in \`${input.field}\` (full origin like \`https://app.example.com\`). Add the production and any preview origins before saving.`,
     );

--- a/packages/backend-core/src/control/analytics-tracker.controller.ts
+++ b/packages/backend-core/src/control/analytics-tracker.controller.ts
@@ -20,6 +20,7 @@ import {
   isWellFormedKey,
   keyPrefix,
   looksLikeBot,
+  parseEnvBool,
   verifyHmac,
 } from '@getmunin/core';
 import { PublicController } from '../common/auth/auth.guard.ts';
@@ -317,8 +318,7 @@ export function originIsAllowed(
 }
 
 function requireTrackerAllowlist(): boolean {
-  const raw = process.env.MUNIN_TRACKER_REQUIRE_ALLOWLIST?.trim().toLowerCase();
-  return raw === '1' || raw === 'true';
+  return parseEnvBool({ name: 'MUNIN_TRACKER_REQUIRE_ALLOWLIST', default: false });
 }
 
 function sendPixel(res: Response): void {

--- a/packages/backend-core/src/modules/conv/channels/channel-webhook.controller.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-webhook.controller.ts
@@ -24,7 +24,7 @@ import {
 } from './adapter.ts';
 import { ChannelIngestService } from './channel-ingest.service.ts';
 
-@PublicController('v1/conversations/channels')
+@PublicController('v1/conversations/channels', { throttle: true })
 export class ChannelWebhookController {
   private readonly logger = new Logger(ChannelWebhookController.name);
   private readonly registry: ChannelAdapterRegistry;
@@ -45,14 +45,14 @@ export class ChannelWebhookController {
   ): Promise<void> {
     const channel = await this.loadChannel(channelId);
     if (!channel) {
-      throw new HttpException('channel not found', HttpStatus.NOT_FOUND);
+      throw new HttpException('webhook verification failed', HttpStatus.UNAUTHORIZED);
     }
     const adapter = this.registry.get(channel.type, channel.vendor);
     if (!adapter || adapter.inbound?.mode !== 'webhook') {
-      throw new HttpException(
-        `channel '${channel.type}:${channel.vendor}' is not webhook-mode`,
-        HttpStatus.BAD_REQUEST,
+      this.logger.warn(
+        `webhook rejected: channel=${channel.id} (${channel.type}:${channel.vendor}) is not webhook-mode`,
       );
+      throw new HttpException('webhook verification failed', HttpStatus.UNAUTHORIZED);
     }
 
     const incoming: IncomingWebhookRequest = {

--- a/packages/backend-core/src/modules/conv/widget/widget-allowlist.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-allowlist.test.ts
@@ -12,8 +12,15 @@ describe('enforceOriginAllowlist', () => {
     else process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST = original;
   });
 
-  it('allows any origin when the allowlist is empty (dev default)', () => {
+  it('rejects all origins when the allowlist is empty (secure default)', () => {
     delete process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST;
+    expect(() =>
+      enforceOriginAllowlist({ originAllowlist: [] }, 'https://attacker.example'),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('allows an empty allowlist only when require-allowlist is explicitly disabled', () => {
+    process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST = '0';
     expect(() =>
       enforceOriginAllowlist({ originAllowlist: [] }, 'https://attacker.example'),
     ).not.toThrow();

--- a/packages/backend-core/src/modules/conv/widget/widget-channel-admin.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-channel-admin.service.ts
@@ -51,6 +51,7 @@ function assertAllowlistPopulated(originAllowlist: readonly string[]): void {
     envVar: 'MUNIN_WIDGET_REQUIRE_ALLOWLIST',
     errorCode: 'origin_allowlist_required',
     field: 'originAllowlist',
+    defaultRequire: true,
   });
 }
 

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { schema, type Tx } from '@getmunin/db';
 import { and, asc, desc, eq, gte, inArray, sql } from 'drizzle-orm';
-import { WebhookDispatcher, getCurrentContext, verifyHmac } from '@getmunin/core';
+import { WebhookDispatcher, getCurrentContext, parseEnvBool, verifyHmac } from '@getmunin/core';
 import { linkVisitorToEndUser } from '../../analytics/visitor-identity.ts';
 import { CuratorJobsService } from '../../curator/curator-jobs.service.ts';
 import { buildSetTopicAndTitleJob } from '../set-topic-job.ts';
@@ -1108,9 +1108,7 @@ export function enforceOriginAllowlist(
 }
 
 export function requireWidgetAllowlist(): boolean {
-  const raw = process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST?.trim().toLowerCase();
-  if (raw === undefined || raw === '') return true;
-  return !(raw === '0' || raw === 'false' || raw === 'off' || raw === 'no');
+  return parseEnvBool({ name: 'MUNIN_WIDGET_REQUIRE_ALLOWLIST', default: true });
 }
 
 export async function loadWidgetChannel(

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -1107,9 +1107,10 @@ export function enforceOriginAllowlist(
   if (!allowed) throw new ForbiddenException('origin_not_allowed');
 }
 
-function requireWidgetAllowlist(): boolean {
+export function requireWidgetAllowlist(): boolean {
   const raw = process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST?.trim().toLowerCase();
-  return raw === '1' || raw === 'true';
+  if (raw === undefined || raw === '') return true;
+  return !(raw === '0' || raw === 'false' || raw === 'off' || raw === 'no');
 }
 
 export async function loadWidgetChannel(

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
@@ -172,8 +172,18 @@ const skipReason = TEST_URL
     token: string = widgetKey,
   ): Promise<{ status: number; json: unknown }> {
     const url = new URL(`${baseUrl}/v1/widget/voice/available`);
-    for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
-    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+    const sessionHeaderMap: Record<string, string> = {
+      sessionId: 'x-munin-session-id',
+      verifiedExternalId: 'x-munin-verified-external-id',
+      userHash: 'x-munin-user-hash',
+    };
+    for (const [k, v] of Object.entries(query)) {
+      const header = sessionHeaderMap[k];
+      if (header) headers[header] = v;
+      else url.searchParams.set(k, v);
+    }
+    const res = await fetch(url, { headers });
     const text = await res.text();
     let json: unknown = null;
     try {

--- a/packages/backend-core/src/modules/conv/widget/widget.controller.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.controller.ts
@@ -44,6 +44,31 @@ import type {
 import { WidgetIngestService } from './widget-ingest.service.ts';
 import { WidgetVoiceService } from './widget-voice.service.ts';
 
+const WIDGET_SESSION_HEADER_MAP: Record<string, string> = {
+  'x-munin-session-id': 'sessionId',
+  'x-munin-session-ids': 'sessionIds',
+  'x-munin-verified-external-id': 'verifiedExternalId',
+  'x-munin-user-hash': 'userHash',
+};
+
+const WIDGET_SESSION_FIELDS = new Set(Object.values(WIDGET_SESSION_HEADER_MAP));
+
+function widgetQueryWithSessionHeaders(
+  rawQuery: Record<string, string>,
+  headers: Record<string, string | string[] | undefined>,
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rawQuery)) {
+    if (!WIDGET_SESSION_FIELDS.has(key)) merged[key] = value;
+  }
+  for (const [header, field] of Object.entries(WIDGET_SESSION_HEADER_MAP)) {
+    const value = headers[header];
+    const resolved = Array.isArray(value) ? value[0] : value;
+    if (resolved !== undefined) merged[field] = resolved;
+  }
+  return merged;
+}
+
 @Controller('v1/widget')
 @UseGuards(AuthGuard, WidgetThrottlerGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
@@ -88,6 +113,7 @@ export class WidgetController {
   @Get('messages')
   async list(
     @Query() rawQuery: Record<string, string>,
+    @Headers() headers: Record<string, string | string[] | undefined>,
     @Headers('origin') origin: string | undefined,
   ): Promise<WidgetListMessagesResult> {
     const ctx = getCurrentContext();
@@ -104,7 +130,9 @@ export class WidgetController {
       throw new ForbiddenException('widget_key_required');
     }
 
-    const parsed = WidgetListMessagesQuery.safeParse(rawQuery);
+    const parsed = WidgetListMessagesQuery.safeParse(
+      widgetQueryWithSessionHeaders(rawQuery, headers),
+    );
     if (!parsed.success) {
       throw new ForbiddenException(`invalid_widget_query: ${parsed.error.message}`);
     }
@@ -120,6 +148,7 @@ export class WidgetController {
   @Get('conversations')
   async listConversations(
     @Query() rawQuery: Record<string, string>,
+    @Headers() headers: Record<string, string | string[] | undefined>,
     @Headers('origin') origin: string | undefined,
   ): Promise<WidgetListConversationsResult> {
     const ctx = getCurrentContext();
@@ -136,7 +165,9 @@ export class WidgetController {
       throw new ForbiddenException('widget_key_required');
     }
 
-    const parsed = WidgetListConversationsQuery.safeParse(rawQuery);
+    const parsed = WidgetListConversationsQuery.safeParse(
+      widgetQueryWithSessionHeaders(rawQuery, headers),
+    );
     if (!parsed.success) {
       throw new ForbiddenException(`invalid_widget_query: ${parsed.error.message}`);
     }
@@ -248,6 +279,7 @@ export class WidgetController {
   @Get('voice/available')
   async voiceAvailable(
     @Query() rawQuery: Record<string, string>,
+    @Headers() headers: Record<string, string | string[] | undefined>,
     @Headers('origin') origin: string | undefined,
   ): Promise<WidgetVoiceAvailabilityResult> {
     const ctx = getCurrentContext();
@@ -264,7 +296,9 @@ export class WidgetController {
       throw new ForbiddenException('widget_key_required');
     }
 
-    const parsed = WidgetVoiceAvailableQuery.safeParse(rawQuery);
+    const parsed = WidgetVoiceAvailableQuery.safeParse(
+      widgetQueryWithSessionHeaders(rawQuery, headers),
+    );
     if (!parsed.success) {
       throw new ForbiddenException(`invalid_widget_voice_available: ${parsed.error.message}`);
     }

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -147,7 +147,25 @@ const skipReason = TEST_URL
     };
     if (headers.Origin === '') delete headers.Origin;
     if (token) headers.Authorization = `Bearer ${token}`;
-    const res = await fetch(`${baseUrl}${path}`, {
+    let finalPath = path;
+    if (method === 'GET') {
+      const url = new URL(path, baseUrl);
+      const sessionHeaderMap: Record<string, string> = {
+        sessionId: 'x-munin-session-id',
+        sessionIds: 'x-munin-session-ids',
+        verifiedExternalId: 'x-munin-verified-external-id',
+        userHash: 'x-munin-user-hash',
+      };
+      for (const [param, header] of Object.entries(sessionHeaderMap)) {
+        const value = url.searchParams.get(param);
+        if (value !== null && headers[header] === undefined) {
+          headers[header] = value;
+          url.searchParams.delete(param);
+        }
+      }
+      finalPath = url.pathname + url.search;
+    }
+    const res = await fetch(`${baseUrl}${finalPath}`, {
       method,
       headers,
       body: body === undefined ? undefined : JSON.stringify(body),
@@ -1044,6 +1062,41 @@ const skipReason = TEST_URL
     const bodyA = resA.json as { messages: Array<{ body: string }> };
     expect(bodyA.messages.map((m) => m.body)).not.toContain('b-only');
     expect(bodyA.messages.map((m) => m.body)).toContain('a-only');
+  });
+
+  it('does not accept a sessionId supplied only in the query string', async () => {
+    const sessionId = 'vis_query_only';
+    await call('POST', '/v1/widget/messages', widgetKey, {
+      channelId,
+      sessionId,
+      messages: [{ role: 'end_user', body: 'query-only-secret' }],
+    });
+
+    const queryOnly = await fetch(
+      `${baseUrl}/v1/widget/messages?${qs({ channelId, sessionId })}`,
+      {
+        method: 'GET',
+        headers: {
+          Origin: 'https://customer.example',
+          Authorization: `Bearer ${widgetKey}`,
+        },
+      },
+    );
+    const queryOnlyText = await queryOnly.text();
+    expect(queryOnly.status).toBe(403);
+    expect(queryOnlyText).not.toContain('query-only-secret');
+
+    const viaHeader = await fetch(`${baseUrl}/v1/widget/messages?${qs({ channelId })}`, {
+      method: 'GET',
+      headers: {
+        Origin: 'https://customer.example',
+        Authorization: `Bearer ${widgetKey}`,
+        'x-munin-session-id': sessionId,
+      },
+    });
+    expect(viaHeader.status).toBe(200);
+    const body = (await viaHeader.json()) as { messages: Array<{ body: string }> };
+    expect(body.messages.map((m) => m.body)).toContain('query-only-secret');
   });
 
   it('returns empty when GET is verified but the contact is bound to a different externalId', async () => {

--- a/packages/backend-core/test-env.ts
+++ b/packages/backend-core/test-env.ts
@@ -21,3 +21,4 @@ if (root) {
 }
 
 process.env.MUNIN_MCP_BURST_PER_MIN ??= '0';
+process.env.MUNIN_WIDGET_REQUIRE_ALLOWLIST ??= '0';

--- a/packages/core/src/env/parse.test.ts
+++ b/packages/core/src/env/parse.test.ts
@@ -72,6 +72,11 @@ describe('parseEnvBool', () => {
     ['false', false],
     ['TRUE', true],
     ['False', false],
+    ['yes', true],
+    ['no', false],
+    ['on', true],
+    ['off', false],
+    ['  On  ', true],
   ])('parses %j as %s', (raw, expected) => {
     process.env[ENV_KEY] = raw;
     expect(parseEnvBool({ name: ENV_KEY, default: !expected })).toBe(expected);
@@ -83,8 +88,9 @@ describe('parseEnvBool', () => {
   });
 
   it('returns default on unrecognized value', () => {
-    process.env[ENV_KEY] = 'yes';
+    process.env[ENV_KEY] = 'maybe';
     expect(parseEnvBool({ name: ENV_KEY, default: false })).toBe(false);
+    expect(parseEnvBool({ name: ENV_KEY, default: true })).toBe(true);
   });
 });
 

--- a/packages/core/src/env/parse.ts
+++ b/packages/core/src/env/parse.ts
@@ -37,12 +37,15 @@ export type ParseEnvBoolOptions = {
   default: boolean;
 };
 
+const TRUE_TOKENS: ReadonlySet<string> = new Set(['1', 'true', 'yes', 'on']);
+const FALSE_TOKENS: ReadonlySet<string> = new Set(['0', 'false', 'no', 'off']);
+
 export function parseEnvBool(opts: ParseEnvBoolOptions): boolean {
   const raw = process.env[opts.name];
   if (raw === undefined) return opts.default;
   const lower = raw.trim().toLowerCase();
-  if (lower === '1' || lower === 'true') return true;
-  if (lower === '0' || lower === 'false') return false;
+  if (TRUE_TOKENS.has(lower)) return true;
+  if (FALSE_TOKENS.has(lower)) return false;
   return opts.default;
 }
 

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -106,8 +106,7 @@ export class CredentialResolver {
     const active = resolvePinnedMembership(memberships, tokenRow.referenceId);
     if (!active) return null;
 
-    const scopes = tokenRow.scopes;
-    const audiences = deriveAudiencesFromScopes(scopes);
+    const { scopes, audiences } = gateOauthGrantsByRole(tokenRow.scopes, active.role);
 
     const actor = new ActorIdentity(
       'user',
@@ -232,4 +231,17 @@ export function deriveAudiencesFromScopes(scopes: string[]): Audience[] {
     if (scope === 'mcp:admin') set.add('admin');
   }
   return Array.from(set);
+}
+
+const MCP_ADMIN_ELIGIBLE_ROLES: ReadonlySet<string> = new Set(['owner', 'admin']);
+
+export function gateOauthGrantsByRole(
+  scopes: readonly string[],
+  role: string | null | undefined,
+): { scopes: string[]; audiences: Audience[] } {
+  const roleAllowsAdmin = !!role && MCP_ADMIN_ELIGIBLE_ROLES.has(role);
+  const effectiveScopes = roleAllowsAdmin
+    ? [...scopes]
+    : scopes.filter((scope) => scope !== 'mcp:admin');
+  return { scopes: effectiveScopes, audiences: deriveAudiencesFromScopes(effectiveScopes) };
 }

--- a/packages/core/src/request/derive-audiences.test.ts
+++ b/packages/core/src/request/derive-audiences.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveAudiencesFromScopes } from './credentials.ts';
+import { deriveAudiencesFromScopes, gateOauthGrantsByRole } from './credentials.ts';
 
 describe('deriveAudiencesFromScopes', () => {
   it('grants admin only when mcp:admin is present', () => {
@@ -20,5 +20,34 @@ describe('deriveAudiencesFromScopes', () => {
 
   it('returns an empty list for an empty scope set', () => {
     expect(deriveAudiencesFromScopes([])).toEqual([]);
+  });
+});
+
+describe('gateOauthGrantsByRole', () => {
+  it('grants the admin audience to owners and admins', () => {
+    for (const role of ['owner', 'admin']) {
+      const granted = gateOauthGrantsByRole(['mcp:admin', 'kb:read'], role);
+      expect(granted.scopes).toEqual(['mcp:admin', 'kb:read']);
+      expect(granted.audiences).toEqual(['admin']);
+    }
+  });
+
+  it('strips mcp:admin and the admin audience for members', () => {
+    const granted = gateOauthGrantsByRole(['mcp:admin', 'kb:read'], 'member');
+    expect(granted.scopes).toEqual(['kb:read']);
+    expect(granted.audiences).toEqual([]);
+  });
+
+  it('strips mcp:admin for an unknown or missing role', () => {
+    expect(gateOauthGrantsByRole(['mcp:admin'], null).scopes).toEqual([]);
+    expect(gateOauthGrantsByRole(['mcp:admin'], undefined).audiences).toEqual([]);
+    expect(gateOauthGrantsByRole(['mcp:admin'], 'viewer').audiences).toEqual([]);
+  });
+
+  it('leaves non-admin scopes untouched regardless of role', () => {
+    expect(gateOauthGrantsByRole(['kb:read', 'crm:write'], 'member').scopes).toEqual([
+      'kb:read',
+      'crm:write',
+    ]);
   });
 });

--- a/packages/core/src/request/oauth-jwt.ts
+++ b/packages/core/src/request/oauth-jwt.ts
@@ -4,7 +4,7 @@ import { eq } from 'drizzle-orm';
 import { decodeProtectedHeader, importJWK, jwtVerify, type JWTPayload } from 'jose';
 import { ActorIdentity } from './context.ts';
 import {
-  deriveAudiencesFromScopes,
+  gateOauthGrantsByRole,
   oauthMcpResourceAudience,
   readMembershipsForUser,
   resolvePinnedMembership,
@@ -96,13 +96,13 @@ export async function resolveOauthJwtAccessToken(
   );
   if (!active) return null;
 
-  const audiences = deriveAudiencesFromScopes(scopes);
+  const { scopes: grantedScopes, audiences } = gateOauthGrantsByRole(scopes, active.role);
 
   const actor = new ActorIdentity(
     'user',
     userId,
     active.orgId,
-    scopes,
+    grantedScopes,
     audiences,
     undefined,
     undefined,


### PR DESCRIPTION
## Summary

Fixes the high- and medium-severity findings from a security review of the auth, tenancy, and untrusted-ingress surfaces. Four fixes, three of which carry a behavioral **breaking change** (all flagged in the changeset).

### 1. Widget session credential moved out of the URL query string (HIGH)
The anonymous widget session token is a bearer credential for a visitor's conversation (read transcript, post as the visitor, overwrite contact email). The read endpoints passed it as a **GET query parameter**, so it leaked into server, proxy, and CDN access logs.

`GET /v1/widget/messages`, `GET /v1/widget/conversations`, and `GET /v1/widget/voice/available` now read `sessionId` / `sessionIds` / `verifiedExternalId` / `userHash` from `x-munin-*` **headers** and no longer honor them in the query string. The bundled `@getmunin/chat-widget` is updated to match.

### 2. OAuth `mcp:admin` gated by org role (MEDIUM–HIGH)
The admin MCP audience was derived purely from token scopes, so any signed-in **member** who consented to an `mcp:admin` grant reached every admin tool. OAuth tokens (opaque + JWT) now only receive `mcp:admin` and the admin audience when the user's org role is `owner`/`admin`; everyone else resolves to self-service. Admin API keys are unaffected.

### 3. Widget origin allowlist required by default (MEDIUM)
An empty `originAllowlist` accepted any origin unless a flag was opted in. The default is now fail-closed; opt out with `MUNIN_WIDGET_REQUIRE_ALLOWLIST=0`.

### 4. Channel webhook endpoint hardened (MEDIUM)
`POST /v1/conversations/channels/:channelId/webhook` is now rate-limited (per-IP, like the other public endpoints) and returns a uniform `401` for unknown-channel and bad-signature to prevent channel-id enumeration.

## Breaking changes
See the changeset. In short: custom widget integrations must send session fields as headers; widget channels now need an origin allowlist (or the opt-out flag); OAuth members lose the admin MCP surface; the webhook endpoint returns `401` (not `404`) for unknown channels.

## Testing
- New/updated unit tests: `gateOauthGrantsByRole` role gating, widget origin allowlist secure default, widget client header transport.
- New integration test: a `sessionId` supplied only in the query string is not accepted; the header path is.
- Ran the affected integration suites against a local Postgres — widget, widget-voice, realtime widget/end-user, all four channel-webhook adapters (vapi/threll/twilio/messagebird), audience/delegated-token, and more: all green. (Four pre-existing `oauth-jwt-resolver` failures in the local env are unrelated — confirmed present on `main`.)
- `typecheck` + `lint` clean on `@getmunin/core`, `@getmunin/backend-core`, `@getmunin/chat-widget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)