### PR TITLE
fix(widget): claim anonymous session on boot for identity carry-over

### DIFF
--- a/.changeset/widget-identify-on-boot.md
+++ b/.changeset/widget-identify-on-boot.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/chat-widget': patch
+---
+
+Fix anonymous→identified chat carry-over: the widget now claims a pre-existing anonymous session on boot when configured with a verified identity (`data-external-id` + `data-user-hash`). Previously it set the in-memory identity for reads but never called `identify`, so the backend's leak-protection returned empty history for the still-anonymous session — a conversation started anonymously (e.g. on a marketing site) was invisible after logging in until the visitor sent a new message. The claim now runs once on connect, before history is loaded.

--- a/apps/chat-widget/src/widget.test.ts
+++ b/apps/chat-widget/src/widget.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { WidgetConfig } from './config.ts';
+
+const h = vi.hoisted(() => {
+  const listeners: { state?: (s: string) => void } = {};
+  return {
+    listeners,
+    identify: vi.fn(() => Promise.resolve({ endUserId: 'eu_1', contactId: 'ctc_1' })),
+    backfillSince: vi.fn(() =>
+      Promise.resolve({ messages: [], hasMore: false, conversation: null }),
+    ),
+    listConversations: vi.fn(() => Promise.resolve([])),
+  };
+});
+
+vi.mock('./session.ts', () => ({
+  getSessionId: () => 'sess_1',
+  getVisitorId: () => 'vis_1',
+  getRecentSessionIds: () => ['sess_1'],
+  mintNewSession: () => 'sess_2',
+  setCurrentSession: () => {},
+}));
+
+vi.mock('./api.ts', () => ({
+  WidgetApiError: class extends Error {
+    constructor(public status: number) {
+      super(`status ${status}`);
+    }
+  },
+  createApiClient: () => ({
+    postMessage: vi.fn(),
+    backfillSince: h.backfillSince,
+    listConversations: h.listConversations,
+    setVisitorEmail: vi.fn(),
+    startConversation: vi.fn(),
+    voiceAvailable: vi.fn(),
+    voiceStart: vi.fn(),
+    voiceEvent: vi.fn(),
+    identify: h.identify,
+    setSessionId: vi.fn(),
+  }),
+}));
+
+vi.mock('./realtime.ts', () => ({
+  createRealtimeClient: () => ({
+    connect: vi.fn(),
+    close: vi.fn(),
+    reconnect: vi.fn(),
+    state: () => 'connected',
+    sendTyping: vi.fn(),
+    sendRead: vi.fn(),
+    setSessionId: vi.fn(),
+    onEvent: () => () => {},
+    onTyping: () => () => {},
+    onState: (l: (s: string) => void) => {
+      h.listeners.state = l;
+      return () => {};
+    },
+  }),
+}));
+
+vi.mock('./ui.ts', () => ({
+  mount: () => new Proxy({}, { get: () => vi.fn() }),
+}));
+
+vi.mock('@getmunin/widget-voice', () => ({
+  createVoiceSession: vi.fn(),
+}));
+
+const { start } = await import('./widget.ts');
+
+const baseConfig: WidgetConfig = {
+  host: 'https://munin.example',
+  widgetKey: 'mn_widget_abc',
+  channelId: 'cch_chan',
+  themeColor: '#10b981',
+  position: 'bottom-right',
+  greeting: null,
+  title: null,
+  eyebrow: null,
+  locale: null,
+  size: 'standard',
+  fonts: 'system',
+  showHistory: true,
+};
+
+const HASH = 'a'.repeat(64);
+
+describe('widget identity carry-over', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.listeners.state = undefined;
+    document.body.innerHTML = '';
+  });
+
+  it('claims the configured identity on connect, before loading history', async () => {
+    start({ ...baseConfig, externalId: 'user_42', userHash: HASH });
+    expect(h.listeners.state).toBeTypeOf('function');
+
+    h.listeners.state!('connected');
+
+    await vi.waitFor(() => expect(h.identify).toHaveBeenCalledTimes(1));
+    expect(h.identify).toHaveBeenCalledWith('user_42', HASH);
+
+    await vi.waitFor(() => expect(h.listConversations).toHaveBeenCalled());
+    expect(h.identify.mock.invocationCallOrder[0]!).toBeLessThan(
+      h.listConversations.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('does not call identify for an anonymous visitor', async () => {
+    start({ ...baseConfig });
+
+    h.listeners.state!('connected');
+    await vi.waitFor(() => expect(h.listConversations).toHaveBeenCalled());
+
+    expect(h.identify).not.toHaveBeenCalled();
+  });
+
+  it('claims only once across reconnects', async () => {
+    start({ ...baseConfig, externalId: 'user_42', userHash: HASH });
+
+    h.listeners.state!('connected');
+    await vi.waitFor(() => expect(h.identify).toHaveBeenCalledTimes(1));
+
+    h.listeners.state!('connected');
+    await vi.waitFor(() => expect(h.listConversations).toHaveBeenCalledTimes(2));
+
+    expect(h.identify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/chat-widget/src/widget.ts
+++ b/apps/chat-widget/src/widget.ts
@@ -38,7 +38,7 @@ function bootstrap(): void {
   }
 }
 
-function start(config: WidgetConfig): void {
+export function start(config: WidgetConfig): void {
   let sessionId = getSessionId(config.channelId, config.cookieDomain);
   const visitorId = getVisitorId(config.channelId, config.cookieDomain);
   let identity: { externalId: string; userHash: string } | undefined =
@@ -46,6 +46,7 @@ function start(config: WidgetConfig): void {
       ? { externalId: config.externalId, userHash: config.userHash }
       : undefined;
   const getIdentity = (): { externalId: string; userHash: string } | undefined => identity;
+  let identityClaimed = false;
   const api = createApiClient({
     host: config.host,
     widgetKey: config.widgetKey,
@@ -72,9 +73,20 @@ function start(config: WidgetConfig): void {
     try {
       await api.identify(externalId, userHash);
       identity = { externalId, userHash };
+      identityClaimed = true;
       realtime.reconnect();
     } catch (err) {
       console.warn('[munin-widget] identify failed:', err);
+    }
+  }
+
+  async function claimConfiguredIdentity(): Promise<void> {
+    if (identityClaimed || !identity) return;
+    identityClaimed = true;
+    try {
+      await api.identify(identity.externalId, identity.userHash);
+    } catch (err) {
+      console.warn('[munin-widget] identify on boot failed:', err);
     }
   }
 
@@ -426,8 +438,11 @@ function start(config: WidgetConfig): void {
   realtime.onState((state) => {
     ui.setConnectionState(state);
     if (state === 'connected') {
-      void backfill();
-      void refreshPastConversations();
+      void (async () => {
+        await claimConfiguredIdentity();
+        void backfill();
+        void refreshPastConversations();
+      })();
     }
   });
 

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -781,6 +781,59 @@ const skipReason = TEST_URL
     expect((followup.json as { contactId: string }).contactId).toBe(anonBody.contactId);
   });
 
+  it('verified GET surfaces an anonymous session only after identify claims it', async () => {
+    const sessionId = `vis_carryover_${Date.now()}`;
+    const externalId = 'user_carryover_7';
+    const userHash = signHmac(externalId, identityVerificationSecret);
+
+    await call('POST', '/v1/widget/messages', widgetKey, {
+      channelId,
+      sessionId,
+      messages: [{ role: 'end_user', body: 'started on marketing' }],
+    });
+
+    // Before identify the anonymous conversation is invisible to a verified
+    // caller (leak-protection) — this is exactly what breaks carry-over.
+    const before = await call(
+      'GET',
+      `/v1/widget/messages?${qs({ channelId, sessionId, verifiedExternalId: externalId, userHash })}`,
+      widgetKey,
+    );
+    expect(before.status).toBe(200);
+    expect((before.json as { messages: unknown[] }).messages).toEqual([]);
+
+    await call('POST', '/v1/widget/identify', widgetKey, {
+      channelId,
+      sessionId,
+      verifiedExternalId: externalId,
+      userHash,
+    });
+
+    // After identify the same verified caller sees the anonymous thread —
+    // the marketing chat carries into the logged-in dashboard.
+    const after = await call(
+      'GET',
+      `/v1/widget/messages?${qs({ channelId, sessionId, verifiedExternalId: externalId, userHash })}`,
+      widgetKey,
+    );
+    expect(after.status).toBe(200);
+    expect((after.json as { messages: Array<{ body: string }> }).messages.map((m) => m.body)).toContain(
+      'started on marketing',
+    );
+
+    const convs = await call(
+      'GET',
+      `/v1/widget/conversations?${qs({ channelId, sessionIds: sessionId, verifiedExternalId: externalId, userHash })}`,
+      widgetKey,
+    );
+    expect(convs.status).toBe(200);
+    expect(
+      (convs.json as { conversations: Array<{ sessionId: string }> }).conversations.map(
+        (c) => c.sessionId,
+      ),
+    ).toContain(sessionId);
+  });
+
   it('identify is idempotent: re-claiming the same session returns the same refs', async () => {
     const sessionId = 'vis_claim_idem';
     const externalId = 'user_idem_99';


### PR DESCRIPTION
## Problem

A chat started anonymously (e.g. on the marketing site) does not carry into the logged-in dashboard — the visitor sees an empty widget after signing in, until they send a new message.

## Root cause

On boot the widget reads `data-external-id` / `data-user-hash` and sets the in-memory `identity` (so reads send verified headers), but it **never calls `identify`** — that's only wired to the manual `window.mn.identify()`. Meanwhile the backend read paths (`widget-ingest.service.ts` `listMessages` / `listConversations`) apply leak-protection: a *verified* caller gets empty unless the session's contact `externalId` matches. An unclaimed anonymous session has none, so history reads back empty. The claim (`claimAnonymousIdentityInTx`) only runs on `startConversation` / `ingest` / `identify` — i.e. after the visitor sends a message.

## Fix

`apps/chat-widget/src/widget.ts`: when the widget is configured with an identity, claim the (possibly carried) anonymous session once on connect, **before** `backfill()` / `refreshPastConversations()`. `identify` already migrates the anonymous contact/conversation to the verified end-user, after which the leak-protected reads return the thread.

No cloud change needed — the dashboard already emits the identity attributes.

## Tests

- `apps/chat-widget/src/widget.test.ts` (new): identify is called on connect (before history load) when an identity is configured; not called for anonymous visitors; claimed only once across reconnects.
- `widget.integration.test.ts`: a verified GET surfaces an anonymous session's conversation only after `identify` claims it (empty before, present after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)