### PR TITLE
fix(widget): migrate read-state when claiming an anonymous session

### DIFF
--- a/.changeset/widget-read-state-carryover.md
+++ b/.changeset/widget-read-state-carryover.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Fix chat-widget read-state loss on identity claim: when an anonymous session is claimed by a verified visitor (`identify`), the anonymous end-user's `conv_message_reads` rows are now migrated to the verified end-user before the anonymous end-user is deleted. Previously the read receipts were cascade-deleted with the anonymous end-user, so already-read agent replies resurfaced as unread (phantom unread badge) after logging in.

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -1024,6 +1024,27 @@ export class WidgetIngestService {
       );
 
     if (sessionContact.endUserId && sessionContact.endUserId !== verifiedEndUserId) {
+      // Read receipts were recorded against the anonymous end-user. Move them
+      // to the verified one so the claimed conversation keeps its read-state —
+      // otherwise every already-read agent message resurfaces as unread after
+      // login. Skip messages the verified user has already read to respect the
+      // (message_id, end_user_id) unique index; those stale anon rows fall away
+      // with the cascade delete below.
+      await tx
+        .update(schema.convMessageReads)
+        .set({ endUserId: verifiedEndUserId })
+        .where(
+          and(
+            eq(schema.convMessageReads.orgId, orgId),
+            eq(schema.convMessageReads.endUserId, sessionContact.endUserId),
+            sql`${schema.convMessageReads.messageId} NOT IN (
+              SELECT ${schema.convMessageReads.messageId}
+              FROM ${schema.convMessageReads}
+              WHERE ${schema.convMessageReads.endUserId} = ${verifiedEndUserId}
+            )`,
+          ),
+        );
+
       await tx
         .delete(schema.endUsers)
         .where(

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -834,6 +834,55 @@ const skipReason = TEST_URL
     ).toContain(sessionId);
   });
 
+  it('carries read-state from the anonymous session to the verified caller on identify', async () => {
+    const sessionId = `vis_read_carryover_${Date.now()}`;
+    const externalId = 'user_read_carryover';
+    const userHash = signHmac(externalId, identityVerificationSecret);
+
+    const posted = await call('POST', '/v1/widget/messages', widgetKey, {
+      channelId,
+      sessionId,
+      messages: [{ role: 'end_user', body: 'anon question' }],
+    });
+    const conversationId = (posted.json as { conversationId: string }).conversationId;
+    const agentMessageId = await insertAgentMessage(conversationId, 'agent answer', sessionId);
+
+    const anonConv = (
+      await db
+        .select({ endUserId: schema.convConversations.endUserId })
+        .from(schema.convConversations)
+        .where(eq(schema.convConversations.id, conversationId))
+        .limit(1)
+    )[0]!;
+    await db.insert(schema.convMessageReads).values({
+      orgId,
+      conversationId,
+      messageId: agentMessageId,
+      endUserId: anonConv.endUserId!,
+    });
+
+    await call('POST', '/v1/widget/identify', widgetKey, {
+      channelId,
+      sessionId,
+      verifiedExternalId: externalId,
+      userHash,
+    });
+
+    // The agent answer was read anonymously; after the claim the verified
+    // caller must still see it as read (no phantom unread badge).
+    const res = await call(
+      'GET',
+      `/v1/widget/messages?${qs({ channelId, sessionId, verifiedExternalId: externalId, userHash })}`,
+      widgetKey,
+    );
+    expect(res.status).toBe(200);
+    const agent = (res.json as { messages: Array<{ id: string; readAt: string | null }> }).messages.find(
+      (m) => m.id === agentMessageId,
+    )!;
+    expect(agent).toBeDefined();
+    expect(agent.readAt).not.toBeNull();
+  });
+
   it('identify is idempotent: re-claiming the same session returns the same refs', async () => {
     const sessionId = 'vis_claim_idem';
     const externalId = 'user_idem_99';


### PR DESCRIPTION
## Problem

After the anonymous→identified carry-over ([#620](https://github.com/getmunin/munin/pull/620)), a chat started anonymously and read on the marketing site shows a phantom unread badge on the dashboard after login — already-read agent replies come back as unread.

## Root cause

`conv_message_reads` rows are keyed by `end_user_id` with `ON DELETE CASCADE`. `claimAnonymousIdentityInTx` migrates the contact/conversation to the verified end-user and then **deletes the anonymous end-user** — cascade-deleting its read receipts. The verified end-user then has no reads for the conversation's messages, so everything reads back as unread.

## Fix

Before deleting the anonymous end-user, migrate its `conv_message_reads` rows to the verified end-user. Messages the verified user has already read are skipped to respect the `(message_id, end_user_id)` unique index; those stale anon rows fall away with the existing cascade delete.

## Test

`widget.integration.test.ts`: an agent reply read anonymously stays `readAt != null` for the verified caller after `identify`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
