### PR TITLE
fix(dashboard): stack live-now card actions below text on mobile

### DIFF
--- a/.changeset/live-now-card-mobile-stack.md
+++ b/.changeset/live-now-card-mobile-stack.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Stack the Live now card actions below the text on small screens so the quote no longer collapses into a narrow column on mobile.

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -275,7 +275,7 @@ function LiveCard({
   return (
     <li className="space-y-0">
       <div
-        className="group/livecard flex items-stretch gap-4 border-[0.5px] border-ink bg-paper px-5 py-4 cursor-pointer transition-colors duration-fast ease-munin hover:border-cobalt dark:border-rule-on-dark dark:bg-card dark:hover:border-cobalt-soft"
+        className="group/livecard flex flex-col gap-4 border-[0.5px] border-ink bg-paper px-5 py-4 cursor-pointer transition-colors duration-fast ease-munin hover:border-cobalt sm:flex-row sm:items-stretch dark:border-rule-on-dark dark:bg-card dark:hover:border-cobalt-soft"
         onClick={handleCardClick}
         role="button"
         tabIndex={0}


### PR DESCRIPTION
## Summary

On phone-width viewports (~414px) the Live now cards on the dashboard overview laid the Reply / Take over buttons side by side with the message quote, crushing the quote into a one-word-per-line column.

The card container now stacks vertically by default and only switches to the side-by-side row from the `sm` breakpoint (640px) up, so on mobile the buttons render as a row below the subject and quote. Desktop is unchanged.

The queue rows use a different single-line hover pattern and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)