### PR TITLE
feat(integrations): EventSink contract and Integrations hub foundations

### DIFF
--- a/.changeset/integration-foundations.md
+++ b/.changeset/integration-foundations.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/core': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Integration foundations: `EventSink` contract on `WebhookDispatcher` for transactional event fan-out to integration bridges, and the Integrations settings hub page that operator bridges and connectors slot into.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Munin — agent guide
 
-MCP-first customer platform made for the agentic era (KB, Conversations, CRM, CMS, Outreach). The agent is the UI: every action runs through MCP tools served at `/mcp`. There is no admin REST API for app data — the dashboard at `apps/web` is a thin shell that drives the same MCP endpoint.
+MCP-first customer platform made for the agentic era (KB, Conversations, CRM, CMS, Outreach). The agent is the primary UI: agents act through MCP tools served at `/mcp`. The dashboard at `apps/web` is a thin shell over the `/v1/*` control plane; `/v1` controllers and MCP tools must both stay thin wrappers over the same service methods — logic lives in the service, never in a controller or tool handler.
 
 ## Repository layout
 
@@ -29,6 +29,16 @@ Monorepo on pnpm + Turborepo.
 | `playbooks` | — | Cross-module packaged workflows (skill markdown only, no tools). |
 
 Each module typically has `<mod>.module.ts`, `<mod>.service.ts`, `<mod>.tools.ts`, and a `skills/` directory of markdown procedures.
+
+## Integration architecture
+
+Three integration categories, three homes. Route new "integrate with X" work by asking what X is:
+
+- **Messaging channel** — a surface customers write to us on (email, SMS, voice, widget). Implement a channel adapter in `conv` (contract: `packages/backend-core/src/modules/conv/CLAUDE.md`).
+- **Operator bridge** — where our team works (Slack; later Teams). One root module per vendor. Bridges subscribe to domain events by registering an `EventSink` on `WebhookDispatcher` (`packages/core/src/webhooks.ts`); sinks run inside the emitting transaction and must only enqueue durable work — external I/O belongs in the module's own out-of-band worker. Inbound vendor webhooks are signature-verified public controllers, and inbound actions run through existing module services as the mapped org member.
+- **Connector** — a customer's system of record we answer questions from (Shopify, Magento, Gastroplanner). Plumbing lives in the `connectors` trunk module (connection storage, credential encryption, vendor registry, `connectors_*` admin tools); typed read surfaces live in domain modules (`commerce`, `bookings`) whose vendor adapters register into the trunk registry. A domain module is a distinct customer-facing noun with its own read contract (orders, bookings, invoices) — never a vendor. Connector reads are live: no vendor data is persisted in Munin.
+
+Operator bridges and connectors both surface in the dashboard on the single Integrations page (`packages/dashboard-pages/src/pages/integrations.tsx`), one section per category, cards under `packages/dashboard-pages/src/components/integrations/`.
 
 ## MCP surface
 

--- a/apps/web/app/[locale]/dashboard/settings/integrations/page.tsx
+++ b/apps/web/app/[locale]/dashboard/settings/integrations/page.tsx
@@ -1,0 +1,1 @@
+export { IntegrationsPage as default } from '@getmunin/dashboard-pages';

--- a/packages/agent-host/src/config.service.test.ts
+++ b/packages/agent-host/src/config.service.test.ts
@@ -37,8 +37,8 @@ function makeRepo(opts: {
 }
 
 function makeWebhooks(): WebhookDispatcher & { emit: ReturnType<typeof vi.fn> } {
-  const stub = { emit: vi.fn().mockResolvedValue('evt_stub') };
-  return stub;
+  const stub = { emit: vi.fn().mockResolvedValue('evt_stub'), registerSink: vi.fn() };
+  return stub as unknown as WebhookDispatcher & { emit: ReturnType<typeof vi.fn> };
 }
 
 function makeHealthStub(): AgentHealthRecorder & {

--- a/packages/agent-host/src/config.service.test.ts
+++ b/packages/agent-host/src/config.service.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { WebhookDispatcher } from '@getmunin/core';
+import { WebhookDispatcher } from '@getmunin/core';
 import { AgentConfigService } from './config.service.ts';
 import type { AgentHealthRecorder } from './agent-health.service.ts';
 import type {
@@ -36,9 +36,12 @@ function makeRepo(opts: {
   };
 }
 
-function makeWebhooks(): WebhookDispatcher & { emit: ReturnType<typeof vi.fn> } {
-  const stub = { emit: vi.fn().mockResolvedValue('evt_stub'), registerSink: vi.fn() };
-  return stub as unknown as WebhookDispatcher & { emit: ReturnType<typeof vi.fn> };
+class FakeWebhookDispatcher extends WebhookDispatcher {
+  override emit = vi.fn().mockResolvedValue('evt_stub');
+}
+
+function makeWebhooks(): FakeWebhookDispatcher {
+  return new FakeWebhookDispatcher();
 }
 
 function makeHealthStub(): AgentHealthRecorder & {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,7 +99,12 @@ export {
   type ParseEnvIntOptions,
 } from './env/index.ts';
 
-export { WebhookDispatcher, type WebhookEventInput } from './webhooks.ts';
+export {
+  WebhookDispatcher,
+  type WebhookEventInput,
+  type EventSink,
+  type EmittedEvent,
+} from './webhooks.ts';
 export {
   chunkDocument,
   estimateTokens,

--- a/packages/core/src/webhooks.ts
+++ b/packages/core/src/webhooks.ts
@@ -10,6 +10,24 @@ export interface WebhookEventInput {
   hopCount?: number;
 }
 
+export interface EmittedEvent {
+  eventId: string;
+  orgId: string;
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * A delivery sink invoked synchronously inside `emit()` — i.e. inside the
+ * request's tenant transaction (`getCurrentContext().db`). Sinks enqueue
+ * durable work (queue-table inserts) transactionally with the event; the
+ * actual external I/O belongs in an out-of-band worker. The webhooks queue
+ * is the built-in sink; integrations (Slack, …) register additional ones.
+ */
+export interface EventSink {
+  onEvent(event: EmittedEvent): Promise<void>;
+}
+
 /**
  * Records a domain event in the `events` table and queues delivery to
  * every active webhook in the org subscribed to this event type.
@@ -19,18 +37,22 @@ export interface WebhookEventInput {
  * in-process via a setInterval (good enough for a solo-dev MVP).
  */
 export class WebhookDispatcher {
+  private readonly sinks: EventSink[] = [];
+
+  registerSink(sink: EventSink): void {
+    this.sinks.push(sink);
+  }
+
   async emit(input: WebhookEventInput): Promise<string> {
     const ctx = getCurrentContext();
     if (!ctx.actor) throw new Error('webhooks.emit requires an authenticated actor');
     const orgId = ctx.actor.orgId;
 
-    // Loop guard.
     const hopCount = input.hopCount ?? 0;
     if (hopCount >= 10) {
       throw new Error(`event hop count exceeded for ${input.type} (correlationId=${ctx.correlationId})`);
     }
 
-    // Persist the event.
     const [event] = await ctx.db
       .insert(schema.events)
       .values({
@@ -45,7 +67,6 @@ export class WebhookDispatcher {
 
     const eventId = event!.id;
 
-    // Find subscribed webhooks.
     const subs = await ctx.db
       .select()
       .from(schema.webhooks)
@@ -55,16 +76,19 @@ export class WebhookDispatcher {
       (w) => w.events.length === 0 || w.events.includes(input.type),
     );
 
-    if (matching.length === 0) return eventId;
+    if (matching.length > 0) {
+      await ctx.db.insert(schema.webhookDeliveries).values(
+        matching.map((w) => ({
+          webhookId: w.id,
+          eventId,
+          nextAttemptAt: new Date(),
+        })),
+      );
+    }
 
-    // Queue deliveries. The actual HTTP attempts are done by the worker.
-    await ctx.db.insert(schema.webhookDeliveries).values(
-      matching.map((w) => ({
-        webhookId: w.id,
-        eventId,
-        nextAttemptAt: new Date(),
-      })),
-    );
+    for (const sink of this.sinks) {
+      await sink.onEvent({ eventId, orgId, type: input.type, payload: input.payload });
+    }
 
     return eventId;
   }

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -115,6 +115,7 @@ export { AgentsPage } from './pages/agents';
 export { ApiKeysPage } from './pages/api-keys';
 export { AuditLogPage } from './pages/audit-log';
 export { ChannelsPage } from './pages/channels';
+export { IntegrationsPage } from './pages/integrations';
 export { TrackersPage } from './pages/trackers';
 export { EndUsersPage } from './pages/end-users';
 export { DashboardPage } from './pages/overview';

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1106,7 +1106,7 @@
     "settings": {
       "groups": {
         "workspace": "Workspace",
-        "access": "Access & integrations",
+        "access": "Access",
         "monitoring": "Monitoring"
       }
     },

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -184,7 +184,8 @@
     "partner": "Partner",
     "openMenu": "Open menu",
     "closeMenu": "Close menu",
-    "organization": "Organization"
+    "organization": "Organization",
+    "integrations": "Integrations"
   },
   "dashboard": {
     "runnerStatusBanner": {
@@ -1228,6 +1229,18 @@
         "failedSummary": "Couldn't reach {host}. No pages were imported. Your agent is still live — import later from Settings.",
         "retry": "Retry import"
       }
+    }
+  },
+  "integrations": {
+    "hero": {
+      "eyebrow": "Integrations",
+      "title": "Connect Munin to <em>the tools you already use</em>",
+      "lede": "Bring conversations into the surfaces your team and customers live in."
+    },
+    "operatorBridges": {
+      "title": "Operator bridges",
+      "blurb": "Triage and reply to conversations from your team's chat tool.",
+      "empty": "Nothing connected yet."
     }
   },
   "assistants": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1106,7 +1106,7 @@
     "settings": {
       "groups": {
         "workspace": "Arbeidsområde",
-        "access": "Tilgang og integrasjoner",
+        "access": "Tilgang",
         "monitoring": "Overvåking"
       }
     },

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -184,7 +184,8 @@
     "partner": "Partner",
     "openMenu": "Åpne meny",
     "closeMenu": "Lukk meny",
-    "organization": "Organisasjon"
+    "organization": "Organisasjon",
+    "integrations": "Integrasjoner"
   },
   "dashboard": {
     "runnerStatusBanner": {
@@ -1228,6 +1229,18 @@
         "failedSummary": "Kunne ikke nå {host}. Ingen sider ble importert. Agenten din er fortsatt aktiv — importer senere fra Innstillinger.",
         "retry": "Prøv import på nytt"
       }
+    }
+  },
+  "integrations": {
+    "hero": {
+      "eyebrow": "Integrasjoner",
+      "title": "Koble Munin til <em>verktøyene du allerede bruker</em>",
+      "lede": "Ta samtaler inn i flatene teamet og kundene dine allerede bruker."
+    },
+    "operatorBridges": {
+      "title": "Operatørbroer",
+      "blurb": "Triager og svar på samtaler fra teamets chatteverktøy.",
+      "empty": "Ingenting tilkoblet ennå."
     }
   },
   "assistants": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1235,11 +1235,11 @@
     "hero": {
       "eyebrow": "Integrasjoner",
       "title": "Koble Munin til <em>verktøyene du allerede bruker</em>",
-      "lede": "Ta samtaler inn i flatene teamet og kundene dine allerede bruker."
+      "lede": "Ta samtaler inn i flatene medarbeiderne og kundene dine allerede bruker."
     },
     "operatorBridges": {
       "title": "Operatørbroer",
-      "blurb": "Triager og svar på samtaler fra teamets chatteverktøy.",
+      "blurb": "Triager og svar på samtaler fra medarbeidernes chatteverktøy.",
       "empty": "Ingenting tilkoblet ennå."
     }
   },

--- a/packages/dashboard-pages/src/nav/settings-groups.ts
+++ b/packages/dashboard-pages/src/nav/settings-groups.ts
@@ -16,6 +16,7 @@ export const OSS_SETTINGS_GROUPS: SettingsSubNavGroup[] = [
       { href: '/dashboard/settings/team', labelKey: 'team' },
       { href: '/dashboard/settings/ai', labelKey: 'ai' },
       { href: '/dashboard/settings/channels', labelKey: 'channels' },
+      { href: '/dashboard/settings/integrations', labelKey: 'integrations' },
       { href: '/dashboard/settings/trackers', labelKey: 'trackers' },
     ],
   },

--- a/packages/dashboard-pages/src/pages/integrations.tsx
+++ b/packages/dashboard-pages/src/pages/integrations.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Hero } from '@getmunin/ui';
+
+/**
+ * Integrations hub: third-party systems connected to Munin, grouped by who
+ * they serve. Operator bridges (Slack, later Teams) serve the team; a
+ * "Connectors" section for customer-facing systems of record (Shopify,
+ * Magento, …) slots in here once those grow a management surface.
+ */
+export function IntegrationsPage() {
+  const t = useTranslations('integrations');
+
+  return (
+    <div className="max-w-3xl space-y-10">
+      <Hero
+        eyebrow={t('hero.eyebrow')}
+        title={t.rich('hero.title', { em: (chunks) => <em>{chunks}</em> })}
+        lede={t('hero.lede')}
+      />
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">{t('operatorBridges.title')}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{t('operatorBridges.blurb')}</p>
+        </div>
+        <div className="space-y-6">
+          <p className="text-sm text-muted-foreground">{t('operatorBridges.empty')}</p>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Shared substrate for the integration work in #615/#622 (Slack operator bridge) and #623 (self-service connectors), extracted so each feature PR carries only its feature and can be reviewed/tested independently.

- **`EventSink` + `registerSink()` on `WebhookDispatcher`** (`packages/core/src/webhooks.ts`): transactional event fan-out for integration bridges. The webhooks delivery queue stays the built-in sink; bridges (Slack, later Teams) register additional sinks that enqueue durable work inside the emitting transaction and do external I/O in their own workers.
- **Integrations settings hub** (`/dashboard/settings/integrations`): page skeleton with the operator-bridges section shell, nav entry, en/nb i18n. Bridge cards and a connectors section slot in via the feature PRs.
- **CLAUDE.md**: integration taxonomy (messaging channels / operator bridges / connectors), the bar for new connector domain modules, the dashboard-`/v1` vs agent-MCP surface rule, and a corrected description of the control plane.

No DB changes, no behavior changes for existing webhooks (delivery queueing is unchanged).

## Land order

This PR lands first. Then: #615 → #622 (rebased onto this, dropping their copies of the dispatcher change and page scaffold) → connectors trunk → commerce → bookings (replacing #623).

🤖 Generated with [Claude Code](https://claude.com/claude-code)