### PR TITLE
fix(ui,dashboard-pages): 1px hairlines with tuned rule weight + border normalization

### DIFF
--- a/.changeset/hairline-1px-normalize.md
+++ b/.changeset/hairline-1px-normalize.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/ui': patch
+'@getmunin/dashboard-pages': patch
+---
+
+1px hairlines everywhere, tuned rule weight, and honest bookings connector copy:
+
+- All `0.5px` borders and inset-shadow outlines are now `1px` — sub-pixel widths rendered inconsistently across devices.
+- Rule alpha compensates for the doubled width (light `0.145 → 0.09`, dark `0.2 → 0.13`) and is now single-sourced from the `--munin-rule-*-alpha` tokens; the tailwind preset, Button, and the team-page role select reference the tokens instead of hardcoding alphas.
+- Buttons, pills, auth-shell CTAs, and the team role select draw their outline with a real `border` again instead of the inset box-shadow workaround (iOS Safari only dropped sub-pixel borders; integer widths are safe). Pill padding compensates so rendered size is unchanged; pill outlines soften to 55% `currentColor`.
+- Dashboard/settings topbars adopt the marketing-site chrome: translucent blurred bar with a soft always-on hairline instead of a full-ink border. System-alerts banner border softens from full ink to `ink/20`.
+- Dialog field hints are smaller and grayer (`text-xs text-ink-mute`) to read as metadata next to labels.
+- Gastroplanner connect dialog now advertises the full bookings surface (check availability + book, change/cancel) instead of lookup only, and the "read directly — never copied" note is reworded to "live against the vendor — nothing stored in Munin" since bookings writes. Sonner toasts get their intended ink border (the CSS var name was previously mistyped and ignored).

--- a/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
+++ b/packages/dashboard-pages/src/components/agent-config/provider-card.tsx
@@ -162,7 +162,7 @@ export function ProviderCard({
               type="button"
               onClick={() => selectPreset(p.id)}
               className={
-                'flex items-center gap-3 rounded-input border-[0.5px] px-4 py-3 text-left transition-colors ' +
+                'flex items-center gap-3 rounded-input border-[1px] px-4 py-3 text-left transition-colors ' +
                 (preset === p.id
                   ? 'border-cobalt bg-cobalt/5 ring-1 ring-inset ring-cobalt'
                   : 'border-rule-soft hover:border-ink/30')
@@ -243,7 +243,7 @@ export function ProviderCard({
               type="button"
               onClick={() => selectPreset(managedPreset.id)}
               className={
-                'flex w-full items-center gap-4 rounded-input border-[0.5px] px-4 py-3.5 text-left transition-colors ' +
+                'flex w-full items-center gap-4 rounded-input border-[1px] px-4 py-3.5 text-left transition-colors ' +
                 (preset === managedPreset.id
                   ? 'border-cobalt bg-cobalt/5 ring-1 ring-inset ring-cobalt'
                   : 'border-rule-soft hover:border-ink/30')

--- a/packages/dashboard-pages/src/components/auth-shell/auth-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/auth-form.tsx
@@ -33,7 +33,7 @@ export const AuthInput = forwardRef<HTMLInputElement, AuthInputProps>(
         ref={ref}
         {...props}
         className={cn(
-          'border-[0.5px] bg-paper px-4 py-3.5 text-[15px] text-ink',
+          'border-[1px] bg-paper px-4 py-3.5 text-[15px] text-ink',
           'placeholder:text-ink-mute',
           'transition-colors duration-fast ease-munin',
           'focus:outline-none focus:ring-[3px] focus:ring-ink/[0.08]',
@@ -58,12 +58,12 @@ export const AuthSubmit = forwardRef<HTMLButtonElement, AuthSubmitProps>(
         ref={ref}
         {...props}
         className={cn(
-          'mt-2 inline-flex w-full items-center justify-center gap-2 px-[18px] py-4 text-[15px] font-medium',
+          'mt-2 inline-flex w-full items-center justify-center gap-2 border-[1px] px-[18px] py-4 text-[15px] font-medium',
           'transition-colors duration-fast ease-munin active:translate-y-px',
           'disabled:cursor-not-allowed disabled:opacity-60',
           variant === 'navy'
-            ? 'bg-ink text-paper shadow-[inset_0_0_0_0.5px_rgb(var(--munin-ink))] hover:bg-cobalt-deep hover:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-accent-deep))]'
-            : 'bg-transparent text-ink shadow-[inset_0_0_0_0.5px_rgb(var(--munin-ink))] hover:bg-ink hover:text-paper',
+            ? 'border-ink bg-ink text-paper hover:border-cobalt-deep hover:bg-cobalt-deep'
+            : 'border-ink bg-transparent text-ink hover:bg-ink hover:text-paper',
           className,
         )}
       >
@@ -102,7 +102,7 @@ export function AuthOAuthButton({
       type="button"
       {...props}
       className={cn(
-        'inline-flex w-full items-center justify-center gap-3.5 border-[0.5px] border-rule-soft bg-paper px-[18px] py-4 text-[15px] text-ink',
+        'inline-flex w-full items-center justify-center gap-3.5 border-[1px] border-rule-soft bg-paper px-[18px] py-4 text-[15px] text-ink',
         'transition-colors duration-fast ease-munin hover:border-ink active:translate-y-px',
         className,
       )}

--- a/packages/dashboard-pages/src/components/auth-shell/auth-invite-card.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/auth-invite-card.tsx
@@ -50,7 +50,7 @@ export function AuthInviteCard({
       </h2>
       <div className="mb-7 max-w-[440px] text-[15px] leading-[1.55] text-ink">{body}</div>
       {meta && meta.length > 0 && (
-        <dl className="mb-6 mt-0 grid grid-cols-[auto_1fr] gap-x-[18px] gap-y-1.5 border-t-[0.5px] border-ink/[0.12] pt-[18px] font-mono text-[11px] tracking-wide text-ink-soft">
+        <dl className="mb-6 mt-0 grid grid-cols-[auto_1fr] gap-x-[18px] gap-y-1.5 border-t-[1px] border-ink/[0.12] pt-[18px] font-mono text-[11px] tracking-wide text-ink-soft">
           {meta.map(({ label, value }) => (
             <div key={label} className="contents">
               <dt className="text-[10px] uppercase tracking-eyebrow text-ink-mute">

--- a/packages/dashboard-pages/src/components/auth-shell/reset-password-page.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/reset-password-page.tsx
@@ -73,7 +73,7 @@ function ResetPasswordInner({ footer }: ResetPasswordPageProps) {
             <Link
               href="/login"
               autoFocus
-              className="mt-2 inline-flex w-full items-center justify-center gap-2 bg-ink px-[18px] py-4 text-[15px] font-medium text-paper shadow-[inset_0_0_0_0.5px_rgb(var(--munin-ink))] transition-colors duration-fast ease-munin hover:bg-cobalt-deep hover:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-accent-deep))] active:translate-y-px"
+              className="mt-2 inline-flex w-full items-center justify-center gap-2 border-[1px] border-ink bg-ink px-[18px] py-4 text-[15px] font-medium text-paper transition-colors duration-fast ease-munin hover:border-cobalt-deep hover:bg-cobalt-deep active:translate-y-px"
             >
               {t('doneCta')}
             </Link>

--- a/packages/dashboard-pages/src/components/auth-shell/verify-email-page.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/verify-email-page.tsx
@@ -44,7 +44,7 @@ function VerifyEmailInner({ footer }: VerifyEmailPageProps) {
           <Link
             href="/login"
             autoFocus
-            className="mt-2 inline-flex w-full items-center justify-center gap-2 bg-ink px-[18px] py-4 text-[15px] font-medium text-paper shadow-[inset_0_0_0_0.5px_rgb(var(--munin-ink))] transition-colors duration-fast ease-munin hover:bg-cobalt-deep hover:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-accent-deep))] active:translate-y-px"
+            className="mt-2 inline-flex w-full items-center justify-center gap-2 border-[1px] border-ink bg-ink px-[18px] py-4 text-[15px] font-medium text-paper transition-colors duration-fast ease-munin hover:border-cobalt-deep hover:bg-cobalt-deep active:translate-y-px"
           >
             {cta}
           </Link>

--- a/packages/dashboard-pages/src/components/copyable-secret.tsx
+++ b/packages/dashboard-pages/src/components/copyable-secret.tsx
@@ -34,7 +34,7 @@ export function CopyableSecret({ label, value, hint }: CopyableSecretProps) {
     <div className="space-y-2">
       <Label className={dialogLabelClass}>{label}</Label>
       <div className="flex items-center gap-2">
-        <code className="flex-1 truncate border-[0.5px] border-rule-soft dark:border-rule-on-dark bg-paper dark:bg-card px-3 py-2 font-mono text-sm text-ink dark:text-foreground">
+        <code className="flex-1 truncate border-[1px] border-rule-soft dark:border-rule-on-dark bg-paper dark:bg-card px-3 py-2 font-mono text-sm text-ink dark:text-foreground">
           {value}
         </code>
         <Button variant="outline" size="sm" onClick={copy} className="gap-1.5">

--- a/packages/dashboard-pages/src/components/dashboard/get-started.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/get-started.tsx
@@ -65,7 +65,7 @@ export function GetStarted() {
       <div className="grid gap-9 md:grid-cols-[1.05fr_1fr] items-start">
         {/* MCP setup column */}
         <div className="min-w-0">
-          <div className="flex justify-between items-baseline border-b-[0.5px] border-ink pb-2.5 mb-4 dark:border-foreground">
+          <div className="flex justify-between items-baseline border-b-[1px] border-ink pb-2.5 mb-4 dark:border-foreground">
             <Eyebrow tone="ink" size="sm" className="font-medium">
               {t('connectMcp')}
             </Eyebrow>
@@ -74,7 +74,7 @@ export function GetStarted() {
             </Eyebrow>
           </div>
 
-          <div className="flex border-[0.5px] border-ink mb-3.5 dark:border-foreground">
+          <div className="flex border-[1px] border-ink mb-3.5 dark:border-foreground">
             {setups.map((s) => {
               const active = s.id === activeId;
               return (
@@ -86,7 +86,7 @@ export function GetStarted() {
                     setCopied(false);
                   }}
                   className={cn(
-                    'flex-1 cursor-pointer px-3.5 py-2.5 flex flex-col items-start gap-0.5 border-r-[0.5px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
+                    'flex-1 cursor-pointer px-3.5 py-2.5 flex flex-col items-start gap-0.5 border-r-[1px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
                     active
                       ? 'bg-ink text-paper dark:bg-foreground dark:text-background'
                       : 'bg-paper hover:bg-paper-deep dark:bg-card dark:hover:bg-secondary',
@@ -106,11 +106,11 @@ export function GetStarted() {
             })}
           </div>
 
-          <div className="bg-paper-deep border-[0.5px] border-ink dark:bg-card dark:border-rule-on-dark">
+          <div className="bg-paper-deep border-[1px] border-ink dark:bg-card dark:border-rule-on-dark">
             <pre className="m-0 px-4 py-4 overflow-x-auto font-mono text-xs leading-[1.6] text-ink dark:text-foreground">
               <code>{setup.snippet}</code>
             </pre>
-            <div className="flex justify-between items-center px-3.5 py-2 border-t-[0.5px] border-rule-soft bg-paper dark:bg-secondary dark:border-rule-on-dark">
+            <div className="flex justify-between items-center px-3.5 py-2 border-t-[1px] border-rule-soft bg-paper dark:bg-secondary dark:border-rule-on-dark">
               <a
                 href={setup.docsHref}
                 target="_blank"
@@ -137,7 +137,7 @@ export function GetStarted() {
               link: (chunks) => (
                 <Link
                   href="/dashboard/settings/api-keys"
-                  className="text-cobalt no-underline border-b-[0.5px] border-current dark:text-cobalt-soft"
+                  className="text-cobalt no-underline border-b-[1px] border-current dark:text-cobalt-soft"
                 >
                   {chunks}
                 </Link>
@@ -148,7 +148,7 @@ export function GetStarted() {
 
         {/* Recipes column */}
         <div className="min-w-0">
-          <div className="flex justify-between items-baseline border-b-[0.5px] border-ink pb-2.5 mb-4 dark:border-foreground">
+          <div className="flex justify-between items-baseline border-b-[1px] border-ink pb-2.5 mb-4 dark:border-foreground">
             <Eyebrow tone="ink" size="sm" className="font-medium">
               {t('recipesEyebrow')}
             </Eyebrow>
@@ -157,9 +157,9 @@ export function GetStarted() {
             </Eyebrow>
           </div>
 
-          <ul className="list-none m-0 p-0 border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+          <ul className="list-none m-0 p-0 border-t-[1px] border-rule-soft dark:border-rule-on-dark">
             {RECIPES.map((r) => (
-              <li key={r.id} className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
+              <li key={r.id} className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
                 <a
                   href={`${docsHost}/guides/recipe-${r.id}`}
                   target="_blank"

--- a/packages/dashboard-pages/src/components/dashboard/inbox-activity-rail.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-activity-rail.tsx
@@ -48,7 +48,7 @@ export function ActivityRail({
   });
 
   return (
-    <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+    <div className="border-t-[1px] border-rule-soft dark:border-rule-on-dark">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}

--- a/packages/dashboard-pages/src/components/dashboard/inbox-conv-drawers.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-conv-drawers.tsx
@@ -23,7 +23,7 @@ export function InlineActionError({
   const reason = isConnectionMessage(message) ? t('actionFailedReasonConnection') : message;
   return (
     <div
-      className="flex items-center gap-[14px] whitespace-nowrap border-[0.5px] border-cobalt bg-[oklch(0.98_0.025_25)] px-3 py-1.5 text-[13px] font-medium text-cobalt dark:border-cobalt-soft dark:bg-cobalt-soft/10 dark:text-cobalt-soft"
+      className="flex items-center gap-[14px] whitespace-nowrap border-[1px] border-cobalt bg-[oklch(0.98_0.025_25)] px-3 py-1.5 text-[13px] font-medium text-cobalt dark:border-cobalt-soft dark:bg-cobalt-soft/10 dark:text-cobalt-soft"
       role="alert"
     >
       <span
@@ -185,11 +185,11 @@ export function SimplifiedConvDrawer({
               value={draftBody}
               onChange={(e) => setDraftEdit(e.target.value)}
               rows={8}
-              className="w-full rounded-input border-[0.5px] border-ink bg-paper px-4 py-3 text-base md:text-sm leading-relaxed outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark dark:text-foreground"
+              className="w-full rounded-input border-[1px] border-ink bg-paper px-4 py-3 text-base md:text-sm leading-relaxed outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark dark:text-foreground"
               autoFocus
             />
           ) : (
-            <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
+            <div className="border-[1px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
               <Markdown>{draft?.body ?? ''}</Markdown>
             </div>
           )}
@@ -199,13 +199,13 @@ export function SimplifiedConvDrawer({
       <div
         className={
           actionError
-            ? 'border-t-[0.5px] border-cobalt dark:border-cobalt-soft'
+            ? 'border-t-[1px] border-cobalt dark:border-cobalt-soft'
             : undefined
         }
       >
         {actionError && (
           <div
-            className="flex items-center gap-3 border-b-[0.5px] border-rule-soft bg-[oklch(0.98_0.025_25)] px-[26px] py-3 text-[13px] font-medium text-cobalt dark:border-rule-on-dark dark:bg-cobalt-soft/10 dark:text-cobalt-soft"
+            className="flex items-center gap-3 border-b-[1px] border-rule-soft bg-[oklch(0.98_0.025_25)] px-[26px] py-3 text-[13px] font-medium text-cobalt dark:border-rule-on-dark dark:bg-cobalt-soft/10 dark:text-cobalt-soft"
             role="alert"
           >
             <span
@@ -317,13 +317,13 @@ export function FullConvDrawer({
       <div
         className={
           actionError
-            ? 'border-t-[0.5px] border-cobalt dark:border-cobalt-soft'
-            : 'border-t-[0.5px] border-rule-soft dark:border-rule-on-dark'
+            ? 'border-t-[1px] border-cobalt dark:border-cobalt-soft'
+            : 'border-t-[1px] border-rule-soft dark:border-rule-on-dark'
         }
       >
         {actionError && (
           <div
-            className="flex items-center gap-3 border-b-[0.5px] border-rule-soft bg-[oklch(0.98_0.025_25)] px-[26px] py-3 text-[13px] font-medium text-cobalt dark:border-rule-on-dark dark:bg-cobalt-soft/10 dark:text-cobalt-soft"
+            className="flex items-center gap-3 border-b-[1px] border-rule-soft bg-[oklch(0.98_0.025_25)] px-[26px] py-3 text-[13px] font-medium text-cobalt dark:border-rule-on-dark dark:bg-cobalt-soft/10 dark:text-cobalt-soft"
             role="alert"
           >
             <span
@@ -357,7 +357,7 @@ export function FullConvDrawer({
             }}
             rows={3}
             placeholder={t('replyPlaceholder')}
-            className="w-full rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-2 text-base md:text-sm outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark"
+            className="w-full rounded-input border-[1px] border-rule-soft bg-paper px-3 py-2 text-base md:text-sm outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark"
           />
           <div className="mt-3 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">

--- a/packages/dashboard-pages/src/components/dashboard/inbox-message-bubble.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-message-bubble.tsx
@@ -56,7 +56,7 @@ export function MessageBubble({ message }: { message: MessageDto }) {
     return (
       <div
         className={cn(
-          'max-w-[85%] border-[0.5px] border-amber-200 bg-amber-50 px-3 py-2 text-sm dark:border-amber-500/30 dark:bg-amber-500/10',
+          'max-w-[85%] border-[1px] border-amber-200 bg-amber-50 px-3 py-2 text-sm dark:border-amber-500/30 dark:bg-amber-500/10',
           isOutbound
             ? 'ml-auto rounded-bubble rounded-tr-[2px]'
             : 'mr-auto rounded-bubble rounded-tl-[2px]',

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -85,7 +85,7 @@ export function QueueSection({ controller }: { controller: InboxController }) {
 
   return (
     <section>
-      <div className="flex items-baseline justify-between gap-4 border-b-[0.5px] border-rule-soft pb-2.5 dark:border-rule-on-dark">
+      <div className="flex items-baseline justify-between gap-4 border-b-[1px] border-rule-soft pb-2.5 dark:border-rule-on-dark">
         <h2 className="font-mono text-[10px] uppercase tracking-eyebrow text-ink dark:text-foreground">
           {t('eyebrow')} · {queue.length}
         </h2>
@@ -275,7 +275,7 @@ function LiveCard({
   return (
     <li className="space-y-0">
       <div
-        className="group/livecard flex flex-col gap-4 border-[0.5px] border-ink bg-paper px-5 py-4 cursor-pointer transition-colors duration-fast ease-munin hover:border-cobalt sm:flex-row sm:items-stretch dark:border-rule-on-dark dark:bg-card dark:hover:border-cobalt-soft"
+        className="group/livecard flex flex-col gap-4 border-[1px] border-ink bg-paper px-5 py-4 cursor-pointer transition-colors duration-fast ease-munin hover:border-cobalt sm:flex-row sm:items-stretch dark:border-rule-on-dark dark:bg-card dark:hover:border-cobalt-soft"
         onClick={handleCardClick}
         role="button"
         tabIndex={0}
@@ -356,7 +356,7 @@ function QueueRow({
   const tone = queueTone(item);
   const labelKey = queueLabelKey(item);
   return (
-    <li className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
+    <li className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
       <div
         className="group/qrow flex items-center gap-4 px-4 py-3 transition-colors duration-fast ease-munin hover:bg-paper-deep cursor-pointer dark:hover:bg-secondary"
         onClick={onOpen}

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms.tsx
@@ -231,7 +231,7 @@ export function CmsQueueDrawer({
           shortcut={t('shortcutSave')}
         />
       ) : (
-        <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+        <div className="border-t-[1px] border-rule-soft dark:border-rule-on-dark">
           <Dialog
             open={schedulerOpen}
             onOpenChange={(o) => {
@@ -262,7 +262,7 @@ export function CmsQueueDrawer({
                       setScheduledAt(e.target.value);
                       if (scheduleError) setScheduleError(null);
                     }}
-                    className="rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-2 font-sans text-sm text-ink outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:border-rule-on-dark dark:bg-card dark:text-foreground"
+                    className="rounded-input border-[1px] border-rule-soft bg-paper px-3 py-2 font-sans text-sm text-ink outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:border-rule-on-dark dark:bg-card dark:text-foreground"
                     autoFocus
                   />
                 </label>
@@ -424,13 +424,13 @@ function FieldEditor({
   replaceLabel: string;
 }) {
   const inputClass = cn(
-    'w-full rounded-input border-[0.5px] bg-paper px-4 py-2 font-sans text-[15px] leading-7 outline-none focus-visible:ring-1 dark:bg-card dark:text-foreground',
+    'w-full rounded-input border-[1px] bg-paper px-4 py-2 font-sans text-[15px] leading-7 outline-none focus-visible:ring-1 dark:bg-card dark:text-foreground',
     invalid
       ? 'border-destructive focus-visible:ring-destructive'
       : 'border-cobalt focus-visible:ring-cobalt',
   );
   const textareaClass = cn(
-    'w-full resize-y rounded-input border-[0.5px] bg-paper px-4 py-3 font-sans text-[15px] leading-7 outline-none focus-visible:ring-1 dark:bg-card dark:text-foreground',
+    'w-full resize-y rounded-input border-[1px] bg-paper px-4 py-3 font-sans text-[15px] leading-7 outline-none focus-visible:ring-1 dark:bg-card dark:text-foreground',
     invalid
       ? 'border-destructive focus-visible:ring-destructive'
       : 'border-cobalt focus-visible:ring-cobalt',
@@ -594,7 +594,7 @@ function FieldEditor({
       );
     default:
       return (
-        <pre className="w-full overflow-x-auto rounded-input border-[0.5px] border-rule-soft bg-paper-deep px-3 py-2 font-mono text-xs text-ink-mute dark:border-rule-on-dark dark:bg-secondary">
+        <pre className="w-full overflow-x-auto rounded-input border-[1px] border-rule-soft bg-paper-deep px-3 py-2 font-mono text-xs text-ink-mute dark:border-rule-on-dark dark:bg-secondary">
           {JSON.stringify(value, null, 2)}
         </pre>
       );
@@ -655,7 +655,7 @@ function FieldViewer({
 
 function ValueBox({ children }: { children: React.ReactNode }) {
   return (
-    <div className="border-[0.5px] border-ink bg-paper px-4 py-3 font-sans text-[15px] leading-7 text-ink dark:bg-card dark:border-rule-on-dark dark:text-foreground">
+    <div className="border-[1px] border-ink bg-paper px-4 py-3 font-sans text-[15px] leading-7 text-ink dark:bg-card dark:border-rule-on-dark dark:text-foreground">
       {children}
     </div>
   );
@@ -679,7 +679,7 @@ function BlockCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="space-y-3 border-[0.5px] border-rule-soft bg-paper-deep/50 p-3 dark:border-rule-on-dark dark:bg-secondary/40">
+    <div className="space-y-3 border-[1px] border-rule-soft bg-paper-deep/50 p-3 dark:border-rule-on-dark dark:bg-secondary/40">
       <div className="flex items-center justify-between gap-2">
         <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
           {label}
@@ -836,7 +836,7 @@ function ListEditor({
 
   if (!itemDef) {
     return (
-      <pre className="w-full overflow-x-auto rounded-input border-[0.5px] border-rule-soft bg-paper-deep px-3 py-2 font-mono text-xs text-ink-mute dark:border-rule-on-dark dark:bg-secondary">
+      <pre className="w-full overflow-x-auto rounded-input border-[1px] border-rule-soft bg-paper-deep px-3 py-2 font-mono text-xs text-ink-mute dark:border-rule-on-dark dark:bg-secondary">
         {JSON.stringify(value, null, 2)}
       </pre>
     );
@@ -1074,7 +1074,7 @@ function AssetFigure({
   aspectLabel: string;
 }) {
   return (
-    <figure className="border-[0.5px] border-ink bg-paper dark:border-rule-on-dark dark:bg-card">
+    <figure className="border-[1px] border-ink bg-paper dark:border-rule-on-dark dark:bg-card">
       <div className="relative aspect-[16/9] w-full overflow-hidden">
         <img
           src={asset.publicUrl}
@@ -1145,7 +1145,7 @@ function AssetDropZone({
   const interactionsDisabled = disabled || uploading;
   return (
     <>
-      <figure className="border-[0.5px] border-rule-soft bg-paper dark:border-rule-on-dark dark:bg-card">
+      <figure className="border-[1px] border-rule-soft bg-paper dark:border-rule-on-dark dark:bg-card">
         <button
           type="button"
           onClick={() => inputRef.current?.click()}
@@ -1165,7 +1165,7 @@ function AssetDropZone({
           aria-label={asset ? replaceLabel : hintLabel}
           aria-invalid={invalid || undefined}
           className={cn(
-            'group relative flex aspect-[16/9] w-full items-center justify-center overflow-hidden border-[0.5px] border-dashed text-center transition',
+            'group relative flex aspect-[16/9] w-full items-center justify-center overflow-hidden border-[1px] border-dashed text-center transition',
             invalid
               ? 'border-destructive bg-destructive/5'
               : dragging

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/crm.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/crm.tsx
@@ -49,7 +49,7 @@ export function CrmQueueDrawer({
           <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
             {t('proposal')}
           </p>
-          <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
+          <div className="border-[1px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
             <p>
               {t.rich('crmMergeBody', {
                 loser: fmt(loser),

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/feedback.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/feedback.tsx
@@ -55,7 +55,7 @@ export function FeedbackQueueDrawer({
           <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
             {t('proposal')}
           </p>
-          <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
+          <div className="border-[1px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
             <p className="whitespace-pre-wrap">{f.body}</p>
             <p className="mt-3 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
               {t(attributionKey, { orgName: '—', userName: '—' })}

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/kb.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/kb.tsx
@@ -103,11 +103,11 @@ export function KbQueueDrawer({
                 value={editedBody}
                 onChange={(e) => setEditedBody(e.target.value)}
                 rows={14}
-                className="w-full resize-y rounded-input border-[0.5px] border-cobalt bg-paper px-4 py-3 text-sm leading-relaxed outline-none focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:text-foreground"
+                className="w-full resize-y rounded-input border-[1px] border-cobalt bg-paper px-4 py-3 text-sm leading-relaxed outline-none focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:text-foreground"
                 autoFocus
               />
             ) : (
-              <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
+              <div className="border-[1px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
                 <Markdown>{editedBody}</Markdown>
               </div>
             )}

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/outreach.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/outreach.tsx
@@ -102,11 +102,11 @@ export function OutreachQueueDrawer({
               value={editedBody}
               onChange={(e) => setEditedBody(e.target.value)}
               rows={14}
-              className="w-full resize-y rounded-input border-[0.5px] border-cobalt bg-paper px-4 py-3 text-sm leading-relaxed outline-none focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:text-foreground"
+              className="w-full resize-y rounded-input border-[1px] border-cobalt bg-paper px-4 py-3 text-sm leading-relaxed outline-none focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:text-foreground"
               autoFocus
             />
           ) : (
-            <div className="border-[0.5px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
+            <div className="border-[1px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
               {item.raw.draftSubject && (
                 <p className="mb-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
                   {t('subject', { subject: item.raw.draftSubject })}

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/shared.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/shared.tsx
@@ -49,12 +49,12 @@ export const MD_COMPONENTS: Components = {
     </div>
   ),
   th: ({ children }) => (
-    <th className="border-[0.5px] border-rule-soft px-2 py-1 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute dark:border-rule-on-dark">
+    <th className="border-[1px] border-rule-soft px-2 py-1 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute dark:border-rule-on-dark">
       {children}
     </th>
   ),
   td: ({ children }) => (
-    <td className="border-[0.5px] border-rule-soft px-2 py-1 align-top dark:border-rule-on-dark">
+    <td className="border-[1px] border-rule-soft px-2 py-1 align-top dark:border-rule-on-dark">
       {children}
     </td>
   ),
@@ -138,7 +138,7 @@ export function DrawerHeader({
   closeLabel: string;
 }) {
   return (
-    <div className="border-b-[0.5px] border-rule-soft px-6 pb-4 pt-5 dark:border-rule-on-dark">
+    <div className="border-b-[1px] border-rule-soft px-6 pb-4 pt-5 dark:border-rule-on-dark">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 space-y-2">
           <div className="flex items-center gap-2">
@@ -182,7 +182,7 @@ export function DrawerFooter({
     <div
       className={cn(
         'flex items-center justify-between gap-2 px-6 py-3',
-        bordered && 'border-t-[0.5px] border-rule-soft dark:border-rule-on-dark',
+        bordered && 'border-t-[1px] border-rule-soft dark:border-rule-on-dark',
       )}
     >
       <div className="flex items-center gap-2">

--- a/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/recent-conversations.tsx
@@ -69,7 +69,7 @@ export function RecentConversationsSection({
 
   return (
     <section>
-      <div className="flex items-baseline justify-between gap-4 border-b-[0.5px] border-rule-soft pb-2.5 dark:border-rule-on-dark">
+      <div className="flex items-baseline justify-between gap-4 border-b-[1px] border-rule-soft pb-2.5 dark:border-rule-on-dark">
         <h2 className="font-mono text-[10px] uppercase tracking-eyebrow text-ink dark:text-foreground">
           {t('eyebrow')} · {visible.length}
         </h2>
@@ -104,7 +104,7 @@ function ConversationRow({
   const ts = conv.lastMessageAt ?? conv.updatedAt;
 
   return (
-    <li className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
+    <li className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
       <div
         className="group/cnvrow relative flex items-center gap-4 px-4 py-3 transition-colors duration-fast ease-munin hover:bg-paper-deep cursor-pointer dark:hover:bg-secondary"
         onClick={onOpen}

--- a/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
@@ -28,7 +28,7 @@ export function UsageKpis({ summary }: UsageKpisProps) {
 
   return (
     <section className="min-w-0">
-      <div className="flex items-baseline justify-between gap-4 border-b-[0.5px] border-rule-soft pb-2.5 mb-3.5 dark:border-rule-on-dark">
+      <div className="flex items-baseline justify-between gap-4 border-b-[1px] border-rule-soft pb-2.5 mb-3.5 dark:border-rule-on-dark">
         <Eyebrow tone="ink" size="sm" className="font-medium">
           {t('headline')}
         </Eyebrow>
@@ -97,7 +97,7 @@ function Kpi({ label, value, previous, spark, format, lowerIsBetter, tone = 'acc
   const t = useTranslations('dashboard.usage.tiles');
   const delta = formatDelta(value, previous, format, lowerIsBetter, t);
   return (
-    <div className="border-[0.5px] border-rule-soft bg-paper px-4 py-3.5 dark:bg-card dark:border-rule-on-dark">
+    <div className="border-[1px] border-rule-soft bg-paper px-4 py-3.5 dark:bg-card dark:border-rule-on-dark">
       <div className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">{label}</div>
       <div className="font-serif text-[28px] leading-none tracking-tight my-1.5 text-ink dark:text-foreground">
         {value === undefined ? '—' : format(value)}

--- a/packages/dashboard-pages/src/components/empty-callout.tsx
+++ b/packages/dashboard-pages/src/components/empty-callout.tsx
@@ -9,7 +9,7 @@ export interface EmptyCalloutProps {
 
 export function EmptyCallout({ title, body }: EmptyCalloutProps) {
   return (
-    <div className="border-[0.5px] border-rule-soft dark:border-rule-on-dark py-12 px-6 text-center space-y-2">
+    <div className="border-[1px] border-rule-soft dark:border-rule-on-dark py-12 px-6 text-center space-y-2">
       <h3 className="font-serif text-xl text-ink dark:text-foreground">{title}</h3>
       <p className="text-sm text-ink-soft dark:text-foreground/70 max-w-md mx-auto">{body}</p>
     </div>

--- a/packages/dashboard-pages/src/components/integrations/connect-connector-dialog.tsx
+++ b/packages/dashboard-pages/src/components/integrations/connect-connector-dialog.tsx
@@ -58,7 +58,7 @@ export function ConnectConnectorDialog({
   return (
     <Dialog open onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="max-w-[720px] p-0">
-        <div className="flex items-center gap-4 border-b-[0.5px] border-rule-soft px-8 py-6 dark:border-rule-on-dark">
+        <div className="flex items-center gap-4 border-b-[1px] border-rule-soft px-8 py-6 dark:border-rule-on-dark">
           <VendorIcon vendor={vendor.vendor} label={vendor.displayName} size={56} markSize={28} />
           <div className="flex flex-1 flex-col gap-1">
             <h2 className="font-serif text-2xl leading-none text-ink dark:text-foreground">
@@ -71,20 +71,20 @@ export function ConnectConnectorDialog({
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-[260px_1fr]">
-          <div className="flex flex-col gap-4 border-b-[0.5px] border-rule-soft bg-paper-deep px-7 py-6 dark:border-rule-on-dark dark:bg-secondary sm:border-b-0 sm:border-r-[0.5px]">
+          <div className="flex flex-col gap-4 border-b-[1px] border-rule-soft bg-paper-deep px-7 py-6 dark:border-rule-on-dark dark:bg-secondary sm:border-b-0 sm:border-r-[1px]">
             <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
               {t('whatAgentsGet')}
             </span>
             <div className="flex flex-col">
               {present.capabilityKeys.map((k) => (
-                <div key={k} className="border-b-[0.5px] border-rule-soft py-2.5 last:border-0 dark:border-rule-on-dark">
+                <div key={k} className="border-b-[1px] border-rule-soft py-2.5 last:border-0 dark:border-rule-on-dark">
                   <span className="block text-[13px] leading-snug text-ink dark:text-foreground">
                     {tc(`capability.${k}`)}
                   </span>
                 </div>
               ))}
             </div>
-            <p className="font-serif text-sm italic text-ink-mute">{t('readLive')}</p>
+            <p className="font-serif text-sm italic text-ink-mute">{t('liveData')}</p>
           </div>
 
           <div className="flex flex-col gap-4 px-8 py-6">
@@ -104,7 +104,7 @@ export function ConnectConnectorDialog({
           </div>
         </div>
 
-        <div className="flex justify-end gap-2.5 border-t-[0.5px] border-rule-soft bg-paper-deep px-8 py-3.5 dark:border-rule-on-dark dark:bg-secondary">
+        <div className="flex justify-end gap-2.5 border-t-[1px] border-rule-soft bg-paper-deep px-8 py-3.5 dark:border-rule-on-dark dark:bg-secondary">
           <Button type="button" variant="outline" onClick={onClose} disabled={busy}>
             {tCommon('cancel')}
           </Button>

--- a/packages/dashboard-pages/src/components/integrations/integration-card.tsx
+++ b/packages/dashboard-pages/src/components/integrations/integration-card.tsx
@@ -13,7 +13,7 @@ export function SectionHeading({
   countLabel?: string;
 }) {
   return (
-    <div className="flex items-end justify-between gap-4 border-b-[0.5px] border-rule-soft pb-3 dark:border-rule-on-dark">
+    <div className="flex items-end justify-between gap-4 border-b-[1px] border-rule-soft pb-3 dark:border-rule-on-dark">
       <div className="flex flex-col gap-1">
         <h2 className="font-serif text-xl leading-none text-ink dark:text-foreground">{title}</h2>
         <span className="text-[13px] text-ink-mute">{subtitle}</span>
@@ -49,7 +49,7 @@ export function IntegrationCard({
   footer: ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-3 border-[0.5px] border-rule-soft bg-paper p-5 dark:border-rule-on-dark dark:bg-card">
+    <div className="flex flex-col gap-3 border-[1px] border-rule-soft bg-paper p-5 dark:border-rule-on-dark dark:bg-card">
       <div className="flex items-center gap-3">
         <VendorIcon vendor={vendor} label={name} />
         <div className="flex min-w-0 flex-col gap-1">

--- a/packages/dashboard-pages/src/components/integrations/vendor-catalog.tsx
+++ b/packages/dashboard-pages/src/components/integrations/vendor-catalog.tsx
@@ -30,7 +30,7 @@ export const VENDOR_PRESENTATION: Record<string, VendorPresentation> = {
   gastroplanner: {
     categoryKey: 'booking',
     descriptionKey: 'gastroplanner',
-    capabilityKeys: ['bookingsLookup'],
+    capabilityKeys: ['bookingsLookup', 'bookingsAvailability', 'bookingsManage'],
     Mark: GastroplannerMark,
   },
 };
@@ -42,7 +42,7 @@ const DOMAIN_CATEGORY: Record<string, string> = {
 
 const DOMAIN_CAPABILITIES: Record<string, string[]> = {
   commerce: ['ordersLookup', 'customersLookup'],
-  bookings: ['bookingsLookup'],
+  bookings: ['bookingsLookup', 'bookingsAvailability', 'bookingsManage'],
 };
 
 export function vendorPresentation(vendor: string, domain?: string): VendorPresentation {
@@ -69,7 +69,7 @@ export function VendorIcon({
   const Mark = VENDOR_PRESENTATION[vendor]?.Mark;
   return (
     <div
-      className="flex flex-none items-center justify-center border-[0.5px] border-rule-soft bg-paper-deep dark:border-rule-on-dark dark:bg-secondary"
+      className="flex flex-none items-center justify-center border-[1px] border-rule-soft bg-paper-deep dark:border-rule-on-dark dark:bg-secondary"
       style={{ width: size, height: size }}
     >
       {Mark ? (

--- a/packages/dashboard-pages/src/components/load-failed.tsx
+++ b/packages/dashboard-pages/src/components/load-failed.tsx
@@ -82,7 +82,7 @@ export function LoadFailed({
 
       <dl
         className={cn(
-          'grid grid-cols-[110px_1fr] gap-x-3 gap-y-1.5 border-[0.5px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary p-4',
+          'grid grid-cols-[110px_1fr] gap-x-3 gap-y-1.5 border-[1px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary p-4',
           isInbox ? 'max-w-[520px]' : 'max-w-[480px]',
         )}
       >

--- a/packages/dashboard-pages/src/components/munin-topbar.tsx
+++ b/packages/dashboard-pages/src/components/munin-topbar.tsx
@@ -6,6 +6,10 @@ import { Settings as SettingsIcon, ArrowLeft, Menu } from 'lucide-react';
 import { Button } from '@getmunin/ui';
 import type { ReactNode } from 'react';
 
+/* Marketing-topbar treatment: translucent blurred bar with a soft hairline. */
+const topbarChromeBase =
+  'sticky top-0 z-40 group-has-[.agent-banner]:top-12 border-b-[1px] border-rule-soft bg-paper/85 backdrop-blur-xl backdrop-saturate-150 dark:border-rule-on-dark dark:bg-[color-mix(in_srgb,var(--card)_85%,transparent)]';
+
 export interface DashboardTopbarProps {
   brand: string;
   brandHref?: string;
@@ -26,7 +30,7 @@ export function DashboardTopbar({
   settingsLabel,
 }: DashboardTopbarProps) {
   return (
-    <header className="sticky top-0 z-40 group-has-[.agent-banner]:top-12 flex h-14 items-stretch gap-6 border-b-[0.5px] border-ink bg-paper px-4 dark:border-rule-on-dark dark:bg-card md:px-10">
+    <header className={`${topbarChromeBase} flex h-14 items-stretch gap-6 px-4 md:px-10`}>
       <Link
         href={brandHref}
         className="flex items-center gap-1 self-center text-ink dark:text-foreground"
@@ -84,7 +88,7 @@ export function SettingsTopbar({
   openMenuLabel,
 }: SettingsTopbarProps) {
   return (
-    <header className="sticky top-0 z-40 group-has-[.agent-banner]:top-12 flex h-14 items-stretch gap-4 border-b-[0.5px] border-ink bg-paper px-4 dark:border-rule-on-dark dark:bg-card md:gap-5 md:px-10">
+    <header className={`${topbarChromeBase} flex h-14 items-stretch gap-4 px-4 md:gap-5 md:px-10`}>
       <Link
         href={backHref}
         aria-label={backLabel}

--- a/packages/dashboard-pages/src/components/page-shell.tsx
+++ b/packages/dashboard-pages/src/components/page-shell.tsx
@@ -21,4 +21,4 @@ export function PageShell({ eyebrow, title, lede, actions, children, className }
 }
 
 export const nativeFieldClass =
-  'h-9 w-full min-w-0 rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-1.5 text-sm text-ink transition-colors duration-fast ease-munin outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt disabled:opacity-50 dark:bg-card dark:text-foreground dark:border-rule-on-dark';
+  'h-9 w-full min-w-0 rounded-input border-[1px] border-rule-soft bg-paper px-3 py-1.5 text-sm text-ink transition-colors duration-fast ease-munin outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt disabled:opacity-50 dark:bg-card dark:text-foreground dark:border-rule-on-dark';

--- a/packages/dashboard-pages/src/components/save-error-stage.tsx
+++ b/packages/dashboard-pages/src/components/save-error-stage.tsx
@@ -47,11 +47,11 @@ export function SaveErrorStage({
         <DialogDescription>{t('sub')}</DialogDescription>
       </DialogHeader>
 
-      <div className="border-[0.5px] border-cobalt/40 dark:border-cobalt-soft/40 bg-paper-deep dark:bg-secondary p-5 space-y-4">
+      <div className="border-[1px] border-cobalt/40 dark:border-cobalt-soft/40 bg-paper-deep dark:bg-secondary p-5 space-y-4">
         <p className="text-sm leading-relaxed text-ink dark:text-foreground">
           {detail.message ?? t('body')}
         </p>
-        <hr className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark" aria-hidden />
+        <hr className="border-t-[1px] border-rule-soft dark:border-rule-on-dark" aria-hidden />
         <dl className="grid grid-cols-[90px_1fr] gap-x-3 gap-y-2 font-mono text-[12px]">
           {detail.requestId && (
             <>

--- a/packages/dashboard-pages/src/components/skeleton.tsx
+++ b/packages/dashboard-pages/src/components/skeleton.tsx
@@ -31,13 +31,13 @@ export function TableSkeleton({ columns, rows = 4 }: { columns: SkeletonColumn[]
   return (
     <div role="status" aria-busy="true">
       <span className="sr-only">Loading…</span>
-      <div className="flex items-center gap-6 border-b-[0.5px] border-rule-soft pb-3 dark:border-rule-on-dark">
+      <div className="flex items-center gap-6 border-b-[1px] border-rule-soft pb-3 dark:border-rule-on-dark">
         {cells('h-2.5')}
       </div>
       {Array.from({ length: rows }).map((_, r) => (
         <div
           key={r}
-          className="flex items-center gap-6 border-b-[0.5px] border-rule-soft py-4 dark:border-rule-on-dark"
+          className="flex items-center gap-6 border-b-[1px] border-rule-soft py-4 dark:border-rule-on-dark"
         >
           {cells('h-4')}
         </div>
@@ -50,7 +50,7 @@ export function CardSkeleton({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        'space-y-3 border-[0.5px] border-rule-soft p-4 dark:border-rule-on-dark',
+        'space-y-3 border-[1px] border-rule-soft p-4 dark:border-rule-on-dark',
         className,
       )}
     >

--- a/packages/dashboard-pages/src/components/system-alerts-banner.tsx
+++ b/packages/dashboard-pages/src/components/system-alerts-banner.tsx
@@ -94,7 +94,7 @@ export function SystemAlertsBanner() {
     <div
       role="alert"
       aria-live="polite"
-      className="agent-banner sticky top-0 z-50 h-12 overflow-hidden border-b-[0.5px] border-ink bg-amber-100 text-ink dark:bg-amber-200/90 dark:text-ink"
+      className="agent-banner sticky top-0 z-50 h-12 overflow-hidden border-b-[1px] border-ink/20 bg-amber-100 text-ink dark:bg-amber-200/90 dark:text-ink"
     >
       <div className="mx-auto flex h-full items-center gap-4 px-4 md:px-10">
         <span className="flex shrink-0 items-center gap-2 whitespace-nowrap border-r border-ink/25 pr-3.5 font-mono text-[10px] uppercase leading-none tracking-[0.16em]">

--- a/packages/dashboard-pages/src/lib/dialog-style.ts
+++ b/packages/dashboard-pages/src/lib/dialog-style.ts
@@ -11,7 +11,7 @@ export const dialogLabelClass =
   'font-sans normal-case tracking-normal text-sm text-ink dark:text-foreground font-semibold leading-none gap-0';
 
 export const dialogHintClass =
-  'font-sans normal-case tracking-normal text-[13px] text-ink-soft dark:text-foreground/70 leading-snug';
+  'font-sans normal-case tracking-normal text-xs text-ink-mute dark:text-foreground/50 leading-snug';
 
 export const dialogButtonClass =
   'font-sans normal-case tracking-normal text-[13px] font-medium h-10 px-4 gap-1.5';
@@ -21,4 +21,4 @@ export const dialogButtonClass =
  * background and a hairline above (matches the mockup).
  */
 export const dialogFooterClass =
-  '-mx-6 -mb-6 mt-6 px-6 py-3 bg-paper-deep border-t-[0.5px] border-rule-soft dark:bg-secondary dark:border-rule-on-dark flex flex-col-reverse gap-2 sm:flex-row sm:justify-end';
+  '-mx-6 -mb-6 mt-6 px-6 py-3 bg-paper-deep border-t-[1px] border-rule-soft dark:bg-secondary dark:border-rule-on-dark flex flex-col-reverse gap-2 sm:flex-row sm:justify-end';

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1273,11 +1273,11 @@
     },
     "dataConnectors": {
       "title": "Data connections",
-      "subtitle": "Read directly — never copied into Munin"
+      "subtitle": "Live against the vendor — nothing is stored in Munin"
     },
     "connectors": {
       "title": "Connections",
-      "lede": "Connected commerce and booking systems agents can look up on a customer's behalf.",
+      "lede": "Connected commerce and booking systems agents can use on a customer's behalf.",
       "name": "Name",
       "namePlaceholder": "e.g. Main store",
       "create": "Connect",
@@ -1300,7 +1300,7 @@
       "connectVendor": "Connect {vendor}",
       "readOnly": "Read-only",
       "whatAgentsGet": "What agents get",
-      "readLive": "Read directly — never copied into Munin.",
+      "liveData": "Live against the vendor — nothing is stored in Munin.",
       "connectedCount": "{count} connected"
     },
     "slack": {
@@ -1333,7 +1333,7 @@
         "slack": "Triage the inbox and reply without leaving your workspace.",
         "shopify": "Orders, customers, and fulfillment — read on behalf of a customer.",
         "magento": "Read orders and customers from your Magento store.",
-        "gastroplanner": "Find, confirm, and look up restaurant bookings.",
+        "gastroplanner": "Check availability, book tables, and manage restaurant bookings.",
         "generic": "Read directly on behalf of a customer."
       },
       "capability": {
@@ -1341,7 +1341,9 @@
         "slackReply": "Reply to customers from the thread.",
         "ordersLookup": "Look up a customer's orders and status.",
         "customersLookup": "Match a conversation to a store customer.",
-        "bookingsLookup": "Find a guest's bookings and details."
+        "bookingsLookup": "Find a guest's bookings and details.",
+        "bookingsAvailability": "Check availability and book a table.",
+        "bookingsManage": "Change or cancel a guest's booking."
       }
     },
     "field": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1284,11 +1284,11 @@
     },
     "dataConnectors": {
       "title": "Datakoblinger",
-      "subtitle": "Leses direkte — aldri kopiert inn i Munin"
+      "subtitle": "Direkte mot leverandøren — ingenting lagres i Munin"
     },
     "connectors": {
       "title": "Koblinger",
-      "lede": "Tilkoblede handels- og bookingsystemer agenter kan slå opp i på vegne av en kunde.",
+      "lede": "Tilkoblede handels- og bookingsystemer agenter kan bruke på vegne av en kunde.",
       "name": "Navn",
       "namePlaceholder": "f.eks. Hovedbutikk",
       "create": "Koble til",
@@ -1311,7 +1311,7 @@
       "connectVendor": "Koble til {vendor}",
       "readOnly": "Skrivebeskyttet",
       "whatAgentsGet": "Hva agenter får",
-      "readLive": "Leses direkte — aldri kopiert inn i Munin.",
+      "liveData": "Direkte mot leverandøren — ingenting lagres i Munin.",
       "connectedCount": "{count} tilkoblet"
     },
     "slack": {
@@ -1344,7 +1344,7 @@
         "slack": "Håndter innboksen og svar uten å forlate arbeidsområdet.",
         "shopify": "Ordrer, kunder og leveringer — lest på vegne av en kunde.",
         "magento": "Les ordrer og kunder fra Magento-butikken din.",
-        "gastroplanner": "Finn, bekreft og slå opp restaurantbookinger.",
+        "gastroplanner": "Sjekk ledige tider, book bord og håndter restaurantbookinger.",
         "generic": "Leses direkte på vegne av en kunde."
       },
       "capability": {
@@ -1352,7 +1352,9 @@
         "slackReply": "Svar kunder fra tråden.",
         "ordersLookup": "Slå opp en kundes ordrer og status.",
         "customersLookup": "Koble en samtale til en butikkunde.",
-        "bookingsLookup": "Finn en gjests bookinger og detaljer."
+        "bookingsLookup": "Finn en gjests bookinger og detaljer.",
+        "bookingsAvailability": "Sjekk ledige tider og book bord.",
+        "bookingsManage": "Endre eller avbestill en gjests booking."
       }
     },
     "field": {

--- a/packages/dashboard-pages/src/pages/accept-invite.tsx
+++ b/packages/dashboard-pages/src/pages/accept-invite.tsx
@@ -75,7 +75,7 @@ function AcceptInviteInner({ footer }: { footer: AuthFooter }) {
             primary={
               <Link
                 href="/dashboard"
-                className="inline-flex items-center gap-2.5 border-[0.5px] border-ink bg-ink px-[22px] py-3.5 text-[15px] font-medium text-paper transition-colors duration-fast ease-munin hover:border-cobalt-deep hover:bg-cobalt-deep"
+                className="inline-flex items-center gap-2.5 border-[1px] border-ink bg-ink px-[22px] py-3.5 text-[15px] font-medium text-paper transition-colors duration-fast ease-munin hover:border-cobalt-deep hover:bg-cobalt-deep"
               >
                 {t('goToDashboard')}
                 <ArrowRight className="size-4" strokeWidth={2} />
@@ -101,7 +101,7 @@ function AcceptInviteInner({ footer }: { footer: AuthFooter }) {
             primary={
               <Link
                 href={session ? '/dashboard' : '/login'}
-                className="inline-flex items-center gap-2 border-[0.5px] border-ink bg-transparent px-[18px] py-3 text-[14px] text-ink transition-colors duration-fast ease-munin hover:bg-ink hover:text-paper"
+                className="inline-flex items-center gap-2 border-[1px] border-ink bg-transparent px-[18px] py-3 text-[14px] text-ink transition-colors duration-fast ease-munin hover:bg-ink hover:text-paper"
               >
                 <ArrowLeft className="size-3.5" strokeWidth={2} />
                 {session ? t('backToDashboard') : t('errors.expired')}

--- a/packages/dashboard-pages/src/pages/activity.tsx
+++ b/packages/dashboard-pages/src/pages/activity.tsx
@@ -130,7 +130,7 @@ export function ActivityPage() {
       />
 
       <section data-screen-label="activity · feed">
-        <header className="flex items-baseline justify-between border-b-[0.5px] border-rule-soft dark:border-rule-on-dark pb-2 mb-0">
+        <header className="flex items-baseline justify-between border-b-[1px] border-rule-soft dark:border-rule-on-dark pb-2 mb-0">
           <h2 className="font-serif text-2xl leading-none">{t('liveStream')}</h2>
           <span className="font-mono text-[11px] uppercase tracking-eyebrow text-ink-mute">
             {t('windowLabel', { count: visible.length, minutes: WINDOW_MS / 60_000 })}
@@ -138,7 +138,7 @@ export function ActivityPage() {
         </header>
 
         <div className="flex min-h-[12rem] flex-col bg-ink dark:bg-card text-paper dark:text-foreground font-mono text-[12px] leading-relaxed px-6 py-4">
-          <div className="grid grid-cols-[6rem_minmax(0,11rem)_minmax(0,12rem)_1fr] gap-x-6 pb-2 mb-1 border-b-[0.5px] border-paper/15 dark:border-rule-on-dark text-[10px] uppercase tracking-eyebrow text-paper/45 dark:text-foreground/45">
+          <div className="grid grid-cols-[6rem_minmax(0,11rem)_minmax(0,12rem)_1fr] gap-x-6 pb-2 mb-1 border-b-[1px] border-paper/15 dark:border-rule-on-dark text-[10px] uppercase tracking-eyebrow text-paper/45 dark:text-foreground/45">
             <span>{t('colTime')}</span>
             <span>{t('colType')}</span>
             <span>{t('colActor')}</span>

--- a/packages/dashboard-pages/src/pages/agents.tsx
+++ b/packages/dashboard-pages/src/pages/agents.tsx
@@ -102,7 +102,7 @@ export function AgentsPage() {
           <div className="-mx-6 overflow-x-auto px-6 md:mx-0 md:px-0">
           <table className="w-full table-fixed">
             <thead>
-              <tr className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark text-left">
+              <tr className="border-b-[1px] border-rule-soft dark:border-rule-on-dark text-left">
                 <Th className="w-[40%]">{t('tableToken')}</Th>
                 <Th className="w-[10%]">{t('tableStatus')}</Th>
                 <Th className="hidden md:table-cell w-[14%]">{t('tableIssued')}</Th>
@@ -142,7 +142,7 @@ export function AgentsPage() {
                 return (
                   <tr
                     key={token.id}
-                    className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark align-middle"
+                    className="border-b-[1px] border-rule-soft dark:border-rule-on-dark align-middle"
                   >
                     <td className="py-4 pr-4 align-top">
                       <div className="flex items-center gap-2 text-sm font-medium text-ink dark:text-foreground">
@@ -196,7 +196,7 @@ export function AgentsPage() {
 function ClientGlyph({ iconUrl, name }: { iconUrl: string | null; name: string }) {
   const glyph = (name.trim()[0] ?? '?').toUpperCase();
   return (
-    <span className="flex size-[18px] shrink-0 items-center justify-center overflow-hidden rounded-[4px] border-[0.5px] border-rule-soft bg-white font-serif text-[10px] leading-none text-ink dark:border-rule-on-dark">
+    <span className="flex size-[18px] shrink-0 items-center justify-center overflow-hidden rounded-[4px] border-[1px] border-rule-soft bg-white font-serif text-[10px] leading-none text-ink dark:border-rule-on-dark">
       {iconUrl ? (
         <img
           src={iconUrl}
@@ -240,7 +240,7 @@ function StatusChip({
         'inline-block px-2 py-0.5 font-mono text-[10px] uppercase tracking-eyebrow',
         status === 'active'
           ? 'bg-cobalt/15 text-cobalt-deep dark:bg-cobalt-soft/20 dark:text-cobalt-soft'
-          : 'border-[0.5px] border-rule-soft dark:border-rule-on-dark text-ink-mute',
+          : 'border-[1px] border-rule-soft dark:border-rule-on-dark text-ink-mute',
       )}
     >
       {label}

--- a/packages/dashboard-pages/src/pages/api-keys.tsx
+++ b/packages/dashboard-pages/src/pages/api-keys.tsx
@@ -126,7 +126,7 @@ export function ApiKeysPage() {
           <div className="-mx-6 overflow-x-auto px-6 md:mx-0 md:px-0">
           <table className="w-full">
             <thead>
-              <tr className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark text-left">
+              <tr className="border-b-[1px] border-rule-soft dark:border-rule-on-dark text-left">
                 <Th>{t('tableName')}</Th>
                 <Th className="hidden md:table-cell">{t('tablePrefix')}</Th>
                 <Th className="hidden md:table-cell">{t('tableCreated')}</Th>
@@ -136,7 +136,7 @@ export function ApiKeysPage() {
             </thead>
             <tbody>
               {keys.map((k) => (
-                <tr key={k.id} className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
+                <tr key={k.id} className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
                   <td className="py-4 pr-4 text-sm font-medium text-ink dark:text-foreground">
                     {k.name}
                   </td>
@@ -334,7 +334,7 @@ function KeyReveal({ value, copyLabel }: { value: string; copyLabel: string }) {
   }
   return (
     <div className="flex items-center gap-2">
-      <code className="flex-1 truncate border-[0.5px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary px-3 py-2 font-mono text-xs text-ink dark:text-foreground">
+      <code className="flex-1 truncate border-[1px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary px-3 py-2 font-mono text-xs text-ink dark:text-foreground">
         {value}
       </code>
       <Button variant="outline" size="sm" onClick={copy} className="gap-1.5">

--- a/packages/dashboard-pages/src/pages/audit-log.tsx
+++ b/packages/dashboard-pages/src/pages/audit-log.tsx
@@ -181,7 +181,7 @@ export function AuditLogPage() {
           <div className="-mx-6 overflow-x-auto px-6 md:mx-0 md:px-0">
           <table className="w-full">
             <thead>
-              <tr className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark text-left">
+              <tr className="border-b-[1px] border-rule-soft dark:border-rule-on-dark text-left">
                 <Th>{t('tableTime')}</Th>
                 <Th className="hidden md:table-cell">{t('tableActor')}</Th>
                 <Th className="hidden md:table-cell">{t('tableClient')}</Th>
@@ -195,7 +195,7 @@ export function AuditLogPage() {
               {items.map((row) => (
                 <tr
                   key={row.id}
-                  className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark align-top"
+                  className="border-b-[1px] border-rule-soft dark:border-rule-on-dark align-top"
                 >
                   <td className="py-3 pr-4 font-mono text-[11px] text-ink-mute whitespace-nowrap">
                     {format.dateTime(new Date(row.createdAt), {

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -656,7 +656,7 @@ function ChannelRow({
   const isDeactivated = !channel.active;
 
   return (
-    <li className="border-[0.5px] border-rule-soft dark:border-rule-on-dark bg-paper dark:bg-card px-5 py-4">
+    <li className="border-[1px] border-rule-soft dark:border-rule-on-dark bg-paper dark:bg-card px-5 py-4">
       <div className="flex items-start justify-between gap-6">
         <div className={cn('min-w-0 flex-1 space-y-3', isDeactivated && 'opacity-50')}>
           <div className="flex items-center gap-3 flex-wrap">
@@ -855,7 +855,7 @@ function AlertFooter({
     ? t('status.deactivatedMessage', { threshold })
     : t('status.failingMessage', { attempt, threshold });
   return (
-    <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t-[0.5px] border-rule-soft pt-3 dark:border-rule-on-dark">
+    <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t-[1px] border-rule-soft pt-3 dark:border-rule-on-dark">
       <div className="flex min-w-0 flex-1 items-center gap-2.5">
         <span className={cn('size-[7px] shrink-0 rounded-full', dotClass)} aria-hidden />
         <span className="truncate text-[13px] text-ink dark:text-foreground">{message}</span>
@@ -932,7 +932,7 @@ function VendorPicker<V extends ChannelVendor>({
   onChange: (next: V) => void;
 }) {
   return (
-    <div className="flex border-[0.5px] border-ink dark:border-foreground">
+    <div className="flex border-[1px] border-ink dark:border-foreground">
       {options.map((opt) => {
         const selected = value === opt.id;
         return (
@@ -942,7 +942,7 @@ function VendorPicker<V extends ChannelVendor>({
             onClick={() => onChange(opt.id)}
             aria-pressed={selected}
             className={cn(
-              'flex flex-1 items-center justify-center gap-2 border-r-[0.5px] border-rule-soft px-3 py-2 text-sm transition-colors last:border-r-0',
+              'flex flex-1 items-center justify-center gap-2 border-r-[1px] border-rule-soft px-3 py-2 text-sm transition-colors last:border-r-0',
               selected
                 ? 'bg-cobalt/5 text-ink dark:text-foreground'
                 : 'text-muted-foreground hover:text-ink dark:hover:text-foreground',
@@ -966,7 +966,7 @@ function OriginChip({ text, muted }: { text: string; muted?: boolean }) {
   return (
     <span
       className={cn(
-        'inline-block border-[0.5px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary px-2 py-0.5 font-mono text-[11px]',
+        'inline-block border-[1px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary px-2 py-0.5 font-mono text-[11px]',
         muted ? 'text-ink-mute italic' : 'text-ink dark:text-foreground',
       )}
     >
@@ -1420,7 +1420,7 @@ function EmailChannelDialog({
             </FormField>
           </div>
 
-          <fieldset className="space-y-3 rounded-md border-[0.5px] px-3 pb-3">
+          <fieldset className="space-y-3 rounded-md border-[1px] px-3 pb-3">
             <legend className="px-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">{t('email.outboundLabel')}</legend>
             <div className="grid gap-3 sm:grid-cols-2">
               <FormField label={t('email.host')} error={fieldErrors.smtpHost}>
@@ -1516,7 +1516,7 @@ function EmailChannelDialog({
             </div>
           </fieldset>
 
-          <fieldset className="space-y-3 rounded-md border-[0.5px] px-3 pb-3">
+          <fieldset className="space-y-3 rounded-md border-[1px] px-3 pb-3">
             <legend className="px-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">{t('email.inboundLabel')}</legend>
             <label className="flex items-center gap-2 text-sm">
               <input
@@ -1890,7 +1890,7 @@ function CopyableSecret({ label, value, hint }: { label: string; value: string; 
     <div className="space-y-1">
       <Label>{label}</Label>
       <div className="flex items-center gap-2">
-        <code className="flex-1 truncate rounded-md border-[0.5px] bg-background px-3 py-2 font-mono text-sm">
+        <code className="flex-1 truncate rounded-md border-[1px] bg-background px-3 py-2 font-mono text-sm">
           {value}
         </code>
         <Button variant="outline" size="sm" onClick={copy}>
@@ -1941,7 +1941,7 @@ function WebhookSecretField({
     <div className="flex flex-col gap-2">
       {value ? (
         <div className="flex items-center gap-2">
-          <code className="flex-1 truncate rounded-md border-[0.5px] bg-background px-3 py-2 font-mono text-sm">
+          <code className="flex-1 truncate rounded-md border-[1px] bg-background px-3 py-2 font-mono text-sm">
             {value}
           </code>
           <Button type="button" variant="outline" size="sm" onClick={copy}>
@@ -1955,7 +1955,7 @@ function WebhookSecretField({
         </div>
       ) : (
         <div className="flex items-center gap-2">
-          <div className="flex-1 truncate rounded-md border-[0.5px] border-dashed bg-background px-3 py-2 font-mono text-sm text-muted-foreground">
+          <div className="flex-1 truncate rounded-md border-[1px] border-dashed bg-background px-3 py-2 font-mono text-sm text-muted-foreground">
             {emptyHint ?? '••••'}
           </div>
           <Button type="button" variant="outline" size="sm" onClick={regenerate}>
@@ -2056,7 +2056,7 @@ function EmbedSnippetDialog({
         <div className="space-y-8 py-2">
           <div className="space-y-3">
             <Label className={dialogLabelClass}>{t('embed.scriptLabel')}</Label>
-            <pre className="overflow-x-auto rounded-md border-[0.5px] bg-muted px-3 py-2 font-mono text-xs">
+            <pre className="overflow-x-auto rounded-md border-[1px] bg-muted px-3 py-2 font-mono text-xs">
               {scriptSnippet}
             </pre>
             <Button variant="outline" size="sm" onClick={copySnippet}>
@@ -2072,7 +2072,7 @@ function EmbedSnippetDialog({
           <div className="space-y-3">
             <Label className={dialogLabelClass}>{t('embed.hashLabel')}</Label>
             <p className={dialogHintClass}>{t('embed.hashHint')}</p>
-            <div className="flex w-fit border-[0.5px] border-ink dark:border-foreground">
+            <div className="flex w-fit border-[1px] border-ink dark:border-foreground">
               {HASH_SNIPPETS.map((s) => {
                 const active = s.language === language;
                 return (
@@ -2081,7 +2081,7 @@ function EmbedSnippetDialog({
                     type="button"
                     onClick={() => setLanguage(s.language)}
                     className={cn(
-                      'w-24 h-7 px-2.5 font-mono text-[11px] uppercase tracking-eyebrow border-r-[0.5px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
+                      'w-24 h-7 px-2.5 font-mono text-[11px] uppercase tracking-eyebrow border-r-[1px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
                       active
                         ? 'bg-ink text-paper dark:bg-foreground dark:text-background'
                         : 'bg-paper hover:bg-paper-deep dark:bg-card dark:hover:bg-secondary',
@@ -2092,7 +2092,7 @@ function EmbedSnippetDialog({
                 );
               })}
             </div>
-            <pre className="overflow-x-auto rounded-md border-[0.5px] bg-muted px-3 py-2 font-mono text-xs">
+            <pre className="overflow-x-auto rounded-md border-[1px] bg-muted px-3 py-2 font-mono text-xs">
               {hashSnippet}
             </pre>
             <Button variant="outline" size="sm" onClick={copyHash}>

--- a/packages/dashboard-pages/src/pages/end-users.tsx
+++ b/packages/dashboard-pages/src/pages/end-users.tsx
@@ -126,7 +126,7 @@ export function EndUsersPage() {
           <div className="-mx-6 overflow-x-auto px-6 md:mx-0 md:px-0">
           <table className="w-full">
             <thead>
-              <tr className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark text-left">
+              <tr className="border-b-[1px] border-rule-soft dark:border-rule-on-dark text-left">
                 <Th>{t('tablePerson')}</Th>
                 <Th className="hidden md:table-cell">{t('tableExternalId')}</Th>
                 <Th>{t('tableLastContact')}</Th>
@@ -135,7 +135,7 @@ export function EndUsersPage() {
             </thead>
             <tbody>
               {filtered.map((eu) => (
-                <tr key={eu.id} className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
+                <tr key={eu.id} className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
                   <td className="py-4 pr-4">
                     <div className="flex items-center gap-3">
                       <Avatar name={eu.name} email={eu.email} />

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -120,7 +120,7 @@ export function OAuthConsentPage({ clientInfo }: OAuthConsentPageProps) {
   if (!clientId || !oauthQuery) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-bone px-6 dark:bg-background">
-        <div className="max-w-md border-[0.5px] border-ink bg-paper p-6 text-sm text-destructive dark:border-rule-on-dark dark:bg-card">
+        <div className="max-w-md border-[1px] border-ink bg-paper p-6 text-sm text-destructive dark:border-rule-on-dark dark:bg-card">
           {t('missingParams')}
         </div>
       </div>
@@ -159,7 +159,7 @@ export function OAuthConsentPage({ clientInfo }: OAuthConsentPageProps) {
           clientName={displayName}
         />
 
-        <section className="mt-8 border-[0.5px] border-ink bg-paper dark:border-rule-on-dark dark:bg-card">
+        <section className="mt-8 border-[1px] border-ink bg-paper dark:border-rule-on-dark dark:bg-card">
           {flow === 'new' ? (
             <RequestPane
               clientInfo={clientInfo}
@@ -300,7 +300,7 @@ function RequestPane({
         {groupedScopes.length === 0 ? (
           <p className="pb-4 text-sm text-ink-soft">{t('noModuleScopes')}</p>
         ) : (
-          <ul className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+          <ul className="border-t-[1px] border-rule-soft dark:border-rule-on-dark">
             {groupedScopes.map((g) => (
               <PermissionRow key={g.module} group={g} />
             ))}
@@ -341,11 +341,11 @@ function IdentityCard({ clientInfo, clientId, displayName }: IdentityCardProps) 
   const registeredLabel = formatRegistered(clientInfo?.created_at);
   return (
     <div
-      className={`flex gap-4 border-b-[0.5px] border-rule-soft px-7 py-5 dark:border-rule-on-dark ${
+      className={`flex gap-4 border-b-[1px] border-rule-soft px-7 py-5 dark:border-rule-on-dark ${
         registeredLabel ? 'items-start' : 'items-center'
       }`}
     >
-      <div className="flex h-[50px] w-[50px] shrink-0 items-center justify-center overflow-hidden rounded-xl border-[0.5px] border-ink bg-white font-serif text-[28px] leading-none text-ink dark:border-rule-on-dark">
+      <div className="flex h-[50px] w-[50px] shrink-0 items-center justify-center overflow-hidden rounded-xl border-[1px] border-ink bg-white font-serif text-[28px] leading-none text-ink dark:border-rule-on-dark">
         {clientInfo?.icon_url ? (
           <img
             src={clientInfo.icon_url}
@@ -387,7 +387,7 @@ function formatRegistered(iso: string | undefined): string | null {
 function TrustTimeline({ clientName }: { clientName: string }) {
   const t = useTranslations('dashboard.oauthConsent');
   return (
-    <div className="flex items-center gap-3 border-b-[0.5px] border-rule-soft bg-paper px-7 py-3 text-[13px] leading-snug text-ink-soft dark:border-rule-on-dark dark:bg-card">
+    <div className="flex items-center gap-3 border-b-[1px] border-rule-soft bg-paper px-7 py-3 text-[13px] leading-snug text-ink-soft dark:border-rule-on-dark dark:bg-card">
       <span className="text-ink-mute">
         <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <circle cx="12" cy="12" r="9" />
@@ -411,7 +411,7 @@ function PermissionRow({ group }: { group: ModuleScopes }) {
     ? `moduleDescriptions.${group.module}.readWrite`
     : `moduleDescriptions.${group.module}.read`;
   return (
-    <li className="grid grid-cols-[1fr_auto] items-center gap-x-4 border-t-[0.5px] border-rule-soft py-3.5 first:border-t-0 dark:border-rule-on-dark">
+    <li className="grid grid-cols-[1fr_auto] items-center gap-x-4 border-t-[1px] border-rule-soft py-3.5 first:border-t-0 dark:border-rule-on-dark">
       <div className="min-w-0">
         <div className="text-[15px] font-semibold text-ink">{t(`modules.${group.module}`)}</div>
         <div className="mt-1 text-[13px] leading-snug text-ink-soft">
@@ -433,7 +433,7 @@ function ScopePill({ kind, label }: { kind: 'read' | 'write'; label: string }) {
       : 'border-rule-soft text-ink-soft';
   return (
     <span
-      className={`whitespace-nowrap rounded-full border-[0.5px] px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.1em] ${cls}`}
+      className={`whitespace-nowrap rounded-full border-[1px] px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.1em] ${cls}`}
     >
       {label}
     </span>
@@ -445,7 +445,7 @@ function ScopePill({ kind, label }: { kind: 'read' | 'write'; label: string }) {
 function ReassuranceBlock({ displayName, userName }: { displayName: string; userName: string }) {
   const t = useTranslations('dashboard.oauthConsent');
   return (
-    <div className="mx-7 my-3 border-[0.5px] border-rule-soft bg-paper-deep px-4 py-3.5 text-[12.5px] leading-relaxed text-ink-soft [overflow-wrap:anywhere] [word-break:break-word] dark:border-rule-on-dark dark:bg-secondary">
+    <div className="mx-7 my-3 border-[1px] border-rule-soft bg-paper-deep px-4 py-3.5 text-[12.5px] leading-relaxed text-ink-soft [overflow-wrap:anywhere] [word-break:break-word] dark:border-rule-on-dark dark:bg-secondary">
       <b className="font-semibold text-ink">{t('reassurance.lead')}</b>{' '}
       {t.rich('reassurance.body', {
         client: () => <b className="font-semibold text-ink">{displayName}</b>,
@@ -473,12 +473,12 @@ interface ActionsFooterProps {
 function ActionsFooter({ userName, busy, onAuthorize, onDeny, onSwitchAccount }: ActionsFooterProps) {
   const t = useTranslations('dashboard.oauthConsent');
   return (
-    <div className="flex flex-wrap items-center gap-3 border-t-[0.5px] border-rule-soft px-7 py-5 dark:border-rule-on-dark">
+    <div className="flex flex-wrap items-center gap-3 border-t-[1px] border-rule-soft px-7 py-5 dark:border-rule-on-dark">
       <button
         type="button"
         onClick={onAuthorize}
         disabled={busy !== null}
-        className="inline-flex h-11 items-center justify-center gap-2 border-[0.5px] border-ink bg-ink px-6 font-sans text-[15px] font-medium text-paper transition hover:bg-cobalt hover:border-cobalt disabled:cursor-not-allowed disabled:opacity-60"
+        className="inline-flex h-11 items-center justify-center gap-2 border-[1px] border-ink bg-ink px-6 font-sans text-[15px] font-medium text-paper transition hover:bg-cobalt hover:border-cobalt disabled:cursor-not-allowed disabled:opacity-60"
       >
         {busy === 'allow' ? t('authorizing') : t('authorize')}
         {busy !== 'allow' && (
@@ -491,7 +491,7 @@ function ActionsFooter({ userName, busy, onAuthorize, onDeny, onSwitchAccount }:
         type="button"
         onClick={onDeny}
         disabled={busy !== null}
-        className="inline-flex h-11 items-center justify-center border-[0.5px] border-ink bg-transparent px-6 font-sans text-[15px] font-medium text-ink transition hover:bg-ink hover:text-paper disabled:cursor-not-allowed disabled:opacity-60"
+        className="inline-flex h-11 items-center justify-center border-[1px] border-ink bg-transparent px-6 font-sans text-[15px] font-medium text-ink transition hover:bg-ink hover:text-paper disabled:cursor-not-allowed disabled:opacity-60"
       >
         {busy === 'deny' ? t('denying') : t('deny')}
       </button>
@@ -529,7 +529,7 @@ function ResultPane({
   return (
     <div className="flex flex-col gap-4 px-7 py-8">
       <div
-        className={`inline-flex h-11 w-11 items-center justify-center rounded-full border-[0.5px] ${
+        className={`inline-flex h-11 w-11 items-center justify-center rounded-full border-[1px] ${
           isGranted
             ? 'border-cobalt/40 bg-cobalt/10 text-cobalt-deep'
             : 'border-rule-soft bg-paper-deep text-ink-soft'

--- a/packages/dashboard-pages/src/pages/team.tsx
+++ b/packages/dashboard-pages/src/pages/team.tsx
@@ -207,7 +207,7 @@ export function TeamPage() {
           <div className="-mx-6 overflow-x-auto px-6 md:mx-0 md:px-0">
           <table className="w-full min-w-[640px]">
             <thead>
-              <tr className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark text-left">
+              <tr className="border-b-[1px] border-rule-soft dark:border-rule-on-dark text-left">
                 <Th>{t('membersTableName')}</Th>
                 <Th>{t('membersTableEmail')}</Th>
                 <Th>{t('membersTableRole')}</Th>
@@ -217,7 +217,7 @@ export function TeamPage() {
             </thead>
             <tbody>
               {members.map((m) => (
-                <tr key={m.userId} className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
+                <tr key={m.userId} className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
                   <td className="py-4 pr-4 text-sm font-medium text-ink dark:text-foreground">
                     {m.name ?? '—'}
                   </td>
@@ -279,7 +279,7 @@ export function TeamPage() {
           <div className="-mx-6 overflow-x-auto px-6 md:mx-0 md:px-0">
           <table className="w-full min-w-[640px]">
             <thead>
-              <tr className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark text-left">
+              <tr className="border-b-[1px] border-rule-soft dark:border-rule-on-dark text-left">
                 <Th>{t('invitesTable.email')}</Th>
                 <Th>{t('invitesTable.role')}</Th>
                 <Th>{t('invitesTable.sent')}</Th>
@@ -289,7 +289,7 @@ export function TeamPage() {
             </thead>
             <tbody>
               {invites.map((inv) => (
-                <tr key={inv.id} className="border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
+                <tr key={inv.id} className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
                   <td className="py-4 pr-4 font-mono text-xs text-ink dark:text-foreground">
                     {inv.email}
                   </td>
@@ -406,7 +406,7 @@ function RoleSelect({
       <select
         value={value}
         onChange={(e) => onChange(e.target.value as MemberRole)}
-        className="appearance-none shadow-[inset_0_0_0_0.5px_rgb(var(--munin-ink)/0.145)] dark:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-fg-on-dark-2)/0.2)] focus-visible:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-accent))] bg-paper dark:bg-card font-mono text-[10px] uppercase tracking-eyebrow text-ink dark:text-foreground py-1.5 pl-3 pr-7 cursor-pointer focus-visible:outline-none"
+        className="appearance-none border-[1px] border-rule-soft dark:border-rule-on-dark focus-visible:border-cobalt bg-paper dark:bg-card font-mono text-[10px] uppercase tracking-eyebrow text-ink dark:text-foreground py-1.5 pl-3 pr-7 cursor-pointer focus-visible:outline-none"
       >
         <option value="owner">{labelOwner}</option>
         <option value="admin">{labelAdmin}</option>
@@ -429,7 +429,7 @@ function RoleChip({
 }) {
   const label = role === 'owner' ? t('roleOwner') : role === 'admin' ? t('roleAdmin') : t('roleMember');
   return (
-    <span className="inline-block border-[0.5px] border-rule-soft dark:border-rule-on-dark font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute py-1 px-2.5">
+    <span className="inline-block border-[1px] border-rule-soft dark:border-rule-on-dark font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute py-1 px-2.5">
       {label}
     </span>
   );

--- a/packages/dashboard-pages/src/pages/trackers.tsx
+++ b/packages/dashboard-pages/src/pages/trackers.tsx
@@ -280,7 +280,7 @@ function TrackerRow({
   const t = useTranslations('dashboard.trackers');
   const origins = tracker.allowedOrigins;
   return (
-    <li className="border-[0.5px] border-rule-soft dark:border-rule-on-dark bg-paper dark:bg-card px-5 py-4">
+    <li className="border-[1px] border-rule-soft dark:border-rule-on-dark bg-paper dark:bg-card px-5 py-4">
       <div className="flex items-start justify-between gap-6">
         <div className="min-w-0 flex-1 space-y-3">
           <h3 className="font-serif text-lg leading-none text-ink dark:text-foreground">
@@ -336,7 +336,7 @@ function OriginChip({ text, muted }: { text: string; muted?: boolean }) {
   return (
     <span
       className={cn(
-        'inline-block border-[0.5px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary px-2 py-0.5 font-mono text-[11px]',
+        'inline-block border-[1px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary px-2 py-0.5 font-mono text-[11px]',
         muted ? 'text-ink-mute italic' : 'text-ink dark:text-foreground',
       )}
     >
@@ -689,7 +689,7 @@ function EmbedSnippetDialog({
         <div className="space-y-8 py-2">
           <div className="space-y-3">
             <Label className={dialogLabelClass}>{t('embed.scriptLabel')}</Label>
-            <pre className="overflow-x-auto rounded-md border-[0.5px] bg-muted px-3 py-2 font-mono text-xs">
+            <pre className="overflow-x-auto rounded-md border-[1px] bg-muted px-3 py-2 font-mono text-xs">
               {scriptSnippet}
             </pre>
             <Button variant="outline" size="sm" onClick={copySnippet}>
@@ -702,7 +702,7 @@ function EmbedSnippetDialog({
           <div className="space-y-3">
             <Label className={dialogLabelClass}>{t('embed.hashLabel')}</Label>
             <p className={dialogHintClass}>{t('embed.hashHint')}</p>
-            <div className="flex w-fit border-[0.5px] border-ink dark:border-foreground">
+            <div className="flex w-fit border-[1px] border-ink dark:border-foreground">
               {HASH_SNIPPETS.map((s) => {
                 const active = s.language === language;
                 return (
@@ -711,7 +711,7 @@ function EmbedSnippetDialog({
                     type="button"
                     onClick={() => setLanguage(s.language)}
                     className={cn(
-                      'w-24 h-7 px-2.5 font-mono text-[11px] uppercase tracking-eyebrow border-r-[0.5px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
+                      'w-24 h-7 px-2.5 font-mono text-[11px] uppercase tracking-eyebrow border-r-[1px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
                       active
                         ? 'bg-ink text-paper dark:bg-foreground dark:text-background'
                         : 'bg-paper hover:bg-paper-deep dark:bg-card dark:hover:bg-secondary',
@@ -722,7 +722,7 @@ function EmbedSnippetDialog({
                 );
               })}
             </div>
-            <pre className="overflow-x-auto rounded-md border-[0.5px] bg-muted px-3 py-2 font-mono text-xs">
+            <pre className="overflow-x-auto rounded-md border-[1px] bg-muted px-3 py-2 font-mono text-xs">
               {hashSnippet}
             </pre>
             <Button variant="outline" size="sm" onClick={copyHash}>

--- a/packages/dashboard-pages/src/pages/usage.tsx
+++ b/packages/dashboard-pages/src/pages/usage.tsx
@@ -84,7 +84,7 @@ export function UsagePage({ slot }: { slot?: ReactNode } = {}) {
         <UsageSkeleton />
       ) : (
         <>
-          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 border-l-[0.5px] border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 border-l-[1px] border-t-[1px] border-rule-soft dark:border-rule-on-dark">
             <Tile
               label={t('tiles.mcpCalls')}
               period={t('tiles.thisMonth')}
@@ -133,11 +133,11 @@ function UsageSkeleton() {
   return (
     <div role="status" aria-busy="true" className="space-y-10">
       <span className="sr-only">Loading…</span>
-      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 border-l-[0.5px] border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 border-l-[1px] border-t-[1px] border-rule-soft dark:border-rule-on-dark">
         {Array.from({ length: 5 }).map((_, i) => (
           <div
             key={i}
-            className="flex min-h-[180px] flex-col gap-4 border-b-[0.5px] border-r-[0.5px] border-rule-soft bg-paper p-6 dark:border-rule-on-dark dark:bg-card"
+            className="flex min-h-[180px] flex-col gap-4 border-b-[1px] border-r-[1px] border-rule-soft bg-paper p-6 dark:border-rule-on-dark dark:bg-card"
           >
             <Skeleton className="h-2.5 w-24" />
             <Skeleton className="h-9 w-20" />
@@ -147,11 +147,11 @@ function UsageSkeleton() {
       </div>
       <div className="space-y-6">
         <Skeleton className="h-6 w-56" />
-        <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+        <div className="border-t-[1px] border-rule-soft dark:border-rule-on-dark">
           {Array.from({ length: 3 }).map((_, i) => (
             <div
               key={i}
-              className="flex items-center justify-between gap-12 border-b-[0.5px] border-rule-soft px-1 py-5 dark:border-rule-on-dark"
+              className="flex items-center justify-between gap-12 border-b-[1px] border-rule-soft px-1 py-5 dark:border-rule-on-dark"
             >
               <Skeleton className="h-4 w-48" />
               <Skeleton className="h-4 w-16" />
@@ -180,7 +180,7 @@ function Tile({
   const delta = useMemo(() => computeDelta(tile, mode), [tile, mode]);
 
   return (
-    <div className="bg-paper dark:bg-card p-6 flex flex-col gap-4 min-h-[180px] border-r-[0.5px] border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
+    <div className="bg-paper dark:bg-card p-6 flex flex-col gap-4 min-h-[180px] border-r-[1px] border-b-[1px] border-rule-soft dark:border-rule-on-dark">
       <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
         {label} · {period}
       </p>
@@ -217,8 +217,8 @@ function ByAgentSection({ data }: { data: UsageByAgentDto | null }) {
         </p>
       </div>
 
-      <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
-        <div className="grid grid-cols-[1fr_auto_auto] gap-x-12 px-1 py-3 border-b-[0.5px] border-rule-soft dark:border-rule-on-dark">
+      <div className="border-t-[1px] border-rule-soft dark:border-rule-on-dark">
+        <div className="grid grid-cols-[1fr_auto_auto] gap-x-12 px-1 py-3 border-b-[1px] border-rule-soft dark:border-rule-on-dark">
           <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
             {t('colAgent')}
           </span>
@@ -237,7 +237,7 @@ function ByAgentSection({ data }: { data: UsageByAgentDto | null }) {
         {data?.agents.map((agent) => (
           <div
             key={agent.id}
-            className="grid grid-cols-[1fr_auto_auto] gap-x-12 items-baseline px-1 py-5 border-b-[0.5px] border-rule-soft dark:border-rule-on-dark"
+            className="grid grid-cols-[1fr_auto_auto] gap-x-12 items-baseline px-1 py-5 border-b-[1px] border-rule-soft dark:border-rule-on-dark"
           >
             <div className="flex flex-col gap-0.5">
               <span className="text-sm font-semibold text-ink dark:text-foreground">{agent.name}</span>

--- a/packages/dashboard-pages/src/shells/settings-shell.tsx
+++ b/packages/dashboard-pages/src/shells/settings-shell.tsx
@@ -97,9 +97,9 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
       />
 
       <div className="flex min-h-[calc(100vh_-_3.5rem)] group-has-[.agent-banner]:min-h-[calc(100vh_-_6.5rem)]">
-        <aside className="sticky top-14 hidden h-[calc(100vh_-_3.5rem)] w-72 shrink-0 flex-col self-start border-r-[0.5px] border-rule-soft bg-bone group-has-[.agent-banner]:top-[6.5rem] group-has-[.agent-banner]:h-[calc(100vh_-_6.5rem)] md:flex dark:border-rule-on-dark dark:bg-secondary">
+        <aside className="sticky top-14 hidden h-[calc(100vh_-_3.5rem)] w-72 shrink-0 flex-col self-start border-r-[1px] border-rule-soft bg-bone group-has-[.agent-banner]:top-[6.5rem] group-has-[.agent-banner]:h-[calc(100vh_-_6.5rem)] md:flex dark:border-rule-on-dark dark:bg-secondary">
           <div className="flex-1 overflow-y-auto px-6 py-10">{navTree}</div>
-          <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+          <div className="border-t-[1px] border-rule-soft dark:border-rule-on-dark">
             {signOutButton}
           </div>
         </aside>
@@ -113,7 +113,7 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
         <SheetContent side="left" className="max-w-[320px] p-0">
           <div className="flex h-full flex-col">
             <div className="flex-1 overflow-y-auto px-6 py-8">{navTree}</div>
-            <div className="border-t-[0.5px] border-rule-soft dark:border-rule-on-dark">
+            <div className="border-t-[1px] border-rule-soft dark:border-rule-on-dark">
               {signOutButton}
             </div>
           </div>

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -17,7 +17,7 @@ function Avatar({
       data-slot="avatar"
       data-size={size}
       className={cn(
-        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border-[0.5px] after:border-rule-soft after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:border-rule-on-dark dark:after:mix-blend-lighten",
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border-[1px] after:border-rule-soft after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:border-rule-on-dark dark:after:mix-blend-lighten",
         className
       )}
       {...props}

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "../cn"
 
 const badgeVariants = cva(
-  "inline-flex items-center gap-1.5 px-2 py-0.5 font-mono text-[9px] uppercase tracking-eyebrow font-medium border-[0.5px] whitespace-nowrap before:content-[''] before:size-[5px] before:rounded-full before:bg-current",
+  "inline-flex items-center gap-1.5 px-2 py-0.5 font-mono text-[9px] uppercase tracking-eyebrow font-medium border-[1px] whitespace-nowrap before:content-[''] before:size-[5px] before:rounded-full before:bg-current",
   {
     variants: {
       variant: {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -5,24 +5,24 @@ import { Loader2 } from "lucide-react"
 import { cn } from "../cn"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap font-mono uppercase tracking-eyebrow text-[10px] font-medium transition-colors duration-fast ease-munin outline-none select-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+  "group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap border-[1px] border-transparent font-mono uppercase tracking-eyebrow text-[10px] font-medium transition-colors duration-fast ease-munin outline-none select-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
   {
     variants: {
       variant: {
         default:
-          "bg-ink text-paper shadow-[inset_0_0_0_0.5px_rgb(var(--munin-ink))] hover:bg-cobalt-deep hover:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-accent-deep))] dark:bg-paper dark:text-ink dark:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-paper))] dark:hover:bg-cobalt-soft dark:hover:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-accent-soft))] dark:hover:text-ink",
+          "border-ink bg-ink text-paper hover:border-cobalt-deep hover:bg-cobalt-deep dark:border-paper dark:bg-paper dark:text-ink dark:hover:border-cobalt-soft dark:hover:bg-cobalt-soft dark:hover:text-ink",
         outline:
-          "bg-transparent text-ink shadow-[inset_0_0_0_0.5px_rgb(var(--munin-ink))] hover:bg-ink hover:text-paper dark:text-paper dark:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-paper))] dark:hover:bg-paper dark:hover:text-ink",
+          "border-ink bg-transparent text-ink hover:bg-ink hover:text-paper dark:border-paper dark:text-paper dark:hover:bg-paper dark:hover:text-ink",
         secondary:
-          "bg-paper-deep text-ink shadow-[inset_0_0_0_0.5px_rgb(var(--munin-ink)/0.145)] hover:bg-ink hover:text-paper hover:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-ink))] dark:bg-secondary dark:text-foreground dark:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-fg-on-dark-2)/0.2)] dark:hover:bg-paper dark:hover:text-ink",
+          "border-rule-soft bg-paper-deep text-ink hover:border-ink hover:bg-ink hover:text-paper dark:border-rule-on-dark dark:bg-secondary dark:text-foreground dark:hover:bg-paper dark:hover:text-ink",
         ghost:
           "text-ink hover:bg-paper-deep dark:text-foreground dark:hover:bg-secondary",
         accent:
-          "bg-cobalt text-paper shadow-[inset_0_0_0_0.5px_rgb(var(--munin-accent))] hover:bg-cobalt-deep hover:shadow-[inset_0_0_0_0.5px_rgb(var(--munin-accent-deep))]",
+          "border-cobalt bg-cobalt text-paper hover:border-cobalt-deep hover:bg-cobalt-deep",
         destructive:
-          "bg-transparent text-destructive shadow-[inset_0_0_0_0.5px_var(--destructive)] hover:bg-destructive hover:text-destructive-foreground",
+          "border-destructive bg-transparent text-destructive hover:bg-destructive hover:text-destructive-foreground",
         link:
-          "border-0 border-b-[0.5px] border-cobalt bg-transparent text-cobalt font-serif italic normal-case tracking-normal text-[15px] hover:text-cobalt-deep hover:border-cobalt-deep h-auto px-0 py-0 dark:text-cobalt-soft dark:border-cobalt-soft",
+          "border-0 border-b-[1px] border-cobalt bg-transparent text-cobalt font-serif italic normal-case tracking-normal text-[15px] hover:text-cobalt-deep hover:border-cobalt-deep h-auto px-0 py-0 dark:text-cobalt-soft dark:border-cobalt-soft",
       },
       size: {
         default: "h-9 gap-1.5 px-3 py-2",

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden border-[0.5px] border-rule-soft bg-paper py-5 text-sm text-foreground has-data-[slot=card-footer]:pb-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 dark:bg-card dark:border-rule-on-dark",
+        "group/card flex flex-col gap-4 overflow-hidden border-[1px] border-rule-soft bg-paper py-5 text-sm text-foreground has-data-[slot=card-footer]:pb-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 dark:bg-card dark:border-rule-on-dark",
         className
       )}
       {...props}
@@ -84,7 +84,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "flex items-center border-t-[0.5px] border-rule-soft bg-paper-deep px-5 py-3 group-data-[size=sm]/card:p-3 dark:bg-secondary dark:border-rule-on-dark",
+        "flex items-center border-t-[1px] border-rule-soft bg-paper-deep px-5 py-3 group-data-[size=sm]/card:p-3 dark:bg-secondary dark:border-rule-on-dark",
         className
       )}
       {...props}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -38,7 +38,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 border-[0.5px] border-ink bg-paper p-6 outline-none transition-opacity duration-200 ease-munin opacity-100 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 dark:bg-card dark:border-rule-on-dark",
+          "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 border-[1px] border-ink bg-paper p-6 outline-none transition-opacity duration-200 ease-munin opacity-100 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 dark:bg-card dark:border-rule-on-dark",
           className
         )}
         {...props}
@@ -53,7 +53,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-left pb-4 border-b-[0.5px] border-rule-soft mb-4 dark:border-rule-on-dark", className)}
+      className={cn("flex flex-col gap-2 text-left pb-4 border-b-[1px] border-rule-soft mb-4 dark:border-rule-on-dark", className)}
       {...props}
     />
   )
@@ -63,7 +63,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-footer"
-      className={cn("mt-6 pt-4 border-t-[0.5px] border-rule-soft flex flex-col-reverse gap-2 sm:flex-row sm:justify-end dark:border-rule-on-dark", className)}
+      className={cn("mt-6 pt-4 border-t-[1px] border-rule-soft flex flex-col-reverse gap-2 sm:flex-row sm:justify-end dark:border-rule-on-dark", className)}
       {...props}
     />
   )

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -41,7 +41,7 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
-          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-40 origin-(--transform-origin) overflow-x-hidden overflow-y-auto border-[0.5px] border-ink bg-popover p-1 text-popover-foreground duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 dark:border-rule-on-dark", className )}
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-40 origin-(--transform-origin) overflow-x-hidden overflow-y-auto border-[1px] border-ink bg-popover p-1 text-popover-foreground duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 dark:border-rule-on-dark", className )}
           {...props}
         />
       </MenuPrimitive.Positioner>
@@ -135,7 +135,7 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
-      className={cn("w-auto min-w-[120px] border-[0.5px] border-ink bg-popover p-1 text-popover-foreground duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 dark:border-rule-on-dark", className )}
+      className={cn("w-auto min-w-[120px] border-[1px] border-ink bg-popover p-1 text-popover-foreground duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 dark:border-rule-on-dark", className )}
       align={align}
       alignOffset={alignOffset}
       side={side}

--- a/packages/ui/src/components/hairline.tsx
+++ b/packages/ui/src/components/hairline.tsx
@@ -11,7 +11,7 @@ function Hairline({ variant = 'soft', className, ...props }: HairlineProps) {
     <hr
       data-slot="hairline"
       className={cn(
-        'border-0 border-t-[0.5px]',
+        'border-0 border-t-[1px]',
         variant === 'hard'
           ? 'border-ink dark:border-foreground'
           : 'border-rule-soft dark:border-rule-on-dark',

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-input border-[0.5px] border-rule-soft bg-paper px-3 py-1.5 text-base md:text-sm text-ink transition-colors duration-fast ease-munin outline-none placeholder:text-ink-mute focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive dark:bg-card dark:text-foreground dark:border-rule-on-dark dark:focus-visible:border-cobalt-soft dark:focus-visible:ring-cobalt-soft",
+        "h-9 w-full min-w-0 rounded-input border-[1px] border-rule-soft bg-paper px-3 py-1.5 text-base md:text-sm text-ink transition-colors duration-fast ease-munin outline-none placeholder:text-ink-mute focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive dark:bg-card dark:text-foreground dark:border-rule-on-dark dark:focus-visible:border-cobalt-soft dark:focus-visible:ring-cobalt-soft",
         className
       )}
       {...props}

--- a/packages/ui/src/components/pill.tsx
+++ b/packages/ui/src/components/pill.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../cn';
 
 const pillVariants = cva(
-  "inline-flex items-center gap-1.5 px-1.5 py-[3px] font-mono text-[9px] leading-none uppercase tracking-eyebrow font-medium shadow-[inset_0_0_0_0.5px_currentColor] whitespace-nowrap before:content-[''] before:size-[5px] before:rounded-full before:bg-current",
+  "inline-flex items-center gap-1.5 px-[5px] py-[2px] font-mono text-[9px] leading-none uppercase tracking-eyebrow font-medium border-[1px] border-[color-mix(in_srgb,currentColor_55%,transparent)] whitespace-nowrap before:content-[''] before:size-[5px] before:rounded-full before:bg-current",
   {
     variants: {
       tone: {

--- a/packages/ui/src/components/section-head.tsx
+++ b/packages/ui/src/components/section-head.tsx
@@ -22,7 +22,7 @@ function SectionHead({
       data-slot="section-head"
       className={cn(
         'flex items-end justify-between gap-4 pb-3',
-        divider && 'border-b-[0.5px] border-rule-soft dark:border-rule-on-dark',
+        divider && 'border-b-[1px] border-rule-soft dark:border-rule-on-dark',
         className,
       )}
       {...props}

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -9,12 +9,12 @@ const sheetVariants = cva(
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b-[0.5px] border-ink data-[starting-style]:-translate-y-full data-[ending-style]:-translate-y-full dark:border-rule-on-dark",
+        top: "inset-x-0 top-0 border-b-[1px] border-ink data-[starting-style]:-translate-y-full data-[ending-style]:-translate-y-full dark:border-rule-on-dark",
         bottom:
-          "inset-x-0 bottom-0 border-t-[0.5px] border-ink data-[starting-style]:translate-y-full data-[ending-style]:translate-y-full dark:border-rule-on-dark",
-        left: "inset-y-0 left-0 h-full w-full max-w-[560px] border-r-[0.5px] border-ink data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full dark:border-rule-on-dark",
+          "inset-x-0 bottom-0 border-t-[1px] border-ink data-[starting-style]:translate-y-full data-[ending-style]:translate-y-full dark:border-rule-on-dark",
+        left: "inset-y-0 left-0 h-full w-full max-w-[560px] border-r-[1px] border-ink data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full dark:border-rule-on-dark",
         right:
-          "inset-y-0 right-0 h-full w-full max-w-[560px] border-l-[0.5px] border-ink data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full dark:border-rule-on-dark",
+          "inset-y-0 right-0 h-full w-full max-w-[560px] border-l-[1px] border-ink data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full dark:border-rule-on-dark",
       },
     },
     defaultVariants: { side: "right" },
@@ -68,7 +68,7 @@ function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn("flex flex-col gap-2 px-6 py-5 border-b-[0.5px] border-rule-soft dark:border-rule-on-dark", className)}
+      className={cn("flex flex-col gap-2 px-6 py-5 border-b-[1px] border-rule-soft dark:border-rule-on-dark", className)}
       {...props}
     />
   )

--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -32,7 +32,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
         {
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
-          "--normal-border-[0.5px]": "rgb(var(--munin-ink))",
+          "--normal-border": "rgb(var(--munin-ink))",
           "--border-radius": "0px",
         } as React.CSSProperties
       }

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -18,7 +18,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
     <thead
       data-slot="table-header"
-      className={cn("[&_tr]:border-b-[0.5px] [&_tr]:border-ink dark:[&_tr]:border-rule-on-dark", className)}
+      className={cn("[&_tr]:border-b-[1px] [&_tr]:border-ink dark:[&_tr]:border-rule-on-dark", className)}
       {...props}
     />
   )
@@ -38,7 +38,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn("border-t-[0.5px] border-rule-soft bg-paper-deep font-medium dark:bg-secondary dark:border-rule-on-dark", className)}
+      className={cn("border-t-[1px] border-rule-soft bg-paper-deep font-medium dark:bg-secondary dark:border-rule-on-dark", className)}
       {...props}
     />
   )
@@ -49,7 +49,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b-[0.5px] border-rule-soft transition-colors duration-fast ease-munin hover:bg-paper-deep data-[state=selected]:bg-paper-deep dark:border-rule-on-dark dark:hover:bg-secondary dark:data-[state=selected]:bg-secondary",
+        "border-b-[1px] border-rule-soft transition-colors duration-fast ease-munin hover:bg-paper-deep data-[state=selected]:bg-paper-deep dark:border-rule-on-dark dark:hover:bg-secondary dark:data-[state=selected]:bg-secondary",
         className
       )}
       {...props}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -15,7 +15,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "inline-flex items-stretch border-b-[0.5px] border-rule-soft text-ink-mute dark:border-rule-on-dark",
+        "inline-flex items-stretch border-b-[1px] border-rule-soft text-ink-mute dark:border-rule-on-dark",
         className
       )}
       {...props}

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -28,8 +28,8 @@
   --munin-invite-bad-bg: 236 211 203;    /* #ECD3CB */
   --munin-invite-bad-ink: 138 42 26;     /* #8A2A1A */
 
-  --munin-rule-soft-alpha: 0.145;   /* hairline rule alpha on light */
-  --munin-rule-on-dark-alpha: 0.2;  /* hairline rule alpha on dark */
+  --munin-rule-soft-alpha: 0.09;    /* hairline rule alpha on light — tuned for 1px rules */
+  --munin-rule-on-dark-alpha: 0.13; /* hairline rule alpha on dark — tuned for 1px rules */
 
   --munin-serif: 'Instrument Serif', 'Times New Roman', serif;
   --munin-sans: 'Inter', 'Helvetica Neue', system-ui, sans-serif;

--- a/packages/ui/src/tailwind-preset.ts
+++ b/packages/ui/src/tailwind-preset.ts
@@ -58,8 +58,8 @@ const muninPreset: Omit<Config, 'content'> = {
         },
         rule: {
           DEFAULT: 'rgb(var(--munin-ink) / <alpha-value>)',
-          soft: 'rgb(var(--munin-ink) / 0.145)',
-          'on-dark': 'rgb(var(--munin-fg-on-dark-2) / 0.2)',
+          soft: 'rgb(var(--munin-ink) / var(--munin-rule-soft-alpha))',
+          'on-dark': 'rgb(var(--munin-fg-on-dark-2) / var(--munin-rule-on-dark-alpha))',
         },
         'auth-navy': {
           DEFAULT: 'rgb(var(--munin-auth-navy) / <alpha-value>)',


### PR DESCRIPTION
## Why

`0.5px` hairlines render inconsistently across devices (dropped or doubled depending on DPR). This moves every border and outline in the dashboard UI to `1px` and compensates the visual weight so the editorial "whisper" look survives the width change.

## What

- **1px everywhere** — all `border-*-[0.5px]` classes and `inset_0_0_0_0.5px` shadow outlines are now 1px, kept in arbitrary-value form (`border-b-[1px]`) so the sweep stays greppable.
- **Tuned + single-sourced rule weight** — perceived weight ≈ width × contrast, so doubling the width halves the alpha: light `0.145 → 0.09`, dark `0.2 → 0.13`. The tailwind preset, Button, and team-page role select now reference the `--munin-rule-*-alpha` tokens instead of carrying hardcoded copies; future tuning is a one-line change in `tokens.css`.
- **Border normalization** — the inset box-shadow outline workaround from #397 existed only because iOS Safari dropped *sub-pixel* borders. With integer widths that's moot, so buttons, pills, auth-shell CTAs, and the team role select use real borders again (transparent border in the Button cva base keeps metrics identical across variants; pill padding absorbs the border so rendered size is unchanged). Pill outlines soften to 55% `currentColor` so status badges stop shouting.
- **Topbar chrome** — dashboard/settings topbars had a full-ink `border-ink` bottom border which turned into a solid black line at 1px. They now use the marketing-site treatment: translucent blurred bar (`bg-paper/85` + backdrop blur/saturate) with an always-on soft hairline. The system-alerts banner border softens from full ink to `ink/20`.
- **Dialog hints** — down to `text-xs text-ink-mute` so they read as metadata next to the semibold labels.
- **Bookings connector copy** — the Gastroplanner connect dialog only advertised lookup; it now lists the full write surface (check availability + book, change/cancel) matching the `bookings_*` tools, and the "read directly — never copied into Munin" note is reworded to "live against the vendor — nothing is stored in Munin" (still true, no longer implying read-only). en + nb.
- **Drive-by fix** — sonner set a CSS var literally named `--normal-border-[0.5px]`, which sonner never reads; toasts now get their intended ink border via `--normal-border`.

## Notes

- `color-mix()` is used for the pill outline and dark-mode topbar translucency — needs Safari 16.2+/Chrome 111+, in line with the dashboard's existing baseline.
- Typecheck + ui tests pass. Eyeballed live on the dashboard (light mode) through the queue list, integrations dialogs, settings, and the alerts banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)