### PR TITLE
fix: localized inline field errors, tier labels, aria-invalid variant

### DIFF
--- a/.changeset/tier-labels-and-connector-field-errors.md
+++ b/.changeset/tier-labels-and-connector-field-errors.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+'@getmunin/ui': patch
+---
+
+Localize the smart/fast model-tier badges (nb: "rask") and surface connector config validation as inline field errors: invalid connector config now returns structured `fieldErrors` instead of a raw zod JSON blob, and the connect dialog highlights the offending inputs with localized per-field messages instead of toasting. The Tailwind preset now defines the `aria-invalid` variant (absent from Tailwind v3 defaults), so the destructive border/ring on invalid inputs actually renders.

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -5333,6 +5333,34 @@
         "security": []
       }
     },
+    "/v1/credentials": {
+      "get": {
+        "operationId": "CredentialHandoffController_describe",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "CredentialHandoff"
+        ],
+        "security": []
+      },
+      "post": {
+        "operationId": "CredentialHandoffController_complete",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "CredentialHandoff"
+        ],
+        "security": []
+      }
+    },
     "/v1/slack/oauth/callback": {
       "get": {
         "operationId": "SlackOAuthController_callback",
@@ -5374,34 +5402,6 @@
         },
         "tags": [
           "SlackEvents"
-        ],
-        "security": []
-      }
-    },
-    "/v1/credentials": {
-      "get": {
-        "operationId": "CredentialHandoffController_describe",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "CredentialHandoff"
-        ],
-        "security": []
-      },
-      "post": {
-        "operationId": "CredentialHandoffController_complete",
-        "parameters": [],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "CredentialHandoff"
         ],
         "security": []
       }

--- a/packages/backend-core/src/modules/connectors/connectors.service.test.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.test.ts
@@ -194,6 +194,30 @@ class FakeAdapter implements ConnectorAdapter {
       ).rejects.toThrow(/unknown vendor/);
     });
 
+    it('rejects invalid config with per-field errors and a readable summary', async () => {
+      const err = await run(() =>
+        connectors.createConnection({
+          vendor: 'fakeshop',
+          name: 'Bad config',
+          config: { host: '', apiToken: 'tok_plaintext_secret' },
+        }),
+      ).then(
+        () => null,
+        (e: unknown) => e,
+      );
+
+      expect(err).toBeInstanceOf(BadRequestException);
+      const response = (err as BadRequestException).getResponse() as {
+        message: string;
+        fieldErrors: Array<{ field: string; message: string }>;
+      };
+      expect(response.message).toMatch(/^connectors_invalid: config for fakeshop: host: /);
+      expect(response.message).not.toMatch(/[[{]/);
+      expect(response.fieldErrors).toHaveLength(1);
+      expect(response.fieldErrors[0]!.field).toBe('host');
+      expect(response.fieldErrors[0]!.message.length).toBeGreaterThan(0);
+    });
+
     it('keeps the stored secret when config is updated without the token', async () => {
       const dto = await createConnection('fakeshop', 'Main store');
       await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);

--- a/packages/backend-core/src/modules/connectors/connectors.service.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.ts
@@ -455,9 +455,17 @@ export class ConnectorsService {
   ): Promise<Record<string, unknown>> {
     const parsed = adapter.configInput.safeParse(config);
     if (!parsed.success) {
-      throw new BadRequestException(
-        `connectors_invalid: config for ${adapter.vendor}: ${parsed.error.message}`,
-      );
+      const fieldErrors = parsed.error.issues.map((issue) => ({
+        field: issue.path.join('.'),
+        message: issue.message,
+      }));
+      const summary = fieldErrors
+        .map((fe) => (fe.field ? `${fe.field}: ${fe.message}` : fe.message))
+        .join('; ');
+      throw new BadRequestException({
+        message: `connectors_invalid: config for ${adapter.vendor}: ${summary}`,
+        fieldErrors,
+      });
     }
     try {
       return await adapter.buildStoredConfig(

--- a/packages/dashboard-pages/src/components/form-field.tsx
+++ b/packages/dashboard-pages/src/components/form-field.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { cloneElement, isValidElement, type ReactElement, type ReactNode } from 'react';
 import { Label } from '@getmunin/ui';
 import { dialogHintClass, dialogLabelClass } from '../lib/dialog-style';
 
@@ -11,17 +11,17 @@ export interface FormFieldProps {
   children: ReactNode;
 }
 
-/**
- * Standard label + control + hint/error wrapper for dialog forms.
- * Pass `error` (a localized string) to swap the hint for a destructive
- * message and switch the visual state. Pair with `aria-invalid` on the
- * underlying input.
- */
 export function FormField({ label, hint, error, children }: FormFieldProps) {
+  const control =
+    error && isValidElement(children)
+      ? cloneElement(children as ReactElement<{ 'aria-invalid'?: boolean }>, {
+          'aria-invalid': true,
+        })
+      : children;
   return (
     <div className="space-y-2">
       <Label className={dialogLabelClass}>{label}</Label>
-      {children}
+      {control}
       {error ? (
         <p className="text-sm text-destructive" role="alert">
           {error}

--- a/packages/dashboard-pages/src/components/integrations/connect-connector-dialog.tsx
+++ b/packages/dashboard-pages/src/components/integrations/connect-connector-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button, Dialog, DialogContent, Input, Label } from '@getmunin/ui';
-import { api } from '../../api';
+import { api, ApiError } from '../../api';
 import { notify } from '../../lib/notify';
 import { dialogLabelClass } from '../../lib/dialog-style';
 import { useTranslateError } from '../../i18n/translate-error';
@@ -33,6 +33,7 @@ export function ConnectConnectorDialog({
   const present = vendorPresentation(vendor.vendor, vendor.domain);
   const [name, setName] = useState('');
   const [values, setValues] = useState<Record<string, string>>({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
 
   const missingRequired = vendor.configFields.some((f) => f.required && !values[f.key]);
@@ -46,10 +47,17 @@ export function ConnectConnectorDialog({
         method: 'POST',
         body: JSON.stringify({ vendor: vendor.vendor, name, config }),
       });
+      setFieldErrors({});
       notify.success(t('created'));
       await onDone();
     } catch (err) {
-      notify.error(translate(err));
+      if (err instanceof ApiError && err.fieldErrors.length > 0) {
+        const next: Record<string, string> = {};
+        for (const fe of err.fieldErrors) next[fe.field] = fe.message;
+        setFieldErrors(next);
+      } else {
+        notify.error(translate(err));
+      }
     } finally {
       setBusy(false);
     }
@@ -98,7 +106,15 @@ export function ConnectConnectorDialog({
                 vendor={vendor.vendor}
                 field={f}
                 value={values[f.key] ?? ''}
-                onChange={(val) => setValues((v) => ({ ...v, [f.key]: val }))}
+                onChange={(val) => {
+                  setValues((v) => ({ ...v, [f.key]: val }));
+                  setFieldErrors((prev) => {
+                    if (!prev[f.key]) return prev;
+                    const { [f.key]: _, ...rest } = prev;
+                    return rest;
+                  });
+                }}
+                error={fieldErrors[f.key]}
               />
             ))}
           </div>

--- a/packages/dashboard-pages/src/components/integrations/vendor-field-row.tsx
+++ b/packages/dashboard-pages/src/components/integrations/vendor-field-row.tsx
@@ -17,11 +17,13 @@ export function VendorFieldRow({
   field,
   value,
   onChange,
+  error,
 }: {
   vendor: string;
   field: VendorField;
   value: string;
   onChange: (value: string) => void;
+  error?: string | null;
 }) {
   const tf = useTranslations('integrations.field');
   const base = `${vendor}.${field.key}`;
@@ -30,6 +32,7 @@ export function VendorFieldRow({
   const placeholder = tf.has(`${base}.placeholder`)
     ? tf(`${base}.placeholder`)
     : field.placeholder;
+  const errorText = error ? (tf.has(`${base}.invalid`) ? tf(`${base}.invalid`) : error) : null;
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -40,8 +43,15 @@ export function VendorFieldRow({
         value={value}
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value)}
+        aria-invalid={errorText ? true : undefined}
       />
-      {hint ? <p className={dialogHintClass}>{hint}</p> : null}
+      {errorText ? (
+        <p className="text-sm text-destructive" role="alert">
+          {errorText}
+        </p>
+      ) : hint ? (
+        <p className={dialogHintClass}>{hint}</p>
+      ) : null}
     </div>
   );
 }

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -579,6 +579,7 @@
         "messagingServiceSidLabel": "Messaging Service SID (optional)",
         "messagingServiceSidHint": "Starts with \"MG\". Use this instead of From number if you have a Messaging Service.",
         "fromOrServiceHint": "Either From number or Messaging Service SID is required — providing both is allowed.",
+        "fromOrServiceRequired": "Provide a From number or a Messaging Service SID.",
         "sendTest": "Send test SMS",
         "messagingService": "messaging service · {sid}",
         "accountSidChip": "account · {sid}",
@@ -713,6 +714,8 @@
         "load": "Could not load channels.",
         "create": "Could not create channel.",
         "required": "Required.",
+        "phoneNumberInvalid": "Use the international format, e.g. +15551234567.",
+        "valueInvalid": "This value isn't valid.",
         "createEmail": "Could not create email channel.",
         "updateEmail": "Could not update email channel.",
         "createTwilioSms": "Could not create Twilio SMS channel.",
@@ -1254,23 +1257,6 @@
       "title": "Operator bridges",
       "subtitle": "Triage & reply from your team's chat tools"
     },
-    "slack": {
-      "title": "Slack",
-      "lede": "Mirror conversations into a Slack channel as threads and alert your team on handover requests. Replies to customers still go out over the conversation's original channel.",
-      "notConfigured": "This deployment has no Slack app configured. Set SLACK_CLIENT_ID and SLACK_CLIENT_SECRET on the backend — the agent skill \"Connect Slack for human handoff\" has the app manifest and steps.",
-      "connect": "Connect Slack",
-      "connectedTo": "Connected to {workspace}.",
-      "channelLabel": "Default channel ID",
-      "channelHint": "The Slack channel conversations mirror into (channel details → About → Channel ID, e.g. C0123456789).",
-      "saveRouting": "Save channel",
-      "routingSaved": "Slack channel saved",
-      "inviteBot": "The bot is not in that channel yet — run /invite @Munin in Slack, then send a test.",
-      "sendTest": "Send test message",
-      "testSent": "Test message sent",
-      "disconnect": "Disconnect",
-      "disconnectConfirm": "Disconnect Slack? Thread links and routing are deleted; conversations in Munin are unaffected.",
-      "failedDeliveries": "{count} mirror deliveries failed in the last 24 hours."
-    },
     "dataConnectors": {
       "title": "Data connections",
       "subtitle": "Live against the vendor — nothing is stored in Munin"
@@ -1351,42 +1337,50 @@
         "shopDomain": {
           "label": "Shop domain",
           "hint": "Your permanent *.myshopify.com domain, not a custom storefront domain.",
-          "placeholder": "your-store.myshopify.com"
+          "placeholder": "your-store.myshopify.com",
+          "invalid": "Enter your *.myshopify.com domain, without https:// or a path."
         },
         "accessToken": {
           "label": "Admin API access token",
-          "hint": "A custom-app token (starts with shpat_) with read_orders + read_customers."
+          "hint": "A custom-app token (starts with shpat_) with read_orders + read_customers.",
+          "invalid": "This doesn't look like a valid token — paste the full shpat_… token."
         },
         "apiVersion": {
           "label": "API version",
-          "hint": "Optional — defaults to a current stable version."
+          "hint": "Optional — defaults to a current stable version.",
+          "invalid": "Use the YYYY-MM format, e.g. 2025-01."
         }
       },
       "magento": {
         "baseUrl": {
           "label": "Store base URL",
           "hint": "The storefront base URL, without the /rest suffix.",
-          "placeholder": "https://store.example.com"
+          "placeholder": "https://store.example.com",
+          "invalid": "Enter a full https:// URL to the store."
         },
         "accessToken": {
           "label": "Integration access token",
-          "hint": "An integration token with read access to Sales + Customers."
+          "hint": "An integration token with read access to Sales + Customers.",
+          "invalid": "This doesn't look like a valid token — paste the full integration token."
         }
       },
       "gastroplanner": {
         "apiToken": {
           "label": "Partner API token",
-          "hint": "Issued by Gastroplanner support for your account."
+          "hint": "Issued by Gastroplanner support for your account.",
+          "invalid": "This doesn't look like a valid token — paste the full token from Gastroplanner."
         },
         "restaurantUri": {
           "label": "Restaurant URI",
           "hint": "The value sent as the X-RESTAURANT header for your venue.",
-          "placeholder": "my-restaurant"
+          "placeholder": "my-restaurant",
+          "invalid": "Enter the X-RESTAURANT value for your venue."
         },
         "baseUrl": {
           "label": "API base URL",
           "hint": "Optional — defaults to https://api.gastroplanner.eu.",
-          "placeholder": "https://api.gastroplanner.eu"
+          "placeholder": "https://api.gastroplanner.eu",
+          "invalid": "Enter a full https:// URL, or leave the field empty for the default."
         }
       }
     }
@@ -1420,7 +1414,7 @@
         "blurb": "Speaks to your customers directly, in the configured persona."
       },
       "background": {
-        "tierLabel": "{tier}",
+        "tierLabel": "{tier, select, smart {smart} fast {fast} other {{tier}}}",
         "neverRan": "Never run for this org yet.",
         "statuses": {
           "pending": "pending",
@@ -1443,7 +1437,7 @@
       "chatAssistant": {
         "title": "Chat assistant",
         "description": "Replies to customers across chat, email, and any other conversation channel.",
-        "tierLabel": "{tier}"
+        "tierLabel": "{tier, select, smart {smart} fast {fast} other {{tier}}}"
       }
     },
     "identity": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -579,6 +579,7 @@
         "messagingServiceSidLabel": "Messaging Service SID (valgfritt)",
         "messagingServiceSidHint": "Starter med «MG». Bruk denne i stedet for avsendernummer hvis du har en Messaging Service.",
         "fromOrServiceHint": "Enten avsendernummer eller Messaging Service SID er påkrevd — begge er også OK.",
+        "fromOrServiceRequired": "Oppgi et avsendernummer eller en Messaging Service SID.",
         "sendTest": "Send test-SMS",
         "messagingService": "messaging service · {sid}",
         "accountSidChip": "account · {sid}",
@@ -713,6 +714,8 @@
         "load": "Kunne ikke laste kanaler.",
         "create": "Kunne ikke opprette kanal.",
         "required": "Påkrevd.",
+        "phoneNumberInvalid": "Bruk internasjonalt format, f.eks. +4791234567.",
+        "valueInvalid": "Verdien er ikke gyldig.",
         "createEmail": "Kunne ikke opprette e-postkanal.",
         "updateEmail": "Kunne ikke oppdatere e-postkanal.",
         "createTwilioSms": "Kunne ikke opprette Twilio SMS-kanal.",
@@ -1248,34 +1251,6 @@
     "hero": {
       "eyebrow": "Integrasjoner",
       "title": "Koble Munin til <em>verktøyene du allerede bruker</em>",
-      "lede": "Ta samtaler inn i flatene teamet og kundene dine allerede bruker."
-    },
-    "operatorBridges": {
-      "title": "Operatørbroer",
-      "blurb": "Triager og svar på samtaler fra teamets chatteverktøy."
-    },
-    "slack": {
-      "title": "Slack",
-      "lede": "Speil samtaler inn i en Slack-kanal som tråder og varsle teamet ved eskaleringer. Svar til kunden går fortsatt ut via samtalens opprinnelige kanal.",
-      "notConfigured": "Denne installasjonen har ingen Slack-app konfigurert. Sett SLACK_CLIENT_ID og SLACK_CLIENT_SECRET på backenden — agentferdigheten «Connect Slack for human handoff» har app-manifestet og stegene.",
-      "connect": "Koble til Slack",
-      "connectedTo": "Koblet til {workspace}.",
-      "channelLabel": "Standard kanal-ID",
-      "channelHint": "Slack-kanalen samtaler speiles inn i (kanaldetaljer → Om → Kanal-ID, f.eks. C0123456789).",
-      "saveRouting": "Lagre kanal",
-      "routingSaved": "Slack-kanal lagret",
-      "inviteBot": "Boten er ikke i kanalen ennå — kjør /invite @Munin i Slack, og send deretter en test.",
-      "sendTest": "Send testmelding",
-      "testSent": "Testmelding sendt",
-      "disconnect": "Koble fra",
-      "disconnectConfirm": "Koble fra Slack? Trådkoblinger og ruting slettes; samtalene i Munin påvirkes ikke.",
-      "failedDeliveries": "{count} speilinger feilet siste 24 timer."
-    }
-  },
-  "integrations": {
-    "hero": {
-      "eyebrow": "Integrasjoner",
-      "title": "Koble Munin til <em>verktøyene du allerede bruker</em>",
       "lede": "Ta samtaler inn i flatene medarbeiderne og kundene dine allerede bruker."
     },
     "operatorBridges": {
@@ -1362,42 +1337,50 @@
         "shopDomain": {
           "label": "Butikkdomene",
           "hint": "Ditt permanente *.myshopify.com-domene, ikke et egendefinert domene.",
-          "placeholder": "din-butikk.myshopify.com"
+          "placeholder": "din-butikk.myshopify.com",
+          "invalid": "Oppgi *.myshopify.com-domenet ditt, uten https:// eller sti."
         },
         "accessToken": {
           "label": "Admin API-token",
-          "hint": "En token fra en egendefinert app (starter med shpat_) med read_orders + read_customers."
+          "hint": "En token fra en egendefinert app (starter med shpat_) med read_orders + read_customers.",
+          "invalid": "Dette ser ikke ut som en gyldig token — lim inn hele shpat_…-tokenen."
         },
         "apiVersion": {
           "label": "API-versjon",
-          "hint": "Valgfritt — bruker en gjeldende stabil versjon som standard."
+          "hint": "Valgfritt — bruker en gjeldende stabil versjon som standard.",
+          "invalid": "Bruk formatet ÅÅÅÅ-MM, f.eks. 2025-01."
         }
       },
       "magento": {
         "baseUrl": {
           "label": "Butikkens URL",
           "hint": "Butikkens grunn-URL, uten /rest-suffiks.",
-          "placeholder": "https://butikk.eksempel.no"
+          "placeholder": "https://butikk.eksempel.no",
+          "invalid": "Oppgi en fullstendig https://-adresse til butikken."
         },
         "accessToken": {
           "label": "Integrasjonstoken",
-          "hint": "En integrasjonstoken med lesetilgang til Sales + Customers."
+          "hint": "En integrasjonstoken med lesetilgang til Sales + Customers.",
+          "invalid": "Dette ser ikke ut som en gyldig token — lim inn hele integrasjonstokenen."
         }
       },
       "gastroplanner": {
         "apiToken": {
           "label": "Partner API-token",
-          "hint": "Utstedes av Gastroplanner-support for kontoen din."
+          "hint": "Utstedes av Gastroplanner-support for kontoen din.",
+          "invalid": "Dette ser ikke ut som en gyldig token — lim inn hele tokenen fra Gastroplanner."
         },
         "restaurantUri": {
           "label": "Restaurant-URI",
           "hint": "Verdien som sendes som X-RESTAURANT-header for stedet ditt.",
-          "placeholder": "min-restaurant"
+          "placeholder": "min-restaurant",
+          "invalid": "Oppgi X-RESTAURANT-verdien for stedet ditt."
         },
         "baseUrl": {
           "label": "API-URL",
           "hint": "Valgfritt — bruker https://api.gastroplanner.eu som standard.",
-          "placeholder": "https://api.gastroplanner.eu"
+          "placeholder": "https://api.gastroplanner.eu",
+          "invalid": "Oppgi en fullstendig https://-adresse, eller la feltet stå tomt for standardverdien."
         }
       }
     }
@@ -1431,7 +1414,7 @@
         "blurb": "Snakker direkte med kundene dine, i den konfigurerte personaen."
       },
       "background": {
-        "tierLabel": "{tier}",
+        "tierLabel": "{tier, select, smart {smart} fast {rask} other {{tier}}}",
         "neverRan": "Aldri kjørt for denne organisasjonen ennå.",
         "statuses": {
           "pending": "venter",
@@ -1454,7 +1437,7 @@
       "chatAssistant": {
         "title": "Chatassistent",
         "description": "Svarer kundene i chat, e-post, og alle andre samtalekanaler.",
-        "tierLabel": "{tier}"
+        "tierLabel": "{tier, select, smart {smart} fast {rask} other {{tier}}}"
       }
     },
     "identity": {

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -1168,9 +1168,22 @@ function zodIssuesToFieldErrors(
     } else if (last === 'port') {
       if (parent === 'outbound') errors.smtpPort = t('email.portInvalid');
       else if (parent === 'inbound') errors.imapPort = t('email.portInvalid');
+    } else if (last === 'fromNumber' || last === 'to') {
+      errors[last] = t('errors.phoneNumberInvalid');
+    } else if (typeof last === 'string') {
+      errors[last] = t('errors.valueInvalid');
     }
   }
   return errors;
+}
+
+function zodIssuesToErrorMessage(
+  issues: ReadonlyArray<{ path: ReadonlyArray<PropertyKey> }>,
+  t: ReturnType<typeof useTranslations<'dashboard.channels'>>,
+): string {
+  return issues.some((i) => i.path[i.path.length - 1] === 'to')
+    ? t('errors.phoneNumberInvalid')
+    : t('errors.valueInvalid');
 }
 
 function widgetAllowlistRequired(): boolean {
@@ -2315,7 +2328,7 @@ function SendTestSmsDialog({
     if (body.trim()) payload.body = body.trim();
     const parsed = SendTwilioSmsTestBody.safeParse(payload);
     if (!parsed.success) {
-      setError(parsed.error.issues[0]?.message ?? 'invalid input');
+      setError(zodIssuesToErrorMessage(parsed.error.issues, t));
       return;
     }
     setSending(true);
@@ -2593,7 +2606,7 @@ function SendTestMessageBirdSmsDialog({
     if (body.trim()) payload.body = body.trim();
     const parsed = SendMessageBirdSmsTestBody.safeParse(payload);
     if (!parsed.success) {
-      setError(parsed.error.issues[0]?.message ?? 'invalid input');
+      setError(zodIssuesToErrorMessage(parsed.error.issues, t));
       return;
     }
     setSending(true);
@@ -2729,6 +2742,13 @@ function AddSmsDialog({
   }, [open]);
 
   async function submitTwilio(): Promise<void> {
+    if (!fromNumber.trim() && !messagingServiceSid.trim()) {
+      setFieldErrors({
+        fromNumber: t('twilioSms.fromOrServiceRequired'),
+        messagingServiceSid: t('twilioSms.fromOrServiceRequired'),
+      });
+      return;
+    }
     const payload: Record<string, unknown> = {
       ...(name.trim() ? { name: name.trim() } : {}),
       ...(accountSid.trim() ? { accountSid: accountSid.trim() } : {}),
@@ -3638,7 +3658,7 @@ function PlaceVapiCallDialog({
     if (customerName.trim()) payload.customerName = customerName.trim();
     const parsed = VapiCallInitiateBody.safeParse(payload);
     if (!parsed.success) {
-      setError(parsed.error.issues[0]?.message ?? 'invalid input');
+      setError(zodIssuesToErrorMessage(parsed.error.issues, t));
       return;
     }
     setPlacing(true);
@@ -3998,7 +4018,7 @@ function PlaceThrellCallDialog({
     if (customerName.trim()) payload.customerName = customerName.trim();
     const parsed = ThrellCallInitiateBody.safeParse(payload);
     if (!parsed.success) {
-      setError(parsed.error.issues[0]?.message ?? 'invalid input');
+      setError(zodIssuesToErrorMessage(parsed.error.issues, t));
       return;
     }
     setPlacing(true);

--- a/packages/ui/src/tailwind-preset.ts
+++ b/packages/ui/src/tailwind-preset.ts
@@ -7,6 +7,11 @@ const muninPreset: Omit<Config, 'content'> = {
   },
   theme: {
     extend: {
+      // Tailwind v3 ships no default `invalid` aria variant (v4 does), so
+      // `aria-invalid:*` utilities compile to nothing without this.
+      aria: {
+        invalid: 'invalid="true"',
+      },
       colors: {
         border: 'var(--border)',
         input: 'var(--input)',


### PR DESCRIPTION
## Summary

Two dashboard papercuts that unraveled into a set of real bugs: untranslated smart/fast tier badges, and connector config validation surfacing as a raw zod JSON blob in a toast.

### Tier badges (AI settings)
- `tierLabel` was a raw `{tier}` pass-through in both locales. Now an ICU select: nb renders `fast` → **rask**, `smart` → **smart**, with an `other` fallback for future tiers. No component changes.

### Connector config validation → inline field errors
- `ConnectorsService.buildStored` now throws `BadRequestException({ message, fieldErrors })` (same shape as the CMS drafts precedent) instead of stringifying the zod issues array. The message is a readable flattened summary for MCP callers and the credential-entry page.
- The connect dialog maps `ApiError.fieldErrors` onto the vendor fields; each field shows a localized "what a valid value looks like" message (`integrations.field.<vendor>.<key>.invalid`, en + nb, all 8 fields across Shopify/Magento/Gastroplanner) with the server message as fallback. Toast only for non-field errors.

### Red borders were silently broken everywhere
- Tailwind v3 ships no default `aria-invalid` variant (v4 does), so the `aria-invalid:border-destructive` styling in the shared `Input` compiled to nothing — in every dialog. The preset now defines it; verified the rules are emitted.

### Channels dialogs had silent no-op submits
- The shared `zodIssuesToFieldErrors` mapper only knew email's fields, but nine dialogs use it: an invalid Twilio from-number / MessageBird originator / Vapi key failed the parse and the submit did nothing, with no feedback. The mapper now covers all flat schema fields (localized E.164 message for phone fields, generic localized fallback otherwise).
- Twilio create's "fromNumber **or** messagingServiceSid" root refine was also swallowed — now pre-checked with a localized message on both fields.
- Test-send / place-call dialogs showed raw zod text (`must be E.164`) — now localized.
- `FormField` injects `aria-invalid` into its child control when an error is set, so all its consumers get the destructive border without per-input wiring.

### Message hygiene
- Removed dead duplicate JSON blocks (`en`: second `slack` block, `nb`: entire shadowed top-level `integrations` block — JSON last-key-wins made them invisible at runtime; verified strict-subset before deleting). en/nb key sets now match exactly, zero duplicate keys.

## Test plan
- [x] New test: invalid connector config → `BadRequestException` with `fieldErrors` + bracket-free summary (18/18 connectors tests pass)
- [x] `dashboard-pages` typecheck + 39 tests pass; backend-core + ui typecheck
- [x] ICU tierLabel rendered for all tier/locale combos via intl-messageformat
- [x] Tailwind compile probe: `[aria-invalid="true"]` border/ring rules emitted
- [x] Manually verified in the dashboard: red border + localized messages on the Magento connect dialog (nb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)