### PR TITLE
fix(connectors): run vendor credential probe outside the DB transaction

### DIFF
--- a/.changeset/connector-probe-outside-transaction.md
+++ b/.changeset/connector-probe-outside-transaction.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Connectors: run the vendor credential probe outside the DB transaction. Credential handoff now persists secrets in a short transaction, then verifies them (the vendor round-trip) after commit via a new optional `CredentialTargetHandler.verify` hook, so the public `/v1/credentials` completion no longer holds a pooled Postgres connection open across a slow vendor call.

--- a/packages/backend-core/src/modules/connectors/connector-credential.handler.ts
+++ b/packages/backend-core/src/modules/connectors/connector-credential.handler.ts
@@ -17,6 +17,10 @@ export class ConnectorCredentialHandler implements CredentialTargetHandler {
   }
 
   apply(targetId: string, secrets: Record<string, string>): Promise<CredentialApplyResult> {
-    return this.connectors.applyCredentials(targetId, secrets);
+    return this.connectors.saveCredentials(targetId, secrets);
+  }
+
+  verify(targetId: string): Promise<CredentialApplyResult> {
+    return this.connectors.verifyConnection(targetId);
   }
 }

--- a/packages/backend-core/src/modules/connectors/connectors.service.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { and, eq } from 'drizzle-orm';
 import { sql } from 'drizzle-orm';
-import { schema } from '@getmunin/db';
+import { schema, type Db, type Tx } from '@getmunin/db';
 import {
   decryptSecretSql,
   encryptSecretSql,
@@ -22,6 +22,7 @@ import {
   type ConnectorDomain,
 } from './connector.ts';
 import { ConnectorVendorError } from './http.ts';
+import { DB } from '../../common/db/db.module.ts';
 import { CredentialHandoffService, type CredentialLink } from '../credential-handoff/credential-handoff.service.ts';
 import type {
   CredentialApplyResult,
@@ -80,11 +81,17 @@ export class ConnectorsService {
     @Inject(ConnectorRegistry) private readonly registry: ConnectorRegistry,
     @Inject(CredentialHandoffService)
     private readonly handoff?: CredentialHandoffService,
+    @Inject(DB) private readonly rootDb?: Db,
   ) {}
 
   private requireHandoff(): CredentialHandoffService {
     if (!this.handoff) throw new Error('credential handoff service not available');
     return this.handoff;
+  }
+
+  private requireRootDb(): Db {
+    if (!this.rootDb) throw new Error('root db not available');
+    return this.rootDb;
   }
 
   listVendors(): ConnectorVendorDto[] {
@@ -188,7 +195,7 @@ export class ConnectorsService {
     };
   }
 
-  async applyCredentials(
+  async saveCredentials(
     connectionId: string,
     secrets: Record<string, string>,
   ): Promise<CredentialApplyResult> {
@@ -196,27 +203,70 @@ export class ConnectorsService {
     const row = await this.requireConnection(connectionId);
     const adapter = this.requireAdapter(row.vendor);
     const stored = await this.buildStored(adapter, { ...(row.config ?? {}), ...secrets });
-    const probe = await this.probe(adapter, stored);
     await ctx.db
       .update(schema.connectorConnections)
       .set({
         config: stored,
         active: true,
         credentialState: 'active',
-        lastTestedAt: new Date(),
-        lastTestError: probe.ok ? null : (probe.error ?? null),
+        lastTestedAt: null,
+        lastTestError: null,
         updatedAt: new Date(),
       })
       .where(eq(schema.connectorConnections.id, row.id));
+    return { ok: true, detail: 'credentials saved' };
+  }
+
+  async applyCredentials(
+    connectionId: string,
+    secrets: Record<string, string>,
+  ): Promise<CredentialApplyResult> {
+    await this.saveCredentials(connectionId, secrets);
+    return this.testConnection({ connectionId });
+  }
+
+  async verifyConnection(connectionId: string): Promise<CredentialApplyResult> {
+    const rootDb = this.requireRootDb();
+    const orgId = getCurrentContext().actor?.orgId;
+    const applyScope = async (tx: Tx): Promise<void> => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
+      if (orgId) await tx.execute(sql`SELECT set_config('app.org_id', ${orgId}, true)`);
+    };
+    const row = await rootDb.transaction(async (tx) => {
+      await applyScope(tx);
+      const rows = await tx
+        .select()
+        .from(schema.connectorConnections)
+        .where(eq(schema.connectorConnections.id, connectionId))
+        .limit(1);
+      return rows[0] ?? null;
+    });
+    if (!row) return { ok: false, error: 'connection no longer exists' };
+    const adapter = this.requireAdapter(row.vendor);
+    const probe = await this.probeDetached(adapter, row.config);
+    await rootDb.transaction(async (tx) => {
+      await applyScope(tx);
+      await tx
+        .update(schema.connectorConnections)
+        .set({
+          lastTestedAt: new Date(),
+          lastTestError: probe.ok ? null : (probe.error ?? null),
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.connectorConnections.id, row.id));
+    });
     return probe;
   }
 
-  private async probe(
+  private async probeDetached(
     adapter: ConnectorAdapter,
     stored: Record<string, unknown>,
   ): Promise<CredentialApplyResult> {
     try {
-      const result = await adapter.testConnection(this.connectionContext({ config: stored } as ConnectionRow));
+      const result = await adapter.testConnection({
+        config: stored,
+        decryptSecret: (ciphertext) => this.decryptDetached(ciphertext),
+      });
       return { ok: true, detail: result.detail };
     } catch (err) {
       if (err instanceof ConnectorVendorError || err instanceof SsrfBlockedError) {
@@ -224,6 +274,20 @@ export class ConnectorsService {
       }
       throw err;
     }
+  }
+
+  private async decryptDetached(ciphertext: string): Promise<string> {
+    return this.requireRootDb().transaction(async (tx) => {
+      await tx.execute(setEncryptionKeySql());
+      const rows = await tx.execute<{ pt: string } & Record<string, unknown>>(
+        sql`SELECT ${decryptSecretSql(ciphertext)} AS pt`,
+      );
+      const pt = rows[0]?.pt;
+      if (pt === undefined || pt === null) {
+        throw new ConnectorVendorError('stored credential could not be decrypted');
+      }
+      return pt;
+    });
   }
 
   private secretKeys(adapter: ConnectorAdapter): string[] {

--- a/packages/backend-core/src/modules/credential-handoff/credential-handoff.integration.test.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-handoff.integration.test.ts
@@ -50,7 +50,7 @@ const skipReason = TEST_URL
     const registry = new ConnectorRegistry([new ShopifyAdapter(stubFetch)]);
     const targets = new CredentialTargetRegistry();
     handoff = new CredentialHandoffService(db, targets);
-    connectors = new ConnectorsService(registry, handoff);
+    connectors = new ConnectorsService(registry, handoff, db);
     targets.register(new ConnectorCredentialHandler(connectors));
   });
 
@@ -134,6 +134,26 @@ const skipReason = TEST_URL
     await expect(handoff.complete(token, { accessToken: 'shpat_again' })).rejects.toThrow(
       /invalid or expired/,
     );
+  });
+
+  it('saves credentials then surfaces a failed vendor probe and records the error', async () => {
+    const created = await asAdmin(() =>
+      connectors.createConnection({
+        vendor: 'shopify',
+        name: 'Main store',
+        config: { shopDomain: 'acme.myshopify.com' },
+      }),
+    );
+    const token = tokenFromUrl(created.credentialLink!.url);
+    respond = () => ({ status: 401, body: {} });
+
+    const result = await handoff.complete(token, { accessToken: 'shpat_bad_token' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/401|403/);
+
+    const listed = await asAdmin(() => connectors.listConnections());
+    expect(listed[0]!.credentialState).toBe('active');
+    expect(listed[0]!.lastTestError).toMatch(/401|403/);
   });
 
   it('rejects an expired link', async () => {

--- a/packages/backend-core/src/modules/credential-handoff/credential-handoff.service.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-handoff.service.ts
@@ -75,12 +75,13 @@ export class CredentialHandoffService {
     const req = await this.resolve(token);
     const handler = this.registry.get(req.targetType);
     if (!handler) throw new NotFoundException('credential_handoff_not_found: link no longer valid');
-    const result = await this.inOrgContext(req.orgId, () => handler.apply(req.targetId, secrets));
+    const applied = await this.inOrgContext(req.orgId, () => handler.apply(req.targetId, secrets));
     await this.db
       .update(schema.credentialRequests)
       .set({ completedAt: new Date() })
       .where(eq(schema.credentialRequests.id, req.id));
-    return result;
+    if (!applied.ok || !handler.verify) return applied;
+    return this.inOrgActor(req.orgId, () => handler.verify!(req.targetId));
   }
 
   private async resolve(token: string) {
@@ -111,5 +112,11 @@ export class CredentialHandoffService {
       const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
       return withContext(ctx, fn);
     });
+  }
+
+  private async inOrgActor<T>(orgId: string, fn: () => Promise<T>): Promise<T> {
+    const actor = new ActorIdentity('system', 'credential-handoff', orgId, ['*'], ['admin']);
+    const ctx: RequestContext = { db: this.db, actor, correlationId: randomUUID() };
+    return withContext(ctx, fn);
   }
 }

--- a/packages/backend-core/src/modules/credential-handoff/credential-target.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-target.ts
@@ -21,11 +21,14 @@ export interface CredentialApplyResult {
  * A domain's plug into the credential-handoff flow. `describe` and `apply`
  * run inside a system-actor request context (org resolved from the link), so
  * implementations use the ambient `getCurrentContext()` db like any tool.
+ * `apply` must be DB-only; put any vendor round-trip in `verify`, which runs
+ * after commit and outside any transaction.
  */
 export interface CredentialTargetHandler {
   readonly targetType: string;
   describe(targetId: string): Promise<CredentialTargetDescription | null>;
   apply(targetId: string, secrets: Record<string, string>): Promise<CredentialApplyResult>;
+  verify?(targetId: string): Promise<CredentialApplyResult>;
 }
 
 export class CredentialTargetRegistry {


### PR DESCRIPTION
## What

The connector credential-handoff completion path held a tenant DB transaction open across the vendor credential probe (up to `REQUEST_TIMEOUT_MS`), so a slow or hung vendor could tie up a pooled Postgres connection. This is reachable via the **public** `/v1/credentials` completion endpoint by anyone holding a valid one-time link, making it an availability concern (connection-pool exhaustion under a slow vendor).

Found during a security audit of the data-connector architecture (Shopify / Magento / Gastroplanner).

## Change

Split "persist credentials" from "verify credentials":

- `CredentialTargetHandler` gains an optional `verify?(targetId)` hook. `apply` is now contractually DB-only; the vendor round-trip belongs in `verify`.
- `CredentialHandoffService.complete` persists in the short `inOrgContext` transaction, marks the link consumed, commits, **then** runs `verify` via a new `inOrgActor` helper that establishes the org's system-actor context *without* opening a transaction.
- `ConnectorsService`: the in-transaction probe is gone. `saveCredentials` persists + activates (DB-only); `verifyConnection` reads the row and writes the probe result in two short transactions on the service-role pool, with the vendor call happening *between* them (decryption during the probe uses per-call short transactions). The detached transactions set `bypass_rls off` + `app.org_id`, staying RLS-scoped to the link's org.
- Email handoff is unchanged — its `apply` does no network I/O, so it has no `verify`.

User-facing behavior is preserved: `complete` still returns the probe result and records `lastTestError`, so a bad credential still surfaces immediately — it just no longer holds a transaction open while the vendor is slow.

## Scope note

The admin-only surfaces (`connectors_test_connection`, control-plane `POST :id/credentials` / `:id/test`) still probe within the ambient request transaction. That's a property of the "whole request in one transaction" design shared by every tool doing network I/O in a handler — not connector-specific — so it's left as-is. The acute, publicly-reachable path is fixed here.

## Testing

- `pnpm -F @getmunin/backend-core typecheck` — clean.
- Ran credential-handoff, connectors, commerce, bookings, and channel-credential suites against a real Postgres with RLS — **75 tests pass**, including a new test asserting a failed vendor probe (`401`) is surfaced and recorded in `lastTestError` while the connection still activates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)