### PR TITLE
chore: pre-commit check blocking new comments in TS/TSX

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+node scripts/check-added-comments.mjs
 pnpm exec lint-staged

--- a/apps/analytics-tracker/src/tracker.test.ts
+++ b/apps/analytics-tracker/src/tracker.test.ts
@@ -15,21 +15,12 @@ let sendBeacon: ReturnType<typeof vi.fn>;
 let keyCounter = 0;
 
 interface LoadOpts {
-  /** Attributes set on the injected <script> tag. `null` values are skipped. */
   attrs?: Record<string, string | null>;
-  /** `script.src`, used for the data-api origin fallback. */
   src?: string;
-  /** Omit the auto-generated data-key (for the "disabled" paths). */
   noKey?: boolean;
-  /** Don't define document.currentScript (simulate inline/unknown script). */
   noCurrentScript?: boolean;
 }
 
-/**
- * Re-runs the tracker IIFE against freshly staged globals and returns the
- * unique data-key bound to this load, so callers can filter beacons emitted
- * by listeners that earlier loads left attached to the shared window.
- */
 async function loadTracker(opts: LoadOpts = {}): Promise<string> {
   const key = opts.noKey ? '' : `mn_track_${++keyCounter}`;
   const script = document.createElement('script');
@@ -52,7 +43,6 @@ async function decode(call: BeaconCall): Promise<Record<string, unknown>> {
   return JSON.parse(await call.blob.text()) as Record<string, unknown>;
 }
 
-/** Beacons sent to a given path, filtered to the load that owns `key`. */
 async function beaconsFor(key: string, pathSuffix: string): Promise<Record<string, unknown>[]> {
   const matches = beacons.filter((b) => b.url.endsWith(pathSuffix));
   const decoded = await Promise.all(matches.map(decode));
@@ -79,6 +69,14 @@ function setReferrer(value: string): void {
   Object.defineProperty(document, 'referrer', { configurable: true, value });
 }
 
+function clearLocalStorageIfAvailable(): void {
+  try {
+    localStorage.clear();
+  } catch {
+    return;
+  }
+}
+
 beforeEach(() => {
   beacons = [];
   sendBeacon = vi.fn((url: string, blob: Blob) => {
@@ -86,11 +84,7 @@ beforeEach(() => {
     return true;
   });
   Object.defineProperty(navigator, 'sendBeacon', { configurable: true, value: sendBeacon });
-  try {
-    localStorage.clear();
-  } catch {
-    // ignore
-  }
+  clearLocalStorageIfAvailable();
   delete (window as { mn?: unknown }).mn;
   setLocation('https://site.example/welcome');
   setReferrer('');

--- a/apps/analytics-tracker/src/tracker.ts
+++ b/apps/analytics-tracker/src/tracker.ts
@@ -1,23 +1,3 @@
-/**
- * Munin analytics tracker — drop-in browser script.
- *
- * Embedded as `<script async src="…/tracker.js" data-key="mn_track_…">`.
- * Auto-fires a page view on DOMContentLoaded, captures referrer + UTM +
- * locale, persists a random visitor id in localStorage, and reports
- * best-effort dwell time on `pagehide`. Optional SPA mode hooks
- * `history.pushState` / `replaceState` so route changes fire fresh
- * views.
- *
- * Exposes `window.mn.track(subjectId, attrs)` for custom events. Once the
- * public API is installed it sets `window.mn.ready = true` and dispatches a
- * `munin:ready` CustomEvent on `document`, so consumers can run
- * initialization code without polling:
- *
- *   window.mn?.ready
- *     ? go()
- *     : document.addEventListener('munin:ready', go, { once: true });
- */
-
 interface TrackAttrs {
   subjectType?: string;
   path?: string;
@@ -104,10 +84,6 @@ const VISITOR_KEY = 'mn.vid';
       localStorage.setItem(VISITOR_KEY, visitorId);
     }
   } catch {
-    // localStorage threw (private window, embedded WebView, locked-down
-    // enterprise browser, storage quota). Fall back to a page-scoped id so
-    // pageviews within the same page lifetime still dedup to one visitor.
-    // Lost on reload — that's the inherent cost of no persistent storage.
     visitorId = freshVisitorId();
   }
 
@@ -118,12 +94,6 @@ const VISITOR_KEY = 'mn.vid';
   function send(payload: BeaconPayload): void {
     try {
       const body = JSON.stringify(payload);
-      // text/plain is in the CORS "safelisted" Content-Type set, so neither
-      // sendBeacon (which always sends cookies) nor fetch trigger a preflight.
-      // application/json would force a preflight that fails because the
-      // beacon endpoint is a public-CORS path and does not return
-      // Access-Control-Allow-Credentials. The server JSON-parses text/plain
-      // bodies on the beacon route — see bootstrap-app.ts body-parser config.
       if (navigator.sendBeacon) {
         const blob = new Blob([body], { type: 'text/plain;charset=UTF-8' });
         navigator.sendBeacon(beaconUrl, blob);

--- a/apps/analytics-tracker/vite.config.ts
+++ b/apps/analytics-tracker/vite.config.ts
@@ -1,20 +1,8 @@
 import { defineConfig } from 'vite';
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, renameSync, readdirSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, renameSync, readdirSync, unlinkSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 
-/**
- * Builds a single IIFE bundle the analytics tracker loads as
- * `<script src=…>`. Mirrors the chat-widget pipeline.
- *
- * Output:
- *   dist/tracker.<sha>.js       – the bundle, content-hashed for
- *                                 immutable CDN caching.
- *   dist/tracker.<sha>.js.map   – source map.
- *   dist/manifest.json          – { current: "tracker.<sha>.js", sha,
- *                                 builtAt }; the backend reads this at
- *                                 boot to wire the unhashed redirect.
- */
 export default defineConfig(({ mode }) => ({
   resolve: {
     conditions: mode === 'development' ? ['development'] : [],
@@ -55,15 +43,13 @@ export default defineConfig(({ mode }) => ({
         const targetMap = join(distDir, `tracker.${sha}.js.map`);
 
         renameSync(sourceJs, targetJs);
-        try {
+        if (existsSync(sourceMap)) {
           const patched = readFileSync(targetJs, 'utf8').replace(
             /\/\/# sourceMappingURL=tracker\.js\.map/,
             `//# sourceMappingURL=tracker.${sha}.js.map`,
           );
           writeFileSync(targetJs, patched);
           renameSync(sourceMap, targetMap);
-        } catch {
-          // sourcemap may be disabled; ignore
         }
 
         const manifest = {

--- a/apps/backend/src/auth/oss-signup.integration.test.ts
+++ b/apps/backend/src/auth/oss-signup.integration.test.ts
@@ -39,7 +39,6 @@ const skipReason = TEST_URL
     db = createDb(TEST_URL!, { serviceRole: true });
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
 
-    // Start from a clean slate so the "first user becomes owner" path runs.
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
     await db.delete(schema.orgInvitations);
     await db.delete(schema.orgMembers);
@@ -121,7 +120,6 @@ const skipReason = TEST_URL
 
   it('signup with a valid pending invitation succeeds even outside the allowlist', async () => {
     const email = `invitee-${Date.now()}@elsewhere.example`;
-    // Find the singleton org id.
     const [orgRow] = await db
       .select({ id: schema.orgs.id })
       .from(schema.orgs)

--- a/apps/backend/src/migrate.ts
+++ b/apps/backend/src/migrate.ts
@@ -1,13 +1,3 @@
-/**
- * OSS migration entry point. Runs the shared schema (extensions, RLS,
- * module SQL, app role) from @getmunin/db, then layers the agent-host
- * singleton DDL on top.
- *
- *   pnpm --filter @getmunin/backend migrate
- *
- * Reads MUNIN_MIGRATE_URL (privileged superuser URL — not the runtime
- * munin_app role). Both halves are idempotent.
- */
 import './load-env.js';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -2,16 +2,6 @@ import './test-env';
 import { defineConfig } from 'vitest/config';
 import swc from 'unplugin-swc';
 
-/**
- * Backend tests touch a shared Postgres (RLS, migrations, multi-tenant
- * fixtures), so running test files in parallel triggers schema-catalog
- * contention ("tuple concurrently updated" from CREATE EXTENSION /
- * CREATE INDEX during runMigrations). Serialize files; tests within a
- * file still run in their declared order.
- *
- * The SWC plugin emits TypeScript decorator metadata, which Nest's DI
- * needs to wire constructors. Vitest's default esbuild loader strips it.
- */
 export default defineConfig({
   plugins: [
     swc.vite({

--- a/apps/chat-widget/src/api.test.ts
+++ b/apps/chat-widget/src/api.test.ts
@@ -139,7 +139,7 @@ describe('api: postMessage', () => {
       body: { conversationId: 'c', displayId: 1, contactId: 'ctc', inserted: 1, skipped: 0 },
     }));
     const client = createApiClient({
-      host: 'https://munin.example', // already stripped by parseConfig but verify here
+      host: 'https://munin.example',
       widgetKey: 'mn_widget_abc',
       channelId: 'cnv_chan',
       sessionId: 'sess_1',

--- a/apps/chat-widget/src/api.ts
+++ b/apps/chat-widget/src/api.ts
@@ -1,20 +1,5 @@
 import type { WidgetVisitor } from './config.ts';
 
-/**
- * Thin REST client for the widget's two endpoints:
- *   POST /v1/widget/messages   — visitor sends a message
- *   GET  /v1/widget/messages   — one-shot reconnect backfill
- *
- * The client is **not** a polling primitive. The realtime client calls
- * `backfillSince()` exactly once per (re)connect; live updates flow over
- * the WebSocket. If you find yourself adding `setInterval` on a method
- * here, stop — the design says no polling.
- *
- * The channel + identity attributes are baked into the client at
- * construction so the rest of the widget code doesn't have to thread
- * them through every call.
- */
-
 export interface ApiIdentity {
   externalId: string;
   userHash: string;

--- a/apps/chat-widget/src/config.test.ts
+++ b/apps/chat-widget/src/config.test.ts
@@ -25,7 +25,7 @@ describe('parseConfig', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.config).toMatchObject({
-      host: 'https://munin.example.com', // trailing slash stripped
+      host: 'https://munin.example.com',
       widgetKey: 'mn_widget_abc',
       channelId: 'cnv_001',
       themeColor: '#0066FF',
@@ -181,8 +181,8 @@ describe('parseConfig', () => {
       'data-munin-host': 'https://h.example',
       'data-widget-key': 'mn_widget_x',
       'data-channel-id': 'c',
-      'data-munin-meta-plan': 'free', // sugar
-      'data-munin-visitor-meta': JSON.stringify({ plan: 'pro', tier: 5, beta: true }), // explicit
+      'data-munin-meta-plan': 'free',
+      'data-munin-visitor-meta': JSON.stringify({ plan: 'pro', tier: 5, beta: true }),
     });
     const result = parseConfig(el);
     expect(result.ok).toBe(true);

--- a/apps/chat-widget/src/config.ts
+++ b/apps/chat-widget/src/config.ts
@@ -1,32 +1,3 @@
-/**
- * Parses the embed snippet's `data-*` attributes into a typed `WidgetConfig`.
- *
- * The widget is configured entirely on its `<script>` tag:
- *   <script src="…/widget.js"
- *           data-munin-host="https://munin.example.com"
- *           data-widget-key="mn_widget_…"
- *           data-channel-id="…"
- *           data-external-id="user_42"
- *           data-user-hash="<hex-hmac>"
- *           data-munin-theme-color="#10b981"
- *           data-munin-position="bottom-right"
- *           data-munin-greeting="Hi! How can we help?"
- *           data-munin-title="Chat with us"
- *           data-munin-locale="en"
- *           data-munin-visitor-name="Ada"
- *           data-munin-visitor-email="ada@example.com"
- *           data-munin-visitor-meta='{"plan":"pro"}'
- *           data-munin-meta-account-id="acc_42"
- *           data-munin-cookie-domain=".getmunin.com"
- *           defer></script>
- *
- * Returns `{ ok: true, config }` or `{ ok: false, errors }`. The widget
- * bootstrap logs (but doesn't throw on) parse errors; the goal is to never
- * break the host page even if the operator misconfigures. Identity attrs
- * are conditional-required: if either `data-external-id` or
- * `data-user-hash` is set, both must be set.
- */
-
 export const WIDGET_END_USER_BODY_MAX_CHARS = 1_000;
 export const WIDGET_END_USER_BODY_HTML_MAX_CHARS = 4_000;
 

--- a/apps/chat-widget/src/realtime.test.ts
+++ b/apps/chat-widget/src/realtime.test.ts
@@ -1,18 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRealtimeClient, type WebSocketLike } from './realtime.ts';
 
-/**
- * In-process WebSocket harness. Tests instantiate `MockWebSocket` via the
- * client's `webSocketCtor` injection point, drive opens / messages /
- * closes, and assert on what the client sent. Each instance is captured
- * in `MockWebSocket.instances` so the test can grab the latest.
- */
 class MockWebSocket implements WebSocketLike {
   static instances: MockWebSocket[] = [];
   static OPEN = 1;
   static CLOSED = 3;
 
-  readyState = 0; // CONNECTING
+  readyState = 0;
   sent: string[] = [];
   url: string;
   protocols?: string | string[];
@@ -38,7 +32,6 @@ class MockWebSocket implements WebSocketLike {
     this.fire('close', undefined);
   }
 
-  // Test driver helpers:
   fakeOpen(): void {
     this.readyState = MockWebSocket.OPEN;
     this.fire('open', undefined);
@@ -182,7 +175,6 @@ describe('realtime: connection lifecycle', () => {
     client.connect();
     const ws = MockWebSocket.instances.at(-1)!;
     ws.fakeOpen();
-    // Inject raw invalid data via the test driver.
     expect(() => (ws).fakeRawMessage('{not valid')).not.toThrow();
     client.close();
   });
@@ -203,7 +195,6 @@ describe('realtime: typing throttle', () => {
     client.connect();
     const ws = MockWebSocket.instances.at(-1)!;
     ws.fakeOpen();
-    // First subscribe message is at index 0; reset.
     ws.sent.length = 0;
 
     client.sendTyping(true);
@@ -214,7 +205,6 @@ describe('realtime: typing throttle', () => {
     expect(ws.sent).toHaveLength(1);
     expect((JSON.parse(ws.sent[0]!) as { isTyping: boolean }).isTyping).toBe(true);
 
-    // After 1.5 s the throttle releases.
     vi.setSystemTime(start + 1600);
     client.sendTyping(true);
     expect(ws.sent).toHaveLength(2);
@@ -253,7 +243,6 @@ describe('realtime: typing throttle', () => {
       sessionId: 'sess_1',
       webSocketCtor: MockWS,
     });
-    // No connect() — sendTyping should be a silent no-op, not throw.
     expect(() => client.sendTyping(true)).not.toThrow();
   });
 });
@@ -278,7 +267,6 @@ describe('realtime: reconnect with exp backoff', () => {
     expect(states.at(-1)).toBe('reconnecting');
     expect(MockWebSocket.instances).toHaveLength(1);
 
-    // First retry uses ~250 ms + jitter; advancing 600 ms is enough.
     vi.advanceTimersByTime(600);
     expect(MockWebSocket.instances).toHaveLength(2);
     const ws2 = MockWebSocket.instances.at(-1)!;
@@ -315,21 +303,16 @@ describe('realtime: reconnect with exp backoff', () => {
       webSocketCtor: MockWS,
     });
     client.connect();
-    // No fakeOpen — close immediately, three times in a row.
     for (let i = 0; i < 3; i++) {
       MockWebSocket.instances.at(-1)!.fakeClose();
       vi.advanceTimersByTime(60_000);
     }
-    // The first call is the initial connect (no setTimeout). Reconnects
-    // after each close use setTimeout. Extract the delays passed.
     const delays = setTimeoutSpy.mock.calls
       .map((c) => Number(c[1]))
       .filter((n) => n >= 250 && n <= 31_000);
-    // Expect each successive delay to be ≥ the previous (within jitter).
     for (let i = 1; i < delays.length; i++) {
       expect(delays[i]).toBeGreaterThanOrEqual(delays[i - 1]! - 250);
     }
-    // And the third delay should be at least 1000 (+ jitter).
     expect(delays[2] ?? 0).toBeGreaterThanOrEqual(1000);
     client.close();
     setTimeoutSpy.mockRestore();

--- a/apps/chat-widget/src/realtime.ts
+++ b/apps/chat-widget/src/realtime.ts
@@ -1,25 +1,5 @@
 import type { ApiIdentity } from './api.ts';
 
-/**
- * WebSocket client for the widget.
- *
- * Lifecycle: `connect()` opens a WebSocket to /v1/realtime, sends a
- * `subscribe` for `widget:<channelId>:<sessionId>`, and emits the
- * `connected` state. Consumers run their one-shot REST backfill in
- * response — the realtime client itself never polls REST.
- *
- * Reconnect: on close (and the network errors that lead there) the
- * client schedules another connect with exponential backoff
- * (250 ms → 30 s, jittered). It re-emits `connected` on each successful
- * (re)open so consumers can re-run the backfill bringing it back in
- * sync with anything they missed during the disconnect.
- *
- * Typing: visitor calls `sendTyping(true)` / `sendTyping(false)`. The
- * client throttles outbound `typing:true` to one frame per 1.5 s
- * (matches the server's throttle so we don't waste frames). Inbound
- * `typing` events from operators surface via `onTyping`.
- */
-
 export type ConnectionState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'closed';
 
 export interface IncomingEvent {
@@ -45,9 +25,7 @@ export interface RealtimeClientDeps {
   channelId: string;
   sessionId: string;
   getIdentity?: () => ApiIdentity | undefined;
-  /** Override the WebSocket constructor for tests. */
   webSocketCtor?: WebSocketConstructor;
-  /** Override the schedule API for tests. */
   setTimeoutImpl?: typeof setTimeout;
   clearTimeoutImpl?: typeof clearTimeout;
 }
@@ -62,10 +40,6 @@ export interface WebSocketLike {
   readyState: number;
   send(data: string): void;
   close(code?: number, reason?: string): void;
-  /** Native browser WebSocket dispatches `Event`, `MessageEvent`, etc.
-   *  We only read `event.data` for messages; everything else is fire-only.
-   *  Listener parameter is `unknown` so a single permissive implementation
-   *  satisfies all event types. */
   addEventListener(type: 'open' | 'message' | 'close' | 'error', listener: (arg?: unknown) => void): void;
 }
 
@@ -120,7 +94,6 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
         }),
       );
     } catch {
-      // socket mid-close; re-queue so the next flush retries
       for (const id of messageIds) pendingReadIds.add(id);
     }
   }
@@ -174,7 +147,6 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
     try {
       socket = new WS(buildUrl(), ['bearer', deps.widgetKey]);
     } catch {
-      // Construction can throw on some browsers if the URL is bad.
       scheduleReconnect();
       return;
     }
@@ -182,8 +154,6 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
     socket.addEventListener('open', () => {
       attempt = 0;
       setState('connected');
-      // Subscribe to our (channelId, sessionId) tuple so the gateway
-      // routes operator-side events back to us.
       try {
         socket.send(
           JSON.stringify({
@@ -222,7 +192,6 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
           }
         }
       }
-      // ready / pong / unknown: ignore
     });
     socket.addEventListener('close', () => {
       ws = null;
@@ -233,8 +202,6 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
       }
     });
     socket.addEventListener('error', () => {
-      // The browser fires `error` then `close`; the close handler
-      // schedules the reconnect. No-op here so we don't double-schedule.
     });
   }
 
@@ -285,8 +252,6 @@ export function createRealtimeClient(deps: RealtimeClientDeps): RealtimeClient {
         if (now - lastTypingSentAt < TYPING_MIN_INTERVAL_MS) return;
         lastTypingSentAt = now;
       } else {
-        // Allow explicit retract regardless of throttle so the operator's
-        // bubble clears immediately.
         lastTypingSentAt = 0;
       }
       try {

--- a/apps/chat-widget/src/session.test.ts
+++ b/apps/chat-widget/src/session.test.ts
@@ -37,9 +37,7 @@ describe('session', () => {
   beforeEach(() => {
     try {
       localStorage.clear();
-    } catch {
-      // ignore
-    }
+    } catch {}
     document.cookie.split(';').forEach((c) => {
       const eq = c.indexOf('=');
       const name = (eq > -1 ? c.slice(0, eq) : c).trim();

--- a/apps/chat-widget/src/ui.test.ts
+++ b/apps/chat-widget/src/ui.test.ts
@@ -82,7 +82,6 @@ describe('ui: mount + lifecycle', () => {
     controller = mount(baseConfig, strings, { onSend: () => {}, onTypingIntent: () => {} });
     ($('.launcher')).click();
     expect($('.welcome-eyebrow').textContent).toBe('Powered by Munin');
-    // First sentence renders plain, second renders italic <em>.
     const h1 = $('.welcome-h1');
     expect(h1.textContent).toMatch(/Hi there\.\s*How can we help\?/);
     expect(h1.querySelector('em')?.textContent).toBe('How can we help?');

--- a/apps/chat-widget/src/ui.ts
+++ b/apps/chat-widget/src/ui.ts
@@ -399,10 +399,6 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
 
   function setConnectionState(state: ConnectionLabel): void {
     if (state === 'connecting') {
-      // Part of an in-flight (re)connect. Leave the bar and any pending grace
-      // timer untouched: a first connect shows nothing, and a mid-outage bounce
-      // (reconnecting → connecting → reconnecting) must not reset the grace clock,
-      // otherwise the bar would never appear during a sustained outage.
       return;
     }
     if (state === 'connected' || state === 'idle') {
@@ -414,9 +410,6 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
       panel.statusEl.textContent = '';
       connectionDisabled = false;
     } else if (state === 'reconnecting') {
-      // Defer the status bar by a grace period so a quick reconnect doesn't flash
-      // the bar and shift the layout. If we're already showing it (or already
-      // waiting), keep the existing timer running.
       if (!panel.statusEl.hidden || reconnectGraceTimer) return;
       reconnectGraceTimer = setTimeout(() => {
         reconnectGraceTimer = null;

--- a/apps/chat-widget/vite.config.ts
+++ b/apps/chat-widget/vite.config.ts
@@ -3,21 +3,6 @@ import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync, renameSync, readdirSync, unlinkSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 
-/**
- * Builds a single IIFE bundle the chat widget loads as `<script src=…>`.
- *
- * Output:
- *   dist/widget.<sha>.js       – the bundle, content-hashed for immutable
- *                                CDN/edge caching (cache-control:
- *                                public, max-age=31536000, immutable).
- *   dist/widget.<sha>.js.map   – source map.
- *   dist/manifest.json         – { current: "widget.<sha>.js", sha,
- *                                builtAt }; the backend reads this at
- *                                boot to wire the unhashed redirect.
- *
- * The bundle is fully self-contained — no runtime CSS imports, no async
- * chunks. Operators paste one `<script>` line; that's it.
- */
 export default defineConfig(({ mode }) => ({
   resolve: {
     conditions: mode === 'development' ? ['development'] : [],
@@ -27,19 +12,15 @@ export default defineConfig(({ mode }) => ({
     cssCodeSplit: false,
     sourcemap: true,
     minify: 'esbuild',
-    emptyOutDir: false, // GC handled by clean-widget.mjs (older bundles
-    //                     stay around for ~7 days so in-flight clients
-    //                     can still fetch the version they were served).
+    emptyOutDir: false,
     lib: {
       entry: resolve(__dirname, 'src/widget.ts'),
       name: 'MuninChatWidget',
       formats: ['iife'],
-      fileName: () => 'widget.js', // renamed below to widget.<sha>.js
+      fileName: () => 'widget.js',
     },
     rollupOptions: {
       output: {
-        // Inline all imports into a single file. The widget is small;
-        // splitting would force operators to host multiple files.
         inlineDynamicImports: true,
       },
     },
@@ -63,16 +44,13 @@ export default defineConfig(({ mode }) => ({
 
         renameSync(sourceJs, targetJs);
         try {
-          // Patch the //# sourceMappingURL footer to point at the hashed map.
           const patched = readFileSync(targetJs, 'utf8').replace(
             /\/\/# sourceMappingURL=widget\.js\.map/,
             `//# sourceMappingURL=widget.${sha}.js.map`,
           );
           writeFileSync(targetJs, patched);
           renameSync(sourceMap, targetMap);
-        } catch {
-          // sourcemap may be disabled; ignore
-        }
+        } catch {}
 
         const manifest = {
           current: `widget.${sha}.js`,
@@ -81,9 +59,6 @@ export default defineConfig(({ mode }) => ({
         };
         writeFileSync(join(distDir, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
 
-        // Prune older hashed bundles in this build's output dir (NOT the
-        // backend's public/ — that's GC'd separately so old hashes stay
-        // resolvable for ~7 days). Within dist/ we only keep the current.
         for (const file of readdirSync(distDir)) {
           if (file === manifest.current) continue;
           if (file === `${manifest.current}.map`) continue;

--- a/apps/web/app/[locale]/dashboard/oauth/consent/page.tsx
+++ b/apps/web/app/[locale]/dashboard/oauth/consent/page.tsx
@@ -12,7 +12,6 @@ async function fetchClientInfo(clientId: string): Promise<OAuthClientInfo | null
   if (!clientId) return null;
   try {
     const res = await fetch(`${API_URL}/v1/oauth/clients/${encodeURIComponent(clientId)}`, {
-      // anonymous lookup — no session cookies. Server-to-server, no CORS.
       cache: 'no-store',
     });
     if (!res.ok) return null;

--- a/apps/web/e2e/locale.spec.ts
+++ b/apps/web/e2e/locale.spec.ts
@@ -6,8 +6,6 @@ test.describe('OSS locale switching', () => {
     const page = await ctx.newPage();
     try {
       await page.goto('/');
-      // Norwegian translations live in messages/nb.json — assert the
-      // tagline differs from the English version.
       const englishTagline = 'The open source customer platform for the agentic era.';
       const tagline = await page.locator('main').first().innerText();
       expect(tagline).not.toContain(englishTagline);

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -17,8 +17,6 @@ export default defineConfig({
   webServer: process.env.MUNIN_E2E_BASE_URL
     ? undefined
     : {
-        // Run Next directly rather than `pnpm dev`: the dev script waits for the
-        // backend on tcp:3001, which the web-only e2e job never starts.
         command: `pnpm exec next dev --port ${PORT}`,
         url: BASE_URL,
         reuseExistingServer: !process.env.CI,

--- a/packages/agent-host/src/web-import.handler.ts
+++ b/packages/agent-host/src/web-import.handler.ts
@@ -216,9 +216,7 @@ async function classifyDocLiveness(urls: string[]): Promise<'alive' | 'gone' | '
       } else {
         return 'alive';
       }
-    } catch {
-      // transient/network error — inconclusive for this candidate, fall through
-    }
+    } catch {}
   }
   return sawGone ? 'gone' : 'unknown';
 }

--- a/packages/agent-runtime/src/prompt-resolver.ts
+++ b/packages/agent-runtime/src/prompt-resolver.ts
@@ -118,7 +118,6 @@ export async function createPromptResolver(
     refresh: (slug) => cache.refresh(slug),
     refreshAll: () => cache.refreshAll(),
     async close(): Promise<void> {
-      // Owned by the caller; close the mcp from main.ts.
     },
   };
 }

--- a/packages/agent-runtime/src/providers/stub.ts
+++ b/packages/agent-runtime/src/providers/stub.ts
@@ -6,7 +6,6 @@ export interface StubScript {
 
 export interface StubProviderHandle {
   provider: Provider;
-  /** Captured calls in order. */
   calls: Array<{ messages: ChatMessage[]; toolNames: string[] }>;
 }
 

--- a/packages/agent-runtime/src/runtime.test.ts
+++ b/packages/agent-runtime/src/runtime.test.ts
@@ -288,7 +288,6 @@ describe('runAgent history compaction', () => {
       provider,
     });
     const sent = calls[0]?.messages ?? [];
-    // [system prompt, untrusted-data note, user, assistant, user]
     expect(sent).toHaveLength(5);
     expect(sent[0]?.role).toBe('system');
     expect(sent[1]?.role).toBe('system');
@@ -324,7 +323,6 @@ describe('runAgent history compaction', () => {
     expect(sent[1]?.role).toBe('system');
     expect(sent[2]?.role).toBe('system');
     expect(sent[2]?.content).toMatch(/^\[Note: \d+ earlier message/);
-    // Only the newest message survives (40 chars fits in 60).
     expect(sent.filter((m) => m.role === 'user' || m.role === 'assistant')).toHaveLength(1);
   });
 });

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -26,7 +26,6 @@ export interface RunAgentArgs {
   history: ConversationMessage[];
   mcp: McpToolHandle;
   abortSignal?: AbortSignal;
-  /** Override provider — used by tests. Defaults to OpenAI-compatible. */
   provider?: Provider;
 }
 

--- a/packages/backend-core/scripts/mcp-sweep.ts
+++ b/packages/backend-core/scripts/mcp-sweep.ts
@@ -1,21 +1,3 @@
-/**
- * Calls every tool exposed by a live MCP server and reports pass/fail.
- *
- * Run against a populated test org to mimic what Anthropic's directory
- * reviewers do — they call every tool and verify each returns a structured
- * response (not "Internal Server Error" / generic "Bad Request").
- *
- *   MCP_URL=https://mcp.getmunin.com/mcp \
- *   MCP_TOKEN=mn_... \
- *   pnpm -F @getmunin/backend-core mcp:sweep
- *
- * Flags (env vars):
- *   MCP_URL          required — full URL of the /mcp endpoint
- *   MCP_TOKEN        required — bearer token (admin API key or session token)
- *   MCP_INCLUDE_WRITES=1   also exercise destructive tools (default: skip)
- *   MCP_ONLY=foo,bar       limit the sweep to a comma-separated allowlist
- *   MCP_SKIP=foo,bar       exclude a comma-separated denylist
- */
 import 'reflect-metadata';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';

--- a/packages/backend-core/src/auth-controller-factory.ts
+++ b/packages/backend-core/src/auth-controller-factory.ts
@@ -4,13 +4,6 @@ interface BetterAuthLike {
   handler: (req: globalThis.Request) => Promise<globalThis.Response>;
 }
 
-/**
- * Marshal an Express request → Fetch Request, hand it to a BetterAuth-like
- * `handler`, then pipe the Fetch Response back to Express. This is the only
- * boilerplate the OSS and cloud auth controllers actually share — each
- * edition wraps it with its own controller class so Nest decorators can
- * mount the routes at `@Controller('auth')`.
- */
 export async function handleAuthRequest(
   auth: BetterAuthLike,
   req: ExpressRequest,

--- a/packages/backend-core/src/auth-env.ts
+++ b/packages/backend-core/src/auth-env.ts
@@ -1,9 +1,3 @@
-/**
- * Env-reading helpers shared between OSS and cloud auth bootstraps.
- * Edition-specific helpers (e.g. allowed-domain allowlist for OSS) stay
- * in the edition's own auth.config.
- */
-
 export function readGoogleProviderFromEnv(): { clientId: string; clientSecret: string } | undefined {
   const clientId = process.env.GOOGLE_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET;

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -66,7 +66,6 @@ export interface MuninAuthCoreOptions {
 
   crossSubDomainCookies?: { domain: string };
 
-  /** Defaults to MUNIN_AUTH_COOKIE_PREFIX, falling back to better-auth's default. */
   cookiePrefix?: string;
 
   rateLimit?: BetterAuthOptions['rateLimit'];

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -14,11 +14,6 @@ const JSON_BODY_LIMIT = '4mb';
 
 const DEFAULT_DEV_WEB_ORIGINS = ['http://localhost:3000', 'http://127.0.0.1:3000'];
 
-/**
- * Hashed widget / tracker bundles match `<name>.<12-hex-sha>.js[.map]?`.
- * Anything else hitting `/widget/...` or `/tracker/...` is rejected with
- * 404 — no path traversal surface, no accidental directory listing.
- */
 const HASHED_WIDGET_FILE_RE = /^widget\.[a-f0-9]{12}\.js(\.map)?$/;
 const HASHED_TRACKER_FILE_RE = /^tracker\.[a-f0-9]{12}\.js(\.map)?$/;
 
@@ -46,49 +41,11 @@ export function readTrustProxySetting(): boolean | number | string | null {
 }
 
 export interface CreateAppOptions extends NestApplicationOptions {
-  /**
-   * Absolute path to the directory holding the chat-widget's hashed
-   * bundle + manifest.json. Defaults to `<cwd>/public/widget` which
-   * matches `apps/backend/public/widget/` after the prebuild copy step.
-   * Pass an explicit path for tests or alternative layouts. If the
-   * directory doesn't exist at boot, the routes log a one-line warning
-   * and serve 503 — the rest of the API still boots.
-   */
   widgetAssetDir?: string;
-  /**
-   * Absolute path to the directory holding the analytics-tracker's hashed
-   * bundle + manifest.json. Defaults to `<cwd>/public/tracker` which
-   * matches `apps/backend/public/tracker/` after the prebuild copy step.
-   * Same shape as `widgetAssetDir`. Missing manifest → 503 on
-   * `/tracker.js`, rest of API still boots.
-   */
   trackerAssetDir?: string;
-  /**
-   * Absolute path to the directory holding the MCP host's brand icons —
-   * `favicon.ico`, `icon.png`, `apple-icon.png`. Served at the root paths
-   * `/favicon.ico`, `/icon.png`, `/apple-icon.png` with a long cache.
-   * Defaults to `<cwd>/public/icons`. Missing files silently 404; this
-   * is what claude.ai web (and similar MCP UIs) fetches to render the
-   * custom-integration tile.
-   */
   iconAssetDir?: string;
 }
 
-/**
- * Boot the Nest app with all the Express-level concerns wired up:
- *   - CORS for the dashboard origins.
- *   - Static-asset GET handler for self-host (LocalFsStorage) — read by
- *     external clients via the URL the storage provider returns from
- *     `publicUrlFor()`.
- *   - Chat-widget bundle: `/widget/<sha>.js` (immutable, year-long cache)
- *     and `/widget.js` (302 redirect to the current sha, short cache).
- *   - Analytics-tracker bundle: same shape at `/tracker/<sha>.js` and
- *     `/tracker.js`.
- *
- * The caller supplies their AppModule (single-tenant for OSS, multi-tenant
- * for cloud). Both editions go through this factory so tests, prod, and
- * dev all share the same boot shape.
- */
 export async function createApp(
   appModule: Type<unknown>,
   opts: CreateAppOptions = {},
@@ -98,11 +55,6 @@ export async function createApp(
     rawBody: true,
     ...nestOpts,
   });
-  // The `text/plain` opt-in lets the analytics-tracker bundle send its JSON
-  // payload via `navigator.sendBeacon` (which always sends cookies) without
-  // triggering a CORS preflight that would fail on public-CORS paths.
-  // Other endpoints still send `application/json`; this just widens what the
-  // JSON parser accepts.
   app.useBodyParser('json', { limit: JSON_BODY_LIMIT, type: ['application/json', 'text/plain'] });
   app.useBodyParser('urlencoded', { extended: true, limit: JSON_BODY_LIMIT });
   const trustProxy = readTrustProxySetting();
@@ -153,15 +105,6 @@ export function isPublicCorsPath(path: string): boolean {
   );
 }
 
-/**
- * Maps the canonical MCP URL onto the internal `/mcp` Nest mount.
- *
- * A cloud deploy can advertise `https://mcp.getmunin.com` (no path) and
- * the middleware rewrites root requests on that host to `/mcp` so the
- * MCP controller sees them. OSS dev keeps `/mcp` → `/mcp` (no-op since
- * `NEXT_PUBLIC_MCP_URL=http://localhost:3001/mcp` matches the internal
- * path verbatim).
- */
 export function publicUrlRewriteMiddleware() {
   const mcp = parseRewriteSource(process.env.NEXT_PUBLIC_MCP_URL ?? 'http://localhost:3001/mcp');
   return (req: Request, _res: Response, next: NextFunction): void => {
@@ -293,7 +236,6 @@ function staticAssetsMiddleware(storage: LocalFsStorage) {
       next();
       return;
     }
-    // Skip the upload endpoint — handled by the StaticAssetsController.
     if (req.path === '/upload' || req.path.startsWith('/upload?')) {
       next();
       return;
@@ -330,12 +272,6 @@ function staticAssetsMiddleware(storage: LocalFsStorage) {
   };
 }
 
-/**
- * In-memory cache of `manifest.json`. Refreshes when the file's mtime
- * changes so a deploy that swaps the manifest in-place picks up without
- * a server restart. Returns `null` if the manifest is missing or
- * malformed — the route handlers translate that to a 503.
- */
 function manifestReader(
   bundleDir: string,
   hashedFileRe: RegExp,

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -18,14 +18,6 @@ import { Reflector } from '@nestjs/core';
 import { mcpResourceUrl, resourceMetadataUrl } from '../../oauth/oauth.constants.ts';
 import { sessionCookieNames } from '../../auth/auth-cookies.ts';
 
-/**
- * Decorator used on routes that should be reachable without auth
- * (signup, oauth discovery). Backed by Nest's `SetMetadata` keyed by a
- * stable string — Symbol() was used originally, but symbol identity
- * across compiled module boundaries proved unreliable in production
- * (well-known OAuth discovery endpoints 401'd even though they had
- * @AllowAnonymous at the method level).
- */
 export const ALLOW_ANONYMOUS = 'munin:allow-anonymous';
 export const AllowAnonymous = () => SetMetadata(ALLOW_ANONYMOUS, true);
 
@@ -33,13 +25,6 @@ export interface PublicControllerOpts {
   throttle?: boolean;
 }
 
-/**
- * Class decorator for controllers whose every route is intentionally
- * anonymous. Bundles `@Controller(path)` + `@AllowAnonymous()` so the
- * "public" intent is a single, greppable declaration — keeping a new
- * public route from accidentally inheriting the cloud build's global
- * AuthGuard. Pass `{ throttle: true }` to also wrap `ThrottlerGuard`.
- */
 export function PublicController(
   path: string,
   opts: PublicControllerOpts = {},
@@ -49,37 +34,16 @@ export function PublicController(
   return applyDecorators(...decorators);
 }
 
-/**
- * Extension point: try additional resolvers when the built-in resolver
- * returns null. Downstream packages plug in here to recognize their own
- * key kinds (e.g. partner credentials) without modifying core code.
- */
 export const ADDITIONAL_CREDENTIAL_RESOLVERS = Symbol('additionalCredentialResolvers');
 export interface AdditionalCredentialResolver {
   resolve(rawKey: string): Promise<ResolvedCredential | null>;
 }
 
-/**
- * Internal augmentation of the Express request used inside this app.
- * Kept local rather than declared on `express-serve-static-core` to avoid
- * cross-package module-resolution issues in this monorepo.
- */
 export interface AuthenticatedRequest {
   headers: Record<string, string | string[] | undefined>;
   credential?: ResolvedCredential;
 }
 
-/**
- * Resolves the bearer token / API key on the incoming request.
- *
- * - Authorization: Bearer <token>            → resolveBearerToken (OAuth or delegated)
- * - Authorization: Bearer mn_<kind>_<rand>   → resolveApiKey, then any registered
- *                                              additional resolvers (cloud plugs in
- *                                              partner-key resolution).
- *
- * On success, attaches `request.credential`. Does NOT open a transaction
- * or set the tenancy context — that's the TenancyInterceptor's job.
- */
 @Injectable()
 export class AuthGuard implements CanActivate {
   private readonly resolver: CredentialResolver;
@@ -178,16 +142,12 @@ function readSessionCookie(cookieHeader: string | undefined): string | null {
     const name = part.slice(0, eq).trim();
     if (!names.includes(name)) continue;
     const raw = decodeURIComponent(part.slice(eq + 1).trim());
-    // BetterAuth signs session tokens as `<token>.<signature>`. Both halves
-    // are stored in the cookie; we only need the token portion to look up
-    // the sessions row, the signature is verified at write time by BA itself.
     const dot = raw.indexOf('.');
     return dot >= 0 ? raw.slice(0, dot) : raw;
   }
   return null;
 }
 
-/** Munin API keys are `mn_<kind>_<random>`. Anything else is treated as a bearer/OAuth token. */
 function looksLikeApiKey(raw: string): boolean {
   return /^mn_[a-z]+_[A-Za-z0-9_-]+$/.test(raw);
 }

--- a/packages/backend-core/src/common/rate-limit/public-throttle.module.ts
+++ b/packages/backend-core/src/common/rate-limit/public-throttle.module.ts
@@ -2,24 +2,6 @@ import { Module } from '@nestjs/common';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { parseEnvInt } from '@getmunin/core';
 
-/**
- * Per-IP rate limiting for anonymous public endpoints (CMS delivery,
- * public skills, public suggestions).
- *
- * Authenticated MCP traffic goes through `RateLimitService` instead —
- * that uses `orgs.rateLimitCounters` and respects per-org caps from
- * `orgs.settings.rateLimits`. To avoid double-counting we don't register
- * `ThrottlerGuard` globally; instead each public controller applies it
- * via `@UseGuards(ThrottlerGuard)` explicitly.
- *
- * Defaults: 60 req/min, 1000 req/hr per IP. Tunable via env:
- *   MUNIN_PUBLIC_THROTTLE_MIN  default 60
- *   MUNIN_PUBLIC_THROTTLE_HOUR default 1000
- *
- * In-memory store. Multi-replica deployments enforce per-replica (each
- * container counts independently). For v1 launch this is good enough;
- * upgrade to a Redis store if abuse patterns emerge.
- */
 @Module({
   imports: [
     ThrottlerModule.forRoot([

--- a/packages/backend-core/src/common/rate-limit/rate-limit.service.ts
+++ b/packages/backend-core/src/common/rate-limit/rate-limit.service.ts
@@ -47,13 +47,6 @@ type BucketCountRow = {
   count: number;
 } & Record<string, unknown>;
 
-/**
- * Postgres-backed sliding-window counters keyed by `(org, bucket, window_start)`.
- * Each `record(bucket)` upserts the current window and returns the post-bump
- * count. Limit enforcement is the caller's responsibility — `consume()` packages
- * the MCP-tool-call recipe (record + check day). Per-minute burst protection
- * lives in `McpBurstGuard` (in-memory, per replica).
- */
 @Injectable()
 export class RateLimitService {
   async record(bucket: Bucket, amount = 1): Promise<number> {

--- a/packages/backend-core/src/common/scheduler-lock/scheduler-lock.ts
+++ b/packages/backend-core/src/common/scheduler-lock/scheduler-lock.ts
@@ -1,27 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { type Db } from '@getmunin/db';
 
-/**
- * Run `fn` only on the replica that wins a per-name Postgres advisory
- * lock. The other replicas' ticks return `null` immediately.
- *
- * Used for in-process schedulers (cron-driven sweep enqueuers, webhook
- * dispatch loops, CMS scheduled publishing, etc.) that would otherwise
- * fire N times on a backend scaled to N replicas.
- *
- * The lock is *transaction-scoped* (`pg_try_advisory_xact_lock`), so it
- * auto-releases when the wrapping transaction commits or rolls back —
- * no connection-pool reuse gotchas, no leaked locks on crash. The
- * lock is held for the full duration of `fn`, which means `fn` blocks
- * a DB connection until it finishes. Keep ticks short (< 60s); for
- * longer work, enqueue into a durable job table (e.g. curator_jobs)
- * and let row-level claim handle the long-running execution.
- *
- * The name is hashed via Postgres `hashtext()` to a 32-bit int — pick
- * names that won't collide accidentally with other advisory locks in
- * the system (the curator job claim uses `FOR UPDATE SKIP LOCKED`, not
- * advisory, so there's no overlap there).
- */
 export async function withSchedulerLock<T>(
   db: Db,
   name: string,

--- a/packages/backend-core/src/common/storage/static-assets.controller.ts
+++ b/packages/backend-core/src/common/storage/static-assets.controller.ts
@@ -15,24 +15,8 @@ import type { Request, Response } from 'express';
 import { PublicController } from '../auth/auth.guard.ts';
 import { STORAGE } from './storage.token.ts';
 
-const MAX_UPLOAD_BYTES = 50 * 1024 * 1024; // 50 MB; tighten via Org.settings later.
+const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
 
-/**
- * Self-host upload endpoint. Active only when MUNIN_STORAGE_PROVIDER is
- * `local` (the default).
- *
- *   PUT/POST /static/assets/upload?key=&exp=&sz=&sig=
- *     Validate the signed URL minted by LocalFsStorage.presignedUpload,
- *     read the request body, write to disk under the storage root.
- *
- * Read serving (`GET /static/assets/<key>`) is registered as Express
- * middleware in `bootstrap-app.ts`, not as a controller route, because
- * Nest 10 + Express 4 doesn't accept catch-all named-wildcard patterns.
- *
- * In S3 mode this returns 404 — uploaders go directly to the presigned
- * S3 URL, reads go to the bucket's public host (or a CDN front
- * configured via MUNIN_STORAGE_S3_PUBLIC_BASE_URL).
- */
 @PublicController('static/assets')
 export class StaticAssetsController {
   constructor(@Inject(STORAGE) private readonly storage: AssetStorage) {}

--- a/packages/backend-core/src/common/storage/storage.token.ts
+++ b/packages/backend-core/src/common/storage/storage.token.ts
@@ -1,6 +1,1 @@
-/**
- * Nest DI token for the global AssetStorage instance. Lives in its own
- * file so the StaticAssetsController can import it without forming a
- * circular dependency with storage.module.ts.
- */
 export const STORAGE = Symbol('AssetStorage');

--- a/packages/backend-core/src/common/tenancy/tenancy.interceptor.ts
+++ b/packages/backend-core/src/common/tenancy/tenancy.interceptor.ts
@@ -32,12 +32,6 @@ export async function applyTenancyGUCs(tx: Db | Tx, actor: ActorIdentity): Promi
   }
 }
 
-/**
- * Set `app.crypt_key` for the current transaction so SQL fragments wrapping
- * pgcrypto's pgp_sym_encrypt / pgp_sym_decrypt can pick it up via
- * current_setting. Silently no-ops when MUNIN_ENCRYPTION_KEY is unset —
- * encryption-aware code paths surface a clear error at use time.
- */
 async function applyEncryptionKeyGUC(tx: Db | Tx): Promise<void> {
   const key = process.env.MUNIN_ENCRYPTION_KEY;
   if (!key) return;

--- a/packages/backend-core/src/common/webhooks/webhook.worker.test.ts
+++ b/packages/backend-core/src/common/webhooks/webhook.worker.test.ts
@@ -103,23 +103,15 @@ interface ReceivedRequest {
       .returning();
     const webhook = { id: webhookRow!.id, secret: webhookRow!.secret };
 
-    // Set up a chat channel so end-user start_conversation can pick one up.
     const [channel] = await db
       .insert(schema.convChannels)
       .values({ orgId, type: 'chat', vendor: 'munin', name: 'Web' })
       .returning();
-    // Provision an end-user + token, then start a conversation through the
-    // service layer directly (we already exercised the MCP path elsewhere).
     const [eu] = await db
       .insert(schema.endUsers)
       .values({ orgId, externalId: 'eu-1', name: 'Alice' })
       .returning();
 
-    // Insert a conversation + first message via service-role db, then emit
-    // the matching events through the WebhookDispatcher's persistence
-    // layer using a quick dispatch step. Easier: create a conv via the
-    // admin REST → MCP path. We'll just use the desk admin tool over MCP.
-    // For simplicity here, do the inserts directly + create the events row.
     const [conv] = await db
       .insert(schema.convConversations)
       .values({
@@ -154,7 +146,6 @@ interface ReceivedRequest {
     expect(delivery.event).toBe('conversation.created');
     expect(delivery.signature).toMatch(/^sha256=/);
 
-    // Signature verifies against the secret that's set on the webhook.
     const sigOnly = delivery.signature!.replace(/^sha256=/, '');
     expect(verifyHmac(delivery.body, webhook.secret, sigOnly)).toBe(true);
 
@@ -200,7 +191,6 @@ interface ReceivedRequest {
     receiverShouldFail = true;
     try {
       const worker = app.get(WebhookWorker);
-      // First attempt: should record an error and schedule a retry.
       const r1 = await worker.tick();
       expect(r1.delivered).toBe(0);
       expect(r1.failed).toBe(1);
@@ -213,7 +203,6 @@ interface ReceivedRequest {
       expect(afterFirst!.error).toMatch(/non-2xx: 500/);
       expect(afterFirst!.nextAttemptAt).toBeInstanceOf(Date);
 
-      // Force the row to "due" again and run 4 more times to exhaust attempts.
       for (let i = 0; i < 4; i++) {
         await db
           .update(schema.webhookDeliveries)

--- a/packages/backend-core/src/common/webhooks/webhook.worker.ts
+++ b/packages/backend-core/src/common/webhooks/webhook.worker.ts
@@ -14,23 +14,8 @@ import { withSchedulerLock } from '../scheduler-lock/index.ts';
 const POLL_INTERVAL_MS = parseEnvInt({ name: 'MUNIN_WEBHOOK_POLL_MS', default: 5000 });
 const MAX_ATTEMPTS = 5;
 const BATCH_SIZE = 25;
-const BACKOFF_BASE_MS = 30_000; // 30s, then 1m, 2m, 4m, 8m for ~16m total span.
+const BACKOFF_BASE_MS = 30_000;
 
-/**
- * In-process webhook delivery worker. Polls `webhook_deliveries` for rows
- * whose `next_attempt_at <= now()` and that haven't yet succeeded, POSTs
- * the signed payload to the webhook URL, and updates the row with the
- * outcome (success → `delivered_at`; failure → bump `attempt`, push
- * `next_attempt_at` forward with exponential backoff).
- *
- * Service-role DB so the worker can read deliveries across orgs without
- * a tenant context. RLS doesn't apply, but every query already filters
- * by webhook_id / org_id transitively, and the worker is internal.
- *
- * One worker instance per backend process is fine for v0.4. If we ever
- * scale horizontally, swap the polling claim for SELECT ... FOR UPDATE
- * SKIP LOCKED or an external queue.
- */
 @Injectable()
 export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
   private timer: NodeJS.Timeout | null = null;
@@ -53,10 +38,6 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
     this.timer = null;
   }
 
-  /**
-   * Drain a batch of due deliveries. Public so tests can call it directly
-   * without waiting on the polling interval.
-   */
   async tick(): Promise<{ attempted: number; delivered: number; failed: number }> {
     if (this.running) return { attempted: 0, delivered: 0, failed: 0 };
     this.running = true;
@@ -114,7 +95,6 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
       .limit(1);
 
     if (!webhookRow || !eventRow || !webhookRow.active) {
-      // Webhook gone or disabled — mark delivered to stop retrying.
       await this.db
         .update(schema.webhookDeliveries)
         .set({
@@ -192,5 +172,4 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
   }
 }
 
-// Exported for tests to clamp polling.
 export { POLL_INTERVAL_MS };

--- a/packages/backend-core/src/common/whoami.controller.ts
+++ b/packages/backend-core/src/common/whoami.controller.ts
@@ -4,12 +4,6 @@ import { AuthGuard } from './auth/auth.guard.ts';
 import { TenancyInterceptor } from './tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from './audit/audit.interceptor.ts';
 
-/**
- * Minimal authenticated endpoint: returns the resolved caller identity.
- *
- * Lets us smoke-test the full chain (AuthGuard → TenancyInterceptor →
- * AuditInterceptor → controller) without needing a real domain module yet.
- */
 @Controller('v1')
 @UseGuards(AuthGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)

--- a/packages/backend-core/src/control/accept-invitation.controller.ts
+++ b/packages/backend-core/src/control/accept-invitation.controller.ts
@@ -32,12 +32,6 @@ interface AcceptRequest {
   userId?: string;
 }
 
-/**
- * Resolve the calling user from a session cookie WITHOUT going through the
- * normal AuthGuard (which calls TenancyInterceptor and would fail because
- * the user isn't a member of the target org yet). We just need the user_id
- * from the session.
- */
 @Injectable()
 class SessionOnlyGuard implements CanActivate {
   private readonly resolver: CredentialResolver;
@@ -52,8 +46,6 @@ class SessionOnlyGuard implements CanActivate {
     if (!sessionToken) {
       throw new ForbiddenException('not_signed_in');
     }
-    // Resolve the session even if there's no membership yet — invitee may
-    // be brand new with no orgs, or have a personal org and be joining a team.
     const userId = await resolveUserIdFromSession(this.resolver, sessionToken);
     if (!userId) throw new ForbiddenException('invalid_session');
     req.userId = userId;
@@ -61,12 +53,6 @@ class SessionOnlyGuard implements CanActivate {
   }
 }
 
-/**
- * Anonymous-cookie accept endpoint. The invitee has signed up or signed
- * in (they have a session cookie) but isn't yet a member of the inviting
- * org, so the regular AuthGuard + TenancyInterceptor pair would fail to
- * route them.
- */
 @Controller('v1/invitations')
 export class AcceptInvitationController {
   constructor(@Inject(InvitationsService) private readonly invites: InvitationsService) {}
@@ -110,15 +96,7 @@ async function resolveUserIdFromSession(
   resolver: CredentialResolver,
   rawToken: string,
 ): Promise<string | null> {
-  // CredentialResolver.resolveSessionToken returns null when the user has
-  // no membership; for the accept flow we want the user_id even then.
-  // Use the underlying `sessions` table lookup directly via a small private
-  // helper exposed as the inner db access. Cleanest: extend CredentialResolver
-  // with a session→user-id helper. For now, call the public API; if it
-  // returns null and the cookie was present, fall back to a direct sessions
-  // lookup.
   const credential = await resolver.resolveSessionToken(rawToken);
   if (credential) return credential.actor.userId ?? credential.actor.id;
-  // Fallback: directly look up the session row.
   return resolver.resolveSessionUserId(rawToken);
 }

--- a/packages/backend-core/src/control/api-keys.controller.ts
+++ b/packages/backend-core/src/control/api-keys.controller.ts
@@ -31,7 +31,6 @@ const CreateApiKeyDto = z.object({
 interface CreatedApiKey {
   id: string;
   name: string;
-  /** Plaintext API key — shown ONCE at creation time. */
   key: string;
   prefix: string;
   scopes: string[];

--- a/packages/backend-core/src/control/audit-log.controller.ts
+++ b/packages/backend-core/src/control/audit-log.controller.ts
@@ -36,11 +36,6 @@ const PAGE_SIZE_MAX = 200;
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
 @RequireRole('owner', 'admin')
 export class AuditLogController {
-  /**
-   * Newest-first cursor pagination. `before` is the createdAt of the last
-   * item from the previous page (ISO string); omit for the first page.
-   * Optional filters: tool, actorType, correlationId.
-   */
   @Get()
   async list(
     @Query('limit') limit?: string,

--- a/packages/backend-core/src/control/cms-delivery.controller.ts
+++ b/packages/backend-core/src/control/cms-delivery.controller.ts
@@ -37,23 +37,6 @@ import {
 import { loadAssetMap } from '../modules/cms/cms.asset-loader.ts';
 import { loadEntryMap } from '../modules/cms/cms.entry-loader.ts';
 
-/**
- * Public delivery API — anonymous JSON for external websites / mobile
- * apps / external integrations. Routes open with `{orgId}` so a CDN can
- * cache cleanly per (org, collection) without per-request auth.
- *
- * Always returns `status='published'`, with one exception: the
- * single-entry route accepts `?preview=<token>` — a signed, short-lived,
- * entry-scoped token (minted via `cms_get_preview_link` or
- * `POST /v1/cms/drafts/:id/preview-link`) that returns the entry
- * regardless of status with `Cache-Control: no-store`. List and search
- * routes never accept it. Everything else about drafts stays on the
- * admin MCP surface.
- *
- * Service-role DB is used because RLS only knows the GUC-scoped tenant
- * context, and there's no auth here. Every SELECT hard-filters
- * `org_id` and `status='published'` so cross-org leakage is impossible.
- */
 @PublicController('v1/cms', { throttle: true })
 export class CmsDeliveryController {
   constructor(

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -56,14 +56,6 @@ import { SlackModule } from '../modules/slack/slack.module.ts';
 import { ConnectorsController } from './connectors.controller.ts';
 import { ConnectorsModule } from '../modules/connectors/connectors.module.ts';
 
-/**
- * Control plane: server-to-server REST endpoints used by an org's backend
- * to mint scoped tokens, manage end-users, manage API keys, and read/update
- * org settings.
- *
- * All require admin API key auth. End-user delegated tokens are NOT
- * permitted on these endpoints — that's the privilege boundary.
- */
 @Module({
   imports: [
     AnalyticsModule,

--- a/packages/backend-core/src/control/conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/conversations.controller.integration.test.ts
@@ -98,14 +98,6 @@ const skipReason = TEST_URL
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
     });
 
-    // Insert the chat channel directly via the service-role connection
-    // (bypasses RLS, commits before app boot). Previously this went through
-    // an MCP tool call after the app started — that path occasionally
-    // flaked under CI: the tool's response was awaited but its result
-    // wasn't validated, so a transient transport error left the channel
-    // missing and every "no active channel configured" assertion below it
-    // failed. Direct insert is one SQL round-trip with deterministic
-    // visibility for the app's separate connection pool.
     await db.insert(schema.convChannels).values({
       orgId: orgAId,
       type: 'chat',

--- a/packages/backend-core/src/control/delegated-token.controller.ts
+++ b/packages/backend-core/src/control/delegated-token.controller.ts
@@ -58,14 +58,6 @@ interface MintResult {
   audiences: string[];
 }
 
-/**
- * Mint a short-lived end-user delegated token.
- *
- * The org's backend (with admin API key) calls this when starting a customer-
- * facing session (voice call, web chat, etc.). The agent runtime gets the
- * resulting token and uses it as bearer when calling MCP tools — its surface
- * is restricted to self-service tools, scoped to that one EndUser.
- */
 @Controller('v1/tokens/delegated')
 @UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
@@ -81,7 +73,6 @@ export class DelegatedTokenController {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
 
-    // Resolve / upsert EndUser.
     let endUserId = input.endUserId;
     if (endUserId) {
       const owned = await ctx.db
@@ -120,7 +111,6 @@ export class DelegatedTokenController {
       }
     }
 
-    // Issue the token.
     const rawToken = buildApiKey('dlg');
     const expiresAt = new Date(Date.now() + input.ttlSeconds * 1000);
 

--- a/packages/backend-core/src/control/email-opens.controller.ts
+++ b/packages/backend-core/src/control/email-opens.controller.ts
@@ -78,10 +78,7 @@ export class EmailOpensController {
           },
         });
       });
-    } catch {
-      // Open tracking is best-effort — swallow DB / webhook errors so the
-      // mail client never sees a broken image.
-    }
+    } catch {}
   }
 }
 

--- a/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
+++ b/packages/backend-core/src/control/end-user-conversations.controller.integration.test.ts
@@ -239,7 +239,6 @@ const skipReason = TEST_URL
       aliceToken,
       'POST',
       `/v1/end-users/me/conversations/${start.body.id}/messages`,
-      // Even if the client tries to spoof the author type, the server forces 'end_user'.
       { body: 'second message', authorType: 'agent' },
     );
     expect(reply.status).toBe(201);

--- a/packages/backend-core/src/control/end-users.controller.ts
+++ b/packages/backend-core/src/control/end-users.controller.ts
@@ -58,10 +58,6 @@ interface EndUserDto {
 export class EndUsersController {
   constructor(@Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher) {}
 
-  /**
-   * Find or create an EndUser by externalId / email / phone.
-   * Returns 200 + the row (whether existing or just-created).
-   */
   @Post('lookup')
   @HttpCode(200)
   async lookup(@Body() body: unknown): Promise<EndUserDto> {

--- a/packages/backend-core/src/control/invitations.service.ts
+++ b/packages/backend-core/src/control/invitations.service.ts
@@ -144,12 +144,6 @@ export class InvitationsService {
     return { revoked: true };
   }
 
-  /**
-   * Accept an invite. Service-role-DB path: the invitee isn't a member of
-   * the target org yet, so RLS would reject. We bypass RLS and validate by
-   * matching the supplied token's hash against an unaccepted, unrevoked,
-   * unexpired row.
-   */
   async lookupByToken(token: string): Promise<{ email: string; role: string; expiresAt: string } | null> {
     if (!token) return null;
     const tokenHash = hashSecret(token);

--- a/packages/backend-core/src/control/overview.controller.integration.test.ts
+++ b/packages/backend-core/src/control/overview.controller.integration.test.ts
@@ -139,7 +139,6 @@ const skipReason = TEST_URL
   });
 
   it('counts conversations needing attention scoped to caller org', async () => {
-    // Seed channels + conversations directly (service-role).
     const [chanA] = await db
       .insert(schema.convChannels)
       .values({ orgId: orgAId, type: 'chat', vendor: 'munin', name: 'A chat', config: {} })
@@ -163,7 +162,6 @@ const skipReason = TEST_URL
     const a = await getBacklog(adminKeyA);
     expect(a.conversationsNeedingAttention).toBe(1);
 
-    // org B sees zero — RLS isolation.
     const b = await getBacklog(adminKeyB);
     expect(b.conversationsNeedingAttention).toBe(0);
   });

--- a/packages/backend-core/src/control/role.decorator.ts
+++ b/packages/backend-core/src/control/role.decorator.ts
@@ -5,18 +5,8 @@ import type { OrgRole } from './role-guard.ts';
 export const REQUIRE_ROLE_KEY = 'munin:require-role';
 export const REQUIRE_ACTOR_TYPE_KEY = 'munin:require-actor-type';
 
-/**
- * Require the calling user to hold one of the listed org roles. Admin API
- * keys with unrestricted scope (`*`) and system actors pass automatically —
- * matching `assertOwnerOrAdmin` semantics. To also block API keys, stack with
- * `@RequireActorType('user')`.
- */
 export const RequireRole = (...roles: OrgRole[]): MethodDecorator & ClassDecorator =>
   SetMetadata(REQUIRE_ROLE_KEY, roles);
 
-/**
- * Restrict the route to specific actor types (e.g. `'user'` for signed-in
- * dashboard sessions only, `'end_user_agent'` for delegated end-user agents).
- */
 export const RequireActorType = (...types: ActorType[]): MethodDecorator & ClassDecorator =>
   SetMetadata(REQUIRE_ACTOR_TYPE_KEY, types);

--- a/packages/backend-core/src/control/role.guard.ts
+++ b/packages/backend-core/src/control/role.guard.ts
@@ -13,12 +13,6 @@ import { DB } from '../common/db/db.module.ts';
 import { type OrgRole } from './role-guard.ts';
 import { REQUIRE_ACTOR_TYPE_KEY, REQUIRE_ROLE_KEY } from './role.decorator.ts';
 
-/**
- * Guards run BEFORE interceptors in Nest's pipeline, so this guard can't
- * use the AsyncLocalStorage context set by TenancyInterceptor. Instead we
- * pull the actor from `req.credential` (attached by AuthGuard) and use
- * the injected service-role DB for the membership lookup.
- */
 @Injectable()
 export class RoleGuard implements CanActivate {
   constructor(
@@ -87,11 +81,6 @@ export class RoleGuard implements CanActivate {
     return true;
   }
 
-  /**
-   * Looks up the caller's role in `org_members`. The injected `db` is the
-   * service-role connection (which bypasses RLS via its connect-time option),
-   * so we don't need the request-scoped tenant transaction here.
-   */
   private async readUserRole(orgId: string, userId: string): Promise<OrgRole | null> {
     await this.db.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
     const rows = await this.db

--- a/packages/backend-core/src/mcp/mcp-burst.guard.ts
+++ b/packages/backend-core/src/mcp/mcp-burst.guard.ts
@@ -9,13 +9,6 @@ interface Window {
 
 const WINDOW_MS = 60_000;
 
-/**
- * Per-replica burst limiter for /mcp. Each pod keeps its own (org || ip) →
- * (count, resetAt) map in memory; entries auto-expire at the end of their
- * minute window. Multi-replica fleets don't enforce a global cap — each
- * pod independently allows up to `MUNIN_MCP_BURST_PER_MIN` (default 60).
- * Adequate for runaway-agent protection; deliberately not a billing gate.
- */
 @Injectable()
 export class McpBurstGuard implements CanActivate {
   private readonly windows = new Map<string, Window>();

--- a/packages/backend-core/src/mcp/mcp.controller.ts
+++ b/packages/backend-core/src/mcp/mcp.controller.ts
@@ -28,17 +28,6 @@ import {
 import { deriveMcpAudience } from './mcp.audience.ts';
 import { mcpResourceOrigin } from '../oauth/oauth.constants.ts';
 
-/**
- * Streamable HTTP entry point for the MCP server.
- *
- * Stateless mode: each POST request constructs a fresh Server + transport,
- * processes the JSON-RPC payload, and tears down. This way each call is
- * audience-filtered to exactly the authenticated actor and there's no
- * cross-session state to lose.
- *
- * GET is used for SSE streaming; DELETE terminates a session id when the
- * SDK exposes one (currently a no-op for stateless mode).
- */
 @Controller('mcp')
 @UseGuards(AuthGuard, McpBurstGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
@@ -90,7 +79,7 @@ export class McpController {
     });
 
     const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined, // stateless
+      sessionIdGenerator: undefined,
       enableJsonResponse: true,
     });
 

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -31,9 +31,6 @@ const skipReason = TEST_URL
 
     await runMigrations(TEST_URL!);
 
-    // Postgres superusers always bypass RLS — the integration test must boot
-    // Nest with the non-superuser munin_app role so the RLS policies actually
-    // apply to delegated end-user requests.
     const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
     process.env.DATABASE_URL = appUrl;
 
@@ -166,7 +163,6 @@ const skipReason = TEST_URL
       const adminTitles = adminHits.map((h) => h.title);
       expect(adminTitles).toContain('Public help');
 
-      // Cleanup so this test doesn't leak documents.
       await c.callTool({
         name: 'kb_delete_document',
         arguments: { id: privateDoc.id, ifVersion: privateDoc.version },
@@ -268,23 +264,18 @@ const skipReason = TEST_URL
       name: 'mcp-it-limited',
       keyHash: hashSecret(limitedKey),
       keyPrefix: keyPrefix(limitedKey),
-      scopes: ['kb:read'], // read-only, no kb:write, no '*'
+      scopes: ['kb:read'],
     });
 
     await withClient(limitedKey, async (c) => {
-      // listTools intersects both audience and scope: kb_search is listed
-      // (caller has kb:read) but kb_create_document is hidden (no kb:write).
       const { tools } = await c.listTools();
       const names = tools.map((t) => t.name);
       expect(names).toContain('kb_search');
       expect(names).not.toContain('kb_create_document');
 
-      // kb_search works (kb:read).
       const search = await c.callTool({ name: 'kb_search', arguments: { query: 'anything' } });
       expect(JSON.stringify(search)).not.toMatch(/Missing required scope/);
 
-      // Defense in depth: even when invoked by name, kb_create_document is
-      // denied at dispatch with a scope error.
       const denied = await c.callTool({
         name: 'kb_create_document',
         arguments: {
@@ -306,7 +297,7 @@ const skipReason = TEST_URL
       name: 'mcp-it-audit',
       keyHash: hashSecret(auditKey),
       keyPrefix: keyPrefix(auditKey),
-      scopes: ['kb:read'], // missing kb:write — kb_create_document will be denied
+      scopes: ['kb:read'],
     });
 
     await withClient(auditKey, async (c) => {
@@ -321,8 +312,6 @@ const skipReason = TEST_URL
       expect(denied.isError).toBe(true);
     });
 
-    // Audit row written by createMcpServer's deny path. Read with bypass on so
-    // we can see the row regardless of org GUC state.
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
     const rows = await db
       .select({ tool: schema.auditLog.tool, result: schema.auditLog.result, error: schema.auditLog.error })
@@ -351,7 +340,6 @@ const skipReason = TEST_URL
       expect(denied.isError).toBe(true);
       expect(denied.content?.[0]?.text ?? '').toMatch(/Missing required scope: kb:read/);
 
-      // ping has no scope requirement — still works for the same actor.
       const ping = await c.callTool({ name: 'ping', arguments: { message: 'ok' } });
       expect(JSON.stringify(ping)).toContain('ok');
     });
@@ -431,7 +419,6 @@ const skipReason = TEST_URL
   }, 30_000);
 
   it('end-user agent sees only self-service tools and only public docs', async () => {
-    // First seed a public + a private doc as admin.
     let publicDocId = '';
     let privateDocId = '';
     let publicVer = 0;

--- a/packages/backend-core/src/mcp/mcp.registry.ts
+++ b/packages/backend-core/src/mcp/mcp.registry.ts
@@ -2,11 +2,6 @@ import { Injectable, OnModuleInit, type Type } from '@nestjs/common';
 import { DiscoveryService, MetadataScanner, ModuleRef } from '@nestjs/core';
 import { McpToolRegistry, MCP_TOOL_META, type McpToolMeta } from '@getmunin/mcp-toolkit';
 
-/**
- * Walks every NestJS provider at boot and registers every method that
- * carries @McpTool metadata. The bound handler is the method with `this`
- * fixed to the provider instance.
- */
 @Injectable()
 export class McpRegistryService extends McpToolRegistry implements OnModuleInit {
   constructor(
@@ -39,5 +34,4 @@ export class McpRegistryService extends McpToolRegistry implements OnModuleInit 
   }
 }
 
-/** Re-export for typing convenience in modules that wire MCP services. */
 export type { Type };

--- a/packages/backend-core/src/mcp/ping.tool.ts
+++ b/packages/backend-core/src/mcp/ping.tool.ts
@@ -7,14 +7,6 @@ const PingInput = z.object({
   message: z.string().optional(),
 });
 
-/**
- * The "hello world" of Munin MCP tools. Used to smoke-test the full pipe:
- *   client → AuthGuard → TenancyInterceptor → MCP transport → tool dispatch
- *   → audit row → response.
- *
- * Visible to both audiences so admin and self-service flows can both hit
- * something in M0.
- */
 @Injectable()
 export class PingMcpTool {
   @McpTool({

--- a/packages/backend-core/src/mcp/skill-loader.ts
+++ b/packages/backend-core/src/mcp/skill-loader.ts
@@ -4,14 +4,7 @@ import type { RegisteredSkill } from '@getmunin/mcp-toolkit';
 import type { Audience } from '@getmunin/core';
 
 export interface SkillSource {
-  /** Absolute path to a directory tree to scan for `*.md` files. */
   root: string;
-  /**
-   * Top-level URI namespace for skills under this root. Files inside
-   * subdirectories use the subdirectory name as the module segment.
-   * If omitted, the namespace is derived from the immediate parent
-   * directory name of each file (one level up from the markdown file).
-   */
   namespace?: string;
 }
 

--- a/packages/backend-core/src/modules/analytics/geoip.service.ts
+++ b/packages/backend-core/src/modules/analytics/geoip.service.ts
@@ -1,20 +1,6 @@
 import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
 import { open as openMaxmind, type CountryResponse, type Reader } from 'maxmind';
 
-/**
- * Resolves a client IP to its ISO 3166-1 alpha-2 country code via a local
- * MaxMind-format `.mmdb` (the official `GeoLite2-Country.mmdb` or any
- * DB-IP-Lite compatible file).
- *
- * The reader memory-maps the file once at boot, so lookups are O(µs) and
- * involve no network calls. If `MUNIN_GEOIP_DB_PATH` is unset or the file
- * fails to open, the service quietly no-ops: `lookupCountry()` returns
- * `null` for every IP, and the rest of the pipeline still records the
- * event (just without a country column).
- *
- * IP is consumed only here and is never persisted. Only the 2-character
- * country code lands on the row.
- */
 @Injectable()
 export class GeoIpService implements OnModuleInit {
   private readonly logger = new Logger(GeoIpService.name);
@@ -30,28 +16,18 @@ export class GeoIpService implements OnModuleInit {
       this.reader = await openMaxmind<CountryResponse>(path);
       this.logger.log(`geoip.enabled: db=${path}`);
     } catch (err) {
-      // Don't crash the app — country resolution is best-effort.
       this.logger.warn(`geoip.disabled: failed to open ${path}: ${(err as Error).message}`);
       this.reader = null;
     }
   }
 
-  /**
-   * Returns an uppercase ISO 3166-1 alpha-2 code, or `null` for: no
-   * configured DB, missing/private/unknown IP, or a record without a
-   * country.
-   */
   lookupCountry(ip: string | undefined): string | null {
     if (!this.reader || !ip) return null;
-    // Strip IPv4-mapped IPv6 prefix ("::ffff:1.2.3.4" → "1.2.3.4") so the
-    // mmdb reader matches against the IPv4 tree. Private/link-local ranges
-    // simply miss in the DB and return null below.
     const normalized = ip.startsWith('::ffff:') ? ip.slice(7) : ip;
     try {
       const record = this.reader.get(normalized);
       const code = record?.country?.iso_code ?? record?.registered_country?.iso_code;
       if (!code) return null;
-      // mmdb always returns 2-char ISO codes, but defend against malformed DBs.
       return code.length === 2 ? code.toUpperCase() : null;
     } catch {
       return null;

--- a/packages/backend-core/src/modules/cms/cms.integration.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.integration.test.ts
@@ -136,7 +136,6 @@ const skipReason = TEST_URL
       );
       expect(collections.find((c) => c.slug === 'pages')).toBeTruthy();
 
-      // Create + publish an entry.
       const entry = parseToolResult<{ id: string; slug: string; version: number; status: string }>(
         await c.callTool({
           name: 'cms_create_entry',
@@ -151,9 +150,6 @@ const skipReason = TEST_URL
       expect(entry.status).toBe('published');
     });
 
-    // Fetch anonymously via the public delivery API. waitFor absorbs the
-    // commit-visibility race between the MCP request transaction and the
-    // controller's separate service-role connection.
     const single = await fetchUntil(
       `${baseUrl}/v1/cms/${orgId}/pages/hello-world`,
       (r) => r.status === 200,
@@ -164,13 +160,11 @@ const skipReason = TEST_URL
     expect(singleJson.slug).toBe('hello-world');
     expect(singleJson.data.title).toBe('Hello, world');
 
-    // ETag round-trip.
     const cached = await fetch(`${baseUrl}/v1/cms/${orgId}/pages/hello-world`, {
       headers: { 'if-none-match': single.headers.get('etag')! },
     });
     expect(cached.status).toBe(304);
 
-    // List works.
     const list = await fetch(`${baseUrl}/v1/cms/${orgId}/pages`);
     expect(list.status).toBe(200);
     const listJson = (await list.json()) as { items: Array<{ slug: string }> };
@@ -189,7 +183,6 @@ const skipReason = TEST_URL
         },
       });
 
-      // Admin search includes drafts.
       const adminHits = parseToolResult<Array<{ slug: string }>>(
         await c.callTool({
           name: 'cms_search',
@@ -199,7 +192,6 @@ const skipReason = TEST_URL
       expect(adminHits.find((h) => h.slug === 'draft-only')).toBeTruthy();
     });
 
-    // Public search hides drafts.
     const search = await fetch(
       `${baseUrl}/v1/cms/${orgId}/search?q=${encodeURIComponent('secret')}&collection=pages`,
     );
@@ -207,16 +199,11 @@ const skipReason = TEST_URL
     const hits = (await search.json()) as Array<{ slug: string }>;
     expect(hits.find((h) => h.slug === 'draft-only')).toBeFalsy();
 
-    // GET on the draft entry returns 404 publicly.
     const fetched = await fetch(`${baseUrl}/v1/cms/${orgId}/pages/draft-only`);
     expect(fetched.status).toBe(404);
   }, 30_000);
 
   it('admin drafts route is not shadowed by the public delivery wildcard', async () => {
-    // `GET /v1/cms/drafts/:id` and the public `GET /v1/cms/:orgId/:collectionSlug`
-    // are both 4-segment routes; `/v1/cms/drafts/<id>` matches both. If the public
-    // controller is registered first it wins (first-match-wins) and 404s with
-    // `cms_not_found: org drafts`, never reaching the auth-guarded drafts route.
     let draftId = '';
     await withClient(adminKey, async (c) => {
       const created = parseToolResult<{ id: string }>(
@@ -233,12 +220,9 @@ const skipReason = TEST_URL
       draftId = created.id;
     });
 
-    // Unauthenticated: must reach the guarded drafts controller (401), NOT the
-    // anonymous public wildcard (which would 404 on org "drafts").
     const anon = await fetch(`${baseUrl}/v1/cms/drafts/${draftId}`);
     expect(anon.status).toBe(401);
 
-    // Authenticated admin: the draft is served for review.
     const authed = await fetch(`${baseUrl}/v1/cms/drafts/${draftId}`, {
       headers: { Authorization: `Bearer ${adminKey}` },
     });
@@ -456,7 +440,6 @@ const skipReason = TEST_URL
       entryVersion = scheduled.version;
     });
 
-    // Push the scheduled time into the past (avoids waiting), then run the worker.
     await db
       .update(schema.cmsEntries)
       .set({ scheduledAt: new Date(Date.now() - 1000) })
@@ -472,7 +455,6 @@ const skipReason = TEST_URL
 
   it('delivery: a locale-specific draft is 404; published siblings in another locale are not silently substituted', async () => {
     await withClient(adminKey, async (c) => {
-      // Add a second locale and create same-slug entries: en=published, es=draft.
       await c.callTool({
         name: 'cms_create_locale',
         arguments: { code: 'es', name: 'Spanish' },
@@ -499,18 +481,13 @@ const skipReason = TEST_URL
       });
     });
 
-    // Without a locale param, the controller picks any published row — should
-    // be the en entry (the es one is a draft and must not appear).
     const noLocale = await fetch(`${baseUrl}/v1/cms/${orgId}/pages/localized`);
     expect(noLocale.status).toBe(200);
     expect(((await noLocale.json()) as { locale: string }).locale).toBe('en');
 
-    // With locale=es: there's no published es entry, so 404 — never a silent
-    // fallback to the en entry.
     const esQuery = await fetch(`${baseUrl}/v1/cms/${orgId}/pages/localized?locale=es`);
     expect(esQuery.status).toBe(404);
 
-    // With locale=en: returns the en entry as expected.
     const enQuery = await fetch(`${baseUrl}/v1/cms/${orgId}/pages/localized?locale=en`);
     expect(enQuery.status).toBe(200);
     expect(((await enQuery.json()) as { locale: string }).locale).toBe('en');

--- a/packages/backend-core/src/modules/cms/cms.schedule.worker.ts
+++ b/packages/backend-core/src/modules/cms/cms.schedule.worker.ts
@@ -16,19 +16,6 @@ import { withSchedulerLock } from '../../common/scheduler-lock/index.ts';
 const POLL_INTERVAL_MS = parseEnvInt({ name: 'MUNIN_CMS_SCHEDULE_POLL_MS', default: 60_000 });
 const BATCH_SIZE = 50;
 
-/**
- * In-process worker that flips `status='scheduled'` entries to
- * `published` when their `scheduled_at` is reached, stamps
- * `published_at`, and fires `cms.entry.published`.
- *
- * Service-role DB so we can read across orgs without a tenant context.
- * For each due entry we open a transaction with `app.bypass_rls=on` and
- * an actor synthesized from the entry's row (so the audit chain has
- * something to attribute), then perform the flip.
- *
- * Disabled in tests via MUNIN_CMS_SCHEDULE_WORKER_DISABLED=1 or
- * NODE_ENV=test; tests call worker.tick() directly.
- */
 @Injectable()
 export class CmsScheduleWorker implements OnModuleInit, OnModuleDestroy {
   private timer: NodeJS.Timeout | null = null;
@@ -54,7 +41,6 @@ export class CmsScheduleWorker implements OnModuleInit, OnModuleDestroy {
     this.timer = null;
   }
 
-  /** Drain a batch of due entries. Public so tests can call directly. */
   async tick(): Promise<{ promoted: number }> {
     if (this.running) return { promoted: 0 };
     this.running = true;
@@ -93,16 +79,12 @@ export class CmsScheduleWorker implements OnModuleInit, OnModuleDestroy {
   }
 
   private async promoteOne(entry: typeof schema.cmsEntries.$inferSelect): Promise<void> {
-    // Look up the collection's slug for the webhook payload.
     const [collection] = await this.db
       .select({ slug: schema.cmsCollections.slug })
       .from(schema.cmsCollections)
       .where(eq(schema.cmsCollections.id, entry.collectionId))
       .limit(1);
 
-    // Synthesize a system actor for the audit chain. The flip runs in a
-    // service-role transaction (bypass=on session-level), so RLS doesn't
-    // gate it; the actor just attributes the audit row.
     const actor = new ActorIdentity('system', 'cms-schedule-worker', entry.orgId, ['*'], ['admin']);
 
     await this.db.transaction(async (tx) => {

--- a/packages/backend-core/src/modules/cms/cms.search.ts
+++ b/packages/backend-core/src/modules/cms/cms.search.ts
@@ -90,16 +90,6 @@ export class CmsSearchService {
     @Inject(DB) private readonly serviceDb: Db,
   ) {}
 
-  /**
-   * Hybrid search across CMS entries. FTS over the generated tsvector
-   * (`fts`) plus pgvector cosine over `embedding`, fused via Reciprocal
-   * Rank Fusion (k=60).
-   *
-   * Admin callers (RLS-scoped to org) see drafts + published. The public
-   * delivery surface passes `publishedOnly: true` + opts.orgId and runs
-   * against the service-role DB so RLS doesn't gate the read; cross-org
-   * leakage is impossible because the SQL hard-filters on org_id.
-   */
   async search(input: SearchInput, opts?: { orgId?: string }): Promise<SearchHit[]> {
     const limit = clampLimit(input.limit, DEFAULT_LIMIT, MAX_LIMIT);
     const trimmed = input.query.trim();

--- a/packages/backend-core/src/modules/cms/cms.service.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.test.ts
@@ -147,8 +147,6 @@ class StubStorage implements AssetStorage {
     return rows.map((r) => r.type);
   }
 
-  // ─── Collections ─────────────────────────────────────────────────────
-
   describe('collections', () => {
     it('createCollection persists, emits webhook, and lists', async () => {
       const created = await run(() =>
@@ -204,7 +202,7 @@ class StubStorage implements AssetStorage {
       const created = await run(() =>
         svc.createCollection({ name: 'Pages', slug: 'pages', fields: [{ name: 't', type: 'text' }] }),
       );
-      await db.execute(sql`DELETE FROM events WHERE org_id = ${orgId}`); // clear creation event
+      await db.execute(sql`DELETE FROM events WHERE org_id = ${orgId}`);
       const renamed = await run(() =>
         svc.updateCollection(created.id, { name: 'Static Pages', description: 'desc' }),
       );
@@ -233,8 +231,6 @@ class StubStorage implements AssetStorage {
       await expect(run(() => svc.getCollection(created.id))).rejects.toThrow(NotFoundException);
     });
   });
-
-  // ─── Entries ─────────────────────────────────────────────────────────
 
   describe('entries', () => {
     async function seedCollection() {
@@ -387,7 +383,6 @@ class StubStorage implements AssetStorage {
       const before = await db.execute<{ search_text: string | null; embedding: string | null }>(
         sql`SELECT search_text, embedding::text AS embedding FROM cms_entries WHERE id = ${entry.id}`,
       );
-      // Update with same data — content hash unchanged.
       const after = await run(() =>
         svc.updateEntry({ id: entry.id, ifVersion: 1, data: { title: 'X' } }),
       );
@@ -581,8 +576,6 @@ class StubStorage implements AssetStorage {
       expect(await eventTypes()).toContain('cms.entry.archived');
     });
   });
-
-  // ─── Assets ──────────────────────────────────────────────────────────
 
   describe('assets', () => {
     it('requestAssetUpload mints a presigned upload and persists a non-uploaded row', async () => {
@@ -786,8 +779,6 @@ class StubStorage implements AssetStorage {
     });
   });
 
-  // ─── Locales ─────────────────────────────────────────────────────────
-
   describe('locales', () => {
     it('createLocale: first locale becomes default; later locales do not unless flagged', async () => {
       const en = await run(() => svc.createLocale({ code: 'en', name: 'English' }));
@@ -832,8 +823,6 @@ class StubStorage implements AssetStorage {
     });
   });
 
-  // ─── References ──────────────────────────────────────────────────────
-
   describe('references', () => {
     it('listInboundReferences returns rows pointing at an entry', async () => {
       await ensureLocale('en');
@@ -866,8 +855,6 @@ class StubStorage implements AssetStorage {
     });
   });
 
-  // ─── RLS ─────────────────────────────────────────────────────────────
-
   describe('RLS', () => {
     it('cross-org RLS isolation: another org cannot see this org\'s collections', async () => {
       const col = await run(() =>
@@ -877,7 +864,6 @@ class StubStorage implements AssetStorage {
           fields: [{ name: 't', type: 'text' }],
         }),
       );
-      // Create a second org and an actor scoped to it.
       const [otherOrg] = await db
         .insert(schema.orgs)
         .values({ name: 'Other Org' })

--- a/packages/backend-core/src/modules/cms/cms.service.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.ts
@@ -70,8 +70,6 @@ export class CmsConflictError extends Error {
 export const ENTRY_STATUSES = ['draft', 'published', 'scheduled', 'archived'] as const;
 export type EntryStatus = (typeof ENTRY_STATUSES)[number];
 
-// ─── DTOs ───────────────────────────────────────────────────────────────
-
 export interface CollectionDto {
   id: string;
   name: string;
@@ -160,8 +158,6 @@ export interface LocaleDto {
   position: number;
 }
 
-// ─── Transfer shapes ─────────────────────────────────────────────────────
-
 export interface CmsLocaleExport {
   id: string;
   code: string;
@@ -217,8 +213,6 @@ export class CmsService {
     @Inject(STORAGE) private readonly storage: AssetStorage,
     @Inject(EmbeddingProviderHolder) private readonly embeddings: EmbeddingProviderHolder,
   ) {}
-
-  // ─── Collections ─────────────────────────────────────────────────────
 
   async listCollections(): Promise<CollectionDto[]> {
     const ctx = getCurrentContext();
@@ -331,8 +325,6 @@ export class CmsService {
     await ctx.db.delete(schema.cmsCollections).where(eq(schema.cmsCollections.id, collection.id));
     return { deleted: true };
   }
-
-  // ─── Entries ─────────────────────────────────────────────────────────
 
   async listEntries(input: {
     collection?: string;
@@ -768,8 +760,6 @@ export class CmsService {
     return result;
   }
 
-  // ─── Assets ──────────────────────────────────────────────────────────
-
   async listAssets(input: { limit?: number }): Promise<AssetDto[]> {
     const ctx = getCurrentContext();
     const limit = clampLimit(input.limit, 50, 200);
@@ -981,8 +971,6 @@ export class CmsService {
     }
 
     await this.storage.delete(rows[0].storageKey).catch(() => {
-      // Storage delete failure shouldn't block row deletion — log via audit
-      // and let an operator GC the orphan later.
     });
     await ctx.db.delete(schema.cmsAssets).where(eq(schema.cmsAssets.id, input.id));
     return { deleted: true };
@@ -1002,8 +990,6 @@ export class CmsService {
       .where(eq(schema.cmsAssetReferences.assetId, assetId))
       .orderBy(desc(schema.cmsAssetReferences.createdAt));
   }
-
-  // ─── Locales ─────────────────────────────────────────────────────────
 
   async listLocales(): Promise<LocaleDto[]> {
     const ctx = getCurrentContext();
@@ -1074,8 +1060,6 @@ export class CmsService {
     return toLocaleDto(row!);
   }
 
-  // ─── References ──────────────────────────────────────────────────────
-
   async listInboundReferences(entryId: string): Promise<{ fromEntryId: string; fieldName: string }[]> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
@@ -1088,8 +1072,6 @@ export class CmsService {
       .orderBy(desc(schema.cmsReferences.createdAt));
     return rows;
   }
-
-  // ─── Transfer (import / export) ──────────────────────────────────────
 
   async exportCms(): Promise<CmsExportData> {
     const ctx = getCurrentContext();
@@ -1373,9 +1355,6 @@ export class CmsService {
     return toAssetDto(row!);
   }
 
-  // ─── Internals ───────────────────────────────────────────────────────
-
-  /** Used by the schedule worker to flip due entries to published. */
   async publishById(id: string): Promise<EntryDto> {
     const existing = await this.loadEntryRow(id);
     return this.transition({ id, ifVersion: existing.version }, 'published');
@@ -1473,7 +1452,6 @@ export class CmsService {
       .where(and(eq(schema.cmsLocales.orgId, orgId), eq(schema.cmsLocales.isDefault, true)))
       .limit(1);
     if (rows[0]) return rows[0].code;
-    // Fall back to the first locale or 'en' if none configured.
     const any = await ctx.db
       .select()
       .from(schema.cmsLocales)
@@ -1604,8 +1582,6 @@ export class CmsService {
   }
 }
 
-// ─── DTO mappers ───────────────────────────────────────────────────────
-
 function toCollectionDto(row: typeof schema.cmsCollections.$inferSelect): CollectionDto {
   return {
     id: row.id,
@@ -1677,8 +1653,6 @@ function toLocaleDto(row: typeof schema.cmsLocales.$inferSelect): LocaleDto {
     position: row.position,
   };
 }
-
-// ─── helpers ───────────────────────────────────────────────────────────
 
 function isValidSlug(slug: string): boolean {
   return /^[a-z0-9][a-z0-9-]{0,63}$/.test(slug);

--- a/packages/backend-core/src/modules/commerce/commerce-adapter.ts
+++ b/packages/backend-core/src/modules/commerce/commerce-adapter.ts
@@ -1,13 +1,5 @@
 import type { ConnectorAdapter, ConnectorConnectionContext } from '../connectors/connector.ts';
 
-/**
- * Commerce-domain connector contract (orders). Every order query takes the
- * customer's email and the adapter is responsible for enforcing ownership —
- * an order that does not belong to that email must come back as `null` /
- * excluded, never as data. The service layer resolves which email to use
- * (the calling end-user's, or an admin-supplied one) and never lets a
- * self-service caller choose it.
- */
 export interface CommerceAdapter extends ConnectorAdapter {
   readonly domain: 'commerce';
 
@@ -16,11 +8,6 @@ export interface CommerceAdapter extends ConnectorAdapter {
     args: { email: string; limit: number },
   ): Promise<CommerceOrderSummary[]>;
 
-  /**
-   * Fetch one order by adapter-native ref or human-facing order number,
-   * returning `null` when it does not exist OR does not belong to `email`
-   * (indistinguishable on purpose — no order-ref oracle).
-   */
   getOrderForCustomer(
     ctx: ConnectorConnectionContext,
     args: { email: string; orderRef?: string; orderNumber?: string },
@@ -28,9 +15,7 @@ export interface CommerceAdapter extends ConnectorAdapter {
 }
 
 export interface CommerceOrderSummary {
-  /** Adapter-native order id; pass back to commerce_get_my_order / commerce_lookup_order. */
   orderRef: string;
-  /** Human-facing order number, e.g. Shopify "#1001" or Magento "000000123". */
   orderNumber: string;
   status: string;
   financialStatus: string | null;

--- a/packages/backend-core/src/modules/commerce/magento.adapter.ts
+++ b/packages/backend-core/src/modules/commerce/magento.adapter.ts
@@ -20,7 +20,6 @@ export const MagentoConfigInput = z.object({
     .url()
     .refine((u) => u.startsWith('https://'), 'baseUrl must be https')
     .transform((u) => u.replace(/\/+$/, '')),
-  /** Integration access token. Optional on update to keep the stored one. */
   accessToken: z.string().min(10).max(256).optional(),
 });
 
@@ -197,7 +196,6 @@ export class MagentoAdapter implements CommerceAdapter {
   private toDetail(order: MagentoOrder, shipments: MagentoShipment[]): CommerceOrderDetail {
     return {
       ...this.toSummary(order),
-      // Child rows of configurable/bundle products duplicate the parent line.
       items: (order.items ?? [])
         .filter((item) => item.parent_item_id == null)
         .map((item) => ({
@@ -262,7 +260,6 @@ function orderSearchParams(email: string, limit: number): string {
   return params.toString();
 }
 
-/** Magento timestamps are "YYYY-MM-DD HH:MM:SS" in UTC without a zone marker. */
 function magentoDateToIso(value: string): string {
   return /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(value)
     ? `${value.replace(' ', 'T')}Z`

--- a/packages/backend-core/src/modules/commerce/shopify.adapter.ts
+++ b/packages/backend-core/src/modules/commerce/shopify.adapter.ts
@@ -22,7 +22,6 @@ export const ShopifyConfigInput = z.object({
     .trim()
     .toLowerCase()
     .regex(SHOP_DOMAIN_RE, 'expected a *.myshopify.com domain (no protocol, no path)'),
-  /** Admin API access token (shpat_…). Optional on update to keep the stored one. */
   accessToken: z.string().min(10).max(256).optional(),
   apiVersion: z
     .string()
@@ -297,7 +296,6 @@ function numericGid(gid: string): string | null {
   return match ? match[1]! : null;
 }
 
-/** Quote a value for the Shopify search query syntax. */
 function searchTerm(value: string): string {
   return `"${value.replace(/(["\\])/g, '\\$1')}"`;
 }

--- a/packages/backend-core/src/modules/connectors/connector.ts
+++ b/packages/backend-core/src/modules/connectors/connector.ts
@@ -1,44 +1,20 @@
 import type { z } from 'zod';
 
-/**
- * Base contract for third-party system connectors.
- *
- * A connector belongs to exactly one *domain* — the product surface its data
- * feeds (commerce → orders, bookings → reservations). The trunk owns what is
- * domain-agnostic: encrypted connection storage, the connectors_* admin CRUD
- * tools, credential testing, and the end-user identity bridge. Each domain
- * submodule extends this contract with its own typed read methods and its own
- * domain tools — domain contracts are deliberately NOT unified; a generic
- * query surface would defeat the narrow, reviewable tool design.
- *
- * Stored connection config is vendor-shaped JSONB. Secret fields are
- * pgcrypto-encrypted before storage (`encryptSecret`) and only decrypted
- * inside adapter calls (`ctx.decryptSecret`). `publicConfig()` is the only
- * projection that may leave the service layer.
- */
 export interface ConnectorAdapter {
   readonly vendor: string;
   readonly domain: ConnectorDomain;
   readonly displayName: string;
-  /** Plaintext admin input schema; drives connectors_create/update_connection validation. */
   readonly configInput: z.ZodType;
   readonly configFields: ConnectorConfigFieldInfo[];
 
-  /**
-   * Turn validated admin input into the stored config, encrypting secrets.
-   * On update, `previous` carries the currently stored config so omitted
-   * secret fields keep their existing ciphertext.
-   */
   buildStoredConfig(
     input: Record<string, unknown>,
     encryptSecret: (plaintext: string) => Promise<string>,
     previous?: Record<string, unknown>,
   ): Promise<Record<string, unknown>>;
 
-  /** Non-secret fields safe to return from admin list/get tools. */
   publicConfig(stored: Record<string, unknown>): Record<string, unknown>;
 
-  /** Verify stored credentials against the vendor (read-only probe). */
   testConnection(ctx: ConnectorConnectionContext): Promise<ConnectorTestResult>;
 }
 
@@ -69,7 +45,6 @@ export class ConnectorRegistry {
     for (const adapter of adapters) this.register(adapter);
   }
 
-  /** Domain modules register their vendor adapters here at module init. */
   register(adapter: ConnectorAdapter): void {
     if (this.byVendor.has(adapter.vendor)) {
       throw new Error(`connector vendor already registered: ${adapter.vendor}`);

--- a/packages/backend-core/src/modules/connectors/connectors.module.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.module.ts
@@ -6,12 +6,6 @@ import { ConnectorCredentialHandler } from './connector-credential.handler.ts';
 import { CredentialHandoffModule } from '../credential-handoff/credential-handoff.module.ts';
 import { CredentialTargetRegistry } from '../credential-handoff/credential-target.ts';
 
-/**
- * Domain-agnostic connector trunk: encrypted connection storage, the
- * connectors_* admin CRUD tools, and the vendor registry. Domain modules
- * (commerce, bookings) import this module and register their adapters into
- * the registry — the trunk never imports a vendor.
- */
 @Module({
   imports: [CredentialHandoffModule],
   providers: [

--- a/packages/backend-core/src/modules/connectors/connectors.service.test.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.test.ts
@@ -26,11 +26,6 @@ const skipReason = TEST_URL
   ? null
   : 'Set TEST_DATABASE_URL to a Postgres URL to run connectors service tests.';
 
-/**
- * Vendor-free fake covering the full adapter contract: one secret field
- * (apiToken) and one plain field (host), so encryption round-trips and
- * secret-retention-on-update are exercised without any real vendor code.
- */
 class FakeAdapter implements ConnectorAdapter {
   test: (ctx: ConnectorConnectionContext) => Promise<ConnectorTestResult> = () =>
     Promise.resolve({ ok: true, detail: 'connected' });

--- a/packages/backend-core/src/modules/connectors/connectors.service.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.ts
@@ -70,11 +70,6 @@ export interface ConnectionScope {
   adapter: ConnectorAdapter;
 }
 
-/**
- * Domain-agnostic trunk: connection storage and lifecycle, plus the shared
- * helpers domain services (commerce, bookings, …) build their typed read
- * surfaces on. Deliberately knows nothing about orders or reservations.
- */
 @Injectable()
 export class ConnectorsService {
   constructor(
@@ -157,11 +152,6 @@ export class ConnectorsService {
     return { ...this.toDto(row!), credentialLink };
   }
 
-  /**
-   * Mint a fresh one-time credential link for a pending connection so the
-   * secret can be entered out-of-band (dashboard form) instead of pasted
-   * into an agent conversation.
-   */
   async requestCredentials(args: { connectionId: string }): Promise<CredentialLink> {
     const row = await this.requireConnection(args.connectionId);
     if (row.credentialState !== 'pending') {
@@ -378,11 +368,6 @@ export class ConnectorsService {
     }
   }
 
-  /**
-   * Pick the connection a domain read runs against: an explicit id (which
-   * must belong to `domain` and be active), or the single active connection
-   * in that domain.
-   */
   async resolveScope(domain: ConnectorDomain, connectionId?: string): Promise<ConnectionScope> {
     const ctx = getCurrentContext();
     if (connectionId) {
@@ -420,11 +405,6 @@ export class ConnectorsService {
     return { connection: rows[0]!, adapter: this.requireAdapter(rows[0]!.vendor) };
   }
 
-  /**
-   * The identity a self-service lookup runs as. Always the calling end-user's
-   * own email — never caller-supplied — so a delegated token can only ever see
-   * the records of the person the org minted it for.
-   */
   async requireEndUserEmail(): Promise<string> {
     const ctx = getCurrentContext();
     const endUserId = ctx.actor?.endUserId;

--- a/packages/backend-core/src/modules/connectors/http.ts
+++ b/packages/backend-core/src/modules/connectors/http.ts
@@ -1,19 +1,9 @@
 export const REQUEST_TIMEOUT_MS = 10_000;
 
-/**
- * Vendor-side failure (bad credentials, HTTP error, malformed response).
- * The service layer maps this to a 4xx instead of letting it surface as a
- * bare 500 from inside the tenant transaction.
- */
 export class ConnectorVendorError extends Error {
   notFound?: boolean;
 }
 
-/**
- * Minimal fetch shape shared by @getmunin/core's safeFetch and test stubs.
- * Adapters must go through this (never global fetch) so every outbound call
- * gets SSRF-guarded DNS resolution — Magento base URLs are user-supplied.
- */
 export type ConnectorFetch = (
   url: string,
   init: {

--- a/packages/backend-core/src/modules/conv/channels/adapter.ts
+++ b/packages/backend-core/src/modules/conv/channels/adapter.ts
@@ -1,35 +1,12 @@
 import type { schema, Db, Tx } from '@getmunin/db';
 
-/**
- * The per-channel-type runtime contract. One adapter per `conv_channels.type`
- * value (`'email'`, `'chat'`, etc.). The generic poll/outbound workers and
- * the chat-widget controller dispatch to the adapter that matches the
- * channel's type.
- *
- * Three inbound modes:
- *   - 'poll'    — runtime calls `tick()` on a timer (e.g. email IMAP).
- *   - 'webhook' — runtime exposes `POST /v1/conversations/channels/:id/webhook`; provider
- *                 → us. Adapter verifies the signature.
- *   - 'push'    — adapter exposes its own controller; agent → us via bearer
- *                 token (e.g. chat widget). Runtime doesn't drive it.
- *   - null      — channel is outbound-only.
- *
- * Outbound is uniform: `send()` is called by `OutboundDeliveryWorker` after
- * loading delivery + message + conversation + channel + contact context.
- * Adapters that don't deliver outbound (push-mode-only) return a no-op
- * SendResult.
- */
 export interface ChannelAdapter {
-  /** Matches `conv_channels.type`. */
   readonly kind: ChannelKind;
 
-  /** Matches `conv_channels.vendor`. One adapter may declare multiple vendors when it serves them internally (e.g. email handles 'smtp' + 'mailer'). */
   readonly vendors: readonly string[];
 
-  /** Send one outbound message. Throws on transport failure. */
   send(ctx: SendContext): Promise<SendResult>;
 
-  /** Inbound mode + per-mode hooks. `null` = outbound-only channel. */
   readonly inbound: InboundMode | null;
 }
 
@@ -67,20 +44,16 @@ export interface SendContext {
   conversation: typeof schema.convConversations.$inferSelect;
   channel: ChannelRow;
   contact: typeof schema.convContacts.$inferSelect | null;
-  /** Per-attempt counter (0-indexed). The worker passes the current value. */
   attempt: number;
 }
 
 export interface SendResult {
-  /** RFC-822 Message-ID, Twilio MessageSid, etc. — stamped on convMessageDeliveries. */
   providerMessageId: string | null;
-  /** Optional opaque payload the worker stores nowhere; useful for tests / logs. */
   rawResponse?: unknown;
 }
 
 export interface PollTickResult {
   messagesIngested: number;
-  /** Optional error text recorded on convInboundState.lastError. */
   lastError?: string | null;
 }
 
@@ -103,26 +76,15 @@ export interface InboundBatch {
   responseOverride?: WebhookResponse;
 }
 
-/**
- * Helper for adapters: read and write the per-channel inbound cursor.
- * `convInboundState` is keyed by channel_id; `cursor` is an open jsonb shape.
- */
 export interface InboundCursorIo<TCursor extends Record<string, unknown>> {
   read(channelId: string): Promise<TCursor | null>;
   write(channelId: string, cursor: TCursor, lastError: string | null): Promise<void>;
 }
 
-/** Re-exported so adapter implementations don't need to import @getmunin/db. */
 export type DbOrTx = Db | Tx;
 
-/** Multi-injection token. Adapters provide themselves via `{ provide: CHANNEL_ADAPTERS, useExisting: <AdapterClass>, multi: true }`. */
 export const CHANNEL_ADAPTERS = Symbol('CHANNEL_ADAPTERS');
 
-/**
- * Registry: looks up an adapter by `(channel.type, channel.vendor)`. The
- * generic workers tolerate misses by marking the delivery 'dead' instead —
- * they don't throw on lookup failure.
- */
 export class ChannelAdapterRegistry {
   private readonly byKey = new Map<string, ChannelAdapter>();
   private readonly adapters: ChannelAdapter[];

--- a/packages/backend-core/src/modules/conv/channels/channel-admin.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-admin.ts
@@ -1,15 +1,6 @@
 import { isSensitiveSchema } from '@getmunin/types';
 import type { z } from 'zod';
 
-/**
- * Vendor-agnostic admin surface for configurable channels.
- *
- * Each configurable vendor registers a `ChannelAdminProvider` (under the
- * `CHANNEL_ADMIN_PROVIDERS` multi-token); the generic `conv_channel_*` MCP
- * tools and `/v1/conversations/channels` endpoints dispatch to it by vendor.
- * Adding a voice/SMS vendor means registering one provider — no new tools,
- * endpoints, or types.
- */
 export type ChannelAdminKind = 'voice' | 'sms';
 
 export interface ChannelConfigFieldInfo {
@@ -60,9 +51,7 @@ export interface ChannelAdminProvider {
   readonly kind: ChannelAdminKind;
   readonly vendor: string;
   readonly displayName: string;
-  /** Validates the `config` blob (no channelId/name). */
   readonly configInput: z.ZodType;
-  /** Field metadata derived from `configInput`, for discovery. */
   readonly configFields: ChannelConfigFieldInfo[];
   readonly capabilities: { call: boolean; sendTest: boolean };
   configure(input: ConfigureChannelInput): Promise<ChannelAdminDto>;

--- a/packages/backend-core/src/modules/conv/channels/channel-credential.service.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-credential.service.ts
@@ -13,12 +13,6 @@ import type {
   CredentialTargetHandler,
 } from '../../credential-handoff/credential-target.ts';
 
-/**
- * Wires conversation channels into the credential-handoff flow so a human can
- * enter a channel's secrets (SMTP/IMAP passwords) through a one-time dashboard
- * link instead of pasting them into an agent conversation. Email today; other
- * vendors as their providers gain secret-only application.
- */
 @Injectable()
 export class ChannelCredentialService implements CredentialTargetHandler {
   readonly targetType = 'channel';

--- a/packages/backend-core/src/modules/conv/channels/inbound-poll.worker.ts
+++ b/packages/backend-core/src/modules/conv/channels/inbound-poll.worker.ts
@@ -22,16 +22,6 @@ const POLL_INTERVAL_MS = parseEnvInt({
 
 const AUTO_DEACTIVATE_THRESHOLD = 5;
 
-/**
- * Generic poll-mode inbound worker. Iterates active channels whose adapter
- * is poll-mode and dispatches `adapter.inbound.tick(channel)`. Per-tick
- * cursor / error bookkeeping lives in `conv_inbound_state`, which adapters
- * read/write themselves (the worker is purely a scheduler).
- *
- * Disabled in tests via `MUNIN_INBOUND_POLL_WORKER_DISABLED=1` (or legacy
- * `MUNIN_EMAIL_INBOUND_WORKER_DISABLED=1`) or `NODE_ENV=test`. Tests call
- * `tick()` directly.
- */
 @Injectable()
 export class InboundPollWorker implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(InboundPollWorker.name);
@@ -65,7 +55,6 @@ export class InboundPollWorker implements OnModuleInit, OnModuleDestroy {
     this.timer = null;
   }
 
-  /** Public so tests can drive a single tick directly. */
   async tick(): Promise<{ channelsPolled: number; messagesIngested: number }> {
     if (this.running) return { channelsPolled: 0, messagesIngested: 0 };
     this.running = true;

--- a/packages/backend-core/src/modules/conv/channels/outbound-delivery.worker.ts
+++ b/packages/backend-core/src/modules/conv/channels/outbound-delivery.worker.ts
@@ -33,15 +33,6 @@ const MAX_ATTEMPTS = 5;
 const BATCH_SIZE = 25;
 const BACKOFF_BASE_MS = 30_000;
 
-/**
- * Drains `conv_message_deliveries` (status='queued' or 'failed' due) and
- * dispatches each row to the adapter that matches the channel's `type`.
- * Handles attempt counting, exponential backoff, terminal 'dead' state, and
- * webhook emission. Adapter only implements `send()`.
- *
- * Disabled in tests via `MUNIN_OUTBOUND_DELIVERY_WORKER_DISABLED=1` (or
- * legacy `MUNIN_EMAIL_OUTBOUND_WORKER_DISABLED=1`) or `NODE_ENV=test`.
- */
 type AttemptOutcome = 'sent' | 'deferred' | 'failed';
 
 @Injectable()

--- a/packages/backend-core/src/modules/conv/conv.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.integration.test.ts
@@ -171,7 +171,6 @@ const skipReason = TEST_URL
       );
       expect(list.find((row) => row.id === startedConv.id)).toBeTruthy();
 
-      // Drop a private internal note (should NOT appear in end-user's view).
       await c.callTool({
         name: 'conv_send_message',
         arguments: {
@@ -180,7 +179,6 @@ const skipReason = TEST_URL
           internal: true,
         },
       });
-      // Then a public reply (should appear).
       return parseToolResult<{ id: string; body: string; internal: boolean }>(
         await c.callTool({
           name: 'conv_send_message',
@@ -218,7 +216,6 @@ const skipReason = TEST_URL
     expect(bodies.find((b) => /2FA/.test(b))).toBeUndefined();
     expect(detail.messages.every((m) => m.internal === false)).toBe(true);
 
-    // Cross-end-user isolation: Bob can't see Alice's conversation.
     const otherList = await rest<{ items: Array<{ id: string }> }>(
       otherEndUserToken,
       'GET',
@@ -453,9 +450,6 @@ const skipReason = TEST_URL
       });
     });
 
-    // The MCP transport's HTTP response can land before postgres-js has
-    // surfaced the just-committed transaction to other pool sessions; give
-    // the read-side a brief moment in the parallel-test case.
     await new Promise((r) => setTimeout(r, 100));
 
     const afterReply = (await db.execute(
@@ -465,8 +459,6 @@ const skipReason = TEST_URL
     expect(afterReply[0]!.payload.conversationId).toBe(conv.id);
     expect(afterReply[0]!.payload.authorType).toBe('agent');
 
-    // A second admin message on the same conversation should NOT re-emit the
-    // event; the flag is already cleared.
     await withClient(adminKey, async (c) => {
       await c.callTool({
         name: 'conv_send_message',

--- a/packages/backend-core/src/modules/conv/conv.service.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.test.ts
@@ -99,8 +99,6 @@ const skipReason = TEST_URL
     return rows.map((r) => r.type);
   }
 
-  // ─── Channels ────────────────────────────────────────────────────────
-
   describe('channels', () => {
     it('createChannel persists with type, name, config', async () => {
       const ch = await run(() =>
@@ -162,8 +160,6 @@ const skipReason = TEST_URL
     });
   });
 
-  // ─── Topics ──────────────────────────────────────────────────────────
-
   describe('topics', () => {
     it('createTopic persists fields and listTopics returns them', async () => {
       const t = await run(() =>
@@ -181,8 +177,6 @@ const skipReason = TEST_URL
       ).rejects.toThrow(ConvInvalidError);
     });
   });
-
-  // ─── Conversations ───────────────────────────────────────────────────
 
   describe('conversations', () => {
     async function seedChannel() {
@@ -369,8 +363,6 @@ const skipReason = TEST_URL
     });
   });
 
-  // ─── Messaging ───────────────────────────────────────────────────────
-
   describe('messaging', () => {
     async function seedConversation(channelType: 'email' | 'chat' = 'email') {
       const vendor = channelType === 'email' ? 'smtp' : 'munin';
@@ -403,7 +395,7 @@ const skipReason = TEST_URL
 
     it('sendMessage emits sent event for staff and queues an email outbound', async () => {
       const { conv } = await seedConversation('email');
-      await db.execute(sql`DELETE FROM events WHERE org_id = ${orgId}`); // clear creation events
+      await db.execute(sql`DELETE FROM events WHERE org_id = ${orgId}`);
       const m = await run(() =>
         svc.sendMessage({
           conversationId: conv.id,
@@ -470,8 +462,6 @@ const skipReason = TEST_URL
       expect(types).not.toContain('conversation.message.sent');
     });
   });
-
-  // ─── Assignment / status ─────────────────────────────────────────────
 
   describe('assignment and status', () => {
     async function seedConv() {
@@ -561,7 +551,6 @@ const skipReason = TEST_URL
           agentMode: 'draft_only',
         }),
       );
-      // Now an inbound end_user reply lands.
       await run(() =>
         svc.sendMessage({
           conversationId: conv.id,
@@ -680,8 +669,6 @@ const skipReason = TEST_URL
     });
   });
 
-  // ─── Search ──────────────────────────────────────────────────────────
-
   describe('search', () => {
     it('searchMessages matches case-insensitively on body', async () => {
       const ch = await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'X' }));
@@ -703,8 +690,6 @@ const skipReason = TEST_URL
       expect(r).toEqual([]);
     });
   });
-
-  // ─── RLS ─────────────────────────────────────────────────────────────
 
   describe('RLS', () => {
     it('cross-org isolation: another org cannot see this org\'s channels', async () => {

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -94,12 +94,6 @@ export interface ConversationSummary {
   displayId: number;
   status: ConversationStatus;
   channelId: string;
-  /**
-   * The channel kind (e.g. 'email' | 'chat' | 'sms' | 'voice'). Populated by
-   * endpoints that JOIN conv_channels — currently only `GET /v1/conversations/:id`.
-   * Other endpoints omit the field rather than fabricating a value; consumers that
-   * need it should call the detail endpoint.
-   */
   channelType?: string;
   endUserId: string | null;
   contactId: string | null;
@@ -112,14 +106,6 @@ export interface ConversationSummary {
   needsHumanAttentionAt: string | null;
   agentMode: AgentMode;
   outreachCampaignId: string | null;
-  /**
-   * True while a voice call is in progress for this conversation. The chat
-   * agent runner uses this to skip auto-replies — the voice channel owns the
-   * conversation's reply loop until the call ends, regardless of vendor. Set
-   * by `WidgetVoiceService` on call start (writes `voiceActive: true` +
-   * `voiceStartedAt` into `conv_conversations.metadata`); cleared by the
-   * active voice adapter when the call ends.
-   */
   voiceActive: boolean;
   updatedAt: string;
   createdAt: string;
@@ -127,12 +113,6 @@ export interface ConversationSummary {
 
 export interface ConversationDetail extends ConversationSummary {
   messages: MessageDto[];
-  /**
-   * The assistant's configured name (`assistants.name`) for the owning org,
-   * or null if unset. Runtime consumers fall back to no name preamble when
-   * null; the wire format carries the configured value verbatim so each
-   * caller controls its own fallback policy.
-   */
   assistantName: string | null;
   endUserLocale: string | null;
   contactEmail: string | null;
@@ -184,7 +164,6 @@ export class ConvService {
     @Inject(AlertsService) private readonly alerts: AlertsService,
   ) {}
 
-  // ─── Channels ───────────────────────────────────────────────────────────
 
   async listChannels(): Promise<ChannelDto[]> {
     const ctx = getCurrentContext();
@@ -280,7 +259,6 @@ export class ConvService {
     return rows[0] ? toChannelDto(rows[0]) : null;
   }
 
-  // ─── Topics ─────────────────────────────────────────────────────────────
 
   async listTopics(): Promise<TopicDto[]> {
     const ctx = getCurrentContext();
@@ -373,7 +351,6 @@ export class ConvService {
     return toConversationSummary(updated);
   }
 
-  // ─── Conversations ──────────────────────────────────────────────────────
 
   async listConversationsByIds(
     ids: string[],
@@ -913,11 +890,6 @@ export class ConvService {
         });
       }
 
-      // Enqueue an outbound delivery row for staff-authored messages on
-      // email channels. The email-outbound worker picks these up, builds
-      // the MIME, and ships them via SMTP. End-user-authored messages on
-      // an email channel arrived via the IMAP poller — they're already
-      // outside; no need to send them again.
       if (
         conv.channelType === 'email' &&
         input.authorType !== 'end_user' &&
@@ -929,13 +901,6 @@ export class ConvService {
     return toMessageDto(row!);
   }
 
-  /**
-   * Insert a `conv_message_deliveries` row for a freshly-created outbound
-   * message on an email channel. Stamps `in_reply_to_header` from the
-   * most-recent successful outbound on the same conversation so reply
-   * chains hold. Lives on ConvService rather than EmailService to keep
-   * sendMessage from importing the email module.
-   */
   private async enqueueEmailOutbound(
     messageId: string,
     conversationId: string,
@@ -1334,7 +1299,6 @@ export class ConvService {
     return rows.map((r) => toMessageDto(r, authorNames));
   }
 
-  // ─── Transfer (import / export) ──────────────────────────────────────────
 
   async exportConv(): Promise<ConvExportData> {
     const ctx = getCurrentContext();
@@ -1525,12 +1489,6 @@ export class ConvService {
     return out;
   }
 
-  /**
-   * Insert a conversation, retrying on `display_id` collision (when two
-   * concurrent inserts in the same org pick the same MAX+1). The unique
-   * index on (org_id, display_id) makes this race detectable; we retry up
-   * to 5 times before giving up.
-   */
   private async insertConversationWithRetry(values: {
     orgId: string;
     channelId: string;
@@ -1564,7 +1522,6 @@ export class ConvService {
   }
 }
 
-// ─── DTO mappers / helpers ─────────────────────────────────────────────────
 
 function toChannelDto(row: typeof schema.convChannels.$inferSelect): ChannelDto {
   return {

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -58,7 +58,6 @@ interface ImapMessageMin {
   source: Buffer | string;
 }
 
-/** IMAP fetcher boundary. Tests inject a stub; production uses imapflow. */
 export interface ImapFetcher {
   fetchSince(opts: {
     host: string;
@@ -128,12 +127,6 @@ class ImapFlowFetcher implements ImapFetcher {
   }
 }
 
-/**
- * Email adapter — IMAP poll inbound, SMTP/Mailer outbound. Behavior matches
- * the prior `EmailInboundWorker` + `EmailOutboundWorker.attemptOne` — they
- * are now thin wrappers over this adapter via `InboundPollWorker` and
- * `OutboundDeliveryWorker`.
- */
 @Injectable()
 export class EmailAdapter implements ChannelAdapter {
   readonly kind = 'email' as const;
@@ -150,7 +143,6 @@ export class EmailAdapter implements ChannelAdapter {
     @Inject(CuratorJobsService) private readonly curatorJobs: CuratorJobsService,
   ) {}
 
-  /** Test-only: swap the IMAP boundary. */
   setFetcher(f: ImapFetcher): void {
     this.fetcher = f;
   }
@@ -220,7 +212,6 @@ export class EmailAdapter implements ChannelAdapter {
       });
       transport.close();
     } else {
-      // Mailer fallback (Resend / Stub).
       await this.mailer.send({
         from: composeFrom(config.addressing.fromName, config.addressing.fromAddress),
         to: recipient,
@@ -235,8 +226,6 @@ export class EmailAdapter implements ChannelAdapter {
 
     return { providerMessageId: built.messageId };
   }
-
-  // ─── inbound poll ───────────────────────────────────────────────────────
 
   private async pollOne(channel: ChannelRow): Promise<PollTickResult> {
     const config = jsonbToStored(channel.config);
@@ -460,8 +449,6 @@ export class EmailAdapter implements ChannelAdapter {
     return `${local}+conv-${conversationId}@${replyDomain}`;
   }
 }
-
-// ─── helpers ────────────────────────────────────────────────────────────────
 
 export async function parseMessage(source: Buffer | string): Promise<ParsedInboundEmail> {
   const parsed: ParsedMail = await simpleParser(source);

--- a/packages/backend-core/src/modules/conv/email/email.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email.integration.test.ts
@@ -136,10 +136,6 @@ class StubImapFetcher implements ImapFetcher {
   }
 
   it('inbound from new sender → new conversation; admin reply → outbound via mailer with Reply-To plus-address; replied inbound threads back', async () => {
-    // 1. Set up an email channel via the admin tool, then poll for the row to
-    //    appear: MCP responses are written to the wire from inside the
-    //    request transaction, so the client gets the response slightly before
-    //    the transaction commits.
     const rawResult = await withClient(adminKey, async (c) =>
       c.callTool({
         name: 'conv_setup_email_channel',
@@ -187,7 +183,6 @@ class StubImapFetcher implements ImapFetcher {
     expect(setupAudit).toHaveLength(1);
     expect(JSON.stringify(setupAudit[0]!.args)).not.toContain('app-pw-stub');
 
-    // 2. Push an inbound email from a brand-new sender.
     fetcher.push(rfc822({
       from: 'Customer One <c1@customer.test>',
       to: 'support@acme.test',
@@ -199,7 +194,6 @@ class StubImapFetcher implements ImapFetcher {
     const ingest1 = await inboundWorker.tick();
     expect(ingest1.messagesIngested).toBe(1);
 
-    // Worker created a contact + conversation on this channel.
     const conv1Rows = await db
       .select()
       .from(schema.convConversations)
@@ -214,7 +208,6 @@ class StubImapFetcher implements ImapFetcher {
       .where(and(eq(schema.convContacts.orgId, orgId), eq(schema.convContacts.email, 'c1@customer.test')));
     expect(contact1Rows).toHaveLength(1);
 
-    // 3. Admin replies via conv_send_message → enqueues an outbound delivery.
     const adminMsgId = await withClient(adminKey, async (c) =>
       parseToolResult<{ id: string }>(
         await c.callTool({
@@ -241,7 +234,6 @@ class StubImapFetcher implements ImapFetcher {
     expect(queued).toHaveLength(1);
     expect(queued[0]!.status).toBe('queued');
 
-    // 4. Outbound worker drains the queue → StubMailer captures the message.
     const drain1 = await outboundWorker.tick();
     expect(drain1.sent).toBe(1);
     expect(mailer.outbox).toHaveLength(1);
@@ -249,14 +241,9 @@ class StubImapFetcher implements ImapFetcher {
     expect(sent1.to).toBe('c1@customer.test');
     expect(sent1.from).toContain('support@acme.test');
     expect(sent1.text).toContain('reset your password');
-    // Headers include the Message-ID we stamped, and Reply-To is the auto plus-address.
     const stampedMessageId = sent1.headers?.['Message-ID'];
     expect(stampedMessageId).toMatch(/^<[^<>]+@acme\.test>$/);
-    // ResendMailer composes Reply-To from msg.replyTo (set via composeReplyToBare for mailer path).
-    // The ‘mailer’ codepath uses replyToTemplate only — undefined here. The stamped
-    // Message-ID is what the inbound side will key off when the customer replies.
 
-    // Delivery row is now 'sent' with the stamped Message-ID persisted for threading.
     const sentRow = (
       await db
         .select()
@@ -266,7 +253,6 @@ class StubImapFetcher implements ImapFetcher {
     expect(sentRow.status).toBe('sent');
     expect(sentRow.messageIdHeader).toBeTruthy();
 
-    // 5. Customer replies — the inbound carries In-Reply-To matching our stamped Message-ID.
     fetcher.push(rfc822({
       from: 'Customer One <c1@customer.test>',
       to: 'support@acme.test',
@@ -280,7 +266,6 @@ class StubImapFetcher implements ImapFetcher {
     const ingest2 = await inboundWorker.tick();
     expect(ingest2.messagesIngested).toBe(1);
 
-    // Threaded into the existing conversation (no new conversation row).
     const allConvs = await db
       .select()
       .from(schema.convConversations)
@@ -290,7 +275,6 @@ class StubImapFetcher implements ImapFetcher {
       .select()
       .from(schema.convMessages)
       .where(eq(schema.convMessages.conversationId, conv1.id));
-    // 1 inbound + 1 admin reply + 1 inbound reply = 3
     expect(messages).toHaveLength(3);
     expect(messages.some((m) => m.body.includes('That worked'))).toBe(true);
   }, 60_000);

--- a/packages/backend-core/src/modules/conv/email/email.tools.ts
+++ b/packages/backend-core/src/modules/conv/email/email.tools.ts
@@ -18,7 +18,6 @@ import {
 } from './email.service.ts';
 
 const SetupInput = z.object({
-  /** Pass to update an existing channel; omit to create one. */
   channelId: z.string().optional(),
   name: z.string().min(1).max(120),
   config: EmailChannelConfigInput,
@@ -234,14 +233,6 @@ export class EmailAdminTools {
   }
 }
 
-/**
- * Pick the right TLS mode for an SMTP host based on the port.
- *
- * Port 465 is the only port that takes implicit TLS — every other common
- * submission port (587, 25, 2525, …) expects plaintext connect + STARTTLS
- * upgrade. The stored `secure` flag is treated as a hint for ambiguous ports
- * only; the port wins when it has a well-known convention.
- */
 export function smtpTransportOptions(
   host: string,
   port: number,

--- a/packages/backend-core/src/modules/conv/set-topic-job.ts
+++ b/packages/backend-core/src/modules/conv/set-topic-job.ts
@@ -2,12 +2,6 @@ import type { EnqueueInput } from '../curator/curator-jobs.service.ts';
 
 export const SET_TOPIC_AND_TITLE_SKILL_URI = 'skill://conv/set-topic-and-title';
 
-/**
- * Build the curator job that classifies a freshly-created inbound
- * conversation into a topic and gives it a short title. Enqueue this once,
- * at the point the conversation is created from its first end-user message —
- * the `dedupeKey` keeps repeated calls (retries, batched inbound) idempotent.
- */
 export function buildSetTopicAndTitleJob(input: {
   conversationId: string;
   channelType?: string;

--- a/packages/backend-core/src/modules/conv/snooze-wake.worker.ts
+++ b/packages/backend-core/src/modules/conv/snooze-wake.worker.ts
@@ -46,7 +46,6 @@ export class SnoozeWakeWorker implements OnModuleInit, OnModuleDestroy {
     this.timer = null;
   }
 
-  /** Public so tests can drive a single tick directly. */
   async tick(): Promise<{ woken: number }> {
     if (this.running) return { woken: 0 };
     this.running = true;

--- a/packages/backend-core/src/modules/conv/widget/widget-adapter.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-adapter.ts
@@ -1,17 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import type { ChannelAdapter, InboundMode, SendContext, SendResult } from '../channels/adapter.ts';
 
-/**
- * Chat-widget adapter — push mode. Inbound is driven by the external agent
- * via the public REST endpoint (`POST /v1/widget/messages`); the
- * runtime doesn't poll or expose a webhook for this kind.
- *
- * Outbound is a no-op for v1: Munin replies render in the customer's own
- * widget code via `conversation.message.sent` webhook subscriptions. If
- * something accidentally enqueues a `conv_message_deliveries` row for a
- * chat channel, `send` returns a successful no-op so the row settles into
- * 'sent' rather than churning forever.
- */
 @Injectable()
 export class WidgetAdapter implements ChannelAdapter {
   readonly kind = 'chat' as const;

--- a/packages/backend-core/src/modules/conv/widget/widget-email-fallback.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-email-fallback.integration.test.ts
@@ -175,7 +175,6 @@ const REPLY_DOMAIN = 'reply.example.test';
     expect(body).not.toContain('sent you');
     expect(body).not.toContain('Reply to this email');
     expect(body).not.toContain('Best regards,');
-    // No assistants row for this org → agent signoff falls back to the channel fromName.
     expect(body).toContain('— Acme Support');
     expect(body).toContain('> Hi, I need help.');
     expect(body.indexOf('— Acme Support')).toBeGreaterThan(body.indexOf('Sure — what are you stuck on?'));
@@ -267,13 +266,6 @@ const REPLY_DOMAIN = 'reply.example.test';
     expect(r1.sent).toBe(1);
     expect(mailer.outbox[0]!.text!).toContain('Old agent reply.');
 
-    // Engage via a new end-user message (resetting the quiet period) and
-    // an agent reply. The old reply remains unread server-side. The
-    // end-user message must be later than `conv_created_at` so r2's
-    // engagement timestamp differs from r1's (otherwise the unique
-    // `(conversation_id, last_engagement_at)` constraint blocks the
-    // second fallback row). The agent message gets a small age so its
-    // `created_at` lands reliably before `tick`'s cutoff.
     await insertMsg(convId, 'end_user', 'Followup question.', 0);
     await insertMsg(convId, 'agent', 'Fresh agent reply.', 50);
 

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -1024,12 +1024,6 @@ export class WidgetIngestService {
       );
 
     if (sessionContact.endUserId && sessionContact.endUserId !== verifiedEndUserId) {
-      // Read receipts were recorded against the anonymous end-user. Move them
-      // to the verified one so the claimed conversation keeps its read-state —
-      // otherwise every already-read agent message resurfaces as unread after
-      // login. Skip messages the verified user has already read to respect the
-      // (message_id, end_user_id) unique index; those stale anon rows fall away
-      // with the cascade delete below.
       await tx
         .update(schema.convMessageReads)
         .set({ endUserId: verifiedEndUserId })

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -66,8 +66,6 @@ const skipReason = TEST_URL
       scopes: ['*'],
     });
 
-    // Stage a fake widget bundle + manifest in a tmp dir so the static-
-    // asset routes have something to serve from createApp().
     widgetAssetDir = mkdtempSync(join(tmpdir(), 'munin-widget-asset-'));
     writeFileSync(join(widgetAssetDir, FIXTURE_BUNDLE), FIXTURE_BUNDLE_BODY);
     writeFileSync(
@@ -86,7 +84,6 @@ const skipReason = TEST_URL
     if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
     baseUrl = `http://127.0.0.1:${address.port}`;
 
-    // Mint a widget channel + key via the admin MCP tool.
     const created = await withClient(adminKey, async (c) => {
       return parseToolResult<{
         id: string;
@@ -416,8 +413,6 @@ const skipReason = TEST_URL
     expect(rotated.widgetKey).toMatch(/^mn_widget_/);
     expect(rotated.widgetKey).not.toEqual(oldKey);
 
-    // Old key revoked. Retry briefly: revocation visibility through the
-    // server's connection pool can lag the rotate tx's commit by a tick.
     let staleStatus = 0;
     await waitFor(async () => {
       const r = await call('POST', '/v1/widget/messages', oldKey, {
@@ -430,7 +425,6 @@ const skipReason = TEST_URL
     });
     expect(staleStatus).toBe(401);
 
-    // New key works.
     const fresh = await call('POST', '/v1/widget/messages', rotated.widgetKey, {
       channelId,
       sessionId: 'vis_post_rotation',
@@ -444,9 +438,6 @@ const skipReason = TEST_URL
     expect(identityVerificationSecret).toBeTruthy();
     expect(identityVerificationSecret.length).toBeGreaterThanOrEqual(32);
 
-    // The secret persists in the channel config (RLS-protected JSONB).
-    // waitFor absorbs commit-visibility races between the MCP tool's
-    // commit and this separate connection's snapshot.
     await waitFor(async () => {
       await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
       const rows = await db
@@ -463,7 +454,6 @@ const skipReason = TEST_URL
       );
     });
 
-    // An update never echoes the secret back through the response.
     const updated = await withClient(adminKey, async (c) => {
       return parseToolResult<{
         config: Record<string, unknown> & { hasIdentityVerificationSecret: boolean };
@@ -515,11 +505,6 @@ const skipReason = TEST_URL
     expect(rotated.identityVerificationSecret.length).toBeGreaterThanOrEqual(32);
     expect(rotated.identityVerificationSecret).not.toEqual(oldSecret);
 
-    // Update the closure's secret BEFORE asserting DB persistence, so a
-    // transient stale-read on this separate connection (commit visibility
-    // can lag the MCP tool response by a tick under load) doesn't poison
-    // every subsequent test that signs with this secret. We then waitFor
-    // the DB to converge.
     identityVerificationSecret = rotated.identityVerificationSecret;
     await waitFor(async () => {
       await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
@@ -533,7 +518,6 @@ const skipReason = TEST_URL
   });
 
   it('rejects identity rotation across tenants', async () => {
-    // Mint a fresh org with its own admin key, channel, and secret.
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
     const [otherOrg] = await db
       .insert(schema.orgs)
@@ -549,9 +533,6 @@ const skipReason = TEST_URL
       scopes: ['*'],
     });
 
-    // Org B's admin attempts to rotate Org A's channel secret. NotFound (404)
-    // because the channel lookup is org-scoped — we must never leak the
-    // existence of another tenant's channel via a different status code.
     let threw: unknown = null;
     try {
       await withClient(otherAdminKey, async (c) => {
@@ -568,7 +549,6 @@ const skipReason = TEST_URL
     expect(threw).toBeTruthy();
     expect(String(threw)).toMatch(/not found|tool error/i);
 
-    // Secret on Org A's channel must be unchanged.
     await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
     const rows = await db
       .select({ config: schema.convChannels.config })
@@ -642,7 +622,6 @@ const skipReason = TEST_URL
   it('rejects a tampered userHash with 403', async () => {
     const externalId = 'user_tamper';
     const good = signHmac(externalId, identityVerificationSecret);
-    // Flip the last hex char.
     const last = good[good.length - 1]!;
     const flipped = last === 'a' ? 'b' : 'a';
     const tampered = good.slice(0, -1) + flipped;
@@ -657,7 +636,6 @@ const skipReason = TEST_URL
   });
 
   it('rejects a userHash signed with a different channels secret (cross-channel replay)', async () => {
-    // Mint a second widget channel within the same org.
     const second = await withClient(adminKey, async (c) => {
       return parseToolResult<{
         id: string;
@@ -673,7 +651,6 @@ const skipReason = TEST_URL
         }),
       );
     });
-    // Sign with channel-2 secret, send to channel-1.
     const externalId = 'user_replay';
     const cross = signHmac(externalId, second.identityVerificationSecret);
     const res = await call('POST', '/v1/widget/messages', widgetKey, {
@@ -792,8 +769,6 @@ const skipReason = TEST_URL
       messages: [{ role: 'end_user', body: 'started on marketing' }],
     });
 
-    // Before identify the anonymous conversation is invisible to a verified
-    // caller (leak-protection) — this is exactly what breaks carry-over.
     const before = await call(
       'GET',
       `/v1/widget/messages?${qs({ channelId, sessionId, verifiedExternalId: externalId, userHash })}`,
@@ -809,8 +784,6 @@ const skipReason = TEST_URL
       userHash,
     });
 
-    // After identify the same verified caller sees the anonymous thread —
-    // the marketing chat carries into the logged-in dashboard.
     const after = await call(
       'GET',
       `/v1/widget/messages?${qs({ channelId, sessionId, verifiedExternalId: externalId, userHash })}`,
@@ -868,8 +841,6 @@ const skipReason = TEST_URL
       userHash,
     });
 
-    // The agent answer was read anonymously; after the claim the verified
-    // caller must still see it as read (no phantom unread badge).
     const res = await call(
       'GET',
       `/v1/widget/messages?${qs({ channelId, sessionId, verifiedExternalId: externalId, userHash })}`,
@@ -1092,13 +1063,11 @@ const skipReason = TEST_URL
     expect(allBody.hasMore).toBe(false);
     expect(allBody.messages.map((m) => m.body)).toEqual(['one', 'two', 'three']);
     expect(allBody.messages.map((m) => m.role)).toEqual(['end_user', 'agent', 'end_user']);
-    // Strictly ascending timestamps (or equal — they were inserted in one tx).
     const times = allBody.messages.map((m) => Date.parse(m.at));
     for (let i = 1; i < times.length; i++) {
       expect(times[i]).toBeGreaterThanOrEqual(times[i - 1]!);
     }
 
-    // since filter: exclude rows with createdAt <= since.
     const since = allBody.messages[0]!.at;
     const after = await call(
       'GET',
@@ -1206,7 +1175,6 @@ const skipReason = TEST_URL
     const otherExt = 'user_other';
     const otherHash = signHmac(otherExt, identityVerificationSecret);
 
-    // Bind the conversation/contact via verified ingest as user_other.
     await call('POST', '/v1/widget/messages', widgetKey, {
       channelId,
       sessionId,
@@ -1215,9 +1183,6 @@ const skipReason = TEST_URL
       messages: [{ role: 'end_user', body: 'belongs to other' }],
     });
 
-    // Now request as a different verified user — same sessionId but
-    // different externalId. Empty response (don't leak that the session
-    // exists for someone else).
     const requesterExt = 'user_requester';
     const requesterHash = signHmac(requesterExt, identityVerificationSecret);
     const res = await call(
@@ -1287,7 +1252,7 @@ const skipReason = TEST_URL
     const res = await call(
       'GET',
       `/v1/widget/messages?${qs({ channelId: second.id, sessionId: 'vis_other' })}`,
-      widgetKey, // wrong key for that channel
+      widgetKey,
     );
     expect(res.status).toBe(403);
   });
@@ -1459,7 +1424,6 @@ const skipReason = TEST_URL
     };
     const agent = body.messages.find((m) => m.role === 'agent')!;
     expect(agent.authorKind).toBe('ai');
-    // No assistants row for this org → falls back to 'Munin'.
     expect(agent.authorName).toBe('Munin');
     expect(body.conversation?.status).toBe('open');
   });

--- a/packages/backend-core/src/modules/credential-handoff/credential-handoff.controller.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-handoff.controller.ts
@@ -13,11 +13,6 @@ const CompleteBody = z.object({
   secrets: z.record(z.string(), z.string().min(1)),
 });
 
-/**
- * Public credential-handoff endpoints — no session. The one-time token in the
- * link is the authorization; a human opens it to enter an integration's
- * secrets in the dashboard instead of pasting them into an agent chat.
- */
 @Controller('v1/credentials')
 export class CredentialHandoffController {
   constructor(private readonly handoff: CredentialHandoffService) {}

--- a/packages/backend-core/src/modules/credential-handoff/credential-handoff.module.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-handoff.module.ts
@@ -3,11 +3,6 @@ import { CredentialTargetRegistry } from './credential-target.ts';
 import { CredentialHandoffService } from './credential-handoff.service.ts';
 import { CredentialHandoffController } from './credential-handoff.controller.ts';
 
-/**
- * Generic one-time credential handoff. Domain modules register a
- * CredentialTargetHandler into the registry; the public controller drives the
- * dashboard entry form. Owns no vendor knowledge.
- */
 @Module({
   controllers: [CredentialHandoffController],
   providers: [

--- a/packages/backend-core/src/modules/credential-handoff/credential-handoff.service.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-handoff.service.ts
@@ -39,10 +39,6 @@ export class CredentialHandoffService {
     @Inject(CredentialTargetRegistry) private readonly registry: CredentialTargetRegistry,
   ) {}
 
-  /**
-   * Mint a one-time link for a target that already exists. Runs in the
-   * caller's authed context; the target's owning module validates targetId.
-   */
   async mint(args: { targetType: string; targetId: string }): Promise<CredentialLink> {
     const ctx = getCurrentContext();
     if (!this.registry.get(args.targetType)) {

--- a/packages/backend-core/src/modules/credential-handoff/credential-target.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-target.ts
@@ -17,13 +17,6 @@ export interface CredentialApplyResult {
   error?: string;
 }
 
-/**
- * A domain's plug into the credential-handoff flow. `describe` and `apply`
- * run inside a system-actor request context (org resolved from the link), so
- * implementations use the ambient `getCurrentContext()` db like any tool.
- * `apply` must be DB-only; put any vendor round-trip in `verify`, which runs
- * after commit and outside any transaction.
- */
 export interface CredentialTargetHandler {
   readonly targetType: string;
   describe(targetId: string): Promise<CredentialTargetDescription | null>;

--- a/packages/backend-core/src/modules/crm/crm.integration.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.integration.test.ts
@@ -73,8 +73,6 @@ const skipReason = TEST_URL
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
     });
 
-    // Second end-user in the SAME org. Used to assert end-user-vs-end-user
-    // isolation: Bob must not be able to read Alice's contact via any tool.
     const [eu2] = await db
       .insert(schema.endUsers)
       .values({ orgId, externalId: 'eu-2', name: 'Bob', email: 'bob@example.com' })
@@ -144,7 +142,6 @@ const skipReason = TEST_URL
       const pipeline = pipelines[0]!;
       const firstStage = pipeline.stages[0]!;
 
-      // Create the end-user's matching CRM contact, plus a sibling for isolation testing.
       const myContact = parseToolResult<{ id: string; name: string | null }>(
         await c.callTool({
           name: 'crm_create_contact',
@@ -177,7 +174,6 @@ const skipReason = TEST_URL
       );
       expect(deal.stageId).toBe(firstStage.id);
 
-      // Move it to "Won" — should stamp closedAt because that stage is winLoss=won.
       const wonStage = pipeline.stages.find((s) => s.name === 'Won')!;
       const moved = parseToolResult<{ closedAt: string | null }>(
         await c.callTool({
@@ -200,7 +196,6 @@ const skipReason = TEST_URL
       );
       expect(activity.contactId).toBe(myContact.id);
 
-      // Updating doNotContact stamps unsubscribedAt automatically.
       const updated = parseToolResult<{ doNotContact: boolean; unsubscribedAt: string | null }>(
         await c.callTool({
           name: 'crm_update_contact',
@@ -211,7 +206,6 @@ const skipReason = TEST_URL
       expect(updated.unsubscribedAt).not.toBeNull();
     });
 
-    // End-user agent: tools/list reflects self-service surface only; sees only own contact.
     await withClient(endUserToken, async (c) => {
       const { tools } = await c.listTools();
       const names = tools.map((t) => t.name);
@@ -250,8 +244,6 @@ const skipReason = TEST_URL
   }, 30_000);
 
   it('end-user isolation: Bob cannot read Alice\'s contact via crm_get_my_contact', async () => {
-    // Bob has no contact linked to him; getMyContact must NOT return Alice's
-    // contact even though it lives in the same org. RLS narrows by end_user_id.
     await withClient(otherEndUserToken, async (c) => {
       const result = (await c.callTool({
         name: 'crm_get_my_contact',
@@ -259,8 +251,6 @@ const skipReason = TEST_URL
       })) as { isError?: boolean; content?: Array<{ text?: string }> };
       expect(result.isError).toBe(true);
       const text = result.content?.[0]?.text ?? '';
-      // Either the service throws crm_not_found, or the RLS-filtered query
-      // returns zero rows — both surface as a not-found error to the caller.
       expect(text).toMatch(/not.?found|no contact/i);
       expect(text).not.toMatch(/Alice/);
     });

--- a/packages/backend-core/src/modules/crm/crm.self-service.tools.ts
+++ b/packages/backend-core/src/modules/crm/crm.self-service.tools.ts
@@ -7,7 +7,6 @@ import { getCurrentContext } from '@getmunin/core';
 const EmptyInput = z.object({});
 
 const UpdateMyContactInput = z.object({
-  /** Self-service callers can only edit basic personal fields, not tags / owner / custom-fields / AI fields. */
   name: z.string().min(1).max(200).optional(),
   phone: z.string().max(40).optional(),
   address: z.string().max(500).optional(),

--- a/packages/backend-core/src/modules/crm/crm.service.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.test.ts
@@ -77,8 +77,6 @@ const skipReason = TEST_URL
     });
   }
 
-  // ─── Contacts ────────────────────────────────────────────────────────
-
   describe('contacts', () => {
     it('createContact persists with the requested fields', async () => {
       const c = await run(() =>
@@ -214,8 +212,6 @@ const skipReason = TEST_URL
     });
   });
 
-  // ─── Companies ───────────────────────────────────────────────────────
-
   describe('companies', () => {
     it('createCompany persists fields', async () => {
       const co = await run(() =>
@@ -237,8 +233,6 @@ const skipReason = TEST_URL
       await expect(run(() => svc.getCompany(randomUUID()))).rejects.toThrow(NotFoundException);
     });
   });
-
-  // ─── Pipelines & deals ───────────────────────────────────────────────
 
   describe('pipelines and deals', () => {
     async function seedPipeline() {
@@ -345,8 +339,6 @@ const skipReason = TEST_URL
     });
   });
 
-  // ─── Activities ──────────────────────────────────────────────────────
-
   describe('activities', () => {
     it('logActivity persists a record and stamps lastContactedAt on the contact', async () => {
       const c = await run(() => svc.createContact({ name: 'A', email: 'a@x' }));
@@ -371,8 +363,6 @@ const skipReason = TEST_URL
     });
   });
 
-  // ─── Search ──────────────────────────────────────────────────────────
-
   describe('search', () => {
     it('searchContacts matches by name / email / phone / title (case-insensitive)', async () => {
       await run(() => svc.createContact({ name: 'Alice', email: 'a@example.com' }));
@@ -390,8 +380,6 @@ const skipReason = TEST_URL
       expect(empty).toEqual([]);
     });
   });
-
-  // ─── RLS ─────────────────────────────────────────────────────────────
 
   describe('merge proposals', () => {
     it('proposeMerge canonicalizes pair and returns embedded contact summaries', async () => {

--- a/packages/backend-core/src/modules/crm/crm.service.ts
+++ b/packages/backend-core/src/modules/crm/crm.service.ts
@@ -257,8 +257,6 @@ export class CrmService {
     @Inject(QUOTAS_SERVICE) private readonly quotas: QuotasService,
   ) {}
 
-  // ─── Contacts ───────────────────────────────────────────────────────────
-
   async listContacts(input: {
     companyId?: string;
     tag?: string;
@@ -532,8 +530,6 @@ export class CrmService {
     return toContactDto(result[0]);
   }
 
-  // ─── Segments ───────────────────────────────────────────────────────────
-
   async listSegments(): Promise<SegmentDto[]> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
@@ -629,15 +625,6 @@ export class CrmService {
     return { deleted: true };
   }
 
-  /**
-   * Resolve a segment to the contacts it currently targets.
-   *
-   * Always excludes contacts that are suppressed (`do_not_contact = true` or
-   * `unsubscribed_at IS NOT NULL`) or that have no recorded lawful basis for
-   * outreach (`consent_lawful_basis IS NULL`). These floors are non-overridable
-   * from the public surface — they live here so every caller (operator UI,
-   * curator skill, future automation) inherits the same compliance posture.
-   */
   async listContactsInSegment(input: { id: string; limit?: number }): Promise<ContactDto[]> {
     const segment = await this.getSegment(input.id);
     const limit = clampLimit(input.limit, 100, 500);
@@ -683,8 +670,6 @@ export class CrmService {
       .limit(limit);
     return rows.map(toContactDto);
   }
-
-  // ─── Companies ──────────────────────────────────────────────────────────
 
   async listCompanies(input: { limit?: number }): Promise<CompanyDto[]> {
     const ctx = getCurrentContext();
@@ -732,8 +717,6 @@ export class CrmService {
     });
     return toCompanyDto(row!);
   }
-
-  // ─── Pipelines / stages / deals ─────────────────────────────────────────
 
   async listPipelines(): Promise<PipelineDto[]> {
     const ctx = getCurrentContext();
@@ -903,8 +886,6 @@ export class CrmService {
     return toDealDto(result[0]);
   }
 
-  // ─── Activities ─────────────────────────────────────────────────────────
-
   async logActivity(input: {
     type: ActivityType;
     subject?: string;
@@ -976,8 +957,6 @@ export class CrmService {
     return rows.map(toActivityDto);
   }
 
-  // ─── Search ─────────────────────────────────────────────────────────────
-
   async searchContacts(input: { query: string; limit?: number }): Promise<ContactDto[]> {
     const ctx = getCurrentContext();
     const limit = clampLimit(input.limit, 25, 100);
@@ -998,8 +977,6 @@ export class CrmService {
       .limit(limit);
     return rows.map(toContactDto);
   }
-
-  // ─── Merge proposals ────────────────────────────────────────────────────
 
   async proposeMerge(input: {
     contactAId: string;
@@ -1317,8 +1294,6 @@ export class CrmService {
     await this.emitMergeEvent('crm.merge_proposal.dismissed', dto);
     return dto;
   }
-
-  // ─── Transfer (import / export) ──────────────────────────────────────────
 
   async exportCrm(): Promise<CrmExportData> {
     const ctx = getCurrentContext();
@@ -1786,8 +1761,6 @@ export class CrmService {
     });
   }
 }
-
-// ─── DTO mappers / helpers ─────────────────────────────────────────────────
 
 export function computeBackfillPatch(
   existing: Record<string, unknown>,

--- a/packages/backend-core/src/modules/crm/crm.tools.ts
+++ b/packages/backend-core/src/modules/crm/crm.tools.ts
@@ -317,8 +317,6 @@ const CrmImportInput = z.object({
 export class CrmAdminTools {
   constructor(@Inject(CrmService) private readonly crm: CrmService) {}
 
-  // Contacts ────────────────────────────────────────────────────────────
-
   @McpTool({
     name: 'crm_list_contacts',
     title: 'CRM: List contacts',
@@ -421,8 +419,6 @@ export class CrmAdminTools {
     return this.crm.searchContacts(args);
   }
 
-  // Companies ───────────────────────────────────────────────────────────
-
   @McpTool({
     name: 'crm_list_companies',
     title: 'CRM: List companies',
@@ -450,8 +446,6 @@ export class CrmAdminTools {
   createCompany(args: z.infer<typeof CreateCompanyInput>) {
     return this.crm.createCompany(args);
   }
-
-  // Pipelines + deals ───────────────────────────────────────────────────
 
   @McpTool({
     name: 'crm_list_pipelines',
@@ -526,8 +520,6 @@ export class CrmAdminTools {
     return this.crm.changeStage(args);
   }
 
-  // Activities ──────────────────────────────────────────────────────────
-
   @McpTool({
     name: 'crm_log_activity',
     title: 'CRM: Log activity',
@@ -557,8 +549,6 @@ export class CrmAdminTools {
     return this.crm.listActivities(args);
   }
 
-  // AI fields ───────────────────────────────────────────────────────────
-
   @McpTool({
     name: 'crm_set_ai_summary',
     title: 'CRM: Set AI summary or next action',
@@ -573,8 +563,6 @@ export class CrmAdminTools {
   setAiSummary(args: z.infer<typeof SetAiSummaryInput>) {
     return this.crm.setAiSummary(args);
   }
-
-  // Merge proposals ─────────────────────────────────────────────────────
 
   @McpTool({
     name: 'crm_propose_merge',
@@ -635,8 +623,6 @@ export class CrmAdminTools {
   dismissMergeProposal(args: z.infer<typeof DismissMergeProposalInput>) {
     return this.crm.dismissMergeProposal(args);
   }
-
-  // Segments ────────────────────────────────────────────────────────────
 
   @McpTool({
     name: 'crm_list_segments',
@@ -725,8 +711,6 @@ export class CrmAdminTools {
     return this.crm.listContactsInSegment(args);
   }
 
-  // Consent ─────────────────────────────────────────────────────────────
-
   @McpTool({
     name: 'crm_set_contact_consent',
     title: 'CRM: Set contact consent',
@@ -741,8 +725,6 @@ export class CrmAdminTools {
   setContactConsent(args: z.infer<typeof SetContactConsentInput>) {
     return this.crm.setContactConsent(args);
   }
-
-  // Transfer ────────────────────────────────────────────────────────────
 
   @McpTool({
     name: 'crm_export',

--- a/packages/backend-core/src/modules/kb/embedding.provider.ts
+++ b/packages/backend-core/src/modules/kb/embedding.provider.ts
@@ -3,11 +3,6 @@ import { readEmbeddingProviderFromEnv, type EmbeddingProvider } from '@getmunin/
 
 export const EMBEDDING_PROVIDER = Symbol('EmbeddingProvider');
 
-/**
- * Lazy singleton: resolve the EmbeddingProvider once at first use, from env.
- * Wrapped as an Injectable so Nest can hand the same instance to every
- * service that asks for it.
- */
 @Injectable()
 export class EmbeddingProviderHolder {
   private cached: EmbeddingProvider | null = null;

--- a/packages/backend-core/src/modules/kb/kb.module.ts
+++ b/packages/backend-core/src/modules/kb/kb.module.ts
@@ -5,12 +5,6 @@ import { KbAdminTools } from './kb.tools.ts';
 import { EmbeddingProviderHolder } from './embedding.provider.ts';
 import { CuratorModule } from '../curator/curator.module.ts';
 
-/**
- * Knowledge Base module: spaces, documents, chunks, versions, search.
- *
- * MCP tool services declared here are picked up by the McpRegistryService
- * via NestJS DiscoveryService at boot — no manual registration needed.
- */
 @Module({
   imports: [CuratorModule],
   providers: [EmbeddingProviderHolder, KbService, KbSearchService, KbAdminTools],

--- a/packages/backend-core/src/modules/kb/kb.search.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.search.test.ts
@@ -120,9 +120,6 @@ const skipReason = TEST_URL
   });
 
   it('returns vector hits when FTS misses', async () => {
-    // FTS won't match because the query has no surface-form overlap with the
-    // doc; the stub embedding is deterministic per-string so the same query
-    // and doc hash to the same neighborhood.
     await runAs(admin, () =>
       kb.createDocument({ spaceId, title: 'Apple', body: 'Apple is a fruit.' }),
     );

--- a/packages/backend-core/src/modules/kb/kb.search.ts
+++ b/packages/backend-core/src/modules/kb/kb.search.ts
@@ -51,15 +51,6 @@ export class KbSearchService {
     @Inject(EmbeddingProviderHolder) private readonly embeddings: EmbeddingProviderHolder,
   ) {}
 
-  /**
-   * Hybrid search: FTS over title+body and chunk content, vector cosine over
-   * chunk embeddings. Per-source ranks are combined via Reciprocal Rank Fusion
-   * (RRF, k=60) so each source contributes monotonic, scale-free votes.
-   *
-   * RLS enforces tenancy + the audiences filter for self-service callers
-   * (only docs whose audiences include 'self_service' surface to end-users).
-   * Caller-passed filters (spaceId) are also AND'd in the SQL.
-   */
   async search(input: SearchInput): Promise<SearchHit[]> {
     const ctx = getCurrentContext();
     const limit = clampLimit(input.limit, DEFAULT_LIMIT, MAX_LIMIT);
@@ -156,8 +147,6 @@ function reciprocalRankFuse(
     const existing = merged.get(row.document_id);
     if (existing) {
       existing.vectorScore = score;
-      // Prefer FTS excerpt if available (highlights matched terms), else use
-      // the vector excerpt (the most-similar chunk).
       if (!existing.hit.excerpt) existing.hit.excerpt = row.excerpt;
     } else {
       merged.set(row.document_id, {

--- a/packages/backend-core/src/modules/kb/kb.service.test.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.test.ts
@@ -315,7 +315,6 @@ const skipReason = TEST_URL
       const after = await run(() => svc.listSpaces());
       expect(after.find((s) => s.slug === CURATION_INBOX_SLUG)).toBeDefined();
 
-      // A second proposal reuses the same inbox space.
       const second = await run(() =>
         svc.proposeCurationCandidate({
           subject: 'Refunds policy',
@@ -344,7 +343,6 @@ const skipReason = TEST_URL
       expect(published.tags).not.toEqual(expect.arrayContaining(['candidate', 'curation']));
       expect(published.title).toBe('How to reset password');
 
-      // The candidate doc is gone from the inbox.
       await expect(run(() => svc.getDocument(candidate.id))).rejects.toThrow(KbNotFoundError);
     });
 

--- a/packages/backend-core/src/modules/kb/kb.service.ts
+++ b/packages/backend-core/src/modules/kb/kb.service.ts
@@ -136,8 +136,6 @@ export class KbService {
     @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
   ) {}
 
-  // ─── Spaces ─────────────────────────────────────────────────────────────
-
   async listSpaces(): Promise<SpaceDto[]> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
@@ -177,8 +175,6 @@ export class KbService {
       .returning();
     return toSpaceDto(row!);
   }
-
-  // ─── Documents ──────────────────────────────────────────────────────────
 
   async listDocuments(input: {
     spaceId?: string;
@@ -361,9 +357,6 @@ export class KbService {
     return this.removeDocument(existing, { emitCandidateDismissed: true });
   }
 
-  // Publishing a candidate deletes its inbox row through here too — with
-  // emitCandidateDismissed off, so the publish doesn't also announce a
-  // dismissal.
   private async removeDocument(
     existing: typeof schema.kbDocuments.$inferSelect,
     opts: { emitCandidateDismissed: boolean },
@@ -390,8 +383,6 @@ export class KbService {
     }
     return { deleted: true };
   }
-
-  // ─── Curation ───────────────────────────────────────────────────────────
 
   async listCurationCandidates(limit?: number): Promise<CurationCandidateSummary[]> {
     const items = await this.listDocuments({ tag: 'candidate', limit: limit ?? 200 });
@@ -520,8 +511,6 @@ export class KbService {
     });
   }
 
-  // ─── Versions ───────────────────────────────────────────────────────────
-
   async listVersions(documentId: string): Promise<VersionDto[]> {
     const ctx = getCurrentContext();
     await this.assertDocumentExists(documentId);
@@ -585,8 +574,6 @@ export class KbService {
     });
     return toDocumentDto(updated!);
   }
-
-  // ─── Transfer (import / export) ──────────────────────────────────────────
 
   async exportKb(): Promise<KbExportData> {
     const ctx = getCurrentContext();
@@ -705,8 +692,6 @@ export class KbService {
     return rows[0] ?? null;
   }
 
-  // ─── Internals ──────────────────────────────────────────────────────────
-
   private async loadSpace(spaceId: string): Promise<typeof schema.kbSpaces.$inferSelect> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
@@ -770,8 +755,6 @@ export class KbService {
     try {
       vectors = await provider.embed(chunks.map((c) => c.content));
     } catch {
-      // Embedding failure shouldn't block the write — leave vectors null and
-      // let FTS carry search until a re-index repairs them.
       vectors = chunks.map(() => null);
     }
     await ctx.db.insert(schema.kbDocumentChunks).values(
@@ -786,8 +769,6 @@ export class KbService {
     );
   }
 }
-
-// ─── DTO mappers / helpers ─────────────────────────────────────────────────
 
 function toSpaceDto(row: typeof schema.kbSpaces.$inferSelect): SpaceDto {
   return {

--- a/packages/backend-core/src/modules/outreach/outreach.service.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.test.ts
@@ -82,7 +82,6 @@ const skipReason = TEST_URL
     await db.execute(sql`DELETE FROM crm_contacts WHERE org_id = ${orgId}`);
     await db.execute(sql`DELETE FROM crm_segments WHERE org_id = ${orgId}`);
 
-    // Seed: one email channel, one segment with one consenting contact.
     const [ch] = await db
       .insert(schema.convChannels)
       .values({
@@ -218,19 +217,16 @@ const skipReason = TEST_URL
       expect(approved.contact?.email).toBe('jane@acme.com');
       expect(approved.campaign?.name).toBe('launch');
 
-      // Conversation has the campaign id stamped.
       const convRows = await db.execute<{ outreach_campaign_id: string | null }>(
         sql`SELECT outreach_campaign_id FROM conv_conversations WHERE id = ${approved.conversationId!}`,
       );
       expect(convRows[0]!.outreach_campaign_id).toBe(c.id);
 
-      // Message body contains the unsubscribe footer with our public base url.
       const msgRows = await db.execute<{ body: string }>(
         sql`SELECT body FROM conv_messages WHERE id = ${approved.sentMessageId!}`,
       );
       expect(msgRows[0]!.body).toContain('[Unsubscribe](https://test.local/v1/outreach/unsubscribe?token=');
 
-      // An outbound delivery row was queued (email channel + agent author).
       const delivery = await db.execute<{ count: number }>(
         sql`SELECT COUNT(*)::int AS count FROM conv_message_deliveries WHERE message_id = ${approved.sentMessageId!}`,
       );
@@ -255,7 +251,6 @@ const skipReason = TEST_URL
           draftBody: 'body',
         }),
       );
-      // Suppress the contact AFTER the draft.
       await run(() =>
         crm.updateContact({ id: contactId, patch: { doNotContact: true } }),
       );
@@ -419,7 +414,7 @@ const skipReason = TEST_URL
       const ch = await run(() =>
         svc.createCampaign({ name: 'plain', brief: 'b', segmentId, channelId, enabled: true }),
       );
-      void ch; // not used; we want a bare conversation
+      void ch;
       const [plain] = await db
         .insert(schema.convConversations)
         .values({

--- a/packages/backend-core/src/modules/outreach/outreach.service.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.ts
@@ -155,8 +155,6 @@ export class OutreachService {
     @Inject(DB) private readonly db: Db,
   ) {}
 
-  // ─── Campaigns ──────────────────────────────────────────────────────────
-
   async listCampaigns(): Promise<CampaignDto[]> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
@@ -194,7 +192,6 @@ export class OutreachService {
     const actor = ctx.actor!;
     if (!input.name.trim()) throw new OutreachInvalidError('name must be non-empty');
     if (!input.brief.trim()) throw new OutreachInvalidError('brief must be non-empty');
-    // Validate FK targets in this org.
     await this.assertSegmentExists(input.segmentId);
     const channel = await this.loadOutreachChannel(input.channelId);
     if (input.sequenceSteps?.length && channel.type !== 'email') {
@@ -274,8 +271,6 @@ export class OutreachService {
     if (!result[0]) throw new NotFoundException(`outreach_not_found: campaign ${input.id}`);
     return toCampaignDto(result[0]);
   }
-
-  // ─── Proposals ──────────────────────────────────────────────────────────
 
   async listProposals(input: {
     status?: ProposalStatus;
@@ -461,8 +456,6 @@ export class OutreachService {
         `conversation ${input.conversationId} has no contact bound — cannot file reply draft`,
       );
     }
-    // The conversation's contactId is conv_contacts.id, but the proposal's
-    // contactId is crm_contacts.id. Resolve via email match.
     const convContactRows = await ctx.db
       .select({ email: schema.convContacts.email })
       .from(schema.convContacts)
@@ -707,8 +700,6 @@ export class OutreachService {
 
     const channel = await this.loadOutreachChannel(campaign.channelId);
 
-    // Re-check suppression+consent at approve-time (the contact may have
-    // unsubscribed between draft generation and operator approval).
     const contact = await this.crm.getContact(proposal.contactId);
     if (contact.doNotContact || contact.unsubscribedAt || !contact.consentLawfulBasis) {
       throw new OutreachInvalidError(
@@ -724,8 +715,6 @@ export class OutreachService {
       throw new OutreachInvalidError(`contact ${contact.id} has no email — cannot send`);
     }
 
-    // Find or create a conv_contacts row keyed on email so the email
-    // adapter's reply-threading can link inbound replies back here.
     const convContact = await ctx.db.transaction(async (tx) => {
       return this.email.findOrCreateContactByEmail(tx, actor.orgId, contact.email!, contact.name ?? undefined);
     });
@@ -743,9 +732,6 @@ export class OutreachService {
       unsubscribeRequired: campaign.unsubscribeRequired,
     });
 
-    // Create the conversation in `agentMode='draft_only'` so the AI runner
-    // defers on subsequent inbound messages — replies should be drafted by
-    // `skill://outreach/draft-reply-email` and human-approved, not auto-sent.
     const conversation = await this.conv.createConversation({
       channelId: campaign.channelId,
       body,
@@ -983,8 +969,6 @@ export class OutreachService {
         `reply proposal ${proposal.id} has no conversationId — cannot send`,
       );
     }
-    // No unsubscribe footer on replies — the original initial already
-    // carries the link, and replies thread inside the same conversation.
     const sent = await this.conv.sendMessage({
       conversationId: proposal.conversationId,
       body: proposal.draftBody,
@@ -1164,8 +1148,6 @@ export class OutreachService {
     return toProposalDto(updated!, proposal.contact, proposal.campaign);
   }
 
-  // ─── Sequences ──────────────────────────────────────────────────────────
-
   async listDueFollowups(input: { campaignId?: string; limit?: number }): Promise<DueFollowupDto[]> {
     const ctx = getCurrentContext();
     const limit = clampLimit(input.limit, 50, 200);
@@ -1290,8 +1272,6 @@ export class OutreachService {
     };
   }
 
-  // ─── Internal helpers ───────────────────────────────────────────────────
-
   private async assertSegmentExists(segmentId: string): Promise<void> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
@@ -1319,8 +1299,6 @@ export class OutreachService {
       `channel ${channelId} is ${channel.type}:${channel.vendor}; outreach campaigns require an email or voice:vapi channel`,
     );
   }
-
-  // ─── Transfer (import / export) ───────────────────────────────────────────
 
   async exportOutreach(): Promise<OutreachExportData> {
     const ctx = getCurrentContext();
@@ -1482,8 +1460,6 @@ export class OutreachService {
     return rows[0] ?? null;
   }
 }
-
-// ─── DTO mappers / helpers ────────────────────────────────────────────────
 
 function toCampaignDto(row: typeof schema.outreachCampaigns.$inferSelect): CampaignDto {
   return {

--- a/packages/backend-core/src/modules/slack/slack-approvals.integration.test.ts
+++ b/packages/backend-core/src/modules/slack/slack-approvals.integration.test.ts
@@ -222,7 +222,6 @@ function buttonLabels(blocks: unknown[] | undefined): string[] {
   }
 
   async function seedMergeProposal(): Promise<string> {
-    // A pending pair is unique per org — retire earlier seeds first.
     await db
       .update(schema.crmMergeProposals)
       .set({ status: 'dismissed' })

--- a/packages/backend-core/src/modules/slack/slack-bridge.worker.ts
+++ b/packages/backend-core/src/modules/slack/slack-bridge.worker.ts
@@ -52,17 +52,8 @@ type RouteRow = typeof schema.slackChannelRoutes.$inferSelect;
 type DeliveryRow = typeof schema.slackDeliveries.$inferSelect;
 type LinkRow = typeof schema.slackConversationLinks.$inferSelect;
 
-/** Thrown for conditions retrying can't fix — marks the delivery done with a note. */
 class TerminalDeliveryError extends Error {}
 
-/**
- * Drains `slack_deliveries` and projects conversation events into Slack
- * threads (one thread per conversation, created lazily on the first event).
- * Same shape as WebhookWorker: service-role DB, advisory-lock singleton,
- * exponential backoff. Per-conversation ordering is head-of-line: a due row
- * waits while an earlier undelivered, still-retryable row for the same
- * conversation exists.
- */
 @Injectable()
 export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
   private timer: NodeJS.Timeout | null = null;
@@ -97,15 +88,6 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  /**
-   * The NOT EXISTS clause means a batch only ever contains the *head* row of
-   * each conversation's queue — a failed head keeps its successors queued
-   * (ordering), and a delivered head releases the next row. Iterating lets a
-   * chain of events for one conversation drain within a single tick instead
-   * of one per poll interval; a failing head leaves the loop naturally
-   * because its backoff pushes it (and, via NOT EXISTS, its successors) out
-   * of the due set.
-   */
   private async drain(): Promise<{ attempted: number; delivered: number; failed: number }> {
     let attempted = 0;
     let delivered = 0;
@@ -331,14 +313,6 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
       .onConflictDoNothing();
   }
 
-  /**
-   * Approval events post standalone channel notifications rather than thread
-   * replies. Pending events post (or refresh) the message; resolution events
-   * chat.update it in place, drop the buttons, and stamp resolved_at so late
-   * or duplicate resolutions are no-ops. A resolution whose pending message
-   * never surfaced (e.g. the feature shipped mid-lifecycle, or the pending
-   * head perma-failed) posts nothing.
-   */
   private async handleNotification(input: {
     row: DeliveryRow;
     integration: IntegrationRow;
@@ -434,13 +408,6 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
       .onConflictDoNothing();
   }
 
-  /**
-   * Rebuilds the full message for a subject. Pending renders load the subject
-   * fresh so re-proposals refresh in place; a subject that resolved before its
-   * pending row delivered renders the resolved state directly. KB candidates
-   * are deleted on resolve, so their resolution render comes from the event
-   * payload + actor instead of the row.
-   */
   private async renderApproval(
     subject: { subjectType: string; subjectId: string },
     payload: Record<string, unknown>,

--- a/packages/backend-core/src/modules/slack/slack-event-sink.ts
+++ b/packages/backend-core/src/modules/slack/slack-event-sink.ts
@@ -8,11 +8,6 @@ import {
   approvalSubjectRef,
 } from './slack.constants.ts';
 
-/**
- * Registered on the WebhookDispatcher; runs inside the emitting request's
- * tenant transaction, so the queue row commits (or rolls back) together with
- * the event itself. Only enqueues — the bridge worker does the Slack I/O.
- */
 @Injectable()
 export class SlackEventSink implements EventSink {
   async onEvent(event: EmittedEvent): Promise<void> {

--- a/packages/backend-core/src/modules/slack/slack-events.controller.ts
+++ b/packages/backend-core/src/modules/slack/slack-events.controller.ts
@@ -7,13 +7,6 @@ import { SlackInteractionsService } from './slack-interactions.service.ts';
 import { verifySlackSignature } from './slack-signature.ts';
 import { readSlackSigningSecret } from './slack.constants.ts';
 
-/**
- * Public Slack Events API receiver. Signature-verified against the raw body,
- * then acked immediately — Slack retries on slow acks (>3s), which would
- * double-deliver — and processed out-of-band. Dedup is anchored on the
- * (channel, ts) unique index in slack_message_links, so a redelivered event
- * can never produce a second customer message.
- */
 @Controller('v1/slack')
 export class SlackEventsController {
   private readonly logger = new Logger(SlackEventsController.name);
@@ -69,11 +62,6 @@ export class SlackEventsController {
     }
   }
 
-  /**
-   * Interactivity payloads arrive form-encoded (`payload=<json>`), signed
-   * with the same v0 scheme over the raw urlencoded body. Same contract as
-   * events: verify, ack fast, process out-of-band.
-   */
   @Post('interactivity')
   @HttpCode(200)
   handleInteractivity(@Req() req: RawBodyRequest<Request>, @Res() res: Response): void {

--- a/packages/backend-core/src/modules/slack/slack-inbound.service.ts
+++ b/packages/backend-core/src/modules/slack/slack-inbound.service.ts
@@ -42,13 +42,6 @@ const EventCallbackSchema = z.object({
 type MessageEvent = z.infer<typeof MessageEventSchema>;
 type MemberJoinedEvent = z.infer<typeof MemberJoinedEventSchema>;
 
-/**
- * Slack → Munin direction of the bridge. A reply in a mirrored thread is
- * recorded through ConvService.sendMessage() as the mapped org member, so
- * outbound-to-customer delivery, claim, and attention semantics are exactly
- * the dashboard's. Replies from Slack users with no Munin mapping are
- * rejected with an ephemeral notice — never silently attributed.
- */
 @Injectable()
 export class SlackInboundService {
   private readonly logger = new Logger(SlackInboundService.name);
@@ -118,9 +111,6 @@ export class SlackInboundService {
       return;
     }
 
-    // Slack files live on Slack's authenticated CDN; forwarding them to the
-    // customer would require download + re-hosting, which the bridge does not
-    // do yet. Loudly refuse rather than silently dropping them.
     if (text.length === 0) {
       await this.notify(
         token,

--- a/packages/backend-core/src/modules/slack/slack-interactions.service.ts
+++ b/packages/backend-core/src/modules/slack/slack-interactions.service.ts
@@ -57,13 +57,6 @@ const ROUTE_ACTIONS = new Set([
 ]);
 const APPROVAL_ACTIONS = new Set([APPROVAL_APPROVE_ACTION_ID, APPROVAL_DISMISS_ACTION_ID]);
 
-/**
- * Button clicks on the thread parent, mapped onto the same service paths the
- * dashboard uses: Claim → ConversationClaimsService.claim, Close/Reopen →
- * ConvService.changeStatus. The resulting conversation events flow back
- * through the mirror worker, which posts the thread update and refreshes the
- * parent message — no state is written from here directly.
- */
 @Injectable()
 export class SlackInteractionsService {
   private readonly logger = new Logger(SlackInteractionsService.name);
@@ -188,13 +181,6 @@ export class SlackInteractionsService {
     }
   }
 
-  /**
-   * Approve/Dismiss clicks on approval notifications, mapped onto the same
-   * service paths as the dashboard and MCP tools. Success posts nothing from
-   * here — the resolution event loops back through the bridge worker, which
-   * chat.updates the notification in place. Failures surface as ephemeral
-   * messages to the clicker.
-   */
   private async handleApprovalAction(input: {
     actionId: string;
     value: string;

--- a/packages/backend-core/src/modules/slack/slack-oauth.controller.ts
+++ b/packages/backend-core/src/modules/slack/slack-oauth.controller.ts
@@ -20,14 +20,6 @@ function readCookie(header: string | undefined, name: string): string | null {
   return null;
 }
 
-/**
- * Public landing for Slack's OAuth redirect. The org and installing user
- * travel in the HMAC-signed `state` minted by SlackService.installUrl().
- * Dashboard-initiated installs also carry a nonce bound to the
- * `slack_install_nonce` cookie set on the same browser, which the service
- * checks. Always redirects back to the dashboard AI settings page with a
- * `slack=` outcome flag.
- */
 @Controller('v1/slack/oauth')
 export class SlackOAuthController {
   constructor(private readonly slack: SlackService) {}

--- a/packages/backend-core/src/modules/slack/slack-projection.ts
+++ b/packages/backend-core/src/modules/slack/slack-projection.ts
@@ -1,10 +1,3 @@
-/**
- * Provider-neutral projection of conversation events into operator-surface
- * message text. Kept free of Slack API and DB concerns so a future bridge
- * (Teams, …) can lift this layer and only swap the rendering/transport —
- * the mrkdwn dialect is the one Slack-specific ingredient.
- */
-
 export type AuthorKind = 'user' | 'agent' | 'end_user' | 'system';
 
 export interface ConversationSnapshot {
@@ -31,10 +24,6 @@ export interface MessageSnapshot {
   attachments?: MessageAttachment[];
 }
 
-/**
- * conv_messages.attachments is loosely-typed jsonb; read `{url, name}`-shaped
- * entries best-effort and ignore the rest rather than assuming a schema.
- */
 export function parseMessageAttachments(raw: unknown[]): MessageAttachment[] {
   return raw.flatMap((entry) => {
     if (typeof entry !== 'object' || entry === null) return [];
@@ -305,8 +294,6 @@ export function routeConfirmedText(
 export function routeDismissedText(): string {
   return 'Ok — routing can be configured any time from the dashboard (Settings → Integrations) or with slack_set_routing.';
 }
-
-// ─── Approval notifications ─────────────────────────────────────────────────
 
 export const APPROVAL_APPROVE_ACTION_ID = 'munin_approval_approve';
 export const APPROVAL_DISMISS_ACTION_ID = 'munin_approval_dismiss';

--- a/packages/backend-core/src/modules/slack/slack-signature.ts
+++ b/packages/backend-core/src/modules/slack/slack-signature.ts
@@ -3,12 +3,6 @@ import { timingSafeEqual } from '@getmunin/core';
 
 const MAX_SKEW_SECONDS = 300;
 
-/**
- * Slack request signing (v0): hex HMAC-SHA256 of `v0:{timestamp}:{rawBody}`
- * with the app's signing secret, compared constant-time. The ±5 min
- * timestamp window bounds replay. Header values arrive untyped because
- * Node header lookups can yield arrays.
- */
 export function verifySlackSignature(input: {
   signingSecret: string;
   timestamp: unknown;

--- a/packages/backend-core/src/modules/slack/slack-user-mapping.service.ts
+++ b/packages/backend-core/src/modules/slack/slack-user-mapping.service.ts
@@ -7,13 +7,6 @@ import { SlackApiClient } from './slack-api.client.ts';
 
 type IntegrationRow = typeof schema.slackIntegrations.$inferSelect;
 
-/**
- * Slack user → Munin org member resolution, shared by thread replies and
- * button clicks. slack_user_links is the cache; a hit is still re-checked
- * against current org membership so removed members lose access
- * immediately. On miss, auto-map via the Slack profile email ↔ org member
- * email. Returns null for anyone unmappable — callers reject, never guess.
- */
 @Injectable()
 export class SlackUserMappingService {
   private readonly logger = new Logger(SlackUserMappingService.name);

--- a/packages/backend-core/src/modules/slack/slack.constants.ts
+++ b/packages/backend-core/src/modules/slack/slack.constants.ts
@@ -13,12 +13,6 @@ export const SLACK_MIRRORED_EVENT_TYPES: readonly string[] = [
   'conversation.handover_resolved',
 ];
 
-/**
- * Approval-queue events delivered as standalone channel notifications (not
- * conversation threads). Some payloads carry a conversationId (outreach
- * replies) — the sink must NOT treat these as mirror events, or the worker
- * would open a bogus conversation thread for them.
- */
 export const SLACK_APPROVAL_EVENT_TYPES: readonly string[] = [
   'crm.merge_proposal.proposed',
   'crm.merge_proposal.applied',
@@ -32,7 +26,6 @@ export const SLACK_APPROVAL_EVENT_TYPES: readonly string[] = [
   'kb.curation_candidate.dismissed',
 ];
 
-/** Derives the per-subject ordering key + link identity from an approval event. */
 export function approvalSubjectRef(
   eventType: string,
   payload: Record<string, unknown>,
@@ -67,11 +60,6 @@ export interface SlackAppConfig {
   clientSecret: string;
 }
 
-/**
- * The Slack app itself is deployment-level: cloud ships one app, self-hosters
- * register their own from the manifest in skill://slack/connect-slack and set
- * these env vars. Returns null when the deployment has no Slack app.
- */
 export function readSlackAppConfig(): SlackAppConfig | null {
   const clientId = process.env.SLACK_CLIENT_ID;
   const clientSecret = process.env.SLACK_CLIENT_SECRET;

--- a/packages/backend-core/src/modules/slack/slack.service.ts
+++ b/packages/backend-core/src/modules/slack/slack.service.ts
@@ -55,7 +55,6 @@ export interface SlackUserLinkDto {
 }
 
 export interface SlackStatusDto {
-  /** Whether this deployment has a Slack app configured (env credentials). */
   appConfigured: boolean;
   connected: boolean;
   integration: SlackIntegrationDto | null;
@@ -66,7 +65,6 @@ export interface SetRoutingInput {
   slackChannelId: string;
   purpose?: 'default' | 'escalations' | 'approvals';
   mention?: string | null;
-  /** Source-channel override: conversations on this conv channel mirror here. */
   convChannelId?: string | null;
 }
 
@@ -74,24 +72,14 @@ interface InstallState {
   orgId: string;
   userId: string | null;
   exp: number;
-  /**
-   * Present when the install was started from a browser session (the
-   * dashboard). The callback requires a matching `slack_install_nonce`
-   * cookie, so leaking the URL is not enough to complete the install.
-   * Absent for MCP-minted URLs, which a human opens in a fresh browser with
-   * no cookie continuity — those rely on the short TTL and the
-   * team-mismatch guard in completeInstall.
-   */
   nonce?: string;
 }
 
-/** Cookie set by the dashboard install endpoint; consumed by the callback. */
 export const SLACK_INSTALL_NONCE_COOKIE = 'slack_install_nonce';
 
 export interface InstallUrlResult {
   url: string;
   expiresAt: string;
-  /** Set only when bindToSession — the caller stores it in the nonce cookie. */
   sessionNonce?: string;
 }
 
@@ -263,10 +251,6 @@ export class SlackService {
     return { url: url.toString(), expiresAt: new Date(exp).toISOString(), sessionNonce };
   }
 
-  /**
-   * Public OAuth callback path — no tenant context; org + installer come from
-   * the signed state minted by installUrl(). Runs on the service-role DB.
-   */
   async completeInstall(input: {
     code: string;
     state: string;
@@ -277,9 +261,6 @@ export class SlackService {
     const state = verifyInstallState(input.state, config.clientSecret);
     if (!state) throw new BadRequestException('slack_invalid_state');
 
-    // Session binding: a state minted from the dashboard carries a nonce and
-    // is only completable by the same browser (matching httpOnly cookie), so
-    // a leaked/intercepted install URL cannot be redeemed by anyone else.
     if (state.nonce && state.nonce !== input.sessionNonce) {
       throw new BadRequestException('slack_invalid_state');
     }
@@ -298,9 +279,6 @@ export class SlackService {
       .where(eq(schema.slackIntegrations.orgId, state.orgId))
       .limit(1);
 
-    // Never silently repoint an existing workspace to a different one — that
-    // would redirect all mirrored customer conversations elsewhere. Switching
-    // workspaces requires an explicit slack_disconnect first.
     if (existing && existing.teamId !== install.teamId) {
       throw new ConflictException(
         'slack_workspace_mismatch: this org is already connected to a different Slack workspace — disconnect it first, then reinstall',
@@ -404,10 +382,6 @@ export class SlackService {
       )
       .limit(1);
 
-    // One route row per Slack channel, globally: the (team, channel) unique
-    // index is both the multi-org invariant and what keeps thread→org
-    // resolution unambiguous. Pre-checked because a violation inside the
-    // request transaction would surface as a bare 500 at commit time.
     const [conflicting] = await this.db
       .select({
         id: schema.slackChannelRoutes.id,

--- a/packages/backend-core/src/modules/webhooks/webhooks.service.test.ts
+++ b/packages/backend-core/src/modules/webhooks/webhooks.service.test.ts
@@ -95,8 +95,6 @@ const skipReason = TEST_URL
 
   it('delete removes the row, returns a serializable result; second delete is 404', async () => {
     const created = await run(() => svc.create({ url: 'https://hooks.example.com/h' }));
-    // Must return a value (not void): a void return serializes to undefined content
-    // and trips the MCP CallToolResult schema (-32602).
     const result = await run(() => svc.delete(created.id));
     expect(result).toEqual({ deleted: true, id: created.id });
     expect(await run(() => svc.list())).toHaveLength(0);

--- a/packages/backend-core/src/modules/webhooks/webhooks.service.ts
+++ b/packages/backend-core/src/modules/webhooks/webhooks.service.ts
@@ -9,7 +9,6 @@ export interface WebhookDto {
   url: string;
   events: string[];
   active: boolean;
-  /** Plaintext shared secret — returned ONCE at creation time. */
   secret?: string;
   createdAt: string;
   updatedAt: string;

--- a/packages/backend-core/src/oauth/oauth-client-info.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-client-info.controller.ts
@@ -44,17 +44,6 @@ const FAVICON_MIME_ALLOWLIST = new Set([
 const FAVICON_MAX_BYTES = 256 * 1024;
 const FAVICON_BROWSER_TTL_SECONDS = 60 * 60 * 24;
 
-/**
- * Public lookup for the disclosure fields of a registered OAuth client.
- * The consent page renders the client's human-facing name + URL + logo
- * instead of the random RFC 7591 `client_id`. Strictly disclosure-only:
- * we never return `clientSecret`, the full `redirectUris`, or anything
- * else the caller could weaponize — only the host portion of the first
- * redirect URI so the page can render "Returning to claude.ai/...".
- *
- * Anonymous on purpose — the consent page is rendered for any user
- * mid-authorization, before the OAuth flow has issued any credential.
- */
 @PublicController('v1/oauth/clients')
 export class OAuthClientInfoController {
   constructor(@Inject(DB) private readonly db: Db) {}
@@ -156,7 +145,6 @@ function deriveFallbackName(host: string | null): string | null {
   if (!host) return null;
   const known = KNOWN_HOST_NAMES[host];
   if (known) return known;
-  // strip leading www. and return the host so the user sees *something* identifiable
   return host.replace(/^www\./, '');
 }
 

--- a/packages/backend-core/src/realtime/realtime.end-user.integration.test.ts
+++ b/packages/backend-core/src/realtime/realtime.end-user.integration.test.ts
@@ -188,9 +188,7 @@ const skipReason = TEST_URL
             ws.off('message', onMessage);
             resolve(msg);
           }
-        } catch {
-          // ignore
-        }
+        } catch {}
       };
       ws.on('message', onMessage);
     });
@@ -214,9 +212,7 @@ const skipReason = TEST_URL
             ws.off('message', onMessage);
             reject(new Error(`unexpected event: ${JSON.stringify(msg)}`));
           }
-        } catch {
-          // ignore
-        }
+        } catch {}
       };
       ws.on('message', onMessage);
     });

--- a/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
+++ b/packages/backend-core/src/realtime/realtime.widget.integration.test.ts
@@ -169,10 +169,6 @@ const skipReason = TEST_URL
     });
   }
 
-  /**
-   * Waits for the next event message matching `predicate`. Drops `ready` /
-   * `pong` and other framing messages.
-   */
   function nextEvent(
     ws: WebSocket,
     predicate: (msg: { type: string; channel?: string; event?: { type: string } }) => boolean,
@@ -196,19 +192,12 @@ const skipReason = TEST_URL
             ws.off('message', onMessage);
             resolve(msg);
           }
-        } catch {
-          // ignore
-        }
+        } catch {}
       };
       ws.on('message', onMessage);
     });
   }
 
-  /**
-   * Asserts that no event matching `predicate` arrives within `withinMs`.
-   * Used to verify isolation (e.g. session A subscriber should NOT receive
-   * session B's events).
-   */
   function expectNoEvent(
     ws: WebSocket,
     predicate: (msg: { type: string; channel?: string }) => boolean,
@@ -227,9 +216,7 @@ const skipReason = TEST_URL
             ws.off('message', onMessage);
             reject(new Error(`unexpected event: ${JSON.stringify(msg)}`));
           }
-        } catch {
-          // ignore
-        }
+        } catch {}
       };
       ws.on('message', onMessage);
     });
@@ -269,8 +256,6 @@ const skipReason = TEST_URL
       ws.send(
         JSON.stringify({ type: 'subscribe', channel: 'widget', channelId, sessionId }),
       );
-      // Give the server a tick to register the subscription before the
-      // ingest fires the NOTIFY.
       await new Promise((r) => setTimeout(r, 50));
 
       const status = await ingest(
@@ -308,7 +293,6 @@ const skipReason = TEST_URL
       );
       await new Promise((r) => setTimeout(r, 50));
 
-      // Ingest a message under sessionId B; subscriber on A must not see it.
       const noEventP = expectNoEvent(
         wsA,
         (m) => m.type === 'event' && m.channel === `widget:${channelId}:${sessB}`,
@@ -334,9 +318,6 @@ const skipReason = TEST_URL
     const ws = connectWs(widgetKey, { origin: ALLOWED_ORIGIN });
     await waitForOpen(ws);
     try {
-      // Send blocked subscriptions; server should silently drop them. We
-      // verify by ingesting and asserting the only event we receive is on
-      // the legitimate widget subscription.
       ws.send(JSON.stringify({ type: 'subscribe', channel: 'org' }));
       ws.send(
         JSON.stringify({ type: 'subscribe', channel: 'conversation', id: 'cnv_fake' }),
@@ -363,8 +344,6 @@ const skipReason = TEST_URL
   });
 
   it('rejects upgrade for a widget key targeting a different channelId in identity', async () => {
-    // verifiedExternalId / userHash present but the HMAC was signed with a
-    // different channel's secret — the upgrade gate must reject 401.
     const ext = 'user_replay';
     const wrongHash = signHmac(ext, 'unrelated-secret-of-sufficient-length-32-chars');
     const ws = connectWs(widgetKey, {
@@ -387,8 +366,6 @@ const skipReason = TEST_URL
     const hash = signHmac(ext, identitySecret);
     const sessionId = 'rt_verified_match';
 
-    // First, ingest as the verified user so the conversation/contact is
-    // bound to this externalId.
     const ingestStatus = await ingest(
       widgetKey,
       {
@@ -413,7 +390,6 @@ const skipReason = TEST_URL
       );
       await new Promise((r) => setTimeout(r, 50));
 
-      // Send another message; verified subscriber should receive its event.
       await ingest(
         widgetKey,
         {
@@ -440,7 +416,6 @@ const skipReason = TEST_URL
     const ownerHash = signHmac(ownerExt, identitySecret);
     const sessionId = 'rt_verified_mismatch';
 
-    // Bind the session to ownerExt.
     await ingest(
       widgetKey,
       {
@@ -453,10 +428,6 @@ const skipReason = TEST_URL
       ALLOWED_ORIGIN,
     );
 
-    // Now connect as a different verified user; subscribe to the same
-    // sessionId. Server must accept the upgrade (HMAC is valid for this
-    // requester's externalId) but suppress events because the conversation
-    // belongs to ownerExt.
     const requesterExt = 'user_requester';
     const requesterHash = signHmac(requesterExt, identitySecret);
     const ws = connectWs(widgetKey, {
@@ -510,7 +481,6 @@ const skipReason = TEST_URL
   it('fans out visitor typing to operators subscribed to the conversation', async () => {
     const sessionId = 'rt_typing_v2o';
 
-    // Visitor must have a conversation before typing can be routed.
     const ingestRes = await fetch(`${baseUrl}/v1/widget/messages`, {
       method: 'POST',
       headers: {
@@ -533,8 +503,6 @@ const skipReason = TEST_URL
       wsOperator.send(
         JSON.stringify({ type: 'subscribe', channel: 'conversation', id: conversationId }),
       );
-      // Visitor's subscription is technically optional for sending typing
-      // but realistic.
       wsVisitor.send(
         JSON.stringify({ type: 'subscribe', channel: 'widget', channelId, sessionId }),
       );
@@ -654,12 +622,9 @@ const skipReason = TEST_URL
           if (msg.type === 'typing' && msg.authorType === 'visitor' && msg.isTyping) {
             typingCount++;
           }
-        } catch {
-          // ignore
-        }
+        } catch {}
       });
 
-      // Spam 10 typing:true events back-to-back.
       for (let i = 0; i < 10; i++) {
         wsVisitor.send(
           JSON.stringify({
@@ -672,8 +637,6 @@ const skipReason = TEST_URL
         );
       }
 
-      // Wait beyond a single 1.5s window so we'd see a second broadcast if
-      // the throttle were broken — but not enough for the auto-clear.
       await new Promise((r) => setTimeout(r, 600));
       expect(typingCount).toBe(1);
     } finally {
@@ -718,14 +681,11 @@ const skipReason = TEST_URL
         }),
       );
 
-      // Receive the typing:true.
       await nextEvent(
         wsOperator,
         (m) => m.type === 'typing' && (m as { isTyping?: boolean }).isTyping === true,
       );
 
-      // Don't send another typing event; the server's auto-clear should
-      // fire typing:false after 5 s.
       const cleared = await nextEvent(
         wsOperator,
         (m) => m.type === 'typing' && (m as { isTyping?: boolean }).isTyping === false,
@@ -745,7 +705,6 @@ const skipReason = TEST_URL
   it('does not leak visitor typing across sessionIds', async () => {
     const sessA = 'rt_typing_iso_a';
     const sessB = 'rt_typing_iso_b';
-    // Both sessions need conversations.
     for (const s of [sessA, sessB]) {
       await fetch(`${baseUrl}/v1/widget/messages`, {
         method: 'POST',
@@ -762,9 +721,6 @@ const skipReason = TEST_URL
       });
     }
 
-    // wsB is a widget subscriber on session B; should NOT see typing fired
-    // by session A (typing fans out to operators on conversation:<id>, not
-    // to other visitors of the same channel).
     const wsA = connectWs(widgetKey, { origin: ALLOWED_ORIGIN });
     const wsB = connectWs(widgetKey, { origin: ALLOWED_ORIGIN });
     await Promise.all([waitForOpen(wsA), waitForOpen(wsB)]);
@@ -820,7 +776,6 @@ const skipReason = TEST_URL
       );
       await new Promise((r) => setTimeout(r, 50));
 
-      // Operator tries to fire widget-style typing — should be dropped.
       const noVisitorEventP = expectNoEvent(wsVisitor, (m) => m.type === 'typing', 600);
       wsOperator.send(
         JSON.stringify({
@@ -833,7 +788,6 @@ const skipReason = TEST_URL
       );
       await noVisitorEventP;
 
-      // Widget tries to fire conversation-style typing — should be dropped.
       const noOperatorEventP = expectNoEvent(wsOperator, (m) => m.type === 'typing', 600);
       wsVisitor.send(
         JSON.stringify({
@@ -851,14 +805,11 @@ const skipReason = TEST_URL
   });
 
   it('drops widget typing when the (channelId, sessionId) has no conversation yet', async () => {
-    const sessionId = 'rt_typing_pre_conv'; // no ingest first
+    const sessionId = 'rt_typing_pre_conv';
     const wsVisitor = connectWs(widgetKey, { origin: ALLOWED_ORIGIN });
     const wsOperator = new WebSocket(`${wsBase}/v1/realtime`, ['bearer', adminKey]);
     await Promise.all([waitForOpen(wsVisitor), waitForOpen(wsOperator)]);
     try {
-      // Operator subscribes broadly to org so anything that DID fan out
-      // would have a destination — the gateway just shouldn't fan
-      // out at all because no conversation maps to (channelId, sessionId).
       wsOperator.send(JSON.stringify({ type: 'subscribe', channel: 'org' }));
       await new Promise((r) => setTimeout(r, 50));
 

--- a/packages/backend-core/src/scripts/seed-dev.ts
+++ b/packages/backend-core/src/scripts/seed-dev.ts
@@ -1,10 +1,3 @@
-/**
- * Seed a dev org + admin API key against MUNIN_MIGRATE_URL (or DATABASE_URL).
- *
- *   pnpm --filter @getmunin/backend exec tsx src/scripts/seed-dev.ts
- *
- * Prints the API key once. Save it; we don't store the plaintext.
- */
 import { createDb, schema } from '@getmunin/db';
 import { buildApiKey, hashSecret, keyPrefix } from '@getmunin/core';
 import { sql } from 'drizzle-orm';
@@ -17,9 +10,6 @@ async function main() {
   }
   const db = createDb(url);
 
-  // Seed runs as the migration superuser, so RLS doesn't apply and we
-  // freely create rows in any org. Still, set the bypass GUC to make
-  // intent explicit.
   await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
 
   const [org] = await db

--- a/packages/backend-core/vitest.config.ts
+++ b/packages/backend-core/vitest.config.ts
@@ -2,15 +2,6 @@ import './test-env';
 import { defineConfig } from 'vitest/config';
 import swc from 'unplugin-swc';
 
-/**
- * Tests touch a shared Postgres (RLS, migrations, multi-tenant fixtures),
- * so running test files in parallel triggers schema-catalog contention
- * during runMigrations. Serialize files; tests within a file still run in
- * their declared order.
- *
- * The SWC plugin emits TypeScript decorator metadata, which Nest's DI
- * needs to wire constructors. Vitest's default esbuild loader strips it.
- */
 export default defineConfig({
   plugins: [
     swc.vite({

--- a/packages/core/src/chunker.test.ts
+++ b/packages/core/src/chunker.test.ts
@@ -15,7 +15,6 @@ describe('chunkDocument', () => {
   });
 
   it('splits long text into multiple chunks with sequential indices', () => {
-    // ~6000 chars → with target=200 chars (50 tokens) we should get many chunks.
     const para = 'This is a sentence. '.repeat(300);
     const out = chunkDocument(para, { targetTokens: 50, overlapTokens: 8 });
     expect(out.length).toBeGreaterThan(5);
@@ -29,7 +28,6 @@ describe('chunkDocument', () => {
       const prev = out[i - 1]!.content;
       const curr = out[i]!.content;
       const tail = prev.slice(-16);
-      // At least some characters of tail should appear at the start of next.
       const firstWord = curr.split(' ')[0]!;
       expect(prev.includes(firstWord) || tail.length > 0).toBe(true);
     }

--- a/packages/core/src/chunker.ts
+++ b/packages/core/src/chunker.ts
@@ -1,20 +1,5 @@
-/**
- * Document chunking for embedding.
- *
- * Splits a body of text into overlapping windows roughly sized in tokens.
- * We don't bundle a real tokenizer (tiktoken adds ~7MB and we don't need
- * exact accuracy — pgvector chunks just need to be uniformly bounded);
- * instead we estimate tokens at ~4 characters per token, which is a common
- * approximation for English text and BPE-family encoders.
- *
- * Splits prefer paragraph boundaries (\n\n), then sentence boundaries, then
- * fall back to character cuts so very long unbroken text is still bounded.
- */
-
 export interface ChunkOptions {
-  /** Target tokens per chunk. Default 512. */
   targetTokens?: number;
-  /** Overlap between successive chunks, in tokens. Default 64. */
   overlapTokens?: number;
 }
 
@@ -43,7 +28,6 @@ export function chunkDocument(text: string, opts: ChunkOptions = {}): Chunk[] {
   const trimmed = text.trim();
   if (!trimmed) return [];
 
-  // Single chunk: short doc fits in one window.
   if (trimmed.length <= targetChars) {
     return [{ index: 0, content: trimmed, tokenCount: estimateTokens(trimmed) }];
   }
@@ -88,10 +72,6 @@ function lastSentenceEnd(text: string, minCut: number, end: number): number {
   }
   return last === -1 ? -1 : minCut + last + 2;
 }
-
-// ─── Content hashing ──────────────────────────────────────────────────────
-// Cheap stable hash so kb_documents.content_hash can short-circuit
-// re-chunking when only metadata changed.
 
 export function contentHash(title: string, body: string): string {
   let h1 = 0xdeadbeef;

--- a/packages/core/src/crypto/keys.ts
+++ b/packages/core/src/crypto/keys.ts
@@ -1,22 +1,5 @@
 import { randomToken } from './primitives.ts';
 
-/**
- * Munin API-key format: `mn_<kind>_<random>`
- *
- *   kind = 'admin' | 'dlg' (delegated end-user, short-lived)
- *        | 'widget' (chat-widget channel binding; api_keys.channel_id is set)
- *        | 'track' (public analytics tracker key; safe to embed in browsers)
- *
- * The `'part'` kind exists in the type union for downstream packages
- * that mint partner-style credentials; OSS does not produce or accept
- * them.
- *
- * The first 8 chars of the key (`mn_admin`, `mn_dlg__`) are the "prefix"
- * we index by — narrows the row lookup in resolveApiKey before we compute
- * the full hash. Random portion is 32 bytes base64url (~43 chars, ~256
- * bits of entropy).
- */
-
 export type KeyKind = 'admin' | 'part' | 'dlg' | 'widget' | 'track';
 
 const PREFIX_LENGTH = 8;

--- a/packages/core/src/crypto/outreach-tokens.ts
+++ b/packages/core/src/crypto/outreach-tokens.ts
@@ -2,8 +2,6 @@ import { signHmac, timingSafeEqual } from './primitives.ts';
 
 const VERSION = 'v1';
 
-// Unsubscribe links must keep working well after the campaign ships, so this is
-// deliberately generous — it only exists to stop a leaked link replaying forever.
 const DEFAULT_MAX_AGE_SECONDS = 2 * 365 * 24 * 60 * 60;
 const FUTURE_SKEW_SECONDS = 5 * 60;
 

--- a/packages/core/src/crypto/primitives.test.ts
+++ b/packages/core/src/crypto/primitives.test.ts
@@ -76,7 +76,6 @@ const skipPgcrypto = TEST_URL ? null : 'Set TEST_DATABASE_URL to run pgcrypto te
   });
 
   afterAll(() => {
-    // Drizzle wraps a postgres-js Sql client; close via $client.
     void db?.$client.end();
   });
 
@@ -115,7 +114,6 @@ const skipPgcrypto = TEST_URL ? null : 'Set TEST_DATABASE_URL to run pgcrypto te
         const enc = await tx.execute<{ ct: string }>(
           sql`SELECT ${encryptSecretSql('hello')} AS ct`,
         );
-        // Flip a byte mid-payload.
         const original = enc[0]!.ct;
         const flipChar = original.charAt(20) === 'A' ? 'B' : 'A';
         const bad = original.slice(0, 20) + flipChar + original.slice(21);

--- a/packages/core/src/crypto/primitives.ts
+++ b/packages/core/src/crypto/primitives.ts
@@ -1,35 +1,24 @@
 import { createHash, createHmac, randomBytes, timingSafeEqual as nodeTimingSafeEqual } from 'node:crypto';
 import { sql, type SQL } from 'drizzle-orm';
 
-/**
- * Hash a secret (API key, OAuth client secret) for at-rest storage.
- *
- * We use SHA-256 + a fixed pepper from MUNIN_KEY_PEPPER env var. Keys are
- * already high-entropy (24+ bytes random) so adding bcrypt-style work factor
- * isn't necessary; constant-time comparison and pepper avoid the main risks.
- */
 export function hashSecret(secret: string, pepper?: string): string {
   const p = pepper ?? process.env.MUNIN_KEY_PEPPER ?? '';
   return createHash('sha256').update(p).update(secret).digest('hex');
 }
 
-/** Generate a high-entropy token: base64url, no padding, default 32 bytes. */
 export function randomToken(byteLength = 32): string {
   return randomBytes(byteLength).toString('base64url');
 }
 
-/** Sign a payload with HMAC-SHA256, returning hex. */
 export function signHmac(payload: string | Buffer, secret: string): string {
   return createHmac('sha256', secret).update(payload).digest('hex');
 }
 
-/** Verify an HMAC signature against a payload. Constant-time. */
 export function verifyHmac(payload: string | Buffer, secret: string, signature: string): boolean {
   const expected = signHmac(payload, secret);
   return timingSafeEqual(expected, signature);
 }
 
-/** Constant-time string equality. Returns false for mismatched lengths. */
 export function timingSafeEqual(a: string, b: string): boolean {
   const aBuf = Buffer.from(a);
   const bBuf = Buffer.from(b);
@@ -37,25 +26,6 @@ export function timingSafeEqual(a: string, b: string): boolean {
   return nodeTimingSafeEqual(aBuf, bBuf);
 }
 
-// ─── At-rest secret encryption (pgcrypto) ───────────────────────────────────
-// For secrets we need to recover (SMTP / IMAP passwords on conv_channels,
-// future API-provider creds) we lean on Postgres's pgcrypto extension —
-// `pgp_sym_encrypt` / `pgp_sym_decrypt` — instead of rolling AES in TypeScript.
-// pgcrypto is well-audited, ships with stock Postgres, and keeps the crypto
-// adjacent to the data it protects. The extension is enabled by `runMigrations`
-// alongside vector / pg_trgm / citext.
-//
-// Key handling mirrors the existing RLS GUC pattern: the request transaction
-// sets `app.crypt_key` once via SET LOCAL, and the SQL fragments below read it
-// via current_setting. The key never appears in query parameters or logs.
-
-/**
- * Read the at-rest encryption key from `MUNIN_ENCRYPTION_KEY` env. The key is
- * never decoded into a Buffer — it's passed to Postgres as a string and
- * pgcrypto handles the rest. Tolerates base64 / base64url / hex / raw text;
- * the only requirement is that it's stable across deployments (rotation is a
- * v0.5 concern).
- */
 export function readEncryptionKey(): string {
   const raw = process.env.MUNIN_ENCRYPTION_KEY;
   if (!raw) {
@@ -64,35 +34,14 @@ export function readEncryptionKey(): string {
   return raw;
 }
 
-/**
- * SQL helper to set `app.crypt_key` for the current transaction. Call once at
- * the top of a tenant transaction (alongside the RLS GUCs) so subsequent
- * encrypt/decrypt fragments can reach for it via current_setting.
- *
- * Use as: `await tx.execute(setEncryptionKeySql())`.
- */
 export function setEncryptionKeySql(): SQL {
   return sql`SELECT set_config('app.crypt_key', ${readEncryptionKey()}, true)`;
 }
 
-/**
- * SQL fragment that encrypts a value with the per-tx key. Wraps
- * `pgp_sym_encrypt(plain, current_setting('app.crypt_key'))` and base64-
- * encodes the bytea so the result round-trips through text columns / jsonb.
- *
- * Use as: `sql\`UPDATE x SET secret_ct = ${encryptSecretSql(value)} WHERE …\``
- */
 export function encryptSecretSql(plaintext: string | SQL): SQL {
   return sql`encode(pgp_sym_encrypt(${plaintext}, current_setting('app.crypt_key')), 'base64')`;
 }
 
-/**
- * SQL fragment that decrypts a base64-encoded ciphertext column produced by
- * `encryptSecretSql`. Returns `text`; throws (Postgres-side) on a wrong key
- * or corrupted ciphertext.
- *
- * Use as: `sql\`SELECT ${decryptSecretSql(schema.foo.secretCt)} AS pw FROM …\``
- */
 export function decryptSecretSql(ciphertext: string | SQL): SQL {
   return sql`pgp_sym_decrypt(decode(${ciphertext}, 'base64'), current_setting('app.crypt_key'))::text`;
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,11 +1,3 @@
-/**
- * Walk an `Error.cause` chain and produce a single-line description.
- *
- * Undici and other modern Node libraries throw a generic outer error
- * (e.g. `TypeError: fetch failed`) and stash the real reason on `.cause`.
- * This helper unwraps up to `maxDepth` levels and emits `Name[CODE]: msg`
- * for each link, joined by ` <- `.
- */
 export function describeError(err: unknown, maxDepth = 4): string {
   const parts: string[] = [];
   let cur: unknown = err;

--- a/packages/core/src/prompts/cache.ts
+++ b/packages/core/src/prompts/cache.ts
@@ -1,29 +1,14 @@
-/**
- * Shared prompt-cache primitives used by both the chat runtime (agent-runtime,
- * MCP-backed reader) and the voice path (backend-core, DB-backed reader). The
- * source of truth for any prompt is a KB document; this cache is just an
- * in-memory mirror keyed by slug, refilled either eagerly at init or lazily
- * via `refresh(slug)` on a KB-change event / TTL expiry.
- */
-
 export interface KbDocLocation {
   spaceSlug: string;
   slug: string;
 }
 
-/**
- * Strategy for reading a KB document body by (space, slug). Implementations
- * differ — agent-runtime uses an MCP tool call; backend-core hits the DB
- * directly with org-scoped RLS already in place. Both return `null` when the
- * document does not exist (caller decides on fallback strategy).
- */
 export interface KbDocReader {
   getBody(location: KbDocLocation): Promise<string | null>;
 }
 
 export interface PromptCacheEntry {
   location: KbDocLocation;
-  /** Optional default body, used if the KB doc is missing on read. */
   fallback?: string;
 }
 
@@ -34,28 +19,12 @@ export interface PromptCacheOptions {
 }
 
 export interface PromptCache {
-  /**
-   * Return the cached body for `slug`. Falls back to the entry's `fallback`
-   * value if the KB doc was missing at last load, or to an empty string if
-   * no fallback was configured.
-   */
   get(slug: string): string;
-  /**
-   * Whether `slug` was registered when the cache was created. Useful for
-   * filtering KB-change events before calling `refresh`.
-   */
   has(slug: string): boolean;
-  /** Reload the body for `slug` from the underlying reader. */
   refresh(slug: string): Promise<void>;
-  /** Reload every registered slug. */
   refreshAll(): Promise<void>;
 }
 
-/**
- * Build a `PromptCache` and prime it with the bodies of every registered
- * document. Documents that 404 stay in the cache as their `fallback` value
- * (or empty string) so callers can render without null checks.
- */
 export async function createPromptCache(opts: PromptCacheOptions): Promise<PromptCache> {
   const log = opts.logger ?? {};
   const bodies = new Map<string, string>();

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -1,13 +1,3 @@
-/**
- * Built-in prompt defaults. Each prompt lives in its own file so PR diffs and
- * git-blame stay scoped. This index assembles the seedable registry that
- * agent-host writes to the `agent-runtime` KB space on first boot.
- *
- * Adding a new prompt: drop a new file alongside the others exporting
- * `<NAME>_SLUG`, `<NAME>_TITLE`, `DEFAULT_<NAME>`; re-export here; append to
- * `SEEDABLE_PROMPTS`. No other plumbing needed.
- */
-
 import {
   SYSTEM_PROMPT_SLUG,
   SYSTEM_PROMPT_TITLE,
@@ -49,7 +39,6 @@ import {
   DEFAULT_VOICE_OPENER_CONTINUATION,
 } from './voice-opener-continuation.ts';
 
-// ── Slug / body / title constants ───────────────────────────────────
 export {
   SYSTEM_PROMPT_SLUG,
   SYSTEM_PROMPT_TITLE,
@@ -77,13 +66,11 @@ export {
   DEFAULT_VOICE_OPENER_CONTINUATION,
 };
 
-// ── Shared space / namespace constants ──────────────────────────────
 export const AGENT_RUNTIME_PROMPT_SPACE_SLUG = 'agent-runtime';
 export const COMPANY_PROFILE_SPACE_SLUG = 'website-import';
 export const CHANNEL_PROMPT_PREFIX = 'channel-';
 export const COMPANY_PROFILE_SLUG = 'company-profile';
 
-// ── Cache primitives ────────────────────────────────────────────────
 export {
   createPromptCache,
   type KbDocLocation,
@@ -93,18 +80,12 @@ export {
   type PromptCacheOptions,
 } from './cache.ts';
 
-// ── Registry ────────────────────────────────────────────────────────
 export interface SeedablePrompt {
   slug: string;
   title: string;
   body: string;
 }
 
-/**
- * Every prompt that `agent-host` seeds into the `agent-runtime` KB space on
- * first boot. Both runtimes use the same bodies as fallbacks when a KB
- * lookup returns nothing.
- */
 export const SEEDABLE_PROMPTS: readonly SeedablePrompt[] = [
   { slug: SYSTEM_PROMPT_SLUG, title: SYSTEM_PROMPT_TITLE, body: DEFAULT_SYSTEM_PROMPT },
   { slug: CHANNEL_CHAT_SLUG, title: CHANNEL_CHAT_TITLE, body: DEFAULT_CHANNEL_CHAT_PROMPT },

--- a/packages/core/src/providers/embedding.ts
+++ b/packages/core/src/providers/embedding.ts
@@ -1,21 +1,8 @@
-/**
- * Embedding providers used by KB hybrid search.
- *
- * Pluggable so self-hosters can swap OpenAI for a local model (Ollama,
- * Llamafile) or an OpenAI-compatible vendor (Scaleway Generative APIs,
- * vLLM) without forking. The interface returns vectors of a known
- * dimension; the KB / CMS schema commits to a single dim per deployment,
- * controlled by `MUNIN_EMBEDDING_DIMENSIONS` (default 1536).
- */
-
 import { parseEnvInt } from '../env/index.ts';
 
 export interface EmbeddingProvider {
-  /** Vector dimension this provider produces. Must match the kb schema. */
   readonly dimensions: number;
-  /** Human-readable identifier for telemetry / audit. */
   readonly name: string;
-  /** Embed a batch of texts. Order of returned vectors matches input order. */
   embed(texts: readonly string[]): Promise<number[][]>;
 }
 
@@ -25,21 +12,10 @@ export function embeddingColumnType(): EmbeddingColumnType {
   return process.env.MUNIN_EMBEDDING_COLUMN_TYPE === 'halfvec' ? 'halfvec' : 'vector';
 }
 
-// ─── OpenAI ──────────────────────────────────────────────────────────────────
-
 export interface OpenAIEmbeddingOptions {
   apiKey: string;
   model?: string;
   baseUrl?: string;
-  /**
-   * Request a specific vector dimension. When set:
-   *   1. sent as `dimensions` in the request body (honored by
-   *      text-embedding-3-* and by Scaleway's `qwen3-embedding-8b`),
-   *   2. used as the canonical `this.dimensions`,
-   *   3. enforced after the response: vectors longer than this are
-   *      Matryoshka-truncated and L2-renormalized, vectors shorter
-   *      throw a clear error.
-   */
   dimensions?: number;
 }
 
@@ -102,13 +78,6 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
-// ─── Stub (deterministic, for tests / local dev without a key) ──────────────
-
-/**
- * Hash-based deterministic vector. Same input → same output. Intentionally
- * cheap; not a real embedding. Useful when running tests offline or in CI
- * where calling out to OpenAI would burn credits and be flaky.
- */
 export class StubEmbeddingProvider implements EmbeddingProvider {
   readonly dimensions: number;
   readonly name = 'stub';
@@ -149,25 +118,6 @@ function l2Normalize(vec: number[]): number[] {
   return out;
 }
 
-// ─── Env-based factory ───────────────────────────────────────────────────────
-
-/**
- * Resolve an EmbeddingProvider from environment.
- *
- * `MUNIN_EMBEDDING_PROVIDER`:
- *   `openai` (default if `OPENAI_API_KEY` is set) — uses OpenAI-compatible API.
- *   `stub`   (default if no key) — deterministic in-process embeddings.
- *
- * `OPENAI_API_KEY` / `OPENAI_EMBEDDING_MODEL` / `OPENAI_BASE_URL` configure
- * the OpenAI-compatible provider. Point `OPENAI_BASE_URL` at any
- * OpenAI-protocol server (LM Studio, vLLM, Scaleway Generative APIs, etc.).
- *
- * `OPENAI_EMBEDDING_DIMENSIONS` requests a specific output dimension when
- * the upstream model supports Matryoshka truncation (text-embedding-3-*,
- * qwen3-embedding-*). Must match the schema's `EMBEDDING_DIMENSIONS`
- * (the `MUNIN_EMBEDDING_DIMENSIONS` env var) — the factory cross-validates
- * to surface mismatches at boot rather than as silent corruption later.
- */
 export function readEmbeddingProviderFromEnv(): EmbeddingProvider {
   const explicit = process.env.MUNIN_EMBEDDING_PROVIDER?.toLowerCase();
   const expectedDim = readSchemaDimensionsFromEnv();

--- a/packages/core/src/providers/mailer.ts
+++ b/packages/core/src/providers/mailer.ts
@@ -1,43 +1,18 @@
-/**
- * Transactional email abstraction.
- *
- * Pluggable so self-hosters can pick Resend, Postmark, SES, or a local
- * SMTP. Defaults to Resend since that's the lowest-friction option.
- */
-
 export interface MailMessage {
   to: string;
   subject: string;
-  /** Plain-text body. At least one of `text` or `html` is required. */
   text?: string;
-  /** HTML body. */
   html?: string;
   replyTo?: string;
-  /**
-   * Override the Mailer's default sender for this message. Used by the
-   * email-channel outbound worker so per-channel `from` addresses (e.g.
-   * "Acme Support <support@acme.com>") flow through the same Mailer
-   * instance the rest of the app uses for verify / reset / invite mail.
-   */
   from?: string;
-  /**
-   * Extra headers to stamp on the outgoing message. The email-channel
-   * worker uses this for `Message-ID`, `In-Reply-To`, `References`.
-   * Mailers that don't support custom headers (e.g. some hosted APIs)
-   * should pass through the ones they can and ignore the rest.
-   */
   headers?: Record<string, string>;
 }
 
 export interface Mailer {
-  /** Identifier for telemetry / logs. */
   readonly name: string;
-  /** Default `from` address; senders may override per-message later if needed. */
   readonly from: string;
   send(msg: MailMessage): Promise<void>;
 }
-
-// ─── Resend ──────────────────────────────────────────────────────────────────
 
 export interface ResendMailerOptions {
   apiKey: string;
@@ -86,8 +61,6 @@ export class ResendMailer implements Mailer {
   }
 }
 
-// ─── Generic SMTP (covers Scaleway TEM, Postmark, Mailgun, etc.) ────────────
-
 import { createTransport, type Transporter, type SendMailOptions } from 'nodemailer';
 import { parseEnvBool } from '../env/index.ts';
 
@@ -97,7 +70,6 @@ export interface SmtpMailerOptions {
   user: string;
   password: string;
   from: string;
-  /** When true, uses TLS from the start (implicit TLS, typically port 465). When false (default), starts plain and upgrades via STARTTLS. */
   secure?: boolean;
 }
 
@@ -133,17 +105,10 @@ export class SmtpMailer implements Mailer {
   }
 }
 
-// ─── Stub (collects in-memory; for tests + offline dev) ──────────────────────
-
 export interface SentMessage extends MailMessage {
   sentAt: Date;
 }
 
-/**
- * Collects messages in memory instead of sending. Used in tests and as the
- * default when no email provider is configured (so dev-mode signups don't
- * blow up just because RESEND_API_KEY isn't set yet).
- */
 export class StubMailer implements Mailer {
   readonly name = 'stub';
   readonly from: string;
@@ -168,21 +133,6 @@ export class StubMailer implements Mailer {
   }
 }
 
-// ─── Env-based factory ───────────────────────────────────────────────────────
-
-/**
- * Resolve a Mailer from environment.
- *
- * `MUNIN_MAIL_PROVIDER`:
- *   `resend` — HTTP send via Resend (requires RESEND_API_KEY).
- *   `smtp`   — Generic SMTP (Scaleway TEM, Postmark, Mailgun, …). Requires
- *              MUNIN_SMTP_HOST, MUNIN_SMTP_PORT, MUNIN_SMTP_USER,
- *              MUNIN_SMTP_PASSWORD. Optional MUNIN_SMTP_SECURE=1 forces
- *              implicit TLS (port 465); otherwise STARTTLS is used.
- *   `stub`   — in-memory; default when no provider is configured.
- *
- * `MUNIN_MAIL_FROM` — sender address (e.g. "Munin <hello@getmunin.com>").
- */
 export function readMailerFromEnv(): Mailer {
   const provider = process.env.MUNIN_MAIL_PROVIDER?.toLowerCase();
   const from = process.env.MUNIN_MAIL_FROM ?? 'Munin <no-reply@getmunin.com>';

--- a/packages/core/src/request/audit.ts
+++ b/packages/core/src/request/audit.ts
@@ -13,16 +13,7 @@ export interface AuditEventInput {
   userAgent?: string;
 }
 
-/**
- * Records every mutation and tool call. Reads org/actor/correlation
- * from the current request context.
- */
 export class AuditLogger {
-  /**
-   * Insert an audit row. Failures are logged but do not throw — auditing
-   * must never break the user's request. (Consider this a soft requirement;
-   * if audit is failing repeatedly, we'd want the operator to know.)
-   */
   async record(input: AuditEventInput): Promise<void> {
     const ctx = getCurrentContext();
     const orgId = ctx.actor?.orgId || (input.target?.type === 'org' ? input.target.id : null);

--- a/packages/core/src/request/claims.ts
+++ b/packages/core/src/request/claims.ts
@@ -4,23 +4,11 @@ import { getCurrentContext } from './context.ts';
 
 export interface ClaimResult {
   acquired: boolean;
-  /** When acquired === false: who currently holds the claim and until when. */
   holder?: { agentId: string; expiresAt: Date };
-  /** When acquired === true: the claim row id and expiry. */
   claim?: { id: string; expiresAt: Date };
 }
 
-/**
- * Soft locks: "agent X is working on entity Y for the next N minutes."
- *
- * Lease-based, auto-expiring. Other agents see the holder and back off;
- * nobody waits, nobody deadlocks.
- */
 export class ClaimManager {
-  /**
-   * Try to acquire a claim. Returns acquired:false if a non-expired claim
-   * exists held by a different agent.
-   */
   async acquire(
     entityType: string,
     entityId: string,
@@ -32,7 +20,6 @@ export class ClaimManager {
     const orgId = ctx.actor.orgId;
     const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
 
-    // First, sweep expired claims for this entity to keep the table tidy.
     await ctx.db
       .delete(schema.claims)
       .where(
@@ -44,9 +31,6 @@ export class ClaimManager {
         ),
       );
 
-    // Existing live claim? Only agent-held rows participate here; rows
-    // held by a user (the human take-over flow) live in the same table
-    // but have a different lifecycle and shouldn't block agent claims.
     const existing = await ctx.db
       .select()
       .from(schema.claims)
@@ -69,7 +53,6 @@ export class ClaimManager {
       };
     }
 
-    // Same agent re-acquiring? Extend instead of insert.
     if (live && live.agentId === agentId) {
       await ctx.db
         .update(schema.claims)
@@ -78,7 +61,6 @@ export class ClaimManager {
       return { acquired: true, claim: { id: live.id, expiresAt } };
     }
 
-    // Insert new claim.
     const [row] = await ctx.db
       .insert(schema.claims)
       .values({ orgId, entityType, entityId, agentId, expiresAt })
@@ -87,7 +69,6 @@ export class ClaimManager {
     return { acquired: true, claim: { id: row!.id, expiresAt: row!.expiresAt } };
   }
 
-  /** Release a claim by id (only if you hold it). No-op if not yours / already gone. */
   async release(claimId: string, agentId: string): Promise<void> {
     const ctx = getCurrentContext();
     await ctx.db
@@ -95,7 +76,6 @@ export class ClaimManager {
       .where(and(eq(schema.claims.id, claimId), eq(schema.claims.agentId, agentId)));
   }
 
-  /** Extend an active claim. Returns null if not held by this agent. */
   async extend(claimId: string, agentId: string, ttlSeconds: number): Promise<Date | null> {
     const ctx = getCurrentContext();
     const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
@@ -107,7 +87,6 @@ export class ClaimManager {
     return result[0]?.expiresAt ?? null;
   }
 
-  /** Background sweeper — call periodically (e.g. every minute) to drop expired rows globally. */
   async sweepExpired(): Promise<number> {
     const ctx = getCurrentContext();
     const result = await ctx.db.execute(

--- a/packages/core/src/request/oauth-jwt.ts
+++ b/packages/core/src/request/oauth-jwt.ts
@@ -25,9 +25,6 @@ interface JwksRow {
 
 const jwksCache = new Map<string, VerificationKey>();
 
-// Asymmetric algorithms only. Symmetric HMAC (HS*) is deliberately excluded so a
-// stored/injected `oct` key can never enable an alg-confusion bypass where an
-// HS256 token is verified against public-key bytes. BetterAuth mints EdDSA.
 const ALLOWED_JWT_ALGS = new Set([
   'EdDSA',
   'ES256',

--- a/packages/core/src/webhooks.ts
+++ b/packages/core/src/webhooks.ts
@@ -6,7 +6,6 @@ import { signHmac } from './crypto/primitives.ts';
 export interface WebhookEventInput {
   type: string;
   payload: Record<string, unknown>;
-  /** Loop-prevention. Carry forward when re-emitting events from a webhook handler. */
   hopCount?: number;
 }
 
@@ -17,25 +16,10 @@ export interface EmittedEvent {
   payload: Record<string, unknown>;
 }
 
-/**
- * A delivery sink invoked synchronously inside `emit()` — i.e. inside the
- * request's tenant transaction (`getCurrentContext().db`). Sinks enqueue
- * durable work (queue-table inserts) transactionally with the event; the
- * actual external I/O belongs in an out-of-band worker. The webhooks queue
- * is the built-in sink; integrations (Slack, …) register additional ones.
- */
 export interface EventSink {
   onEvent(event: EmittedEvent): Promise<void>;
 }
 
-/**
- * Records a domain event in the `events` table and queues delivery to
- * every active webhook in the org subscribed to this event type.
- *
- * Delivery is fire-and-forget here; an out-of-band worker (M2+) drains the
- * `webhook_deliveries` table with retries. For v0.4 we run the worker
- * in-process via a setInterval (good enough for a solo-dev MVP).
- */
 export class WebhookDispatcher {
   private readonly sinks: EventSink[] = [];
 
@@ -93,10 +77,6 @@ export class WebhookDispatcher {
     return eventId;
   }
 
-  /**
-   * Build the canonical payload + signature header pair for a delivery.
-   * Used by the worker; exposed here so callers (and tests) can replay.
-   */
   static buildSignedRequest(
     eventType: string,
     eventPayload: Record<string, unknown>,

--- a/packages/dashboard-pages/src/api.ts
+++ b/packages/dashboard-pages/src/api.ts
@@ -1,13 +1,5 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
-/**
- * Fetch helper for control-plane endpoints. Sends the BetterAuth session
- * cookie automatically via `credentials: 'include'`; the backend's AuthGuard
- * resolves it to a user-typed actor scoped to that user's org.
- *
- * Throws `ApiError` with a usable message on non-2xx responses so pages can
- * decide between toast vs full-page error.
- */
 export interface ApiFieldError {
   field: string;
   message: string;
@@ -44,8 +36,6 @@ export class ApiError extends Error {
 }
 
 export interface ApiOptions extends RequestInit {
-  /** Don't send the BetterAuth session cookie. For `@PublicController` endpoints
-   *  that would otherwise trip the credentials-mode CORS preflight check. */
   anonymous?: boolean;
 }
 

--- a/packages/dashboard-pages/src/components/dashboard/get-started.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/get-started.tsx
@@ -63,7 +63,7 @@ export function GetStarted() {
       </header>
 
       <div className="grid gap-9 md:grid-cols-[1.05fr_1fr] items-start">
-        {/* MCP setup column */}
+        {}
         <div className="min-w-0">
           <div className="flex justify-between items-baseline border-b-[1px] border-ink pb-2.5 mb-4 dark:border-foreground">
             <Eyebrow tone="ink" size="sm" className="font-medium">
@@ -146,7 +146,7 @@ export function GetStarted() {
           </div>
         </div>
 
-        {/* Recipes column */}
+        {}
         <div className="min-w-0">
           <div className="flex justify-between items-baseline border-b-[1px] border-ink pb-2.5 mb-4 dark:border-foreground">
             <Eyebrow tone="ink" size="sm" className="font-medium">

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms-blocks.test.ts
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms-blocks.test.ts
@@ -35,15 +35,11 @@ const bodyField: CmsFieldDef = {
   options: { blockTypes: [CALLOUT, HEADING] },
 };
 
-// Mirrors the sidecar the draft API returns: asset id → public URL,
-// reversed here to public URL → asset:// URI for save serialization.
 const reverse = new Map<string, string>([
   ['https://cdn.example.com/logo.png', 'asset://asset_logo'],
   ['https://cdn.example.com/icon.png', 'asset://asset_1'],
 ]);
 
-// How the drawer receives a blocks body: asset props expanded to objects,
-// inline asset:// rewritten to public URLs.
 function loadedBlocks(): SBlock[] {
   return [
     {
@@ -244,7 +240,6 @@ describe('computePatch', () => {
     expect(Object.keys(patch)).toEqual(['body']);
     const body = patch.body as SBlock[];
     expect(body[1]?.props.text).toBe('Introduction');
-    // Untouched callout is still normalized: asset object → id, public URL → asset://.
     expect(body[0]?.props.icon).toBe('asset_1');
     expect(body[0]?.props.text).toBe('See ![logo](asset://asset_logo)');
   });

--- a/packages/dashboard-pages/src/components/munin-topbar.tsx
+++ b/packages/dashboard-pages/src/components/munin-topbar.tsx
@@ -6,7 +6,6 @@ import { Settings as SettingsIcon, ArrowLeft, Menu } from 'lucide-react';
 import { Button } from '@getmunin/ui';
 import type { ReactNode } from 'react';
 
-/* Marketing-topbar treatment: translucent blurred bar with a soft hairline. */
 const topbarChromeBase =
   'sticky top-0 z-40 group-has-[.agent-banner]:top-12 border-b-[1px] border-rule-soft bg-paper/85 backdrop-blur-xl backdrop-saturate-150 dark:border-rule-on-dark dark:bg-[color-mix(in_srgb,var(--card)_85%,transparent)]';
 

--- a/packages/dashboard-pages/src/components/save-error-stage.tsx
+++ b/packages/dashboard-pages/src/components/save-error-stage.tsx
@@ -26,11 +26,6 @@ export interface SaveErrorStageProps {
   retrying?: boolean;
 }
 
-/**
- * Drop-in "save failed" stage for dialog forms. Replaces the form view while
- * preserving the parent component's input state — clicking Back returns to the
- * form with values intact, Retry re-attempts the same submit.
- */
 export function SaveErrorStage({
   detail,
   onBack,

--- a/packages/dashboard-pages/src/lib/dialog-style.ts
+++ b/packages/dashboard-pages/src/lib/dialog-style.ts
@@ -1,12 +1,3 @@
-/**
- * Shared typography + spacing tokens for in-dialog form elements.
- * Dialog forms use a sans-serif prose voice (sentence case, no eyebrow tracking)
- * instead of the editorial mono-caps style used in page chrome.
- *
- * Apply via the component's `className` prop — tailwind-merge resolves conflicts
- * with the component's own base classes.
- */
-
 export const dialogLabelClass =
   'font-sans normal-case tracking-normal text-sm text-ink dark:text-foreground font-semibold leading-none gap-0';
 
@@ -16,9 +7,5 @@ export const dialogHintClass =
 export const dialogButtonClass =
   'font-sans normal-case tracking-normal text-[13px] font-medium h-10 px-4 gap-1.5';
 
-/**
- * Use on `<DialogFooter>` to get the paper-deep footer strip with edge-to-edge
- * background and a hairline above (matches the mockup).
- */
 export const dialogFooterClass =
   '-mx-6 -mb-6 mt-6 px-6 py-3 bg-paper-deep border-t-[1px] border-rule-soft dark:bg-secondary dark:border-rule-on-dark flex flex-col-reverse gap-2 sm:flex-row sm:justify-end';

--- a/packages/dashboard-pages/src/lib/use-load-failed-props.tsx
+++ b/packages/dashboard-pages/src/lib/use-load-failed-props.tsx
@@ -5,17 +5,6 @@ import { useTranslations } from 'next-intl';
 import type { ApiError } from '../api';
 import type { LoadFailedProps } from '../components/load-failed';
 
-/**
- * Returns a function that builds settings-size `<LoadFailed>` props from an
- * `ApiError`. All visible strings are pulled from `dashboard.loadFailed.*`
- * translations.
- *
- * Usage:
- *   const buildLoadFailed = useSettingsLoadFailedProps();
- *   if (loadError && !hasLoadedOnce) {
- *     return <LoadFailed {...buildLoadFailed('team', loadError, () => void retry(), retrying)} />;
- *   }
- */
 export function useSettingsLoadFailedProps() {
   const t = useTranslations('dashboard.loadFailed');
   const tCommon = useTranslations('common');
@@ -46,10 +35,6 @@ export function useSettingsLoadFailedProps() {
   );
 }
 
-/**
- * Returns a function that builds inbox-size `<LoadFailed>` props from an
- * `ApiError`. Inbox uses a larger heading and a flock-themed copy line.
- */
 export function useInboxLoadFailedProps() {
   const t = useTranslations('dashboard.loadFailed');
   const tCommon = useTranslations('common');

--- a/packages/dashboard-pages/src/lib/use-load-gate.ts
+++ b/packages/dashboard-pages/src/lib/use-load-gate.ts
@@ -3,16 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError } from '../api';
 
-/**
- * Tracks initial-load state for a page that fetches data on mount.
- *
- * Pages should call `tryLoad()` from an effect. The first failure becomes
- * `loadError`; once a load succeeds, `hasLoadedOnce` flips to `true` and
- * subsequent failures still update `loadError` but the page can choose to
- * keep rendering its last-good data instead of replacing the view.
- *
- * Auto-retries every 30s while `loadError` is set.
- */
 export function useLoadGate(loader: () => Promise<void>) {
   const [loadError, setLoadError] = useState<ApiError | null>(null);
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);

--- a/packages/dashboard-pages/src/lib/validators.ts
+++ b/packages/dashboard-pages/src/lib/validators.ts
@@ -1,11 +1,3 @@
-/**
- * Lightweight client-side validators for use inside dialog forms.
- * Each returns `true` when the input is acceptable, `false` otherwise.
- * They are intentionally permissive — the backend's Zod schemas are the
- * source of truth; these just filter out clearly-malformed input so we
- * don't waste a network round-trip on it.
- */
-
 const HOST_RE =
   /^(localhost|(?:\d{1,3}\.){3}\d{1,3}|[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+)$/;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -18,8 +18,6 @@ export interface OAuthClientInfo {
 }
 
 export interface OAuthConsentPageProps {
-  /** Server-fetched client info. If `null`, the page falls back to client-side
-   *  rendering of the raw `client_id` (e.g. when the lookup failed). */
   clientInfo: OAuthClientInfo | null;
 }
 
@@ -191,8 +189,6 @@ export function OAuthConsentPage({ clientInfo }: OAuthConsentPageProps) {
   );
 }
 
-// ─── editorial header ────────────────────────────────────────────────
-
 interface EditorialHeaderProps {
   flow: FlowState;
   clientName: string;
@@ -253,8 +249,6 @@ function EditorialHeader({ flow, clientName }: EditorialHeaderProps) {
     </header>
   );
 }
-
-// ─── request pane (the `new` state) ─────────────────────────────────
 
 interface RequestPaneProps {
   clientInfo: OAuthClientInfo | null;
@@ -327,8 +321,6 @@ function RequestPane({
   );
 }
 
-// ─── identity card ──────────────────────────────────────────────────
-
 interface IdentityCardProps {
   clientInfo: OAuthClientInfo | null;
   clientId: string;
@@ -382,8 +374,6 @@ function formatRegistered(iso: string | undefined): string | null {
   return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
 }
 
-// ─── trust timeline ─────────────────────────────────────────────────
-
 function TrustTimeline({ clientName }: { clientName: string }) {
   const t = useTranslations('dashboard.oauthConsent');
   return (
@@ -402,8 +392,6 @@ function TrustTimeline({ clientName }: { clientName: string }) {
     </div>
   );
 }
-
-// ─── permission row ─────────────────────────────────────────────────
 
 function PermissionRow({ group }: { group: ModuleScopes }) {
   const t = useTranslations('dashboard.oauthConsent');
@@ -440,8 +428,6 @@ function ScopePill({ kind, label }: { kind: 'read' | 'write'; label: string }) {
   );
 }
 
-// ─── reassurance ────────────────────────────────────────────────────
-
 function ReassuranceBlock({ displayName, userName }: { displayName: string; userName: string }) {
   const t = useTranslations('dashboard.oauthConsent');
   return (
@@ -459,8 +445,6 @@ function ReassuranceBlock({ displayName, userName }: { displayName: string; user
     </div>
   );
 }
-
-// ─── actions ────────────────────────────────────────────────────────
 
 interface ActionsFooterProps {
   userName: string;
@@ -512,8 +496,6 @@ function ActionsFooter({ userName, busy, onAuthorize, onDeny, onSwitchAccount }:
     </div>
   );
 }
-
-// ─── result pane (granted / denied) ─────────────────────────────────
 
 function ResultPane({
   flow,
@@ -582,8 +564,6 @@ function Spinner() {
     />
   );
 }
-
-// ─── inline keyframes (kept local so we don't bloat global CSS) ─────
 
 if (typeof document !== 'undefined') {
   const id = 'munin-consent-spin-keyframes';

--- a/packages/dashboard-pages/src/pages/team.tsx
+++ b/packages/dashboard-pages/src/pages/team.tsx
@@ -482,9 +482,7 @@ function EditMemberDialog({
       if (isSelf) {
         try {
           await authClient.updateUser({ name: trimmed });
-        } catch {
-          /* Better Auth session refresh is best-effort */
-        }
+        } catch {}
       }
       onClose();
     } catch (err) {

--- a/packages/db/src/id.ts
+++ b/packages/db/src/id.ts
@@ -3,7 +3,6 @@ import { randomBytes } from 'node:crypto';
 const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
 const ACCEPT_MAX = 256 - (256 % ALPHABET.length);
 
-/** Generate a short random suffix using a-z0-9, length 22 (≈113 bits of entropy). */
 function suffix(): string {
   let out = '';
   while (out.length < 22) {
@@ -16,10 +15,6 @@ function suffix(): string {
   return out;
 }
 
-/**
- * Build a prefixed ID like `org_<22-char-suffix>`.
- * Stripe-style. Far more useful in logs and APIs than raw UUIDs.
- */
 export function makeId(prefix: string): string {
   return `${prefix}_${suffix()}`;
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -8,22 +8,6 @@ import { dirname, resolve } from 'node:path';
 const REQUIRED_EXTENSIONS = ['vector', 'pg_trgm', 'citext', 'pgcrypto'];
 const APP_ROLE = 'munin_app';
 
-/**
- * Run Drizzle migrations against the given Postgres connection string.
- *
- * Steps, in order:
- *   1. Ensure required Postgres extensions exist (pgvector, pg_trgm, citext, pgcrypto).
- *   2. Apply Drizzle SQL migrations from packages/db/drizzle/.
- *   3. Apply RLS policies from packages/db/src/sql/rls.sql.
- *   4. Ensure a non-superuser application role `munin_app` exists with
- *      CRUD privileges on the public schema. Application traffic should
- *      connect as this role so RLS policies are enforced (Postgres
- *      superusers always bypass RLS by design, regardless of FORCE).
- *
- * Idempotent: each step is safe to re-run. Should be invoked with
- * credentials that can CREATE EXTENSION and CREATE ROLE — typically the
- * database owner or a superuser.
- */
 export async function runMigrations(connectionString: string, migrationsFolder?: string) {
   const here = dirname(fileURLToPath(import.meta.url));
   const folder = migrationsFolder ?? resolve(here, '..', 'drizzle');
@@ -42,17 +26,12 @@ export async function runMigrations(connectionString: string, migrationsFolder?:
   const client = postgres(connectionString, { max: 1 });
   const db = drizzle(client);
 
-  // 1. Extensions.
   for (const ext of REQUIRED_EXTENSIONS) {
     await client.unsafe(`CREATE EXTENSION IF NOT EXISTS ${ext};`);
   }
 
-  // 2. Schema migrations.
   await migrate(db, { migrationsFolder: folder });
 
-  // 3. RLS policies and module post-migration SQL (FTS columns, HNSW indexes,
-  //    per-module RLS, helper functions). postgres-js client.unsafe supports
-  //    multi-statement scripts.
   await client.unsafe(readFileSync(rlsPath, 'utf8'));
   await client.unsafe(readFileSync(kbPath, 'utf8'));
   await client.unsafe(readFileSync(convPath, 'utf8'));
@@ -64,8 +43,6 @@ export async function runMigrations(connectionString: string, migrationsFolder?:
   await client.unsafe(readFileSync(slackPath, 'utf8'));
   await client.unsafe(readFileSync(connectorsPath, 'utf8'));
 
-  // 4. App role (idempotent). Password defaults to the role name; override
-  //    via MUNIN_APP_PASSWORD for non-dev deployments.
   const appPassword = process.env.MUNIN_APP_PASSWORD ?? APP_ROLE;
   await client.unsafe(`
     DO $$
@@ -94,9 +71,6 @@ function escapeSqlLiteral(s: string): string {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  // Migrations need owner privileges (CREATE EXTENSION, CREATE ROLE).
-  // Prefer the privileged MUNIN_MIGRATE_URL when present; fall back to
-  // DATABASE_URL for dev where they're often the same.
   const url = process.env.MUNIN_MIGRATE_URL ?? process.env.DATABASE_URL;
   if (!url) {
     console.error('MUNIN_MIGRATE_URL or DATABASE_URL is required');

--- a/packages/db/src/migrations-journal.test.ts
+++ b/packages/db/src/migrations-journal.test.ts
@@ -29,13 +29,6 @@ describe('drizzle migration journal', () => {
     });
   });
 
-  // The bug this guards against: drizzle's migrator applies a migration only when
-  // its `when` is greater than the newest timestamp already recorded in the target
-  // database. A migration whose `when` is *lower* than an earlier one is therefore
-  // silently skipped on any DB that is already past that earlier timestamp — while
-  // a fresh DB (CI) applies everything in idx order and looks fine. So an out-of-order
-  // timestamp only breaks real, already-migrated deployments. Keep `when` strictly
-  // increasing with idx and CI catches it before release.
   it('`when` timestamps are strictly increasing with idx', () => {
     for (let i = 1; i < entries.length; i++) {
       const prev = entries[i - 1]!;

--- a/packages/db/src/rls.test.ts
+++ b/packages/db/src/rls.test.ts
@@ -14,14 +14,9 @@ const skipReason = TEST_URL
   let orgB: string;
 
   beforeAll(async () => {
-    // Assumes migrations have already been run (locally: `pnpm db:migrate`;
-    // in CI: the workflow's migrate step). The munin_app role must exist.
-    // Connect as the non-superuser app role so RLS policies actually apply —
-    // Postgres superusers always bypass RLS regardless of FORCE.
     const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
     client = postgres(appUrl, { max: 2 });
 
-    // Create two orgs in service-role mode (bypass via session-local GUC).
     await client.begin(async (sql) => {
       await sql`SELECT set_config('app.bypass_rls', 'on', true)`;
       const ts = Date.now();
@@ -45,7 +40,6 @@ const skipReason = TEST_URL
 
   afterAll(async () => {
     if (!client) return;
-    // Clean up
     await client.begin(async (sql) => {
       await sql`SELECT set_config('app.bypass_rls', 'on', true)`;
       await sql`DELETE FROM end_users WHERE org_id IN (${orgA}, ${orgB})`;
@@ -98,7 +92,6 @@ const skipReason = TEST_URL
   });
 
   it('delegated end-user scope further constrains visibility to that user', async () => {
-    // Find Org A's eu id.
     const aEu = await client.begin(async (sql) => {
       await sql`SELECT set_config('app.bypass_rls', 'on', true)`;
       const rows = await sql`SELECT id FROM end_users WHERE org_id = ${orgA} LIMIT 1`;
@@ -116,12 +109,6 @@ const skipReason = TEST_URL
     expect(rows[0]!.id).toBe(aEu);
   });
 
-  // Meta-test: enforce the "every org-scoped table has RLS" invariant.
-  // If you add a new table with an `org_id` column, you must also enable
-  // row-level security on it and add a tenant_isolation policy (typically
-  // in packages/db/src/sql/<module>.sql). The few exempt tables are listed
-  // explicitly below — usually because tenancy is delegated to a parent
-  // table's policy via FK or the table is a system-level catalog.
   it('every table with an org_id column has RLS enabled', async () => {
     const exempt = new Set<string>([]);
     const rows = await client.begin(async (sql) => {

--- a/packages/docs-pages/src/_components/copy-prompt-button.tsx
+++ b/packages/docs-pages/src/_components/copy-prompt-button.tsx
@@ -18,7 +18,6 @@ export function CopyPromptButton({ prompt, label }: CopyPromptButtonProps) {
         setTimeout(() => setCopied(false), 1400);
       })
       .catch(() => {
-        /* noop */
       });
   }
 

--- a/packages/docs-pages/src/_components/curl-block.tsx
+++ b/packages/docs-pages/src/_components/curl-block.tsx
@@ -12,7 +12,6 @@ export function CurlBlock({ command, label }: { command: string; label?: string 
         setTimeout(() => setCopied(false), 1200);
       })
       .catch(() => {
-        /* noop */
       });
   };
   return (

--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -22,6 +22,7 @@ export default tseslint.config(
       },
     },
     rules: {
+      'no-empty': ['error', { allowEmptyCatch: true }],
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/consistent-type-imports': ['warn', { prefer: 'type-imports' }],

--- a/packages/mcp-toolkit/src/decorator.ts
+++ b/packages/mcp-toolkit/src/decorator.ts
@@ -2,15 +2,6 @@ import 'reflect-metadata';
 import type { z } from 'zod';
 import type { Audience } from '@getmunin/core';
 
-/**
- * Metadata captured by the @McpTool() decorator.
- *
- * - `audiences` controls which token types can see/call this tool. Self-service
- *   tokens never see admin-only tools (filtered from tools/list).
- * - `scopes` is checked at call time; missing scopes return an error.
- * - `input` is a Zod schema; converted to JSON Schema for tools/list and used
- *   for runtime validation on tools/call.
- */
 export interface McpToolMeta<TInput extends z.ZodObject = z.ZodObject> {
   name: string;
   description: string;
@@ -25,30 +16,12 @@ export interface McpToolMeta<TInput extends z.ZodObject = z.ZodObject> {
 
 export const MCP_TOOL_META = Symbol.for('munin.mcp.tool.meta');
 
-/**
- * Decorator marking a method as an MCP tool. The runtime registry
- * (M0.5+) uses NestJS DiscoveryService to find every method carrying
- * this metadata and registers it as a callable MCP tool.
- *
- * Usage:
- * ```ts
- *   @McpTool({
- *     name: 'kb_search',
- *     description: 'Search knowledge base documents',
- *     audiences: ['admin', 'self_service'],
- *     scopes: ['kb:read'],
- *     input: z.object({ query: z.string() }),
- *   })
- *   async search(args: { query: string }) { ... }
- * ```
- */
 export function McpTool<T extends z.ZodObject>(meta: McpToolMeta<T>) {
   return function (target: object, propertyKey: string | symbol): void {
     Reflect.defineMetadata(MCP_TOOL_META, meta, target, propertyKey);
   };
 }
 
-/** Read the metadata stored by @McpTool, if any. */
 export function getMcpToolMeta(target: object, propertyKey: string | symbol): McpToolMeta | undefined {
   return Reflect.getMetadata(MCP_TOOL_META, target, propertyKey) as McpToolMeta | undefined;
 }

--- a/packages/mcp-toolkit/src/dispatch.ts
+++ b/packages/mcp-toolkit/src/dispatch.ts
@@ -204,9 +204,6 @@ export async function callTool(
     content: [
       {
         type: 'text' as const,
-        // JSON.stringify(undefined) returns undefined (not a string), which fails
-        // the MCP CallToolResult schema. Coalesce so a void-returning tool still
-        // yields a valid result instead of a transport-level -32602 error.
         text: typeof value === 'string' ? value : JSON.stringify(value ?? null),
       },
     ],

--- a/packages/mcp-toolkit/src/in-process-client.test.ts
+++ b/packages/mcp-toolkit/src/in-process-client.test.ts
@@ -117,8 +117,6 @@ describe('openInProcessMcpClient', () => {
   });
 
   it('callTool coerces a void return into a valid text result (never undefined)', async () => {
-    // Regression: JSON.stringify(undefined) === undefined, which fails the MCP
-    // CallToolResult schema and surfaces as a transport-level -32602 error.
     const client = openInProcessMcpClient({
       registry: buildRegistry(),
       actor: adminActor(),

--- a/packages/mcp-toolkit/src/registry.ts
+++ b/packages/mcp-toolkit/src/registry.ts
@@ -4,18 +4,10 @@ import type { McpToolMeta } from './decorator.ts';
 
 export interface RegisteredMcpTool {
   meta: McpToolMeta;
-  /** Bound handler — already has `this` resolved to the providing service instance. */
   handler: (args: unknown) => unknown;
-  /** JSON Schema (draft 2020-12) generated from meta.input via zod 4. */
   inputJsonSchema: object;
 }
 
-/**
- * Holds every @McpTool-decorated method discovered at app boot.
- *
- * Lookup is by tool name (unique). Registration order is preserved so the
- * tools/list response is stable.
- */
 export class McpToolRegistry {
   private readonly byName = new Map<string, RegisteredMcpTool>();
 
@@ -27,7 +19,6 @@ export class McpToolRegistry {
     this.byName.set(meta.name, { meta, handler, inputJsonSchema });
   }
 
-  /** All tools, optionally filtered to those visible to the given audience. */
   list(audience?: Audience): RegisteredMcpTool[] {
     const all = Array.from(this.byName.values());
     if (!audience) return all;

--- a/packages/mcp-toolkit/src/skill-tools.ts
+++ b/packages/mcp-toolkit/src/skill-tools.ts
@@ -3,15 +3,6 @@ import type { Audience } from '@getmunin/core';
 export const SKILLS_LIST_TOOL = 'skills_list';
 export const SKILLS_READ_TOOL = 'skills_read';
 
-/**
- * Single source of truth for the synthetic skill tools. These mirror the MCP
- * `resources/list` / `resources/read` surface as plain tools so clients that
- * don't expose server resources can still discover and read `skill://` guides.
- *
- * Consumed both by the dispatch layer (live `tools/list`) and the public tool
- * catalog so the two never drift. They carry no scopes; output is filtered by
- * the caller's audience at call time.
- */
 export interface SkillToolDescriptor {
   name: string;
   title: string;

--- a/packages/ui/src/tailwind-preset.ts
+++ b/packages/ui/src/tailwind-preset.ts
@@ -7,8 +7,6 @@ const muninPreset: Omit<Config, 'content'> = {
   },
   theme: {
     extend: {
-      // Tailwind v3 ships no default `invalid` aria variant (v4 does), so
-      // `aria-invalid:*` utilities compile to nothing without this.
       aria: {
         invalid: 'invalid="true"',
       },

--- a/packages/widget-voice/src/signaling.ts
+++ b/packages/widget-voice/src/signaling.ts
@@ -1,30 +1,14 @@
 import type { VoiceTranscriptEvent } from './types.ts';
 
-/**
- * Callbacks the generic WebRtcVoiceSession registers with a SignalingChannel.
- * A channel translates the vendor's WebSocket message framing into these.
- */
 export interface SignalingHandlers {
-  /** Remote SDP answer received. */
   onAnswer(sdp: string): void;
-  /** Remote trickle ICE candidate (vendors that embed ICE in the answer never call this). */
   onRemoteCandidate(candidate: RTCIceCandidateInit): void;
-  /** A transcript turn delivered over the signaling channel, if the vendor supports it. */
   onTranscript(event: VoiceTranscriptEvent): void;
-  /** A vendor-specific lifecycle/state string, if delivered over the channel. */
   onRemoteState(state: string): void;
-  /** The signaling channel closed. */
   onClosed(): void;
-  /** A transport-level error. */
   onError(error: Error): void;
 }
 
-/**
- * The vendor-specific half of the in-browser WebRTC path: owns the WebSocket
- * and the vendor's message framing. The generic session owns the peer
- * connection and media. Add a new SDK-less vendor by implementing this and
- * registering it under a protocol name.
- */
 export interface SignalingChannel {
   open(handlers: SignalingHandlers): Promise<void>;
   sendOffer(sdp: string): void;

--- a/packages/widget-voice/src/types.ts
+++ b/packages/widget-voice/src/types.ts
@@ -43,13 +43,6 @@ export interface VapiVoiceDescriptor {
   assistantOverrides?: Record<string, unknown>;
 }
 
-/**
- * Generic browser-WebRTC descriptor for vendors that expose raw signaling
- * (a WebSocket + single-use token + ICE servers) instead of a drop-in SDK.
- * `signalingProtocol` selects the registered signaling adapter that knows the
- * vendor's WS message framing; everything else (peer connection, media, state)
- * is handled generically by WebRtcVoiceSession.
- */
 export interface WebRtcVoiceDescriptor {
   vendor: string;
   transport: 'webrtc';

--- a/packages/widget-voice/src/vendors/threll-signaling.ts
+++ b/packages/widget-voice/src/vendors/threll-signaling.ts
@@ -19,16 +19,6 @@ interface ThrellEvent {
   isFinal?: boolean;
 }
 
-/**
- * Signaling adapter for Threll's web-call WebSocket.
- *
- * Protocol (threll-voice-server `/ws/sessions/{sessionId}`):
- *   - client → server first frame: { event: 'offer', sdp, sessionId }
- *   - server → client: { type: 'answer', sdp }  (server ICE embedded in the answer)
- *   - client → server (optional trickle): { type: 'candidate', candidate, sdpMid, sdpMLineIndex }
- *     and { type: 'ice-complete' }
- *   - server → client events: { type: 'event', event: 'state'|'transcript', ... }
- */
 class ThrellSignalingChannel implements SignalingChannel {
   private ws: WebSocket | null = null;
 

--- a/packages/widget-voice/src/webrtc-session.ts
+++ b/packages/widget-voice/src/webrtc-session.ts
@@ -7,12 +7,6 @@ import type {
   WebRtcVoiceDescriptor,
 } from './types.ts';
 
-/**
- * Vendor-agnostic in-browser voice session over WebRTC. Owns the peer
- * connection, microphone capture, and remote audio playback; delegates the
- * vendor's signaling framing to a SignalingChannel. Reused by any SDK-less
- * vendor — only the SignalingChannel differs.
- */
 export class WebRtcVoiceSession implements VoiceSession {
   private pc: RTCPeerConnection | null = null;
   private localStream: MediaStream | null = null;
@@ -133,7 +127,6 @@ export class WebRtcVoiceSession implements VoiceSession {
       },
       onRemoteCandidate: (candidate) => {
         void pc.addIceCandidate(candidate).catch(() => {
-          // a failed trickle candidate is non-fatal
         });
       },
       onTranscript: (payload) => {
@@ -164,7 +157,6 @@ export class WebRtcVoiceSession implements VoiceSession {
     }
     this.audioEl.srcObject = stream;
     void this.audioEl.play().catch(() => {
-      // autoplay may be blocked until a user gesture; the widget triggers start on a click
     });
   }
 

--- a/scripts/check-added-comments.mjs
+++ b/scripts/check-added-comments.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+
+const CHECKED_FILE = /\.(ts|tsx|mts|cts)$/;
+
+const EXEMPT_FILES = new Set(['packages/db/src/schema.ts']);
+
+const ALLOWED = [
+  /^\/\/\/\s*<reference\b/,
+  /^\/\/\s*eslint-(disable|enable)/,
+  /^\/\/\s*@ts-(expect-error|ignore|nocheck|check)\b/,
+  /^\/\*\s*(eslint|@ts-|istanbul\s+ignore|v8\s+ignore|@__PURE__|@vite-ignore)/,
+];
+
+function isAllowed(comment) {
+  return ALLOWED.some((re) => re.test(comment));
+}
+
+function trailingCommentIndex(line) {
+  let from = 0;
+  for (;;) {
+    const i = line.indexOf('//', from);
+    if (i <= 0) return -1;
+    if (line[i - 1] === ' ' || line[i - 1] === '\t') return i;
+    from = i + 2;
+  }
+}
+
+function commentIn(line) {
+  const trimmed = line.trim();
+  if (trimmed.startsWith('//') || trimmed.startsWith('/*')) return trimmed;
+  const i = trailingCommentIndex(line);
+  return i === -1 ? null : line.slice(i).trim();
+}
+
+const diff = execFileSync(
+  'git',
+  ['diff', '--cached', '-U0', '--diff-filter=ACMR', '--no-color'],
+  { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+);
+
+let file = null;
+let checking = false;
+let lineNo = 0;
+const findings = [];
+
+for (const raw of diff.split('\n')) {
+  if (raw.startsWith('+++ b/')) {
+    file = raw.slice(6);
+    checking = CHECKED_FILE.test(file) && !EXEMPT_FILES.has(file);
+    continue;
+  }
+  if (raw.startsWith('@@')) {
+    const m = /\+(\d+)/.exec(raw);
+    lineNo = m ? Number(m[1]) : 0;
+    continue;
+  }
+  if (!checking || !raw.startsWith('+') || raw.startsWith('+++')) continue;
+  const line = raw.slice(1);
+  const current = lineNo;
+  lineNo += 1;
+  const comment = commentIn(line);
+  if (comment && !isAllowed(comment)) {
+    findings.push(`${file}:${current}  ${line.trim()}`);
+  }
+}
+
+if (findings.length > 0) {
+  console.error('✖ New comments in staged TS/TSX changes:\n');
+  for (const f of findings) console.error(`  ${f}`);
+  console.error(
+    '\nThis repo keeps TS/TSX comment-free — put rationale in the commit message,',
+  );
+  console.error(
+    'PR body, changeset, or a test name instead. Directives (eslint-disable,',
+  );
+  console.error(
+    '@ts-expect-error, /// <reference>) are allowed. Bypass deliberately with',
+  );
+  console.error('git commit --no-verify.');
+  process.exit(1);
+}


### PR DESCRIPTION
## What

Two-part enforcement of the repo's no-comments convention:

### 1. Pre-commit check for new comments

`scripts/check-added-comments.mjs` runs first in `.husky/pre-commit`. It parses the staged diff (`git diff --cached -U0`) and fails the commit when **added** lines in `.ts/.tsx/.mts/.cts` introduce a comment — own-line `//`, block `/* */`, or trailing `code // note`.

- **Allowed**: `eslint-disable`/`eslint-enable`, `@ts-expect-error`/`@ts-ignore`/`@ts-nocheck`/`@ts-check`, `/// <reference>`, `/* eslint ... */`, istanbul/v8-ignore and `@__PURE__`/`@vite-ignore` pragmas.
- **Exempt**: `packages/db/src/schema.ts` — value-domain notes next to `varchar` columns document data constraints the type system can't express, the TS analog of the repo's SQL-comment exemption. Tests are deliberately NOT exempt.
- **Escape hatch**: `git commit --no-verify`.
- URLs (`https://…`) don't false-positive: trailing detection requires whitespace before `//`.

### 2. One-time strip of existing comments

767 comments removed across 167 files, using typescript-eslint's comment tokens (not regex) — so `//` and `/* */` sequences inside template strings survived untouched: the docs-page code samples (`packages/docs-pages/.../chat-widget/page.tsx`) and the chat-widget's CSS-in-string section markers are intact.

Kept:
- `packages/db/src/schema.ts` (per the exemption above)
- **`packages/sdk` JSDoc** — public API documentation with usage examples, rendered in consumers' IDEs. Flagging explicitly: say the word if this should go too.
- Directives (same allowlist as the check).

Knock-on changes:
- ~10 `catch` blocks whose only body was an "ignore" comment became empty; rather than restructuring each, the shared eslint config now sets `no-empty: allowEmptyCatch` (a standard idiom) and they're bare `catch {}`.
- `apps/analytics-tracker/vite.config.ts`: optional-sourcemap try/catch replaced with an `existsSync` check.
- `apps/analytics-tracker/src/tracker.test.ts`: `clearLocalStorageIfAvailable()` helper replaces two comment-only catches.

Notable rationale that lived only in deleted comments, recorded here for posterity:
- `cms.integration.test.ts` `fetchUntil`: absorbs the commit-visibility race between the MCP request transaction and the delivery controller's separate service-role connection — don't "simplify" to plain `fetch`.
- Same file, drafts-route test: `GET /v1/cms/drafts/:id` and the public wildcard are both 4-segment routes; controller registration order in `control.module.ts` is first-match-wins and therefore load-bearing.
- `cms-delivery.controller.ts` (removed header): runs on a service-role connection because there's no auth for RLS to scope; every SELECT hard-filters `org_id` + `status='published'` (or a verified preview token) so cross-org leakage is impossible.

## Testing

- Check script: scratch file with all comment forms flagged with correct `file:line`; directives, URL-in-string, and `schema.ts` passed; clean stage exits 0; the hook vetted this PR's own commits.
- After the strip: workspace typecheck green; core 377, backend-core 1109 (excluding the 9 known environmental `src/oauth` failures — verified identical on a clean tree), chat-widget 122, agent-host 90, dashboard-pages 39, mcp-toolkit 74, db 24, analytics-tracker 23, widget-voice 22 — all passing.

No changeset: tooling + comment-only changes (the eslint-config package is private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)