### PR TITLE
ci: regenerate THIRD_PARTY_LICENSES.md on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # Branch tip, not the merge commit, so the regen step can push back. Fork PRs
+      # fall back to the default ref: their head branch does not exist here.
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
 
       - uses: pnpm/action-setup@v5
 
@@ -166,6 +170,21 @@ jobs:
 
       - name: Install
         run: pnpm install --frozen-lockfile
+
+      # Dependabot cannot run licenses:generate, so its bumps failed this job by
+      # construction. The check below still runs, so an unapproved license blocks merge.
+      - name: Regenerate notices for Dependabot
+        if: startsWith(github.head_ref, 'dependabot/')
+        run: |
+          pnpm licenses:generate
+          if git diff --quiet -- THIRD_PARTY_LICENSES.md; then
+            echo 'THIRD_PARTY_LICENSES.md already up to date'
+          else
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git commit -m 'chore: regenerate THIRD_PARTY_LICENSES.md' -- THIRD_PARTY_LICENSES.md
+            git push origin HEAD:"$GITHUB_HEAD_REF"
+          fi
 
       - name: Check licenses
         run: pnpm licenses:check


### PR DESCRIPTION
Dependabot PRs could not pass CI in this repo. Both #660 and #661 failed the `license policy` job and passed everything else: Dependabot changes `pnpm-lock.yaml` but cannot run `pnpm licenses:generate`, so `THIRD_PARTY_LICENSES.md` was never regenerated to match. That made the job fail **by construction** on every Dependabot PR, and the failure carried no signal about whether the bump was safe.

The job now regenerates the file and commits it back onto `dependabot/*` branches, then still runs `pnpm licenses:check`. So:

- a stale notices file is auto-fixed instead of blocking
- an **unapproved license** in a newly pulled dependency still fails the job and blocks the merge

Human PRs are unaffected — `lint-staged` already regenerates the file on any lockfile change locally, and the check runs for them exactly as before.

## Notes on the two subtle bits

**Checkout ref.** Pushing a commit needs the branch tip rather than the `pull_request` merge commit, so checkout takes `github.head_ref` — but only for same-repo PRs. Fork PRs fall back to the default ref, because their head branch does not exist in this repo; without that guard the job would break on every external contribution.

**Token.** Confirmed empirically rather than assumed: the Dependabot-triggered run on #661 reported `Contents: write`, so the default `GITHUB_TOKEN` can push here and no PAT or `workflow_run` indirection is needed. Pushes made with `GITHUB_TOKEN` do not retrigger workflows, so there is no loop.

## Verification

- `actionlint` clean on the workflow (validates the `if`/`ref` expressions and shellchecks the `run` block)
- YAML parses; job graph unchanged (`build`, `licenses`, `e2e`)
- Both branches of the shell logic dry-run in a throwaway repo with a real remote: the changed-file path commits **only** `THIRD_PARTY_LICENSES.md` (an unrelated dirty file was left untracked, not swept in) and pushes to the correct branch; the already-current path no-ops without committing

The next Dependabot PR is the real test — if it still fails, the fallback is to keep consolidating bumps by hand as in #658 and #662.

No changeset: this touches only CI config, so no published package's contents change. Happy to add one if you'd rather every merge carry a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)