### PR TITLE
fix(slack): build OAuth redirect URI from the auth origin

### DIFF
--- a/.changeset/slack-oauth-redirect-auth-origin.md
+++ b/.changeset/slack-oauth-redirect-auth-origin.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Build the Slack OAuth redirect URI from the auth origin (`NEXT_PUBLIC_AUTH_URL`) instead of the MCP resource origin, so browser-facing install flows land on the `api.*` host that Slack apps register as the callback. Falls back to the MCP origin when no auth URL is set, matching single-origin self-host deployments.

--- a/packages/backend-core/src/modules/slack/skills/connect-slack.md
+++ b/packages/backend-core/src/modules/slack/skills/connect-slack.md
@@ -58,7 +58,7 @@ Munin cloud ships a Slack app; skip this on cloud. On self-host, check `slack_ge
    - `SLACK_CLIENT_SECRET`
    - `SLACK_SIGNING_SECRET` (signs the Events API requests that power reply-from-Slack)
 
-The redirect URL must exactly match `https://<api-base>/v1/slack/oauth/callback`, and the events request URL `https://<api-base>/v1/slack/events` — the same base that serves `/mcp`. Slack verifies the events URL with a challenge when you save it; the backend must be reachable and have `SLACK_SIGNING_SECRET` set first.
+The redirect URL must exactly match `https://<api-base>/v1/slack/oauth/callback`, and the events request URL `https://<api-base>/v1/slack/events` — where `<api-base>` is the backend's auth origin (`NEXT_PUBLIC_AUTH_URL`, or the origin of `NEXT_PUBLIC_MCP_URL` when unset). Slack verifies the events URL with a challenge when you save it; the backend must be reachable and have `SLACK_SIGNING_SECRET` set first.
 
 Workspaces installed before the `channels:history` scope was added must reinstall via a fresh `slack_get_install_url` link before thread replies reach Munin. Likewise, workspaces installed before `chat:write.customize` was added show mirrored messages with a text author label instead of per-speaker names/icons until reinstalled.
 

--- a/packages/backend-core/src/modules/slack/slack.service.ts
+++ b/packages/backend-core/src/modules/slack/slack.service.ts
@@ -17,7 +17,7 @@ import {
   verifyHmac,
 } from '@getmunin/core';
 import { DB } from '../../common/db/db.module.ts';
-import { mcpResourceOrigin } from '../../oauth/oauth.constants.ts';
+import { authorizationServerUrl } from '../../oauth/oauth.constants.ts';
 import { SlackApiClient, SlackApiError } from './slack-api.client.ts';
 import { testMessageText } from './slack-projection.ts';
 import { readSlackAppConfig, SLACK_BOT_SCOPES } from './slack.constants.ts';
@@ -84,7 +84,7 @@ export interface InstallUrlResult {
 }
 
 export function slackOAuthRedirectUri(): string {
-  return `${mcpResourceOrigin()}/v1/slack/oauth/callback`;
+  return `${authorizationServerUrl()}/v1/slack/oauth/callback`;
 }
 
 export async function encryptSecretValue(db: Db | Tx, plaintext: string): Promise<string> {


### PR DESCRIPTION
## Problem

Slack installs on cloud fail with **"redirect_uri did not match any configured URIs. Passed URI: https://mcp.dev.getmunin.com/v1/slack/oauth/callback"**.

`slackOAuthRedirectUri()` built the callback from `mcpResourceOrigin()` (the origin of `NEXT_PUBLIC_MCP_URL`), so cloud passed the `mcp.*` host while the Slack app registers the `api.*` callback. Per the cloud terraform convention, browser-facing human flows live on `api.*`; machines hit `mcp.*` for MCP — and the Slack install is a browser flow.

## Change

- `slackOAuthRedirectUri()` now builds from `authorizationServerUrl()` — `NEXT_PUBLIC_AUTH_URL` when set (cloud: `https://api.<env>.getmunin.com`), falling back to the MCP origin, so single-origin self-host deployments are unchanged.
- `connect-slack.md` now defines `<api-base>` as the auth origin (with the MCP-origin fallback) instead of "the same base that serves `/mcp`".

## Deploy note

The redirect host flips from `mcp.*` to `api.*` for cloud, so both Slack apps need the `api.*` callback in their OAuth redirect URLs before this ships:

- Munin (dev): `https://api.dev.getmunin.com/v1/slack/oauth/callback`
- Munin (prod): `https://api.getmunin.com/v1/slack/oauth/callback`

Already-installed workspaces are unaffected; this only matters for new installs/reinstalls.

## Testing

- `pnpm -F @getmunin/backend-core typecheck`
- Slack unit tests (install-state, manifest sync) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)