### PR TITLE
fix(auth): link social sign-ins by verified email; redirect OAuth errors to the app

### DIFF
--- a/.changeset/oauth-account-linking.md
+++ b/.changeset/oauth-account-linking.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+Auth: link Google/GitHub sign-ins to an existing account with the same verified email instead of failing with `account_not_linked`. OAuth errors now redirect to the app's login/signup page (via `errorCallbackURL`) instead of the API origin root, which returned a 404.

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -157,7 +157,13 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
         }
       : undefined,
     socialProviders,
-    account: { encryptOAuthTokens: true },
+    account: {
+      encryptOAuthTokens: true,
+      accountLinking: {
+        enabled: true,
+        trustedProviders: ['google', 'github'],
+      },
+    },
     user: opts.deleteUser
       ? {
           deleteUser: {

--- a/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
@@ -11,6 +11,7 @@ import {
   resumeOauthAuthorizeUrl,
   hasOauthAuthorizeParams,
   socialCallbackUrl,
+  absoluteCallbackUrl,
 } from '../../auth/post-signin-redirect';
 import {
   AuthShell,
@@ -120,6 +121,7 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
                 void authClient.signIn.social({
                   provider: 'google',
                   callbackURL: socialCallbackUrl(params, redirectTo),
+                  errorCallbackURL: absoluteCallbackUrl('/login'),
                 });
               }}
             >
@@ -134,6 +136,7 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
                 void authClient.signIn.social({
                   provider: 'github',
                   callbackURL: socialCallbackUrl(params, redirectTo),
+                  errorCallbackURL: absoluteCallbackUrl('/login'),
                 });
               }}
             >

--- a/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
@@ -143,6 +143,7 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
                 void authClient.signIn.social({
                   provider: 'google',
                   callbackURL: socialCallbackUrl(params, redirectTo),
+                  errorCallbackURL: absoluteCallbackUrl('/signup'),
                 });
               }}
             >
@@ -157,6 +158,7 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
                 void authClient.signIn.social({
                   provider: 'github',
                   callbackURL: socialCallbackUrl(params, redirectTo),
+                  errorCallbackURL: absoluteCallbackUrl('/signup'),
                 });
               }}
             >


### PR DESCRIPTION
## Problem

Signing in with Google against an account that already exists (same email, created via email/password or a different provider) fails with `account_not_linked`, and the error redirect lands on the **API origin root** (`https://api.<env>.getmunin.com/?error=account_not_linked`) which has no route → 404 JSON.

## Fix

- **Account linking** (`auth-factory.ts`): enable `account.accountLinking` with `trustedProviders: ['google', 'github']`. Both verify email ownership, so linking a social identity to an existing same-email account is safe (better-auth's documented trusted-provider pattern). The sign-in now links instead of erroring.
- **Error redirect** (`login-form.tsx`, `signup-form.tsx`): pass `errorCallbackURL` (absolute, app origin) on `signIn.social`, so any residual OAuth error returns to the app's `/login` / `/signup` instead of the API root.

## Notes

- `callbackURL` was already absolute to the app origin; only the error path was unset, hence the API-root 404.
- No dep changes (no license regen). Changeset: patch × `backend-core` + `dashboard-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)