### PR TITLE
fix(slack): allow anonymous callers on Slack webhook controllers

### DIFF
--- a/.changeset/slack-webhooks-allow-anonymous.md
+++ b/.changeset/slack-webhooks-allow-anonymous.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Mark the Slack webhook controllers (`/v1/slack/events`, `/v1/slack/interactivity`, `/v1/slack/oauth/*`, `/v1/slack/avatars`) as anonymous-callable via `PublicController`. Deployments that register `AuthGuard` as a global `APP_GUARD` were returning 401 "invalid or expired credential" to Slack before signature verification ever ran, which broke button interactions and inbound event delivery. Slack authenticates these routes with its signing secret (and the OAuth callback with signed state + a nonce cookie), not a Munin credential. The events/interactivity endpoint is now also rate-limited like other public webhook endpoints.

--- a/packages/backend-core/src/modules/slack/slack-avatars.controller.ts
+++ b/packages/backend-core/src/modules/slack/slack-avatars.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Get, NotFoundException, Param, Res } from '@nestjs/common';
+import { Get, NotFoundException, Param, Res } from '@nestjs/common';
 import type { Response } from 'express';
+import { PublicController } from '../../common/auth/auth.guard.ts';
 import { SLACK_AVATAR_FALLBACK_PNG, SLACK_AVATAR_PNGS } from './slack-avatars.generated.ts';
 
 const FILE_RE = /^([A-Z0-9]|default)\.png$/;
 
-@Controller('v1/slack/avatars')
+@PublicController('v1/slack/avatars')
 export class SlackAvatarsController {
   @Get(':file')
   serve(@Param('file') file: string, @Res() res: Response): void {

--- a/packages/backend-core/src/modules/slack/slack-controllers-public.test.ts
+++ b/packages/backend-core/src/modules/slack/slack-controllers-public.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { PATH_METADATA } from '@nestjs/common/constants.js';
+import { ALLOW_ANONYMOUS } from '../../common/auth/auth.guard.ts';
+import { SlackAvatarsController } from './slack-avatars.controller.ts';
+import { SlackEventsController } from './slack-events.controller.ts';
+import { SlackOAuthController } from './slack-oauth.controller.ts';
+
+const cases = [
+  { name: 'SlackEventsController', cls: SlackEventsController, path: 'v1/slack' },
+  { name: 'SlackOAuthController', cls: SlackOAuthController, path: 'v1/slack/oauth' },
+  { name: 'SlackAvatarsController', cls: SlackAvatarsController, path: 'v1/slack/avatars' },
+];
+
+describe('Slack controllers stay callable without a Munin credential when AuthGuard is registered as a global APP_GUARD (Slack signs requests instead of sending a bearer token)', () => {
+  for (const { name, cls, path } of cases) {
+    it(`${name} sets ALLOW_ANONYMOUS and keeps its route path`, () => {
+      expect(Reflect.getMetadata(ALLOW_ANONYMOUS, cls)).toBe(true);
+      expect(Reflect.getMetadata(PATH_METADATA, cls)).toBe(path);
+    });
+  }
+});

--- a/packages/backend-core/src/modules/slack/slack-events.controller.ts
+++ b/packages/backend-core/src/modules/slack/slack-events.controller.ts
@@ -1,13 +1,14 @@
-import { Controller, HttpCode, Logger, Post, Req, Res } from '@nestjs/common';
+import { HttpCode, Logger, Post, Req, Res } from '@nestjs/common';
 import type { RawBodyRequest } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { describeError } from '@getmunin/core';
+import { PublicController } from '../../common/auth/auth.guard.ts';
 import { SlackInboundService } from './slack-inbound.service.ts';
 import { SlackInteractionsService } from './slack-interactions.service.ts';
 import { verifySlackSignature } from './slack-signature.ts';
 import { readSlackSigningSecret } from './slack.constants.ts';
 
-@Controller('v1/slack')
+@PublicController('v1/slack', { throttle: true })
 export class SlackEventsController {
   private readonly logger = new Logger(SlackEventsController.name);
 

--- a/packages/backend-core/src/modules/slack/slack-oauth.controller.ts
+++ b/packages/backend-core/src/modules/slack/slack-oauth.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Query, Req, Res } from '@nestjs/common';
+import { Get, Query, Req, Res } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
+import { PublicController } from '../../common/auth/auth.guard.ts';
 import { SlackService, SLACK_INSTALL_NONCE_COOKIE } from './slack.service.ts';
 import { readWebBaseUrl } from './slack.constants.ts';
 
@@ -20,7 +21,7 @@ function readCookie(header: string | undefined, name: string): string | null {
   return null;
 }
 
-@Controller('v1/slack/oauth')
+@PublicController('v1/slack/oauth')
 export class SlackOAuthController {
   constructor(private readonly slack: SlackService) {}
 

--- a/packages/backend-core/src/modules/slack/slack.module.ts
+++ b/packages/backend-core/src/modules/slack/slack.module.ts
@@ -1,5 +1,6 @@
 import { Inject, Module, OnModuleInit } from '@nestjs/common';
 import { WebhookDispatcher } from '@getmunin/core';
+import { PublicThrottleModule } from '../../common/rate-limit/public-throttle.module.ts';
 import { ConvModule } from '../conv/conv.module.ts';
 import { CrmModule } from '../crm/crm.module.ts';
 import { KbModule } from '../kb/kb.module.ts';
@@ -17,7 +18,7 @@ import { SlackEventsController } from './slack-events.controller.ts';
 import { SlackAvatarsController } from './slack-avatars.controller.ts';
 
 @Module({
-  imports: [ConvModule, CrmModule, KbModule, OutreachModule],
+  imports: [ConvModule, CrmModule, KbModule, OutreachModule, PublicThrottleModule],
   providers: [
     SlackApiClient,
     SlackService,


### PR DESCRIPTION
## Problem

In munin-cloud, clicking a button on a mirrored conversation in Slack fails with **"This app responded with Status Code 401"**.

Probing prod confirms the 401 is not the controller's signature check — it's `AuthGuard`:

```
POST https://api.getmunin.com/v1/slack/interactivity  (unsigned)
→ 401 {"message":"invalid or expired credential","error":"Unauthorized","statusCode":401}
```

OSS applies `AuthGuard` per controller, so the Slack webhook controllers worked there. munin-cloud registers it as a global `APP_GUARD`, and none of the Slack controllers carried `ALLOW_ANONYMOUS` — so every Slack-originated request (interactivity clicks, event deliveries, avatar fetches) was rejected before signature verification ran. Inbound event delivery (`/v1/slack/events`) was silently broken too; Slack will disable an events URL that keeps failing.

## Fix

Switch the three Slack controllers to `PublicController`, matching `channel-webhook.controller.ts`:

- `SlackEventsController` → `@PublicController('v1/slack', { throttle: true })` — auth is the Slack signing-secret HMAC.
- `SlackOAuthController` → `@PublicController('v1/slack/oauth')` — auth is signed state + install nonce cookie.
- `SlackAvatarsController` → `@PublicController('v1/slack/avatars')` — static immutable PNGs.

`SlackModule` now imports `PublicThrottleModule` so the events/interactivity `ThrottlerGuard` resolves.

## Regression test

`slack-controllers-public.test.ts` asserts all three controllers set `ALLOW_ANONYMOUS` (the metadata a global `APP_GUARD` honors) and keep their route paths.

## After deploy

Check the Slack app admin → Event Subscriptions: if Slack disabled the events URL after repeated failures, it needs a re-verify there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)