### PR TITLE
feat(slack): thread outreach approvals per campaign with daily parents and a full-draft modal

### DIFF
--- a/.changeset/slack-outreach-approval-threads.md
+++ b/.changeset/slack-outreach-approval-threads.md
@@ -1,0 +1,6 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/db': patch
+---
+
+Slack outreach approvals now thread per campaign instead of posting one standalone message per draft: a parent message carries a live pending count (flipping to an all-handled banner at zero, with one parent per campaign per UTC day, so daily waves never land in a buried thread), each draft posts as a compact thread reply with a shorter body preview, and a new *View full draft* button opens the complete subject and body in a Slack modal so reviewing no longer requires the dashboard.

--- a/packages/backend-core/src/modules/slack/skills/connect-slack.md
+++ b/packages/backend-core/src/modules/slack/skills/connect-slack.md
@@ -109,11 +109,11 @@ Call `slack_test` — it posts a hello message to the default channel. Then conf
 
 ## Approval notifications
 
-Items waiting on a human decision post as standalone messages (not threads) with approve/dismiss buttons, and the message updates in place once the item is decided — from Slack, the dashboard, or an agent:
+Items waiting on a human decision post with approve/dismiss buttons, and the message updates in place once the item is decided — from Slack, the dashboard, or an agent:
 
-- **CRM merge proposals** — duplicate contacts with the recommended keeper and confidence. *Apply merge* / *Dismiss*.
-- **Outreach drafts** — pending proposals with campaign, recipient, subject, and a body preview. *Approve & send* (this sends the real email) / *Dismiss*. Draft edits refresh the message.
-- **KB curation candidates** — drafted knowledge-base articles awaiting review. *Publish to \<space\>* when the draft proposes a target space, otherwise only *Dismiss* (deletes the draft) plus a dashboard link for picking a space.
+- **CRM merge proposals** — standalone messages: duplicate contacts with the recommended keeper and confidence. *Apply merge* / *Dismiss*.
+- **Outreach drafts** — grouped per campaign: one parent message with a live pending count, each draft a thread reply with campaign, recipient, subject, and a short body preview. *Approve & send* (this sends the real email) / *View full draft* (opens the complete draft in a modal, no dashboard needed) / *Dismiss*. Draft edits refresh the reply. When every draft in the wave is decided the parent flips to an all-handled banner. Parents last one day (UTC): the first draft of a new day posts a fresh parent (the campaign-wide pending count moves with it), and a previous parent that still showed pending drafts is rewritten to a "continued in a newer thread" notice — its still-pending replies stay actionable.
+- **KB curation candidates** — standalone messages: drafted knowledge-base articles awaiting review. *Publish to \<space\>* when the draft proposes a target space, otherwise only *Dismiss* (deletes the draft) plus a dashboard link for picking a space.
 
 Routing: they land in the `approvals` channel when routed (`slack_set_routing` with `purpose: "approvals"`), otherwise fall back to the escalations channel, then the default channel:
 

--- a/packages/backend-core/src/modules/slack/slack-api.client.ts
+++ b/packages/backend-core/src/modules/slack/slack-api.client.ts
@@ -81,6 +81,17 @@ export class SlackApiClient {
     });
   }
 
+  async openView(input: {
+    token: string;
+    triggerId: string;
+    view: Record<string, unknown>;
+  }): Promise<void> {
+    await this.call('views.open', input.token, {
+      trigger_id: input.triggerId,
+      view: input.view,
+    });
+  }
+
   async postEphemeral(input: {
     token: string;
     channel: string;

--- a/packages/backend-core/src/modules/slack/slack-approvals.integration.test.ts
+++ b/packages/backend-core/src/modules/slack/slack-approvals.integration.test.ts
@@ -39,7 +39,7 @@ class FakeSlackApi extends SlackApiClient {
       throw new SlackApiError('rate_limited', 1_000);
     }
     this.counter += 1;
-    const ts = `1700000000.${String(this.counter).padStart(6, '0')}`;
+    const ts = `${Math.floor(Date.now() / 1000)}.${String(this.counter).padStart(6, '0')}`;
     this.posted.push({
       channel: input.channel,
       text: input.text,
@@ -257,13 +257,13 @@ function buttonLabels(blocks: unknown[] | undefined): string[] {
     };
   }
 
-  async function seedOutreachProposal(): Promise<string> {
+  async function seedOutreachProposal(contactId = contactAId): Promise<string> {
     const [proposal] = await db
       .insert(schema.outreachProposals)
       .values({
         orgId,
         campaignId,
-        contactId: contactAId,
+        contactId,
         kind: 'initial',
         draftSubject: 'Hello from Munin',
         draftBody: 'We just launched — want a demo?',
@@ -469,7 +469,7 @@ function buttonLabels(blocks: unknown[] | undefined): string[] {
     expect(api.updated).toHaveLength(1);
   });
 
-  it('posts outreach drafts without opening a conversation thread, then resolves on sent', async () => {
+  it('posts outreach drafts as thread replies under a campaign parent, then resolves on sent', async () => {
     const api = new FakeSlackApi();
     const worker = new SlackBridgeWorker(db, api);
     const proposalId = await seedOutreachProposal();
@@ -483,12 +483,23 @@ function buttonLabels(blocks: unknown[] | undefined): string[] {
     expect(delivery!.conversationId).toBeNull();
 
     await worker.tick();
-    expect(api.posted).toHaveLength(1);
-    const posted = api.posted[0]!;
-    expect(posted.threadTs).toBeUndefined();
-    expect(posted.text).toContain('Outreach draft awaiting approval');
-    expect(posted.text).toContain('Hello from Munin');
-    expect(buttonLabels(posted.blocks)).toEqual(['Approve & send', 'Dismiss']);
+    expect(api.posted).toHaveLength(2);
+    const parent = api.posted[0]!;
+    expect(parent.threadTs).toBeUndefined();
+    expect(parent.text).toContain('Outreach drafts awaiting approval — Spring launch');
+    const reply = api.posted[1]!;
+    expect(reply.threadTs).toBe(parent.ts);
+    expect(reply.text).toContain('Outreach draft awaiting approval');
+    expect(reply.text).toContain('Hello from Munin');
+    expect(buttonLabels(reply.blocks)).toEqual(['Approve & send', 'View full draft', 'Dismiss']);
+
+    expect(api.updated).toHaveLength(1);
+    expect(api.updated[0]!.ts).toBe(parent.ts);
+    expect(api.updated[0]!.text).toContain('1 draft pending');
+
+    const parentLink = await notificationLink('outreach_campaign', campaignId);
+    expect(parentLink?.slackTs).toBe(parent.ts);
+    expect(parentLink?.resolvedAt).toBeNull();
 
     await db
       .update(schema.outreachProposals)
@@ -502,9 +513,101 @@ function buttonLabels(blocks: unknown[] | undefined): string[] {
     await emit('outreach.proposal.sent', { proposalId });
     await worker.tick();
 
-    expect(api.updated).toHaveLength(1);
-    expect(api.updated[0]!.text).toContain('*Approved — email sent* by *Dana Decider*');
-    expect(actionIds(api.updated[0]!.blocks)).toEqual([]);
+    expect(api.updated).toHaveLength(3);
+    expect(api.updated[1]!.ts).toBe(reply.ts);
+    expect(api.updated[1]!.text).toContain('*Approved — email sent* by *Dana Decider*');
+    expect(actionIds(api.updated[1]!.blocks)).toEqual([]);
+    expect(api.updated[2]!.ts).toBe(parent.ts);
+    expect(api.updated[2]!.text).toContain('All outreach drafts handled — Spring launch');
+
+    const resolvedParent = await notificationLink('outreach_campaign', campaignId);
+    expect(resolvedParent?.resolvedAt).not.toBeNull();
+  });
+
+  it('reuses the campaign parent for further drafts and bumps the pending count', async () => {
+    const api = new FakeSlackApi();
+    const worker = new SlackBridgeWorker(db, api);
+    const firstId = await seedOutreachProposal();
+    const secondId = await seedOutreachProposal(contactBId);
+
+    await emit('outreach.proposal.created', { proposalId: firstId });
+    await emit('outreach.proposal.created', { proposalId: secondId });
+    await worker.tick();
+
+    expect(api.posted).toHaveLength(3);
+    const parent = api.posted[0]!;
+    expect(api.posted[1]!.threadTs).toBe(parent.ts);
+    expect(api.posted[2]!.threadTs).toBe(parent.ts);
+    const lastParentUpdate = api.updated.filter((u) => u.ts === parent.ts).at(-1);
+    expect(lastParentUpdate!.text).toContain('2 drafts pending');
+  });
+
+  it('rotates to a fresh parent on a new day, marking the old one moved', async () => {
+    const api = new FakeSlackApi();
+    const worker = new SlackBridgeWorker(db, api);
+    const firstId = await seedOutreachProposal();
+
+    await emit('outreach.proposal.created', { proposalId: firstId });
+    await worker.tick();
+
+    const staleTs = `${Math.floor(Date.now() / 1000) - 25 * 3600}.000001`;
+    await db
+      .update(schema.slackNotificationLinks)
+      .set({ slackTs: staleTs })
+      .where(
+        and(
+          eq(schema.slackNotificationLinks.subjectType, 'outreach_campaign'),
+          eq(schema.slackNotificationLinks.subjectId, campaignId),
+        ),
+      );
+
+    const secondId = await seedOutreachProposal(contactBId);
+    await emit('outreach.proposal.created', { proposalId: secondId });
+    await worker.tick();
+
+    expect(api.posted).toHaveLength(4);
+    const newParent = api.posted[2]!;
+    expect(newParent.threadTs).toBeUndefined();
+    expect(newParent.text).toContain('Outreach drafts awaiting approval — Spring launch');
+    expect(api.posted[3]!.threadTs).toBe(newParent.ts);
+
+    const movedNotice = api.updated.find((u) => u.ts === staleTs);
+    expect(movedNotice!.text).toContain('continued in a newer thread');
+
+    const parentLink = await notificationLink('outreach_campaign', campaignId);
+    expect(parentLink?.slackTs).toBe(newParent.ts);
+    expect(parentLink?.resolvedAt).toBeNull();
+  });
+
+  it('rotates to a fresh parent when a new wave starts after the previous one resolved', async () => {
+    const api = new FakeSlackApi();
+    const worker = new SlackBridgeWorker(db, api);
+    const firstId = await seedOutreachProposal();
+
+    await emit('outreach.proposal.created', { proposalId: firstId });
+    await worker.tick();
+    await db
+      .update(schema.outreachProposals)
+      .set({ status: 'dismissed' })
+      .where(eq(schema.outreachProposals.id, firstId));
+    await emit('outreach.proposal.dismissed', { proposalId: firstId });
+    await worker.tick();
+
+    const firstParentTs = api.posted[0]!.ts;
+    const secondId = await seedOutreachProposal();
+    await emit('outreach.proposal.created', { proposalId: secondId });
+    await worker.tick();
+
+    expect(api.posted).toHaveLength(4);
+    const newParent = api.posted[2]!;
+    expect(newParent.threadTs).toBeUndefined();
+    expect(newParent.ts).not.toBe(firstParentTs);
+    expect(api.posted[3]!.threadTs).toBe(newParent.ts);
+    expect(api.updated.some((u) => u.text.includes('continued in a newer thread'))).toBe(false);
+
+    const parentLink = await notificationLink('outreach_campaign', campaignId);
+    expect(parentLink?.slackTs).toBe(newParent.ts);
+    expect(parentLink?.resolvedAt).toBeNull();
   });
 
   it('skips outreach draft edits that never surfaced', async () => {

--- a/packages/backend-core/src/modules/slack/slack-bridge.worker.ts
+++ b/packages/backend-core/src/modules/slack/slack-bridge.worker.ts
@@ -18,6 +18,8 @@ import {
   mergeProposalApprovalText,
   messageBodyText,
   messageText,
+  outreachCampaignParentMovedText,
+  outreachCampaignParentText,
   outreachProposalApprovalText,
   parentStateLine,
   parseMessageAttachments,
@@ -53,6 +55,13 @@ type DeliveryRow = typeof schema.slackDeliveries.$inferSelect;
 type LinkRow = typeof schema.slackConversationLinks.$inferSelect;
 
 class TerminalDeliveryError extends Error {}
+
+function slackTsIsToday(slackTs: string): boolean {
+  const postedAtSec = Number.parseFloat(slackTs);
+  if (!Number.isFinite(postedAtSec)) return false;
+  const day = (d: Date) => d.toISOString().slice(0, 10);
+  return day(new Date(postedAtSec * 1000)) === day(new Date());
+}
 
 @Injectable()
 export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
@@ -358,6 +367,9 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
         .update(schema.slackNotificationLinks)
         .set({ resolvedAt: new Date() })
         .where(eq(schema.slackNotificationLinks.id, link.id));
+      if (subject.subjectType === 'outreach_proposal') {
+        await this.refreshOutreachParent(integration, subject.subjectId, token);
+      }
       return;
     }
 
@@ -375,16 +387,30 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
           .update(schema.slackNotificationLinks)
           .set({ resolvedAt: new Date() })
           .where(eq(schema.slackNotificationLinks.id, link.id));
+        if (subject.subjectType === 'outreach_proposal') {
+          await this.refreshOutreachParent(integration, subject.subjectId, token);
+        }
       }
       return;
     }
     if (row.eventType === 'outreach.proposal.updated') return;
 
+    let threadTs: string | undefined;
+    let channel = route.slackChannelId;
+    if (subject.subjectType === 'outreach_proposal') {
+      const parent = await this.ensureOutreachParent(integration, route, subject.subjectId, token);
+      if (parent) {
+        threadTs = parent.slackTs;
+        channel = parent.slackChannelId;
+      }
+    }
+
     let posted;
     try {
       posted = await this.api.postMessage({
         token,
-        channel: route.slackChannelId,
+        channel,
+        threadTs,
         text: rendering.text,
         blocks: rendering.blocks,
       });
@@ -406,6 +432,156 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
         resolvedAt: rendering.resolved ? new Date() : null,
       })
       .onConflictDoNothing();
+    if (subject.subjectType === 'outreach_proposal') {
+      await this.refreshOutreachParent(integration, subject.subjectId, token);
+    }
+  }
+
+  private async outreachParentContext(proposalId: string): Promise<{
+    campaignId: string;
+    campaignName: string;
+    pendingCount: number;
+  } | null> {
+    const [proposal] = await this.db
+      .select({ campaignId: schema.outreachProposals.campaignId })
+      .from(schema.outreachProposals)
+      .where(eq(schema.outreachProposals.id, proposalId))
+      .limit(1);
+    if (!proposal) return null;
+    const [campaign] = await this.db
+      .select({ name: schema.outreachCampaigns.name })
+      .from(schema.outreachCampaigns)
+      .where(eq(schema.outreachCampaigns.id, proposal.campaignId))
+      .limit(1);
+    const [pending] = await this.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(schema.outreachProposals)
+      .where(
+        and(
+          eq(schema.outreachProposals.campaignId, proposal.campaignId),
+          eq(schema.outreachProposals.status, 'pending'),
+        ),
+      );
+    return {
+      campaignId: proposal.campaignId,
+      campaignName: campaign?.name ?? 'a campaign',
+      pendingCount: pending?.count ?? 0,
+    };
+  }
+
+  private async outreachParentLink(
+    integrationId: string,
+    campaignId: string,
+  ): Promise<typeof schema.slackNotificationLinks.$inferSelect | null> {
+    const [link] = await this.db
+      .select()
+      .from(schema.slackNotificationLinks)
+      .where(
+        and(
+          eq(schema.slackNotificationLinks.integrationId, integrationId),
+          eq(schema.slackNotificationLinks.subjectType, 'outreach_campaign'),
+          eq(schema.slackNotificationLinks.subjectId, campaignId),
+        ),
+      )
+      .limit(1);
+    return link ?? null;
+  }
+
+  private async ensureOutreachParent(
+    integration: IntegrationRow,
+    route: RouteRow,
+    proposalId: string,
+    token: string,
+  ): Promise<{ slackTs: string; slackChannelId: string } | null> {
+    const context = await this.outreachParentContext(proposalId);
+    if (!context) return null;
+    const link = await this.outreachParentLink(integration.id, context.campaignId);
+    if (
+      link &&
+      !link.resolvedAt &&
+      link.slackChannelId === route.slackChannelId &&
+      slackTsIsToday(link.slackTs)
+    ) {
+      return { slackTs: link.slackTs, slackChannelId: link.slackChannelId };
+    }
+
+    const text = outreachCampaignParentText(
+      context.campaignName,
+      context.pendingCount,
+      `${readWebBaseUrl()}/dashboard`,
+    );
+    let posted;
+    try {
+      posted = await this.api.postMessage({ token, channel: route.slackChannelId, text });
+    } catch (err) {
+      if (err instanceof SlackApiError && err.apiError === 'not_in_channel') {
+        throw new TerminalDeliveryError('bot_not_in_channel');
+      }
+      throw err;
+    }
+    if (link && !link.resolvedAt) {
+      await this.api
+        .updateMessage({
+          token,
+          channel: link.slackChannelId,
+          ts: link.slackTs,
+          text: outreachCampaignParentMovedText(context.campaignName),
+        })
+        .catch(() => undefined);
+    }
+    if (link) {
+      await this.db
+        .update(schema.slackNotificationLinks)
+        .set({ slackChannelId: posted.channel, slackTs: posted.ts, resolvedAt: null })
+        .where(eq(schema.slackNotificationLinks.id, link.id));
+    } else {
+      await this.db
+        .insert(schema.slackNotificationLinks)
+        .values({
+          orgId: integration.orgId,
+          integrationId: integration.id,
+          subjectType: 'outreach_campaign',
+          subjectId: context.campaignId,
+          slackChannelId: posted.channel,
+          slackTs: posted.ts,
+        })
+        .onConflictDoUpdate({
+          target: [
+            schema.slackNotificationLinks.integrationId,
+            schema.slackNotificationLinks.subjectType,
+            schema.slackNotificationLinks.subjectId,
+          ],
+          set: { slackChannelId: posted.channel, slackTs: posted.ts, resolvedAt: null },
+        });
+    }
+    return { slackTs: posted.ts, slackChannelId: posted.channel };
+  }
+
+  private async refreshOutreachParent(
+    integration: IntegrationRow,
+    proposalId: string,
+    token: string,
+  ): Promise<void> {
+    const context = await this.outreachParentContext(proposalId);
+    if (!context) return;
+    const link = await this.outreachParentLink(integration.id, context.campaignId);
+    if (!link) return;
+    await this.api.updateMessage({
+      token,
+      channel: link.slackChannelId,
+      ts: link.slackTs,
+      text: outreachCampaignParentText(
+        context.campaignName,
+        context.pendingCount,
+        `${readWebBaseUrl()}/dashboard`,
+      ),
+    });
+    if (context.pendingCount === 0 && !link.resolvedAt) {
+      await this.db
+        .update(schema.slackNotificationLinks)
+        .set({ resolvedAt: new Date() })
+        .where(eq(schema.slackNotificationLinks.id, link.id));
+    }
   }
 
   private async renderApproval(
@@ -423,6 +599,7 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
 
     let text: string;
     let approveLabel: string | null;
+    let viewLabel: string | undefined;
     let resolution: ApprovalResolution | null;
 
     if (subject.subjectType === 'crm_merge_proposal') {
@@ -482,6 +659,7 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
         dashboardUrl,
       });
       approveLabel = 'Approve & send';
+      viewLabel = 'View full draft';
       const derived: ApprovalOutcome | null =
         outcome ??
         (proposal?.status === 'sent'
@@ -528,7 +706,7 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
       text: resolution
         ? `${text}\n${approvalResolvedLine(resolution.outcome, resolution.decidedByName)}`
         : text,
-      blocks: approvalBlocks(text, value, { approveLabel }, resolution),
+      blocks: approvalBlocks(text, value, { approveLabel, viewLabel }, resolution),
       resolved: resolution !== null,
     };
   }

--- a/packages/backend-core/src/modules/slack/slack-interactions.integration.test.ts
+++ b/packages/backend-core/src/modules/slack/slack-interactions.integration.test.ts
@@ -31,6 +31,7 @@ class FakeSlackApi extends SlackApiClient {
   usersById = new Map<string, { email: string | null }>();
   ephemerals: { user: string; text: string }[] = [];
   updated: { channel: string; ts: string; text: string }[] = [];
+  views: { triggerId: string; view: Record<string, unknown> }[] = [];
 
   override usersInfo(input: { token: string; user: string }) {
     const entry = this.usersById.get(input.user);
@@ -53,6 +54,11 @@ class FakeSlackApi extends SlackApiClient {
 
   override updateMessage(input: { token: string; channel: string; ts: string; text: string }) {
     this.updated.push({ channel: input.channel, ts: input.ts, text: input.text });
+    return Promise.resolve();
+  }
+
+  override openView(input: { token: string; triggerId: string; view: Record<string, unknown> }) {
+    this.views.push({ triggerId: input.triggerId, view: input.view });
     return Promise.resolve();
   }
 }
@@ -572,6 +578,55 @@ class FakeSlackApi extends SlackApiClient {
       expect(proposal!.status).toBe('dismissed');
       expect(proposal!.decidedByActorId).toBe(memberUserId);
       expect(api.ephemerals).toHaveLength(0);
+    });
+
+    it('view button opens a modal with the full draft', async () => {
+      const proposalId = await seedOutreachProposal();
+      await linkSubject('outreach_proposal', proposalId);
+
+      await interactions.processBlockActions(
+        approvalPayload('munin_approval_view', `outreach_proposal:${proposalId}`, {
+          trigger_id: 'trig_view_1',
+        }),
+      );
+
+      expect(api.views).toHaveLength(1);
+      expect(api.views[0]!.triggerId).toBe('trig_view_1');
+      const view = api.views[0]!.view as { blocks: Array<{ text?: { text: string } }> };
+      const texts = view.blocks.map((b) => b.text?.text ?? '').join('\n');
+      expect(texts).toContain('*Campaign:* Launch · initial');
+      expect(texts).toContain('Grace Hopper (grace@example.com)');
+      expect(texts).toContain('*Subject:* Hi');
+      expect(texts).toContain('Want a demo?');
+      expect(api.ephemerals).toHaveLength(0);
+    });
+
+    it('view button without a trigger id is a no-op', async () => {
+      const proposalId = await seedOutreachProposal();
+      await linkSubject('outreach_proposal', proposalId);
+
+      await interactions.processBlockActions(
+        approvalPayload('munin_approval_view', `outreach_proposal:${proposalId}`),
+      );
+
+      expect(api.views).toHaveLength(0);
+      expect(api.ephemerals).toHaveLength(0);
+    });
+
+    it('view button on a deleted draft posts an ephemeral notice', async () => {
+      const proposalId = await seedOutreachProposal();
+      await linkSubject('outreach_proposal', proposalId);
+      await db.execute(sql`DELETE FROM outreach_proposals WHERE id = ${proposalId}`);
+
+      await interactions.processBlockActions(
+        approvalPayload('munin_approval_view', `outreach_proposal:${proposalId}`, {
+          trigger_id: 'trig_view_2',
+        }),
+      );
+
+      expect(api.views).toHaveLength(0);
+      expect(api.ephemerals).toHaveLength(1);
+      expect(api.ephemerals[0]!.text).toContain('no longer exists');
     });
 
     it('surfaces a service rejection (already dismissed) as an ephemeral', async () => {

--- a/packages/backend-core/src/modules/slack/slack-interactions.service.ts
+++ b/packages/backend-core/src/modules/slack/slack-interactions.service.ts
@@ -22,6 +22,7 @@ import { SlackService, decryptSecretValue } from './slack.service.ts';
 import {
   APPROVAL_APPROVE_ACTION_ID,
   APPROVAL_DISMISS_ACTION_ID,
+  APPROVAL_VIEW_ACTION_ID,
   CLAIM_ACTION_ID,
   CLOSE_ACTION_ID,
   RELEASE_ACTION_ID,
@@ -29,6 +30,7 @@ import {
   ROUTE_DEFAULT_ACTION_ID,
   ROUTE_DISMISS_ACTION_ID,
   ROUTE_ESCALATIONS_ACTION_ID,
+  outreachDraftModalView,
   parseApprovalValue,
   routeConfirmedText,
   routeDismissedText,
@@ -39,6 +41,7 @@ const BlockActionsSchema = z.object({
   user: z.object({ id: z.string().min(1) }),
   channel: z.object({ id: z.string().min(1) }).optional(),
   message: z.object({ ts: z.string().min(1) }).optional(),
+  trigger_id: z.string().min(1).optional(),
   actions: z
     .array(z.object({ action_id: z.string().min(1), value: z.string().optional() }))
     .min(1),
@@ -84,6 +87,16 @@ export class SlackInteractionsService {
         slackChannelId: parsed.data.channel.id,
         slackUserId: parsed.data.user.id,
         promptTs: parsed.data.message?.ts ?? null,
+      });
+      return;
+    }
+    const viewAction = parsed.data.actions.find((a) => a.action_id === APPROVAL_VIEW_ACTION_ID);
+    if (viewAction?.value) {
+      await this.handleViewDraft({
+        value: viewAction.value,
+        triggerId: parsed.data.trigger_id ?? null,
+        slackChannelId: parsed.data.channel?.id ?? null,
+        slackUserId: parsed.data.user.id,
       });
       return;
     }
@@ -177,6 +190,88 @@ export class SlackInteractionsService {
       }
       this.logger.error(
         `slack action ${action.action_id} failed for ${conversationId}: ${describeError(err)}`,
+      );
+    }
+  }
+
+  private async handleViewDraft(input: {
+    value: string;
+    triggerId: string | null;
+    slackChannelId: string | null;
+    slackUserId: string;
+  }): Promise<void> {
+    if (!input.triggerId) return;
+    const subject = parseApprovalValue(input.value);
+    if (!subject || subject.subjectType !== 'outreach_proposal') return;
+
+    const [link] = await this.db
+      .select()
+      .from(schema.slackNotificationLinks)
+      .where(
+        and(
+          eq(schema.slackNotificationLinks.subjectType, subject.subjectType),
+          eq(schema.slackNotificationLinks.subjectId, subject.subjectId),
+        ),
+      )
+      .limit(1);
+    if (!link) return;
+    if (input.slackChannelId && input.slackChannelId !== link.slackChannelId) return;
+
+    const [integration] = await this.db
+      .select()
+      .from(schema.slackIntegrations)
+      .where(eq(schema.slackIntegrations.id, link.integrationId))
+      .limit(1);
+    if (!integration || !integration.active) return;
+    const token = await decryptSecretValue(this.db, integration.encryptedBotToken);
+
+    const [proposal] = await this.db
+      .select()
+      .from(schema.outreachProposals)
+      .where(eq(schema.outreachProposals.id, subject.subjectId))
+      .limit(1);
+    if (!proposal) {
+      await this.api
+        .postEphemeral({
+          token,
+          channel: link.slackChannelId,
+          user: input.slackUserId,
+          text: ':mag: This draft no longer exists.',
+        })
+        .catch((err: unknown) => this.logger.warn(`ephemeral notice failed: ${describeError(err)}`));
+      return;
+    }
+
+    const [campaign] = await this.db
+      .select({ name: schema.outreachCampaigns.name })
+      .from(schema.outreachCampaigns)
+      .where(eq(schema.outreachCampaigns.id, proposal.campaignId))
+      .limit(1);
+    const [contact] = await this.db
+      .select({ name: schema.crmContacts.name, email: schema.crmContacts.email })
+      .from(schema.crmContacts)
+      .where(eq(schema.crmContacts.id, proposal.contactId))
+      .limit(1);
+    const contactLabel =
+      contact?.name && contact.email
+        ? `${contact.name} (${contact.email})`
+        : (contact?.name ?? contact?.email ?? 'unknown contact');
+
+    try {
+      await this.api.openView({
+        token,
+        triggerId: input.triggerId,
+        view: outreachDraftModalView({
+          kind: proposal.kind,
+          campaignName: campaign?.name ?? 'a campaign',
+          contactLabel,
+          draftSubject: proposal.draftSubject,
+          draftBody: proposal.draftBody,
+        }),
+      });
+    } catch (err) {
+      this.logger.warn(
+        `slack draft modal failed for ${subject.subjectId}: ${describeError(err)}`,
       );
     }
   }

--- a/packages/backend-core/src/modules/slack/slack-projection.test.ts
+++ b/packages/backend-core/src/modules/slack/slack-projection.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   APPROVAL_DISMISS_ACTION_ID,
+  APPROVAL_VIEW_ACTION_ID,
   approvalBlocks,
   approvalResolvedLine,
   authorLabel,
@@ -10,6 +11,9 @@ import {
   kbCandidateApprovalText,
   mergeProposalApprovalText,
   messageText,
+  outreachCampaignParentMovedText,
+  outreachCampaignParentText,
+  outreachDraftModalView,
   outreachProposalApprovalText,
   parentStateLine,
   parseApprovalValue,
@@ -233,6 +237,19 @@ describe('approval texts', () => {
     expect(text).not.toContain('x'.repeat(600));
   });
 
+  it('keeps the outreach preview short so the thread reply stays compact', () => {
+    const text = outreachProposalApprovalText({
+      kind: 'initial',
+      campaignName: 'Spring launch',
+      contactLabel: 'Ada Lovelace',
+      draftSubject: null,
+      draftBodyPreview: 'y'.repeat(300),
+      dashboardUrl: 'https://app.example.com/dashboard',
+    });
+    expect(text).toContain('truncated');
+    expect(text).not.toContain('y'.repeat(250));
+  });
+
   it('renders a KB candidate with and without a proposed target', () => {
     const withTarget = kbCandidateApprovalText({
       title: 'Weekend hours',
@@ -291,5 +308,81 @@ describe('approvalBlocks', () => {
     expect(approvalResolvedLine('applied', null)).toContain('Merge applied');
     expect(approvalResolvedLine('published', 'A')).toContain('Published to the knowledge base');
     expect(approvalResolvedLine('dismissed', null)).toContain('Dismissed');
+  });
+
+  it('adds a view button between approve and dismiss when a view label is given', () => {
+    const blocks = approvalBlocks(
+      'body',
+      value,
+      { approveLabel: 'Approve & send', viewLabel: 'View full draft' },
+      null,
+    );
+    const actions = blocks[1] as unknown as { elements: Array<Record<string, unknown>> };
+    expect(actions.elements.map((e) => e.action_id)).toEqual([
+      'munin_approval_approve',
+      APPROVAL_VIEW_ACTION_ID,
+      APPROVAL_DISMISS_ACTION_ID,
+    ]);
+    expect(actions.elements.every((e) => e.value === value)).toBe(true);
+  });
+});
+
+describe('outreachCampaignParentText', () => {
+  it('shows the pending count with a dashboard link', () => {
+    const text = outreachCampaignParentText('Spring <launch>', 3, 'https://app.example.com/dashboard');
+    expect(text).toContain('*Outreach drafts awaiting approval — Spring &lt;launch&gt;*');
+    expect(text).toContain('3 drafts pending');
+    expect(text).toContain('<https://app.example.com/dashboard|Review all in Munin>');
+  });
+
+  it('uses the singular noun for one pending draft', () => {
+    expect(outreachCampaignParentText('Spring', 1, 'https://x')).toContain('1 draft pending');
+  });
+
+  it('flips to an all-handled banner at zero pending', () => {
+    const text = outreachCampaignParentText('Spring', 0, 'https://x');
+    expect(text).toContain('*All outreach drafts handled — Spring*');
+    expect(text).not.toContain('pending');
+  });
+
+  it('renders the moved notice for a rotated parent', () => {
+    const text = outreachCampaignParentMovedText('Spring <launch>');
+    expect(text).toContain('*Outreach drafts — Spring &lt;launch&gt;*');
+    expect(text).toContain('continued in a newer thread');
+  });
+});
+
+describe('outreachDraftModalView', () => {
+  it('renders header fields and the full body', () => {
+    const view = outreachDraftModalView({
+      kind: 'initial',
+      campaignName: 'Spring launch',
+      contactLabel: 'Ada <ada@example.com>',
+      draftSubject: 'Hello there',
+      draftBody: 'Full body text',
+    }) as { type: string; blocks: Array<{ type: string; text?: { text: string } }> };
+    expect(view.type).toBe('modal');
+    expect(view.blocks[0]!.text!.text).toContain('*Campaign:* Spring launch · initial');
+    expect(view.blocks[0]!.text!.text).toContain('Ada &lt;ada@example.com&gt;');
+    expect(view.blocks[0]!.text!.text).toContain('*Subject:* Hello there');
+    expect(view.blocks[1]!.type).toBe('divider');
+    expect(view.blocks[2]!.text!.text).toBe('Full body text');
+  });
+
+  it('splits long bodies into multiple sections within the block text limit', () => {
+    const body = Array.from({ length: 200 }, (_, i) => `line ${i} ${'z'.repeat(40)}`).join('\n');
+    const view = outreachDraftModalView({
+      kind: 'reply',
+      campaignName: 'Spring',
+      contactLabel: 'Ada',
+      draftSubject: null,
+      draftBody: body,
+    }) as { blocks: Array<{ type: string; text?: { text: string } }> };
+    const sections = view.blocks.slice(2);
+    expect(sections.length).toBeGreaterThan(1);
+    for (const section of sections) {
+      expect(section.text!.text.length).toBeLessThanOrEqual(2900);
+    }
+    expect(sections.map((s) => s.text!.text).join('\n')).toBe(body);
   });
 });

--- a/packages/backend-core/src/modules/slack/slack-projection.ts
+++ b/packages/backend-core/src/modules/slack/slack-projection.ts
@@ -297,6 +297,7 @@ export function routeDismissedText(): string {
 
 export const APPROVAL_APPROVE_ACTION_ID = 'munin_approval_approve';
 export const APPROVAL_DISMISS_ACTION_ID = 'munin_approval_dismiss';
+export const APPROVAL_VIEW_ACTION_ID = 'munin_approval_view';
 
 const APPROVAL_SUBJECT_TYPES = [
   'crm_merge_proposal',
@@ -355,12 +356,85 @@ export function outreachProposalApprovalText(snap: OutreachProposalApprovalSnaps
   ];
   if (snap.draftSubject) lines.push(`*Subject:* ${escapeSlackText(snap.draftSubject)}`);
   lines.push(
-    ...truncate(escapeSlackText(snap.draftBodyPreview), 500)
+    ...truncate(escapeSlackText(snap.draftBodyPreview), 200)
       .split('\n')
       .map((line) => `> ${line}`),
   );
   lines.push(`<${snap.dashboardUrl}|Review in Munin>`);
   return lines.join('\n');
+}
+
+export function outreachCampaignParentText(
+  campaignName: string,
+  pendingCount: number,
+  dashboardUrl: string,
+): string {
+  if (pendingCount === 0) {
+    return `:white_check_mark: *All outreach drafts handled — ${escapeSlackText(campaignName)}*`;
+  }
+  const noun = pendingCount === 1 ? 'draft' : 'drafts';
+  return [
+    `:outbox_tray: *Outreach drafts awaiting approval — ${escapeSlackText(campaignName)}*`,
+    `${pendingCount} ${noun} pending · <${dashboardUrl}|Review all in Munin>`,
+  ].join('\n');
+}
+
+export function outreachCampaignParentMovedText(campaignName: string): string {
+  return `:outbox_tray: *Outreach drafts — ${escapeSlackText(campaignName)}* — continued in a newer thread below`;
+}
+
+const MODAL_SECTION_MAX_CHARS = 2900;
+const MODAL_MAX_BODY_SECTIONS = 90;
+
+function chunkModalText(text: string): string[] {
+  const chunks: string[] = [];
+  let rest = text;
+  while (rest.length > 0 && chunks.length < MODAL_MAX_BODY_SECTIONS) {
+    if (rest.length <= MODAL_SECTION_MAX_CHARS) {
+      chunks.push(rest);
+      rest = '';
+      break;
+    }
+    const window = rest.slice(0, MODAL_SECTION_MAX_CHARS);
+    const breakAt = window.lastIndexOf('\n');
+    const cut = breakAt > MODAL_SECTION_MAX_CHARS / 2 ? breakAt : MODAL_SECTION_MAX_CHARS;
+    chunks.push(rest.slice(0, cut));
+    rest = rest.slice(cut).replace(/^\n/, '');
+  }
+  if (rest.length > 0 && chunks.length >= MODAL_MAX_BODY_SECTIONS) {
+    chunks.push('… _(truncated)_');
+  }
+  return chunks;
+}
+
+export interface OutreachDraftModalSnapshot {
+  kind: string;
+  campaignName: string;
+  contactLabel: string;
+  draftSubject: string | null;
+  draftBody: string;
+}
+
+export function outreachDraftModalView(snap: OutreachDraftModalSnapshot): Record<string, unknown> {
+  const headerLines = [
+    `*Campaign:* ${escapeSlackText(snap.campaignName)} · ${escapeSlackText(snap.kind)}`,
+    `*To:* ${escapeSlackText(snap.contactLabel)}`,
+  ];
+  if (snap.draftSubject) headerLines.push(`*Subject:* ${escapeSlackText(snap.draftSubject)}`);
+  const bodySections = chunkModalText(escapeSlackText(snap.draftBody)).map((chunk) => ({
+    type: 'section',
+    text: { type: 'mrkdwn', text: chunk },
+  }));
+  return {
+    type: 'modal',
+    title: { type: 'plain_text', text: 'Outreach draft' },
+    close: { type: 'plain_text', text: 'Close' },
+    blocks: [
+      { type: 'section', text: { type: 'mrkdwn', text: headerLines.join('\n') } },
+      { type: 'divider' },
+      ...bodySections,
+    ],
+  };
 }
 
 export interface KbCandidateApprovalSnapshot {
@@ -411,7 +485,7 @@ export interface ApprovalResolution {
 export function approvalBlocks(
   text: string,
   value: string,
-  opts: { approveLabel: string | null },
+  opts: { approveLabel: string | null; viewLabel?: string },
   resolution: ApprovalResolution | null,
 ): SlackBlock[] {
   if (resolution) {
@@ -429,6 +503,7 @@ export function approvalBlocks(
     ...(opts.approveLabel
       ? [actionButton(APPROVAL_APPROVE_ACTION_ID, opts.approveLabel, value, 'primary')]
       : []),
+    ...(opts.viewLabel ? [actionButton(APPROVAL_VIEW_ACTION_ID, opts.viewLabel, value)] : []),
     actionButton(APPROVAL_DISMISS_ACTION_ID, 'Dismiss', value, 'danger'),
   ];
   return [

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2105,6 +2105,9 @@ export const slackDeliveries = pgTable(
 // proposal, KB curation candidate). Created by the bridge worker when the
 // pending notification posts; resolution events chat.update the same message
 // and stamp resolved_at so late or duplicate resolutions are no-ops.
+// Outreach proposals also get a per-campaign thread parent row (subject_type
+// 'outreach_campaign'); a resolved parent, or one from a previous UTC day, is
+// reused for the next wave by pointing the row at a freshly posted message.
 export const slackNotificationLinks = pgTable(
   'slack_notification_links',
   {


### PR DESCRIPTION
## Why

An agent wave (e.g. 5 drafts at 06:30) posted five near-screen-height standalone messages to the approvals channel — spammy, and the 500-char body preview made each one huge.

## What

**Per-campaign threading with daily parents**
- Each outreach proposal now posts as a compact thread reply (preview shrunk to 200 chars) under a per-campaign parent message showing a live pending count and a dashboard link.
- The pending count is recomputed from `outreach_proposals` on every event, so it stays correct no matter where a decision happens (Slack button, dashboard, agent withdraw). At zero it flips to an "All outreach drafts handled" banner and the parent link is stamped resolved.
- Parents last one UTC day: the first draft of a new day (or after the previous wave resolved, or after a channel-routing change) posts a fresh parent at the bottom of the channel. A superseded parent that still showed pending drafts is rewritten to a "continued in a newer thread" notice; its replies stay actionable.
- The parent is stored in the existing `slack_notification_links` table as `subject_type 'outreach_campaign'` and the same row is repointed on rotation — no migration.

**View full draft modal**
- New button on each proposal reply opens a `views.open` modal with the full subject + body (chunked under Slack's 3000-char section limit), fetched fresh from the DB at click time — reviewing no longer requires the dashboard. Deleted drafts answer with an ephemeral notice.
- Viewing is read-only and needs no linked Munin account; approve/dismiss still require the account link. Approval deliberately stays on the message (modals don't auto-close on block actions, and the reply is the surface that updates with the outcome).

Merge proposals and KB curation candidates keep their existing standalone behavior.

## Testing

- `pnpm vitest run src/modules/slack/` — 9 files, 127 tests passing (new coverage: parent count lifecycle, same-thread reuse, resolved-wave and new-day rotation with moved-notice, modal open / missing trigger_id / deleted draft).
- Workspace typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)