### PR TITLE
fix(cms): never keep an image variant heavier than its master

### DIFF
--- a/.changeset/cms-variant-never-heavier.md
+++ b/.changeset/cms-variant-never-heavier.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/backend-core': patch
+---
+
+CMS: never keep an image variant that is heavier than its master.
+
+The variant ladder assumed recompressing to WebP q80 always beats the original. For an already-efficiently-compressed photographic JPEG at full width it does not — WebP loses that contest. On a real asset a 199,523-byte JPEG master produced a 214,250-byte "derivative", and because delivery resolves inline `asset://` to the widest variant, the delivery path served 7% *more* bytes than the master it was supposed to improve on.
+
+- Any rendition whose encoded bytes are not smaller than the master is discarded rather than stored. `widestVariantUrl` then falls back to the next-widest rendition, or to the master when none qualify, so the invariant is now "a variant is only ever offered if it is genuinely lighter".
+- Renditions dropped by this rule are also deleted from storage, so re-deriving an asset that previously produced an oversized variant reclaims that object instead of orphaning it.
+- `VARIANT_LADDER_VERSION` goes to 2, so the CMS worker's reconciliation pass re-derives every existing asset under the new rule. No backfill or manual repair.
+
+The regression escaped its own test: the suite already asserted "every variant is lighter than the master", but built the fixture from `sharp({create})` with a flat solid colour, which compresses so trivially that the assertion could not fail. The fixture is now a noisy JPEG master, which reproduces the failure against the old code, and there is explicit coverage for dropping the oversized rendition and for reclaiming a superseded object.

--- a/packages/backend-core/src/modules/cms/cms.integration.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.integration.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'node:os';
 import { createApp } from '../../bootstrap-app.ts';
 import { AppModule } from '../../app.module.ts';
 import { CmsScheduleWorker } from './cms.schedule.worker.ts';
+import { VARIANT_LADDER_VERSION } from './cms.variants.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
@@ -883,7 +884,7 @@ const skipReason = TEST_URL
       .from(schema.cmsAssets)
       .where(sql`id = ${assetId}`)
       .limit(1);
-    expect(row!.variantsVersion).toBe(1);
+    expect(row!.variantsVersion).toBe(VARIANT_LADDER_VERSION);
     expect(row!.width).toBe(800);
     expect(row!.variants.map((v) => v.width)).toEqual([320, 640, 800]);
   }, 60_000);
@@ -912,7 +913,7 @@ const skipReason = TEST_URL
       .from(schema.cmsAssets)
       .where(sql`id = ${asset!.id}`)
       .limit(1);
-    expect(row!.variantsVersion).toBe(1);
+    expect(row!.variantsVersion).toBe(VARIANT_LADDER_VERSION);
     expect(row!.variants).toEqual([]);
   }, 60_000);
 

--- a/packages/backend-core/src/modules/cms/cms.variants.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.variants.test.ts
@@ -59,6 +59,20 @@ function master(width: number, height: number): Promise<Buffer> {
     .toBuffer();
 }
 
+function noisyJpegMaster(width: number, height: number, quality = 70): Promise<Buffer> {
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 128, g: 128, b: 128 },
+      noise: { type: 'gaussian', mean: 128, sigma: 60 },
+    },
+  })
+    .jpeg({ quality })
+    .toBuffer();
+}
+
 describe('variantWidthsFor', () => {
   it('never upscales past the source width', () => {
     expect(variantWidthsFor(1536)).toEqual([320, 640, 1024, 1536]);
@@ -172,6 +186,38 @@ describe('deriveVariantColumns', () => {
     for (const variant of columns.variants) {
       expect(variant.sizeBytes).toBeLessThan(body.length);
     }
+  });
+
+  it('drops a rendition that recompresses heavier than an already-efficient master', async () => {
+    const storage = new MemoryStorage();
+    const body = await noisyJpegMaster(1200, 800);
+    const columns = await deriveVariantColumns(storage, {
+      mime: 'image/jpeg',
+      storageKey: 'cms/org_1/noisy.jpg',
+      body,
+    });
+
+    expect(columns.variants.length).toBeGreaterThan(0);
+    for (const variant of columns.variants) {
+      expect(variant.sizeBytes).toBeLessThan(body.length);
+    }
+    expect(columns.variants.some((v) => v.width === 1200)).toBe(false);
+    expect([...storage.written.keys()]).not.toContain('cms/org_1/noisy-1200w.webp');
+  });
+
+  it('removes a superseded rendition left behind by an earlier ladder version', async () => {
+    const storage = new MemoryStorage();
+    const body = await noisyJpegMaster(1200, 800);
+    const stale = 'cms/org_1/noisy-1200w.webp';
+    await storage.writeDirect(stale, Buffer.alloc(999_999));
+
+    await deriveVariantColumns(storage, {
+      mime: 'image/jpeg',
+      storageKey: 'cms/org_1/noisy.jpg',
+      body,
+    });
+
+    expect(storage.written.has(stale)).toBe(false);
   });
 
   it('settles non-images without touching storage', async () => {

--- a/packages/backend-core/src/modules/cms/cms.variants.ts
+++ b/packages/backend-core/src/modules/cms/cms.variants.ts
@@ -2,7 +2,7 @@ import sharp from 'sharp';
 import type { AssetStorage } from '@getmunin/core';
 import type { AssetVariant } from '@getmunin/types';
 
-export const VARIANT_LADDER_VERSION = 1;
+export const VARIANT_LADDER_VERSION = 2;
 
 const LADDER_WIDTHS = [320, 640, 1024, 1536, 2048];
 const FULL_WIDTH_CAP = 2560;
@@ -96,8 +96,13 @@ export async function deriveVariantColumns(
   const rendered = await renderVariants(input.body, source);
 
   const variants: AssetVariant[] = [];
+  const superseded: string[] = [];
   for (const variant of rendered) {
     const key = variantKeyFor(input.storageKey, variant.width);
+    if (variant.body.length >= input.body.length) {
+      superseded.push(key);
+      continue;
+    }
     await storage.writeDirect(key, variant.body, { mime: 'image/webp' });
     variants.push({
       width: variant.width,
@@ -108,6 +113,7 @@ export async function deriveVariantColumns(
       sizeBytes: variant.body.length,
     });
   }
+  await discardSuperseded(storage, superseded);
 
   return {
     width: source.width,
@@ -126,6 +132,14 @@ export function widestVariantUrl(asset: {
     null,
   );
   return widest?.publicUrl ?? asset.publicUrl;
+}
+
+async function discardSuperseded(storage: AssetStorage, keys: string[]): Promise<void> {
+  for (const key of keys) {
+    await storage.delete(key).catch((err: unknown) => {
+      console.warn(`[cms.variants] could not remove superseded ${key}: ${describeSharpError(err)}`);
+    });
+  }
 }
 
 function describeSharpError(err: unknown): string {


### PR DESCRIPTION
Follow-up to #677, found on dev before it reached anyone. **No release yet** — this is staged for the next one.

## The bug

The ladder assumed recompressing to WebP q80 always beats the original. For an already-efficiently-compressed photographic JPEG at full width, it doesn't — WebP loses that contest.

Observed on dev across four real assets:

| asset | master | full-width variant | |
|---|---|---|---|
| generated hero (webp) | 1,502,708 | 1536w = 124,332 | ✅ 12× lighter |
| demo-figure-b.jpg | 35,018 | 1200w = 19,952 | ✅ |
| **demo-figure-a.jpg** | **199,523** | **1200w = 214,250** | ❌ **7% heavier** |
| demo-cover.jpg | 188,486 | 1600w = 77,200 | ✅ |

Because delivery resolves inline `asset://` to the widest variant, the delivery path served *more* bytes than the master it was meant to improve on. A published journal entry (`component-gallery`) was already offering that 214 KB "derivative" next to its 199 KB master in two blocks.

## The fix

- Discard any rendition whose encoded bytes are not smaller than the master. The invariant becomes "a variant is only ever offered when it is genuinely lighter", and `widestVariantUrl` falls back to the next-widest rendition — or the master when none qualify.
- Delete dropped renditions from storage. Re-deriving an asset that previously produced an oversized variant now reclaims that object instead of orphaning it, which matters because the ladder is versioned and will be re-derived again in future.
- `VARIANT_LADDER_VERSION` → 2, so the worker's reconciliation pass repairs every existing asset with no backfill and no manual intervention. This is the first real exercise of that design, and it is why the original PR chose a reconciliation loop over a one-shot script.

## The test that should have caught it

The suite already asserted `'every variant is lighter than the master'` — and it passed, because the fixture was `sharp({create})` with a flat solid colour. A synthetic master that compresses trivially made the assertion vacuous. That is the actual root cause of this escaping review.

The fixture is now a noisy JPEG at q70, which reproduces the real condition (master 441,751 → WebP80@1200 560,512, a 27% margin so it won't flake across libvips versions). I verified both new tests **fail against the old implementation and pass against the new** — checked explicitly rather than assumed, since the whole point is that the previous test could not fail.

Coverage added: dropping the oversized rendition, and reclaiming a superseded object left behind by an earlier ladder version.

## Verification

- 19/19 in `cms.variants.test.ts`; `@getmunin/backend-core` typecheck clean.
- Typecheck also caught that sharp's `Create` type requires `background` alongside `noise` — vitest alone would not have.

## Note

Prod is currently running the 4.71.0 behaviour with this defect present, deployed deliberately: most assets improve enormously and one regressed 7%. This PR is ready to go out whenever the next release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)