### PR TITLE
fix(agent): widget agent reaches commerce/bookings connectors, with email identity guard

### DIFF
--- a/.changeset/widget-agent-connector-scopes.md
+++ b/.changeset/widget-agent-connector-scopes.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/agent-runtime': patch
+'@getmunin/agent-host': patch
+---
+
+The end-user conversation agent can now reach commerce and bookings connectors: its delegated identity previously carried only conv/kb/crm scopes, so every `commerce_*` and `bookings_*` tool was stripped at the `/mcp` scope intersection and the widget agent deferred to a human even with a configured Shopify or Gastroplanner connection. The in-process runner resolves the connector scopes per conversation from the org's active connections, so orgs without a commerce or bookings connection never see those tools.
+
+Alongside the wider scopes, self-service connector lookups no longer trust self-reported emails: browser-supplied widget emails (first-ingest visitor payload and the save-conversation box) are stamped `emailSource: 'visitor'` on the end-user record, and `requireEndUserEmail` rejects anonymous identities and visitor-sourced emails with `connectors_unverified`. This closes an account-takeover vector where an anonymous chat visitor could claim someone else's email and read their orders or cancel their bookings. Emails asserted by trusted paths — inbound email, SMS/voice caller ID, operator-minted delegated tokens, the admin API — keep working.

--- a/packages/agent-host/src/end-user-scopes.test.ts
+++ b/packages/agent-host/src/end-user-scopes.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { endUserScopesForConnectorDomains } from './runner.service.ts';
+
+describe('endUserScopesForConnectorDomains', () => {
+  it('grants only base scopes when no connector is active', () => {
+    const scopes = endUserScopesForConnectorDomains([]);
+    expect(scopes).toEqual(['conv:read', 'conv:write', 'crm:read', 'crm:write', 'kb:read']);
+  });
+
+  it('adds commerce:read when a commerce connection is active', () => {
+    const scopes = endUserScopesForConnectorDomains(['commerce']);
+    expect(scopes).toContain('commerce:read');
+    expect(scopes).not.toContain('bookings:read');
+    expect(scopes).not.toContain('bookings:write');
+  });
+
+  it('adds bookings read and write when a bookings connection is active', () => {
+    const scopes = endUserScopesForConnectorDomains(['bookings']);
+    expect(scopes).toContain('bookings:read');
+    expect(scopes).toContain('bookings:write');
+    expect(scopes).not.toContain('commerce:read');
+  });
+
+  it('handles multiple and duplicate domains', () => {
+    const scopes = endUserScopesForConnectorDomains(['commerce', 'bookings', 'commerce']);
+    expect(scopes).toContain('commerce:read');
+    expect(scopes).toContain('bookings:read');
+    expect(scopes.filter((s) => s === 'commerce:read')).toHaveLength(1);
+  });
+
+  it('ignores unknown connector domains', () => {
+    const scopes = endUserScopesForConnectorDomains(['invoices']);
+    expect(scopes).toEqual(['conv:read', 'conv:write', 'crm:read', 'crm:write', 'kb:read']);
+  });
+});

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -8,7 +8,8 @@ import {
 } from '@nestjs/common';
 import { hostname } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import type { Db } from '@getmunin/db';
+import { schema, type Db } from '@getmunin/db';
+import { and, eq } from 'drizzle-orm';
 import {
   InProcessMuninRestClientFactoryService,
   McpRegistryService,
@@ -25,7 +26,7 @@ import {
   type MessageReceivedBusEvent,
   type RealtimeBusSubscription,
 } from '@getmunin/backend-core';
-import { parseEnvBool } from '@getmunin/core';
+import { getCurrentContext, parseEnvBool } from '@getmunin/core';
 import {
   createConversationHandler,
   createPromptResolver,
@@ -79,16 +80,28 @@ const CURATOR_MAX_SCHEDULED_DELAY_MS = 24 * 60 * 60 * 1000;
 const CONVERSATION_SWEEP_LIMIT = 50;
 const CURATOR_MAX_TOOL_ITERATIONS = 16;
 
-const DEFAULT_END_USER_AGENT_SCOPES: readonly string[] = [
-  'bookings:read',
-  'bookings:write',
-  'commerce:read',
+const BASE_END_USER_AGENT_SCOPES: readonly string[] = [
   'conv:read',
   'conv:write',
   'crm:read',
   'crm:write',
   'kb:read',
 ];
+
+const CONNECTOR_DOMAIN_SCOPES: ReadonlyMap<string, readonly string[]> = new Map([
+  ['commerce', ['commerce:read']],
+  ['bookings', ['bookings:read', 'bookings:write']],
+]);
+
+export function endUserScopesForConnectorDomains(
+  domains: readonly string[],
+): readonly string[] {
+  const scopes = [...BASE_END_USER_AGENT_SCOPES];
+  for (const domain of new Set(domains)) {
+    scopes.push(...(CONNECTOR_DOMAIN_SCOPES.get(domain) ?? []));
+  }
+  return scopes;
+}
 
 export type GenerateTrigger = 'chat' | 'scheduled';
 
@@ -441,17 +454,15 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       config: handlerConfig,
       rest,
       prompts,
-      openMcp: ({ endUserId }) =>
-        Promise.resolve(
-          openEndUserAgentMcpClient({
-            db: this.db,
-            orgId,
-            endUserId,
-            registry: this.mcpRegistry,
-            skills: this.mcpSkills,
-            scopes: DEFAULT_END_USER_AGENT_SCOPES,
-          }),
-        ),
+      openMcp: async ({ endUserId }) =>
+        openEndUserAgentMcpClient({
+          db: this.db,
+          orgId,
+          endUserId,
+          registry: this.mcpRegistry,
+          skills: this.mcpSkills,
+          scopes: await this.endUserAgentScopes(id, orgId),
+        }),
       provider,
       beforeGenerate: this.options?.beforeGenerate
         ? () =>
@@ -756,6 +767,32 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
         await Promise.allSettled([...inFlight]);
       },
     };
+  }
+
+  private async endUserAgentScopes(configId: string, orgId: string): Promise<readonly string[]> {
+    try {
+      const rows = await runWithServiceContext(
+        this.db,
+        configId,
+        async () => {
+          const ctx = getCurrentContext();
+          return ctx.db
+            .selectDistinct({ domain: schema.connectorConnections.domain })
+            .from(schema.connectorConnections)
+            .where(
+              and(
+                eq(schema.connectorConnections.orgId, orgId),
+                eq(schema.connectorConnections.active, true),
+              ),
+            );
+        },
+        { orgId },
+      );
+      return endUserScopesForConnectorDomains(rows.map((r) => r.domain));
+    } catch (err) {
+      this.scopedLogger(configId, 'chat').warn(`connector scope lookup failed: ${describe(err)}`);
+      return endUserScopesForConnectorDomains([...CONNECTOR_DOMAIN_SCOPES.keys()]);
+    }
   }
 
   private scopedLogger(id: string, sub: string): {

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -80,11 +80,14 @@ const CONVERSATION_SWEEP_LIMIT = 50;
 const CURATOR_MAX_TOOL_ITERATIONS = 16;
 
 const DEFAULT_END_USER_AGENT_SCOPES: readonly string[] = [
+  'bookings:read',
+  'bookings:write',
+  'commerce:read',
   'conv:read',
   'conv:write',
-  'kb:read',
   'crm:read',
   'crm:write',
+  'kb:read',
 ];
 
 export type GenerateTrigger = 'chat' | 'scheduled';

--- a/packages/agent-runtime/src/munin-rest.ts
+++ b/packages/agent-runtime/src/munin-rest.ts
@@ -293,7 +293,16 @@ export function createMuninRestClient(opts: CreateMuninRestClientOptions): Munin
         body: JSON.stringify({
           endUserId,
           audiences: ['self_service'],
-          scopes: ['conv:read', 'conv:write', 'kb:read', 'crm:read', 'crm:write'],
+          scopes: [
+            'bookings:read',
+            'bookings:write',
+            'commerce:read',
+            'conv:read',
+            'conv:write',
+            'crm:read',
+            'crm:write',
+            'kb:read',
+          ],
           ttlSeconds,
         }),
       });

--- a/packages/backend-core/src/modules/connectors/connectors.service.test.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.test.ts
@@ -337,6 +337,54 @@ class FakeAdapter implements ConnectorAdapter {
         /no email identity/,
       );
     });
+
+    it('rejects an anonymous end-user even when an email is on the record', async () => {
+      const [eu] = await db
+        .insert(schema.endUsers)
+        .values({
+          orgId,
+          externalId: 'anon:sess-guard',
+          email: 'victim@example.com',
+          metadata: { anonymous: true, emailSource: 'visitor' },
+        })
+        .returning();
+      const actor = new ActorIdentity(
+        'end_user_agent',
+        'tok_anon_email',
+        orgId,
+        ['commerce:read'],
+        ['self_service'],
+        eu!.id,
+      );
+
+      await expect(run(() => connectors.requireEndUserEmail(), actor)).rejects.toThrow(
+        /connectors_unverified/,
+      );
+    });
+
+    it('rejects a verified end-user whose email was self-reported in chat', async () => {
+      const [eu] = await db
+        .insert(schema.endUsers)
+        .values({
+          orgId,
+          externalId: 'crm-usr-77',
+          email: 'victim2@example.com',
+          metadata: { emailSource: 'visitor' },
+        })
+        .returning();
+      const actor = new ActorIdentity(
+        'end_user_agent',
+        'tok_visitor_email',
+        orgId,
+        ['commerce:read'],
+        ['self_service'],
+        eu!.id,
+      );
+
+      await expect(run(() => connectors.requireEndUserEmail(), actor)).rejects.toThrow(
+        /connectors_unverified/,
+      );
+    });
   });
 
   describe('vendorCall', () => {

--- a/packages/backend-core/src/modules/connectors/connectors.service.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.ts
@@ -412,7 +412,7 @@ export class ConnectorsService {
       throw new BadRequestException('connectors_invalid: end-user identity required');
     }
     const rows = await ctx.db
-      .select({ email: schema.endUsers.email })
+      .select({ email: schema.endUsers.email, metadata: schema.endUsers.metadata })
       .from(schema.endUsers)
       .where(eq(schema.endUsers.id, endUserId))
       .limit(1);
@@ -420,6 +420,12 @@ export class ConnectorsService {
     if (!email) {
       throw new BadRequestException(
         'connectors_invalid: your session has no email identity, which this lookup requires',
+      );
+    }
+    const meta = rows[0]?.metadata as { anonymous?: boolean; emailSource?: string } | null;
+    if (meta?.anonymous === true || meta?.emailSource === 'visitor') {
+      throw new BadRequestException(
+        'connectors_unverified: this email was self-reported in chat and is not verified, so personal lookups are not allowed; ask the customer to write in from their email address or use a signed-in session',
       );
     }
     return email;

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -373,7 +373,15 @@ export class WidgetIngestService {
     if (endUserId) {
       await tx
         .update(schema.endUsers)
-        .set({ ...patch, updatedAt: new Date() })
+        .set({
+          ...patch,
+          ...(patch.email
+            ? {
+                metadata: sql`COALESCE(${schema.endUsers.metadata}, '{}'::jsonb) || '{"emailSource":"visitor"}'::jsonb`,
+              }
+            : {}),
+          updatedAt: new Date(),
+        })
         .where(eq(schema.endUsers.id, endUserId));
     }
 
@@ -748,12 +756,14 @@ export class WidgetIngestService {
               ...(input.visitorId ? { visitorId: input.visitorId } : {}),
             };
       if (input.locale) baseMetadata.locale = input.locale;
+      const visitorEmail = input.visitor?.email?.trim().toLowerCase() ?? null;
+      if (visitorEmail) baseMetadata.emailSource = 'visitor';
       const [created] = await tx
         .insert(schema.endUsers)
         .values({
           orgId,
           externalId,
-          email: input.visitor?.email?.trim().toLowerCase() ?? null,
+          email: visitorEmail,
           name: input.visitor?.name ?? null,
           metadata: baseMetadata,
         })

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -258,6 +258,15 @@ const skipReason = TEST_URL
     const first = messages.find((m) => m.authorType === 'end_user')!;
     expect((first.metadata).sessionId).toBe(sessionId);
     expect((first.metadata).providerMessageId).toBe('evt_1');
+
+    const endUsers = await db
+      .select({ email: schema.endUsers.email, metadata: schema.endUsers.metadata })
+      .from(schema.endUsers)
+      .where(
+        and(eq(schema.endUsers.orgId, orgId), eq(schema.endUsers.externalId, `anon:${sessionId}`)),
+      );
+    expect(endUsers[0]?.email).toBe('vita@example.com');
+    expect(endUsers[0]?.metadata).toMatchObject({ anonymous: true, emailSource: 'visitor' });
   });
 
   it('persists locale into end_users.metadata on first ingest', async () => {
@@ -1392,6 +1401,15 @@ const skipReason = TEST_URL
         ),
       );
     expect(contacts[0]?.email).toBe('set-mid-convo@example.com');
+
+    const endUsers = await db
+      .select({ email: schema.endUsers.email, metadata: schema.endUsers.metadata })
+      .from(schema.endUsers)
+      .where(
+        and(eq(schema.endUsers.orgId, orgId), eq(schema.endUsers.externalId, `anon:${sid}`)),
+      );
+    expect(endUsers[0]?.email).toBe('set-mid-convo@example.com');
+    expect(endUsers[0]?.metadata).toMatchObject({ anonymous: true, emailSource: 'visitor' });
   });
 
   it('rejects PATCH /visitor with mismatched channelId', async () => {


### PR DESCRIPTION
## Summary

The end-user (widget) conversation agent could never use a configured Shopify/Magento/Gastroplanner connector: its delegated identity only carried `conv`/`kb`/`crm` scopes, so every `commerce_*` and `bookings_*` tool was stripped at the `/mcp` scope intersection and the agent deferred to a human ("a teammate will follow up") even for a simple "what products do you sell?".

Three changes, one per commit:

1. **Grant commerce and bookings scopes to the end-user agent** — both in the in-process runner (`DEFAULT_END_USER_AGENT_SCOPES`) and the HTTP `mintDelegatedToken` path. The self-service tools were already built and audience-gated for this; the scopes were simply never widened when those modules landed.

2. **Reject self-reported chat emails as identity** — the self-service tools bind server-side to `end_users.email`, but widget visitors can type any email into the save-conversation box, and that email landed on the end-user record unverified. With connector scopes now granted, an anonymous visitor claiming `victim@example.com` could read the victim's orders or cancel their bookings. Browser-supplied emails (first-ingest visitor payload and `setVisitor`) are now stamped `emailSource: 'visitor'`, and `requireEndUserEmail` rejects anonymous identities and visitor-sourced emails with `connectors_unverified`. Verified embeds are covered too: the identity `userHash` only signs `externalId`, so a boot-payload email is end-user-tamperable. Trusted paths (inbound email, SMS/voice caller ID, operator-minted delegated tokens, admin API) keep working, as does the anonymous email-fallback transcript worker (it only sends TO the stored address).

3. **Only grant connector scopes the org has active connections for** — tool listing is gated by audience + scopes alone, so static scopes would surface order/booking tools to every org, inviting the agent to promise capabilities that end in "no active connection" errors. The runner now resolves scopes per conversation open via one indexed `selectDistinct` on active `connector_connections`; activating a connector surfaces its tools on the next turn, no restart. On lookup failure it fails open (calls without a connection still get a clean 400). The remote-runner HTTP path keeps the static list since it cannot see the connections table.

## Tests

- New guard cases in `connectors.service.test.ts` (anonymous identity with email, verified identity with visitor-sourced email → both rejected).
- `widget.integration.test.ts` asserts both ingest paths stamp `emailSource: 'visitor'`.
- New `end-user-scopes.test.ts` covers the domain→scope mapping (base-only, per-domain, dedupe, unknown domains).
- Ran commerce/bookings/conv/connectors suites (434 tests), agent-host + agent-runtime suites, and workspace typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)