### PR TITLE
fix(core): flag crawlers whose name ends in a bot token

### DIFF
--- a/.changeset/bot-ua-suffix-match.md
+++ b/.changeset/bot-ua-suffix-match.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/core': patch
+---
+
+Fix the bot user-agent filter missing every crawler whose name ends in "bot".
+
+`BOT_UA` was `/\b(bot|crawler|spider|…)\b/i`. The leading `\b` requires a non-word character before the token, so `Googlebot/2.1`, `bingbot/2.0`, `GPTBot`, `ClaudeBot`, `Amazonbot`, `AhrefsBot`, `SemrushBot` and `Bytespider` all sailed through — i.e. the naming convention every real crawler uses. Only the separated forms (`compatible; bot`, `Slackbot-LinkExpanding`) were caught, and the full Googlebot UA matched by accident because it contains `/bot.html`.
+
+Dropping the leading boundary catches suffixed names while the trailing `\b` still rejects words that merely start with a token (`Botanical`). `looksLikeBot` strips known device brands that end in a bot token — currently Cubot phones — before testing, so real Android traffic isn't dropped; a crawler UA that also names such a device is still flagged.
+
+Affects `/v1/a/t`, `/v1/a/v`, `/v1/a/s` and the email-open pixel. Expect page-view and email-open counts to drop where crawlers and link-preview prefetch were previously being counted as readers. Agents with no matching token at all (`facebookexternalhit`, `WhatsApp`, `meta-externalagent`) are still counted; catching those needs a vendor name list, which this does not add.

--- a/packages/core/src/http/bot-ua.test.ts
+++ b/packages/core/src/http/bot-ua.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { looksLikeBot } from './bot-ua.ts';
+
+const CRAWLERS = [
+  'Googlebot/2.1',
+  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+  'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+  'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot',
+  'Mozilla/5.0 (compatible) ClaudeBot/1.0; +claudebot@anthropic.com',
+  'Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)',
+  'Mozilla/5.0 (compatible; Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)',
+  'Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)',
+  'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)',
+  'Mozilla/5.0 (compatible; SemrushBot/7~bl)',
+  'Mozilla/5.0 (compatible; YandexBot/3.0)',
+  'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)',
+  'Mozilla/5.0 (compatible; bot)',
+  'Twitterbot/1.0',
+  'UptimeMonitor/1.0',
+];
+
+const HUMANS = [
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Mobile/15E148 Safari/604.1',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0',
+  'Mozilla/5.0 (Linux; Android 13; CUBOT NOTE 21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+  'Mozilla/5.0 (Linux; Android 10; CUBOT_X30 Build/QP1A.190711.020) Chrome/103.0.0.0',
+  'Mozilla/5.0 Botanical/1.0',
+];
+
+describe('looksLikeBot', () => {
+  it.each(CRAWLERS)('flags %s', (userAgent) => {
+    expect(looksLikeBot(userAgent)).toBe(true);
+  });
+
+  it.each(HUMANS)('leaves %s alone', (userAgent) => {
+    expect(looksLikeBot(userAgent)).toBe(false);
+  });
+
+  it('treats a missing user agent as human', () => {
+    expect(looksLikeBot(undefined)).toBe(false);
+    expect(looksLikeBot(null)).toBe(false);
+    expect(looksLikeBot('')).toBe(false);
+  });
+
+  it('still flags a crawler that names a device brand', () => {
+    expect(looksLikeBot('Mozilla/5.0 (Linux; Android 13; CUBOT NOTE 21) Googlebot/2.1')).toBe(
+      true,
+    );
+  });
+
+  it('is stateless across calls despite the global device pattern', () => {
+    for (let i = 0; i < 3; i++) {
+      expect(looksLikeBot('Googlebot/2.1')).toBe(true);
+      expect(looksLikeBot(HUMANS[3])).toBe(false);
+    }
+  });
+});

--- a/packages/core/src/http/bot-ua.ts
+++ b/packages/core/src/http/bot-ua.ts
@@ -1,6 +1,8 @@
-export const BOT_UA = /\b(bot|crawler|spider|preview|linkcheck|monitor)\b/i;
+export const BOT_UA = /(bot|crawler|spider|preview|linkcheck|monitor)\b/i;
+
+export const DEVICE_NAMES_ENDING_IN_A_BOT_TOKEN = /cubot/gi;
 
 export function looksLikeBot(userAgent: string | undefined | null): boolean {
   if (!userAgent) return false;
-  return BOT_UA.test(userAgent);
+  return BOT_UA.test(userAgent.replace(DEVICE_NAMES_ENDING_IN_A_BOT_TOKEN, ''));
 }


### PR DESCRIPTION
Follow-up to #692, which is where this defect surfaced: a new `/v1/a/s` test sending `Googlebot/2.1` recorded a search event.

## The bug

```ts
export const BOT_UA = /\b(bot|crawler|spider|preview|linkcheck|monitor)\b/i;
```

The leading `\b` requires a non-word character before the token. `Googlebot` has `e` before `bot`, so it does not match — and neither does any other crawler using the `<Name>Bot` convention, which is all of them:

| User agent | Before | After |
|---|---|---|
| `Googlebot/2.1` | reader | crawler |
| `bingbot/2.0` | reader | crawler |
| `GPTBot/1.2` | reader | crawler |
| `ClaudeBot/1.0` | reader | crawler |
| `Amazonbot/0.1`, `Applebot` | reader | crawler |
| `AhrefsBot`, `SemrushBot`, `YandexBot` | reader | crawler |
| `Bytespider` | reader | crawler |
| `compatible; bot`, `Slackbot-LinkExpanding` | crawler | crawler |

The full Googlebot UA (`…Googlebot/2.1; +http://www.google.com/bot.html`) matched only by accident, via the `/bot.html` in its URL — which is why the two existing `Googlebot/2.1` assertions in `cms.integration.test.ts` and `analytics-tracker.integration.test.ts` never caught it: both check the row count synchronously, before the fire-and-forget insert lands, so they passed either way. They now assert something real.

## The fix

Drop the leading boundary. The trailing `\b` still rejects words that merely *start* with a token, so `Botanical/1.0` stays a reader.

The one real false positive from widening is Cubot, an Android phone brand whose UA is `…Android 13; CUBOT NOTE 21)`. `looksLikeBot` strips known device brands ending in a bot token before testing, so those readers keep counting; a crawler UA that also names such a device is still flagged. `BOT_UA` stays exported unchanged in shape for anyone matching directly, but `looksLikeBot` is the API with the exclusion.

## Blast radius

Applies to `/v1/a/t`, `/v1/a/v`, `/v1/a/s` and the email-open pixel — every caller of `looksLikeBot`. **Expect page-view and email-open counts to drop** where crawlers and link-preview prefetch were being counted as readers. That is the point, and it compounds with #692's `views` change, so both land in the same release window rather than looking like two separate mystery drops.

Checked mail-client UAs for new false positives: Gmail's image proxy (`…via ggpht.com GoogleImageProxy`), Apple Mail, Thunderbird and Outlook carry no bot token, so open tracking is unaffected except where a crawler was doing the fetching.

Not fixed here: agents with no matching token at all — `facebookexternalhit`, `WhatsApp`, `meta-externalagent` — are still counted as readers. Catching those needs a vendor name list, which is a different change with a different maintenance story. Same for the `linkcheck` token, which doesn't match W3C's actual `W3C-checklink` agent.

## Verification

- New `packages/core/src/http/bot-ua.test.ts`: 24 cases over real UA strings — 15 crawlers, 6 human browsers incl. two Cubot forms, empty/undefined, the mixed device+crawler case, and repeat calls (the device pattern is global, so statelessness is worth pinning).
- `@getmunin/core` 410 tests pass; `backend-core` analytics + cms + control suites (318 tests) pass.
- Pre-existing on this checkout and unrelated: 9 `src/oauth` failures from a `readApiBaseUrl` test-ordering flake — they reproduce on clean `main` with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
