### PR TITLE
fix(cms): asset panel cuts at two rows and opens an asset in a dialog

### DIFF
--- a/.changeset/cms-assets-panel-dialog.md
+++ b/.changeset/cms-assets-panel-dialog.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/inspector-app': patch
+'@getmunin/dashboard-pages': patch
+---
+
+CMS: the `cms_list_assets` panel shows two rows and opens an asset in a dialog.
+
+The panel rendered every asset the tool returned — an org with 60 images got 60 thumbnails, and picking one appended a detail block below the fold, so the thing you clicked and the thing you wanted to read were never on screen together.
+
+- **Eight thumbnails, then a footer control.** The grid is pinned to four columns (two on narrow hosts) and cut at two rows. The footer carries the state and the action: `8 OF 16 ASSETS` alongside `SHOW ALL 16 ↓`, toggling back to `SHOW FEWER ↑`. Nothing is dropped silently — the count is always the full total, and the toggle only appears when there is something hidden.
+- **Clicking a thumbnail opens a modal over the grid**, not a block under it: scrim, viewport-centered card, image scaled to fit, then the name, mime and size, alt text, the public URL with a copy-to-clipboard button, and the usage line from `cms_list_asset_usage` (still fetched once per asset and cached). Escape, the ✕ and a scrim click all close it. Copy degrades quietly where the host iframe withholds clipboard access.
+- **The backdrop matches the shared dialog** (`packages/ui` `DialogBackdrop`): `ink/40`, no blur, no drop shadow. The design mock called for a blurred scrim and a 60px shadow, but nothing else in the system does that — none of the 21 UI components carry a shadow at all.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Operator bridges and connectors both surface in the dashboard on the single Inte
 - Skill markdown under `<module>/skills/<slug>.md` is auto-loaded by `skill-loader.ts` and surfaced as MCP `resources/list` URIs (`skill://<module>/<slug>`).
 - Tool + skill enforcement lives in `packages/mcp-toolkit/src/server.ts`. Scopes are intersected against `actor.scopes` at call time.
 - The same `/mcp` serves admin agents (OAuth-authorized) and end-user agents (delegated tokens minted via `delegated-token.controller.ts`).
+- **The public catalog is deliberately the full surface.** `/v1/public/mcp-tools` and `/v1/public/skills` (and the `docs-fixtures/*.json` behind the docs site) are anonymous and list *every* tool and skill an authenticated admin agent could call, admin/setup ones included. That is the product pitch — customers evaluate what their agents can do before signing up. A review finding that "admin tools are publicly listed" is applying an internal-admin-panel threat model that doesn't fit; push back rather than adding an audience filter. A skill with genuinely sensitive content opts out with `public: false` in its frontmatter; the default stays opt-out, never opt-in.
 
 ### Adding a new MCP tool — checklist
 
@@ -80,12 +81,17 @@ Tools are a public product surface and are reviewed for the Anthropic Software D
 
 - TypeScript strict everywhere. Path-style absolute imports inside packages.
 - Branch names: `<type>/<kebab-summary>`, where `type` is one of `feat|fix|chore|docs|refactor|test|ci|perf|build|revert` (same set as Conventional Commits) — e.g. `feat/website-import-reconcile`, `fix/redos-tag-strip`, `chore/bump-getmunin-4.51.0`. Branch from `main`. Tool-generated branches (`changeset-release/main`) are exempt. Enforced by the `.husky/pre-push` hook.
-- No comments unless they explain a non-obvious *why* (see global rules).
+- **No new comments in TS/JS.** Not JSDoc, not a one-liner above a tricky branch, not in tests — "but this explains a non-obvious *why*" is not an exception. Put the why in the changeset, the PR body, or a test name that encodes the invariant. Comments the repo already has stay; the rule is about comments you add. `packages/db/src/sql/*.sql` and migrations are the one exception — they keep their section headers and policy rationale.
+- No `as unknown as` double casts. When a class only needs one or two methods of a dependency, declare a narrow interface, type the constructor param as that interface (the concrete class satisfies it structurally, the `@Inject` token stays the class), and type test stubs as the interface too.
 - Zod schemas for all MCP tool inputs and external boundaries.
 - Tests live alongside source (`*.test.ts`, `*.integration.test.ts`). Integration tests gate on `TEST_DATABASE_URL`.
+- **Formatting is `eslint --fix`, not Prettier.** There's a `.prettierrc`, but nothing enforces it: `packages/eslint-config` uses `eslint-config-prettier` (which only disables conflicting rules) and `lint-staged.config.mjs` runs `eslint --fix` per package. Don't run `prettier --write` to tidy an edit — it reformats already-committed lines and buries the real change in churn. Match the surrounding style instead.
 - New features that touch DB → migration + RLS policy + per-module SQL in `packages/db/src/sql/<module>.sql`.
 - Migrations: `drizzle-kit generate` assigns a random `NNNN_adjective_noun` name — always rename the `.sql` file (and its `meta/NNNN_snapshot.json` + the `_journal.json` tag) to a meaningful `NNNN_<what_it_does>.sql`, e.g. `0048_cms_asset_references.sql`.
-- Always smoke-test a migration against a throwaway local DB before opening the PR — especially any data backfill. Create a scratch DB on the local Postgres (`docker-postgres-1`), `MUNIN_MIGRATE_URL=… pnpm -F @getmunin/db db:migrate`, seed representative pre-existing rows, run the backfill, and assert the result. A backfill that only ran against an empty DB is untested. Note: data migrations that read FORCE-RLS tables must `set_config('app.bypass_rls','on',true)` — verify by querying as the non-superuser `munin_app` role (a superuser connection bypasses RLS and hides the bug).
+- Always smoke-test a migration against a throwaway local DB before opening the PR — especially any data backfill. Create a scratch DB on the local Postgres (`docker-postgres-1`), `MUNIN_MIGRATE_URL=… pnpm -F @getmunin/db db:migrate`, seed representative pre-existing rows, run the backfill, and assert the result. A backfill that only ran against an empty DB is untested. Smoke-test against a DB **already at the previous migration**, not a fresh one — the failure below only shows up on an existing deploy. Note: data migrations that read FORCE-RLS tables must `set_config('app.bypass_rls','on',true)` — verify by querying as the non-superuser `munin_app` role (a superuser connection bypasses RLS and hides the bug).
+- **The `_journal.json` `when` timestamp must strictly increase with `idx`.** Drizzle applies a migration only if its `when` beats the newest one already recorded in the target DB, so a migration whose `when` is *lower* than its predecessor's is silently skipped on every DB past that point — while a fresh CI database applies everything in `idx` order and looks green. Renaming or regenerating a migration is exactly when a bad timestamp sneaks in. This shipped once (0048 `cms_asset_references`) and killed the 4.62.0 deploy with `relation … does not exist`. `packages/db/src/migrations-journal.test.ts` now guards it; also write migrations idempotently (`CREATE … IF NOT EXISTS`, backfill only when empty) so a corrected timestamp can re-run harmlessly.
+- Changesets: `.changeset/config.json` ignores `@getmunin/{backend,web,eslint-config,tsconfig}` — they ship from the release tag, not the registry. **One changeset file may not list an ignored package alongside a published one**; `changeset version` fails with "Mixed changesets that contain both ignored and not ignored packages are not allowed". Touching both `apps/web` and a published package? Declare only the published ones — the app's changes still ship with the commit, they just don't earn a version bump.
+- Lockfile change (even a devDep) → the pre-commit hook regenerates `THIRD_PARTY_LICENSES.md`, and CI's `license policy` job byte-compares a fresh generation. Regenerate from a clean `pnpm install --frozen-lockfile`; a dev-polluted `node_modules` produces "_No LICENSE file shipped_" placeholders that diverge from CI. The check prints its diff — read it before assuming the file is stale.
 
 ## Common dev commands
 
@@ -118,7 +124,12 @@ Then set in `.env` and restart the backend (it re-reads `.env` on every `--watch
 - `MUNIN_AUTH_TRUSTED_ORIGINS=…,https://<tunnel>`
 - `MUNIN_INBOUND_POLL_WORKER_DISABLED=1` if you seed email channels without a real mailbox — the poll worker auto-deactivates channels after repeated failures, which then fails outreach approvals with `channel … is not active`.
 
-The web dev server bakes `NEXT_PUBLIC_API_URL` into its bundles at compile time — if the login page shows "Couldn't reach the server", the web process was started with a stale value; restart it with `NEXT_PUBLIC_API_URL=http://localhost:3001`.
+**`apps/web` never sees the workspace-root `.env`.** Next only reads `.env*` from its own project directory and there is none, so `NEXT_PUBLIC_API_URL` falls back to `http://localhost:3001` (`packages/dashboard-pages/src/api.ts`, `auth-client.ts`) — an https page calling http, which the browser blocks. The login form then reports "Couldn't reach the server" while the backend is perfectly healthy and `/auth/sign-in/email` answers fine through the proxy. Write `apps/web/.env.local` (gitignored) with `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_AUTH_URL` and `NEXT_PUBLIC_MCP_URL` pointed at the tunnel, and/or export them in the shell that runs `pnpm dev`; setting them only in the root `.env` fixes the backend and silently leaves the browser on localhost. Restart web after changing them — the values are inlined at compile time. Don't try to confirm the baked value by grepping the login HTML: `NEXT_PUBLIC_*` lands in Turbopack's lazily-served JS chunks, not the server-rendered markup.
+
+Two more local-rig facts:
+
+- The dev database is `munin_dev`, not `munin`. After switching branches run `MUNIN_MIGRATE_URL=postgres://munin:munin@localhost:5432/munin_dev pnpm -F @getmunin/db db:migrate`, or the backend crash-loops on missing tables and the tunnel serves 502s that look like proxy faults.
+- Any `MUNIN_PUBLIC_URL` / `NEXT_PUBLIC_*_URL` in the root `.env` — tunnel values *or plain localhost* — makes ~9 `src/oauth/*` tests fail locally with `ERR_JWT_CLAIM_VALIDATION_FAILED` and metadata mismatches. `packages/backend-core/test-env.ts` loads the file and its values win over what the tests set themselves. Not a regression, and CI is clean: `mv .env .env.bak` for the run.
 
 In claude.ai: Settings → Connectors → Add custom connector → `https://<tunnel>/mcp`, then sign in through the local dashboard when prompted. For headless smoke tests skip OAuth entirely: create an admin key (`mn_admin_*`) and drive `/mcp` over JSON-RPC with `Authorization: Bearer`.
 
@@ -127,11 +138,14 @@ MCP Apps (`ui://` panels) specifics:
 - Hosts cache `ui://` resources **per URI** and tell the model "the widget rendered" even when the iframe stays blank — serve panels under content-addressed URIs (see `inspector.resource.ts`) so rebuilds bust the cache.
 - An app that never completes `App.connect()` renders nothing, silently. Don't import the ext-apps SDK from esm.sh (its `zod/v4` shim drops named exports and the SDK throws at import time inside the iframe); bundle the SDK, or use jsdelivr `+esm` for inline spikes.
 - Tool results over ~150k characters abort widget rendering — keep list-tool payloads bounded.
+- **The panel can't know which tool produced its result** — `@modelcontextprotocol/ext-apps` delivers the content and the arguments, never the tool name — so `packages/inspector-app/src/app.tsx` routes to views by payload *shape*, using the guards in `types.ts`. A new view therefore needs a shape-distinguishable payload (a key no other tool returns, like `proposedTargetSpaceSlug` or `utmSource`) and a guard that stays mutually exclusive with the others. Every list guard requires a non-empty array: `[]` is ambiguous across every list tool, so it renders the neutral empty state instead of guessing.
 - Tools can declare `_meta: { ui: { visibility: ['app'] } }` to be callable **only from the panel** — Apps-capable hosts hide them from the model, so the action requires a human click (e.g. `outreach_approve_proposal`). This is host-enforced: hosts without MCP Apps still expose the tool normally, so keep `destructiveHint`, scopes, and service-level state checks as the real backstops. The panel and the model share one credential per session — scopes cannot separate them.
 
 ## Skill and task URI naming
 
 Conventions for `skill://*` markdown under `packages/backend-core/src/modules/*/skills/` and `task://*` URIs in `packages/types/src/job-catalog.ts`.
+
+A feature an agent operates isn't done until a skill describes it. The skill markdown *is* the agent-facing UI here, so treat adding or extending one as a first-class deliverable of the feature — not a follow-up — and regenerate fixtures with `pnpm -F @getmunin/backend-core docs:generate`.
 
 ### Slug
 

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1675,9 +1675,16 @@
       "title": "Assets",
       "subline": "{count} assets, newest first — click one for details.",
       "notUploaded": "not uploaded",
+      "detailEyebrow": "Asset detail",
+      "close": "Close",
+      "copyUrl": "Copy URL",
+      "copied": "Copied",
       "usageLoading": "Checking usage…",
       "usageNone": "Not referenced by any entry.",
       "usageCount": "Referenced by {count} entry fields",
+      "showAll": "Show all {count} ↓",
+      "collapse": "Show fewer ↑",
+      "footShowing": "{visible} of {total} assets",
       "foot": "{count} assets"
     },
     "products": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1675,9 +1675,16 @@
       "title": "Filer",
       "subline": "{count} filer, nyeste først — klikk på en for detaljer.",
       "notUploaded": "ikke lastet opp",
+      "detailEyebrow": "Fildetaljer",
+      "close": "Lukk",
+      "copyUrl": "Kopier URL",
+      "copied": "Kopiert",
       "usageLoading": "Sjekker bruk…",
       "usageNone": "Ikke referert av noen oppføringer.",
       "usageCount": "Referert av {count} felt",
+      "showAll": "Vis alle {count} ↓",
+      "collapse": "Vis færre ↑",
+      "footShowing": "{visible} av {total} filer",
       "foot": "{count} filer"
     },
     "products": {

--- a/packages/inspector-app/src/styles.css
+++ b/packages/inspector-app/src/styles.css
@@ -384,6 +384,15 @@ body.host-mobile .panel {
   color: var(--fg-3);
 }
 
+.ledger-foot-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 16px 10px 24px;
+  background: var(--paper-deep);
+}
+
 .plain {
   padding: 22px 24px;
 }
@@ -769,9 +778,15 @@ select.target-select {
 
 .asset-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 14px;
   padding: 4px 24px 18px;
+}
+
+@media (max-width: 560px) {
+  .asset-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .asset-card {
@@ -787,10 +802,6 @@ select.target-select {
 
 .asset-card:hover {
   border-color: var(--ink);
-}
-
-.asset-card-open {
-  border-color: var(--accent);
 }
 
 .asset-thumb {
@@ -822,20 +833,136 @@ select.target-select {
   color: var(--fg-3);
 }
 
-.asset-detail {
-  padding: 14px 24px 18px;
-  border-top: 1px solid var(--rule);
+.asset-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgb(var(--munin-ink) / 0.4);
 }
 
-.asset-detail-line {
-  margin: 4px 0 0;
+.asset-dialog {
+  width: min(520px, 100%);
+  max-height: 100%;
+  overflow: auto;
+  text-align: left;
+  background: var(--paper);
+  border: 1px solid var(--ink);
+}
+
+.asset-dialog-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 10px 10px 20px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.asset-dialog-head .eyebrow {
+  margin-bottom: 0;
+}
+
+.asset-dialog-close {
+  font-family: var(--munin-mono);
+  font-size: 13px;
+  line-height: 1;
+  padding: 6px 8px;
+  color: var(--fg-2);
+  transition: color 120ms var(--ease);
+}
+
+.asset-dialog-close:hover {
+  color: var(--ink);
+}
+
+.asset-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 240px;
+  object-fit: contain;
+  background: var(--paper-deep);
+  border-bottom: 1px solid var(--rule);
+}
+
+.asset-preview-file {
+  font-family: var(--munin-mono);
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+
+.asset-dialog-body {
+  padding: 18px 20px 22px;
+}
+
+.asset-dialog-title {
+  margin: 0;
+  font-family: var(--munin-serif);
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  word-break: break-word;
+}
+
+.asset-dialog-meta {
+  margin: 8px 0 0;
+  font-family: var(--munin-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--fg-3);
+}
+
+.asset-dialog-alt {
+  margin: 14px 0 0;
   font-size: 13px;
   color: var(--fg-2);
-  word-break: break-all;
 }
 
-.asset-detail-line a {
+.asset-url {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 18px;
+  padding: 8px 10px;
+  background: var(--paper-deep);
+  border: 1px solid var(--rule);
+}
+
+.asset-url-text {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--munin-mono);
+  font-size: 11px;
   color: var(--accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.asset-url .chip-btn {
+  padding: 6px 10px;
+}
+
+.asset-usage {
+  margin: 16px 0 0;
+  padding-top: 14px;
+  border-top: 1px solid var(--rule);
+  font-family: var(--munin-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--fg-2);
+}
+
+.asset-usage-error {
+  color: rgb(var(--munin-alert-bad-ink));
 }
 
 /* Commerce product catalog */

--- a/packages/inspector-app/src/views/assets.tsx
+++ b/packages/inspector-app/src/views/assets.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { App as McpApp } from '@modelcontextprotocol/ext-apps';
 import {
   errorText,
@@ -13,16 +13,29 @@ import { useI18n } from '../i18n';
 
 type Usage = { rows: AssetUsageRow[] } | { error: string } | 'loading';
 
+const DISPLAY_LIMIT = 8;
+
 export function AssetsView({ app, initial }: { app: McpApp; initial: CmsAsset[] }) {
   const { t } = useI18n();
   const [assets] = useState<CmsAsset[]>(initial);
+  const [expanded, setExpanded] = useState(false);
   const [openId, setOpenId] = useState<string | null>(null);
   const [usage, setUsage] = useState<Record<string, Usage>>({});
+  const [copied, setCopied] = useState(false);
 
-  async function toggle(asset: CmsAsset) {
-    const next = openId === asset.id ? null : asset.id;
-    setOpenId(next);
-    if (!next || usage[asset.id] !== undefined) return;
+  useEffect(() => {
+    if (openId === null) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpenId(null);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [openId]);
+
+  async function openAsset(asset: CmsAsset) {
+    setOpenId(asset.id);
+    setCopied(false);
+    if (usage[asset.id] !== undefined) return;
     setUsage((prev) => ({ ...prev, [asset.id]: 'loading' }));
     try {
       const result = await app.callServerTool({
@@ -45,6 +58,17 @@ export function AssetsView({ app, initial }: { app: McpApp; initial: CmsAsset[] 
     }
   }
 
+  async function copyUrl(url: string) {
+    if (!navigator.clipboard) return;
+    const ok = await navigator.clipboard.writeText(url).then(
+      () => true,
+      () => false,
+    );
+    if (ok) setCopied(true);
+  }
+
+  const truncated = assets.length > DISPLAY_LIMIT;
+  const visible = expanded ? assets : assets.slice(0, DISPLAY_LIMIT);
   const open = assets.find((a) => a.id === openId) ?? null;
   const openUsage = open ? usage[open.id] : undefined;
 
@@ -58,12 +82,8 @@ export function AssetsView({ app, initial }: { app: McpApp; initial: CmsAsset[] 
         </div>
       </div>
       <div className="asset-grid">
-        {assets.map((asset) => (
-          <button
-            key={asset.id}
-            className={`asset-card${openId === asset.id ? ' asset-card-open' : ''}`}
-            onClick={() => void toggle(asset)}
-          >
+        {visible.map((asset) => (
+          <button key={asset.id} className="asset-card" onClick={() => void openAsset(asset)}>
             {asset.mime.startsWith('image/') ? (
               <img
                 className="asset-thumb"
@@ -84,38 +104,85 @@ export function AssetsView({ app, initial }: { app: McpApp; initial: CmsAsset[] 
           </button>
         ))}
       </div>
+      <div className="ledger-foot ledger-foot-bar">
+        <span>
+          {truncated
+            ? t('assets.footShowing', { visible: visible.length, total: assets.length })
+            : t('assets.foot', { count: assets.length })}
+        </span>
+        {truncated && (
+          <button className="chip-btn" onClick={() => setExpanded((value) => !value)}>
+            {expanded ? t('assets.collapse') : t('assets.showAll', { count: assets.length })}
+          </button>
+        )}
+      </div>
       {open && (
-        <div className="asset-detail">
-          <div className="eyebrow">{open.name}</div>
-          <p className="asset-detail-line">
-            {open.mime} · {formatBytes(open.sizeBytes)}
-            {open.altText && ` · ${open.altText}`}
-          </p>
-          <p className="asset-detail-line">
-            <a href={open.publicUrl} target="_blank" rel="noreferrer">
-              {open.publicUrl}
-            </a>
-          </p>
-          {openUsage === 'loading' && <p className="mute">{t('assets.usageLoading')}</p>}
-          {openUsage !== undefined && openUsage !== 'loading' && 'error' in openUsage && (
-            <p className="line line-error">{openUsage.error}</p>
-          )}
-          {openUsage !== undefined && openUsage !== 'loading' && 'rows' in openUsage && (
-            <p className="asset-detail-line">
-              {openUsage.rows.length === 0
-                ? t('assets.usageNone')
-                : t('assets.usageCount', { count: openUsage.rows.length })}
-              {openUsage.rows.length > 0 && (
-                <span className="mute">
-                  {' — '}
-                  {[...new Set(openUsage.rows.map((r) => r.fieldName))].join(', ')}
-                </span>
+        <div className="asset-scrim" role="presentation" onClick={() => setOpenId(null)}>
+          <div
+            className="asset-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-label={open.name}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="asset-dialog-head">
+              <span className="eyebrow eyebrow-accent">{t('assets.detailEyebrow')}</span>
+              <button
+                className="asset-dialog-close"
+                aria-label={t('assets.close')}
+                onClick={() => setOpenId(null)}
+              >
+                ✕
+              </button>
+            </div>
+            {open.mime.startsWith('image/') ? (
+              <img
+                className="asset-preview"
+                src={open.publicUrl}
+                alt={open.altText ?? open.name}
+              />
+            ) : (
+              <span className="asset-preview asset-preview-file">
+                {extensionOf(open) || open.mime}
+              </span>
+            )}
+            <div className="asset-dialog-body">
+              <h2 className="asset-dialog-title">{open.name}</h2>
+              <p className="asset-dialog-meta">
+                {open.mime} · {formatBytes(open.sizeBytes)}
+                {!open.uploaded && ` · ${t('assets.notUploaded')}`}
+              </p>
+              {open.altText && <p className="asset-dialog-alt">{open.altText}</p>}
+              <div className="asset-url">
+                <a
+                  className="asset-url-text"
+                  href={open.publicUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {open.publicUrl}
+                </a>
+                <button className="chip-btn" onClick={() => void copyUrl(open.publicUrl)}>
+                  {copied ? t('assets.copied') : t('assets.copyUrl')}
+                </button>
+              </div>
+              {openUsage === 'loading' && <p className="asset-usage">{t('assets.usageLoading')}</p>}
+              {openUsage !== undefined && openUsage !== 'loading' && 'error' in openUsage && (
+                <p className="asset-usage asset-usage-error">{openUsage.error}</p>
               )}
-            </p>
-          )}
+              {openUsage !== undefined && openUsage !== 'loading' && 'rows' in openUsage && (
+                <p className="asset-usage">
+                  {openUsage.rows.length === 0
+                    ? t('assets.usageNone')
+                    : t('assets.usageCount', { count: openUsage.rows.length })}
+                  {openUsage.rows.length > 0 &&
+                    ` — ${[...new Set(openUsage.rows.map((r) => r.fieldName))].join(', ')}`}
+                </p>
+              )}
+            </div>
+          </div>
         </div>
       )}
-      <div className="ledger-foot">{t('assets.foot', { count: assets.length })}</div>
     </Chrome>
   );
 }


### PR DESCRIPTION
`cms_list_assets` rendered every asset the tool returned — an org with 60 images got 60 thumbnails — and clicking one appended a detail block *below* the grid, so the thumbnail you clicked and the metadata you wanted were never on screen together.

## The panel

- **Eight thumbnails, then a footer control.** Grid pinned to four columns (two on narrow hosts) and cut at two rows. The footer carries the state and the action: `8 OF 16 ASSETS` next to `SHOW ALL 16 ↓`, toggling back to `SHOW FEWER ↑`. The count is always the full total and the toggle only appears when something is hidden — nothing is dropped silently.
- **Clicking a thumbnail opens a modal over the grid** (variant 2A of the design doc): scrim, viewport-centered card, image scaled to fit, then name, mime and size, alt text, the public URL with copy-to-clipboard, and the usage line from `cms_list_asset_usage` — still fetched once per asset and cached. Escape, the ✕ and a scrim click all close it. Copy degrades quietly where the host iframe withholds clipboard permission.
- **The backdrop matches the shared `packages/ui` dialog**: `ink/40`, no blur, no drop shadow. The mock called for a blurred scrim and a 60px shadow, but nothing else in the system does that — none of the 21 UI components carry a shadow at all.

Two calls worth flagging: the grid moved from `auto-fill` to a fixed 4 columns because a 6-wide grid wrapped 8 items as 6+2, and the scrim is `position: fixed` so the dialog centers in the visible iframe rather than in the panel. If a host sizes the iframe taller than the panel, that scrim will darken the empty strip below it.

## CLAUDE.md

Second commit, reviewable on its own. The comment convention read *"no comments unless they explain a non-obvious why"*, which isn't the bar applied in review — it's zero new comments in TS/JS, SQL exempt. That line is corrected, and the rules that so far only existed as tribal knowledge are written down: no `as unknown as` double casts, Prettier isn't enforced (`eslint --fix` is), the `_journal.json` `when` must increase monotonically (this one killed the 4.62.0 deploy), a changeset may not mix ignored and published packages, and a lockfile change means regenerating `THIRD_PARTY_LICENSES.md` from a clean install. Also: `apps/web` never reads the workspace-root `.env`, the inspector routes views by payload shape because ext-apps never sends the tool name, the public MCP catalog is full-surface by design, and a skill doc is a deliverable rather than a follow-up.

## Verification

Lint, typecheck and `vite build` pass for `inspector-app`; `dashboard-pages` typechecks. Rendered the view against the 16 fixture assets in a throwaway harness and screenshotted collapsed, expanded (nb), and the dialog at desktop and 430px widths.

Then end-to-end through a live claude.ai custom connector: 16 real assets seeded via `cms_upload_asset_from_base64` (8 with alt text, 4 without, one referenced by a `blog-posts` entry's `hero` field so both usage branches show), asset URLs served over https so the iframe CSP lets them load, and the served panel confirmed to be the fresh bundle with no blur and no shadow. `COPY URL` inside claude.ai is the one path not verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)