### PR TITLE
fix(dashboard-pages): eyebrows stop echoing the heading below them

### DIFF
--- a/.changeset/quiet-eyebrows-stop-echoing.md
+++ b/.changeset/quiet-eyebrows-stop-echoing.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Eyebrows no longer echo the heading they sit above. The OAuth consent outcome screens paired "Authorization granted" with the H1 "Access granted." — and in Norwegian both collapsed to the identical string "Tilgang gitt", since `tilgang` covers both *authorization* and *access*. They now name the flow state instead ("Authorization complete" / "Autorisering fullført", "Authorization cancelled" / "Autorisering avbrutt"), leaving the ✓ glyph and the heading to carry the outcome.
+
+Two inspector panels repeated a noun the same way and now add information instead: the outreach proposals eyebrow reads "Awaiting approval" (was "Pending proposals", above "Outreach proposals"), and the merge panel reads "Possible duplicates" (was "Pending merge proposals", above "Contact merges").

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -923,7 +923,7 @@
       "actingAs": "Authorizing as <user></user>",
       "switchAccount": "Not you? Switch account",
       "granted": {
-        "eyebrow": "Authorization granted",
+        "eyebrow": "Authorization complete",
         "title": "Access <em>granted</em>.",
         "sub": "<client></client> can now act in <strong>Munin</strong> within the scopes you approved. Sending you back to the app.",
         "panelTitle": "<client></client> is connected.",
@@ -931,7 +931,7 @@
         "redirecting": "Returning to {host}…"
       },
       "denied": {
-        "eyebrow": "Authorization denied",
+        "eyebrow": "Authorization cancelled",
         "title": "Access <em>denied</em>.",
         "sub": "No token was issued. <client></client> can't reach anything in <strong>Munin</strong>. Returning you to the app.",
         "panelTitle": "Nothing was shared.",
@@ -1554,7 +1554,7 @@
       "empty": "Connected — the result is an empty list."
     },
     "proposals": {
-      "eyebrow": "Pending proposals",
+      "eyebrow": "Awaiting approval",
       "title": "Outreach proposals",
       "sublineEmpty": "Nothing waiting — the queue is clear.",
       "sublinePending": "{count} waiting for review — approving delivers it.",
@@ -1602,7 +1602,7 @@
       "revisedAfterReview": "Revised {count}× after a reviewer opened it — read it again before approving"
     },
     "merge": {
-      "eyebrow": "Pending merge proposals",
+      "eyebrow": "Possible duplicates",
       "title": "Contact merges",
       "sublineEmpty": "Nothing waiting — the queue is clear.",
       "sublinePending": "{count} waiting for review — applying merges the contacts.",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -923,7 +923,7 @@
       "actingAs": "Godkjenner som <user></user>",
       "switchAccount": "Ikke deg? Bytt konto",
       "granted": {
-        "eyebrow": "Tilgang gitt",
+        "eyebrow": "Autorisering fullført",
         "title": "Tilgang <em>gitt</em>.",
         "sub": "<client></client> kan nå handle i <strong>Munin</strong> innenfor de omfangene du godkjente. Sender deg tilbake til applikasjonen.",
         "panelTitle": "<client></client> er tilkoblet.",
@@ -931,7 +931,7 @@
         "redirecting": "Returnerer til {host} …"
       },
       "denied": {
-        "eyebrow": "Tilgang avslått",
+        "eyebrow": "Autorisering avbrutt",
         "title": "Tilgang <em>avslått</em>.",
         "sub": "Ingen token ble utstedt. <client></client> får ikke tilgang til noe i <strong>Munin</strong>. Sender deg tilbake til applikasjonen.",
         "panelTitle": "Ingenting ble delt.",
@@ -1554,7 +1554,7 @@
       "empty": "Tilkoblet — resultatet er en tom liste."
     },
     "proposals": {
-      "eyebrow": "Ventende forslag",
+      "eyebrow": "Venter på godkjenning",
       "title": "Utgående forslag",
       "sublineEmpty": "Ingenting venter — køen er tom.",
       "sublinePending": "{count} venter på gjennomgang — godkjenning leverer det.",
@@ -1602,7 +1602,7 @@
       "revisedAfterReview": "Endret {count}× etter at noen åpnet det til gjennomgang — les det på nytt før du godkjenner"
     },
     "merge": {
-      "eyebrow": "Ventende flettinger",
+      "eyebrow": "Mulige duplikater",
       "title": "Kontaktflettinger",
       "sublineEmpty": "Ingenting venter — køen er tom.",
       "sublinePending": "{count} venter på gjennomgang — å flette slår sammen kontaktene.",


### PR DESCRIPTION
The OAuth consent success screen showed an eyebrow that just restated the H1. In English it was near-identical; in Norwegian it collapsed to the *same* string, because `tilgang` covers both *authorization* and *access*:

| | eyebrow (before) | title |
|---|---|---|
| granted en | Authorization granted | Access _granted_. |
| granted nb | Tilgang gitt | Tilgang _gitt_. |
| denied en | Authorization denied | Access _denied_. |
| denied nb | Tilgang avslått | Tilgang _avslått_. |

The outcome eyebrows now name the flow state, leaving the ✓ glyph and the cobalt H1 to carry the outcome. Swept all ~40 eyebrow/title sibling pairs in both locales for exact, substring, and ≥60% word-overlap collisions; the only other cases were two inspector panels repeating a noun, which now add information instead.

## After

| Key | en | nb |
|---|---|---|
| `oauthConsent.granted.eyebrow` | Authorization complete | Autorisering fullført |
| `oauthConsent.denied.eyebrow` | Authorization cancelled | Autorisering avbrutt |
| `inspector.proposals.eyebrow` | Awaiting approval | Venter på godkjenning |
| `inspector.merge.eyebrow` | Possible duplicates | Mulige duplikater |

Copy only — no component or logic changes. Titles untouched.

Note: the request-state eyebrow one screen earlier still reads `OAuth 2.1 · authorization request`, so the three states in that flow no longer share a prefix. Left as-is deliberately; easy to trim in a follow-up if we'd rather they match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HwhYb3yU3qnGjtFRodQxm