### PR TITLE
fix(outreach): duplicate proposals and names conflict instead of 500

### DIFF
--- a/.changeset/outreach-conflict-prechecks.md
+++ b/.changeset/outreach-conflict-prechecks.md
@@ -1,0 +1,27 @@
+---
+'@getmunin/backend-core': patch
+---
+
+fix(outreach): duplicate proposals and campaign names return a conflict, not a 500
+
+Four outreach write paths leaned on a `try/catch` around the insert (or nothing at
+all) to turn a unique violation into a `ConflictException`. That never worked over
+`/mcp`: the handler runs inside the request's tenant transaction, so the violation
+poisons it and the *commit* fails after the handler returns — past the catch —
+surfacing as a bare `{"statusCode":500,"message":"Internal server error"}`.
+
+Each now pre-checks with a `SELECT` before the failing statement:
+
+- `outreach_propose_first_touch` — a second **pending** first-touch for the same
+  (campaign, contact) was unguarded; the pre-check only looked for `sent` /
+  `approved`.
+- `outreach_propose_reply` — a second pending reply for the same conversation had
+  no pre-check at all.
+- `outreach_create_campaign` — duplicate campaign name within the org.
+- `outreach_update_campaign` — renaming a campaign onto an existing name had
+  neither a pre-check nor a catch, so it was always a raw 500.
+
+The existing catches stay as backstops for genuine races. `outreach_propose_followup`
+already pre-checked and is unchanged. The pre-checks also mean these paths no longer
+depend on the unique index's *name*, which is what made the failure invisible until
+an index rename exposed it.

--- a/packages/backend-core/src/modules/outreach/outreach.integration.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.integration.test.ts
@@ -541,6 +541,146 @@ const skipReason = TEST_URL
     });
   });
 
+  it('a duplicate pending first-touch conflicts over /mcp instead of failing the transaction', async () => {
+    await withClient(adminKey, async (c) => {
+      const created = firstJson(
+        await c.callTool({
+          name: 'outreach_create_campaign',
+          arguments: {
+            name: 'pending-dup-guard',
+            brief: 'A second pending first-touch must not reach the unique index.',
+            segmentId,
+            channelId,
+          },
+        }),
+      ) as { id: string };
+
+      const first = await c.callTool({
+        name: 'outreach_propose_first_touch',
+        arguments: {
+          campaignId: created.id,
+          contactId,
+          draftSubject: 'Hi Jane',
+          draftBody: 'First touch.',
+        },
+      });
+      expect(first.isError, JSON.stringify(first)).not.toBe(true);
+
+      const dup = await c.callTool({
+        name: 'outreach_propose_first_touch',
+        arguments: {
+          campaignId: created.id,
+          contactId,
+          draftSubject: 'Hi Jane again',
+          draftBody: 'Second touch.',
+        },
+      });
+      const raw = JSON.stringify(dup);
+      expect(dup.isError).toBe(true);
+      expect(raw).toContain('outreach_conflict');
+      expect(raw).toContain('pending');
+      expect(raw).not.toContain('duplicate key value');
+      expect(raw).not.toContain('Internal server error');
+    });
+  });
+
+  it('a duplicate pending reply conflicts over /mcp instead of failing the transaction', async () => {
+    const [convContact] = await db
+      .insert(schema.convContacts)
+      .values({ orgId, email: 'jane@acme.com', name: 'Jane Doe' })
+      .returning();
+    const nextDisplay = await db.execute<{ next: number }>(
+      sql`SELECT conv_next_display_id(${orgId}) AS next`,
+    );
+    const [campaign] = await db
+      .insert(schema.outreachCampaigns)
+      .values({
+        orgId,
+        name: 'reply-dup-guard',
+        brief: 'A second pending reply must not reach the unique index.',
+        segmentId,
+        channelId,
+        enabled: true,
+        unsubscribeRequired: true,
+        createdByActorType: 'admin_agent',
+        createdByActorId: 'outreach-it-setup',
+      })
+      .returning();
+    const [conv] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        channelId,
+        contactId: convContact!.id,
+        displayId: nextDisplay[0]!.next,
+        status: 'open',
+        outreachCampaignId: campaign!.id,
+      })
+      .returning();
+
+    await withClient(adminKey, async (c) => {
+      const first = await c.callTool({
+        name: 'outreach_propose_reply',
+        arguments: { conversationId: conv!.id, draftBody: 'Happy to help.' },
+      });
+      expect(first.isError, JSON.stringify(first)).not.toBe(true);
+
+      const dup = await c.callTool({
+        name: 'outreach_propose_reply',
+        arguments: { conversationId: conv!.id, draftBody: 'Happy to help, again.' },
+      });
+      const raw = JSON.stringify(dup);
+      expect(dup.isError).toBe(true);
+      expect(raw).toContain('outreach_conflict');
+      expect(raw).not.toContain('duplicate key value');
+      expect(raw).not.toContain('Internal server error');
+    });
+  });
+
+  it('create_campaign and update_campaign conflict on a duplicate name instead of failing the transaction', async () => {
+    await withClient(adminKey, async (c) => {
+      const args = {
+        name: 'name-dup-guard',
+        brief: 'Campaign names are unique per org.',
+        segmentId,
+        channelId,
+      };
+      const created = firstJson(
+        await c.callTool({ name: 'outreach_create_campaign', arguments: args }),
+      ) as { id: string };
+
+      const dup = await c.callTool({ name: 'outreach_create_campaign', arguments: args });
+      const dupRaw = JSON.stringify(dup);
+      expect(dup.isError).toBe(true);
+      expect(dupRaw).toContain('outreach_conflict');
+      expect(dupRaw).not.toContain('duplicate key value');
+      expect(dupRaw).not.toContain('Internal server error');
+
+      const other = firstJson(
+        await c.callTool({
+          name: 'outreach_create_campaign',
+          arguments: { ...args, name: 'name-dup-guard-other' },
+        }),
+      ) as { id: string };
+
+      const renameClash = await c.callTool({
+        name: 'outreach_update_campaign',
+        arguments: { id: other.id, patch: { name: args.name } },
+      });
+      const renameRaw = JSON.stringify(renameClash);
+      expect(renameClash.isError).toBe(true);
+      expect(renameRaw).toContain('outreach_conflict');
+      expect(renameRaw).not.toContain('duplicate key value');
+      expect(renameRaw).not.toContain('Internal server error');
+
+      const renameSelf = await c.callTool({
+        name: 'outreach_update_campaign',
+        arguments: { id: created.id, patch: { name: args.name } },
+      });
+      expect(renameSelf.isError, JSON.stringify(renameSelf)).not.toBe(true);
+    });
+  });
+
   it('automation flags default to autoDraftFirstTouch=false / autoDraftReplies=true and are togglable', async () => {
     await withClient(adminKey, async (c) => {
       const created = firstJson(

--- a/packages/backend-core/src/modules/outreach/outreach.service.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.service.ts
@@ -1,7 +1,7 @@
 import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { makeId, schema, type Db } from '@getmunin/db';
 import { DB } from '../../common/db/db.module.ts';
-import { and, asc, desc, eq, getTableColumns, inArray, sql, type SQL } from 'drizzle-orm';
+import { and, asc, desc, eq, getTableColumns, inArray, ne, sql, type SQL } from 'drizzle-orm';
 import { newImportResult, resolveId } from '../../common/transfer/transfer.helpers.ts';
 import type { IdMap, ImportResult } from '../../common/transfer/transfer.types.ts';
 import {
@@ -245,6 +245,7 @@ export class OutreachService {
         'sequenceSteps require an email channel — follow-ups thread into the initial email conversation',
       );
     }
+    await this.assertCampaignNameFree(input.name);
     try {
       const [row] = await ctx.db
         .insert(schema.outreachCampaigns)
@@ -304,6 +305,10 @@ export class OutreachService {
           );
         }
       }
+    }
+    if (input.patch.name !== undefined) {
+      if (!input.patch.name.trim()) throw new OutreachInvalidError('name must be non-empty');
+      await this.assertCampaignNameFree(input.patch.name, input.id);
     }
     const updates: Record<string, unknown> = { updatedAt: new Date() };
     for (const [k, v] of Object.entries(input.patch)) {
@@ -461,7 +466,7 @@ export class OutreachService {
           eq(schema.outreachProposals.campaignId, input.campaignId),
           eq(schema.outreachProposals.contactId, input.contactId),
           eq(schema.outreachProposals.kind, 'initial'),
-          inArray(schema.outreachProposals.status, ['sent', 'approved']),
+          inArray(schema.outreachProposals.status, ['pending', 'sent', 'approved']),
         ),
       )
       .limit(1);
@@ -559,6 +564,23 @@ export class OutreachService {
     if (!crmContact) {
       throw new OutreachInvalidError(
         `no CRM contact found for ${email} on conversation ${input.conversationId}`,
+      );
+    }
+    const [openReply] = await ctx.db
+      .select({ status: schema.outreachProposals.status })
+      .from(schema.outreachProposals)
+      .where(
+        and(
+          eq(schema.outreachProposals.campaignId, conv.outreachCampaignId),
+          eq(schema.outreachProposals.contactId, crmContact.id),
+          eq(schema.outreachProposals.kind, 'reply'),
+          inArray(schema.outreachProposals.status, ['pending', 'approved']),
+        ),
+      )
+      .limit(1);
+    if (openReply) {
+      throw new ConflictException(
+        `outreach_conflict: a ${openReply.status} reply proposal already exists for this conversation`,
       );
     }
     try {
@@ -1590,6 +1612,27 @@ export class OutreachService {
       .where(eq(schema.crmSegments.id, segmentId))
       .limit(1);
     if (!rows[0]) throw new OutreachInvalidError(`segment ${segmentId} does not exist`);
+  }
+
+  private async assertCampaignNameFree(name: string, exceptId?: string): Promise<void> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor!;
+    const [taken] = await ctx.db
+      .select({ id: schema.outreachCampaigns.id })
+      .from(schema.outreachCampaigns)
+      .where(
+        and(
+          eq(schema.outreachCampaigns.orgId, actor.orgId),
+          eq(schema.outreachCampaigns.name, name),
+          exceptId ? ne(schema.outreachCampaigns.id, exceptId) : undefined,
+        ),
+      )
+      .limit(1);
+    if (taken) {
+      throw new ConflictException(
+        `outreach_conflict: campaign with name "${name}" already exists`,
+      );
+    }
   }
 
   private async loadOutreachChannel(


### PR DESCRIPTION
## What

Four `outreach_*` write paths relied on a `try/catch` around the insert — or on nothing at all — to turn a unique violation into a `ConflictException`. Per the rule in `CLAUDE.md`, that never worked over `/mcp`: the handler runs inside the request's outer tenant transaction, so the violation poisons it and the **commit** fails *after* the handler returns, past any in-handler catch. The caller gets a bare `{"statusCode":500,"message":"Internal server error"}`.

Each now pre-checks with a `SELECT` before the failing statement:

| Tool | Before |
|---|---|
| `outreach_propose_first_touch` | pre-check only matched `sent` / `approved`, so a second **pending** first-touch for the same (campaign, contact) reached the unique index → 500 |
| `outreach_propose_reply` | no pre-check at all; a second pending reply for one conversation → 500 |
| `outreach_create_campaign` | catch-only on `outreach_campaigns_org_name_uq` → 500 |
| `outreach_update_campaign` | neither a pre-check nor a catch, so a rename onto an existing name was *always* a raw 500 |

`outreach_propose_followup` already pre-checked (its `queued` guard) and is unchanged. The existing catches stay as backstops for genuine races.

## Why it stayed hidden

The guards keyed off the unique index's *name*. `feat/outreach-scheduled-sends` renames `outreach_proposals_pending_pair_uq` → `outreach_proposals_open_pair_uq`; any mismatch between code and schema silently turns every duplicate into a 500. Pre-checking removes that coupling entirely.

## Verification

Reverting just the `'pending'` addition and re-running the new test reproduces the real failure at the transport layer:

```
SdkHttpError: Error POSTing to endpoint: {"statusCode":500,"message":"Internal server error"}
```

Three new MCP-level tests drive `/mcp` with an admin key and assert the response contains `outreach_conflict` and contains **neither** `duplicate key value` **nor** `Internal server error`.

- `pnpm -F @getmunin/backend-core test` — 111 files, 1340 tests, all passing
- workspace `typecheck` + `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)