### PR TITLE
fix(conv): dedupe Threll transcripts and emit status_changed on voice auto-close

### DIFF
--- a/.changeset/threll-transcript-dedup.md
+++ b/.changeset/threll-transcript-dedup.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/db': patch
+---
+
+Fix two voice channel bugs found while testing Threll:
+
+- Phone calls stored every transcript turn twice. Threll redelivers the full call transcript as a burst of `call.transcript` events shortly after the live turns already streamed in, with no signal distinguishing the redelivery from the original. `ThrellAdapter` now dedupes voice messages on insert via a partial unique index on `(conversation_id, threllCallId, voiceTurnIndex, threllRole)`, so a redelivered turn is dropped instead of creating a second `conv_messages` row — and a second copy mirrored into Slack. The migration also collapses turns already duplicated on existing deploys, keeping the earliest copy of each.
+- A voice call that auto-closed on hangup still looked open everywhere except the dashboard. Both voice adapters closed the conversation with a raw `UPDATE` and emitted only `conversation.voice.call_ended`, which no operator bridge consumes: `conversation.status_changed` never fired, so the Slack thread parent kept rendering the open state with a "Close" button until someone clicked it, and the `skill://crm/extract-contact-from-message` pass that every other close enqueues never ran for voice — the channel most likely to have a name or email volunteered out loud. `ThrellAdapter` and `VapiAdapter` now write call metadata and then route the status transition through `ConvService.changeStatus`, so an auto-close emits the same events, clears human-attention state, releases the runner lease, and enqueues the same follow-up job as a manual close.

--- a/packages/backend-core/src/modules/conv/threll/threll-adapter.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-adapter.ts
@@ -40,12 +40,17 @@ import {
 import { findOrCreateContactByPhone } from '../contact-by-phone.ts';
 import { jsonbToStored } from './threll.service.ts';
 import { ThrellToolBridge } from './threll-tool-bridge.ts';
+import { ConvService } from '../conv.service.ts';
 
 interface ThrellCustomer {
   number?: string;
   name?: string | null;
   personId?: string | null;
   language?: string | null;
+}
+
+interface ConversationStatusWriter {
+  changeStatus(input: { id: string; status: 'closed' }): Promise<unknown>;
 }
 
 interface ThrellEvent {
@@ -81,6 +86,7 @@ export class ThrellAdapter implements ChannelAdapter {
     @Inject(ThrellClientService) private readonly client: ThrellClientService,
     @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
     @Inject(ThrellToolBridge) private readonly tools: ThrellToolBridge,
+    @Inject(ConvService) private readonly conv: ConversationStatusWriter,
   ) {}
 
   readonly inbound: InboundMode = {
@@ -300,8 +306,9 @@ export class ThrellAdapter implements ChannelAdapter {
       delete nextMeta.voiceStartedAt;
       await tx
         .update(schema.convConversations)
-        .set({ metadata: nextMeta, status: 'closed', updatedAt: new Date() })
+        .set({ metadata: nextMeta, updatedAt: new Date() })
         .where(eq(schema.convConversations.id, conversation.id));
+      await this.conv.changeStatus({ id: conversation.id, status: 'closed' });
       await this.webhooks.emit({
         type: 'conversation.voice.call_ended',
         payload: {
@@ -322,38 +329,39 @@ export class ThrellAdapter implements ChannelAdapter {
     args: { role: 'user' | 'assistant'; text: string; callId: string; voiceTurnIndex: number },
   ): Promise<void> {
     const authorType = args.role === 'user' ? 'end_user' : 'agent';
-    const authorId = args.role === 'user' ? conversation.contactId ?? 'voice-user' : 'threll';
-    const [stored] = await tx
-      .insert(schema.convMessages)
-      .values({
-        orgId: channel.orgId,
-        conversationId: conversation.id,
-        authorType,
-        authorId: authorId || 'threll',
-        body: args.text,
-        internal: false,
-        metadata: {
-          threllCallId: args.callId,
-          threllRole: args.role,
-          voiceTurnIndex: args.voiceTurnIndex,
-        },
-      })
-      .returning();
+    const authorId = (args.role === 'user' ? conversation.contactId ?? 'voice-user' : 'threll') || 'threll';
+    const metadata = {
+      threllCallId: args.callId,
+      threllRole: args.role,
+      voiceTurnIndex: args.voiceTurnIndex,
+    };
+    const newId = makeId('cvm');
+    const inserted = await tx.execute<{ id: string }>(sql`
+      INSERT INTO conv_messages
+        (id, org_id, conversation_id, author_type, author_id, body, internal, metadata)
+      VALUES
+        (${newId}, ${channel.orgId}, ${conversation.id}, ${authorType}, ${authorId}, ${args.text}, false,
+         ${JSON.stringify(metadata)}::jsonb)
+      ON CONFLICT (conversation_id, ((metadata ->> 'threllCallId')), ((metadata ->> 'voiceTurnIndex')), ((metadata ->> 'threllRole')))
+        WHERE (metadata ->> 'threllCallId') IS NOT NULL
+      DO NOTHING
+      RETURNING id
+    `);
+    const storedId = inserted[0]?.id;
+    if (!storedId) return;
     await tx
       .update(schema.convConversations)
       .set({ lastMessageAt: new Date(), updatedAt: new Date() })
       .where(eq(schema.convConversations.id, conversation.id));
-    if (stored) {
-      await this.webhooks.emit({
-        type: 'conversation.message.received',
-        payload: {
-          conversationId: conversation.id,
-          messageId: stored.id,
-          authorType,
-          internal: false,
-        },
-      });
-    }
+    await this.webhooks.emit({
+      type: 'conversation.message.received',
+      payload: {
+        conversationId: conversation.id,
+        messageId: storedId,
+        authorType,
+        internal: false,
+      },
+    });
   }
 
   private async runAsSystem<T = void>(

--- a/packages/backend-core/src/modules/conv/threll/threll.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll.integration.test.ts
@@ -572,6 +572,41 @@ const skipReason = TEST_URL
     expect(msgs[1]!.authorType).toBe('agent');
   });
 
+  it('ignores a redelivered transcript turn instead of storing it twice', async () => {
+    const callId = 'call_threll_redelivered';
+    const turn = {
+      type: 'call.transcript',
+      data: {
+        callId,
+        role: 'user',
+        text: 'Can you check my order status?',
+        isFinal: true,
+        turnIndex: 0,
+      },
+    };
+    const r1 = await postEvent(turn);
+    expect(r1.status).toBe(204);
+    const r2 = await postEvent(turn);
+    expect(r2.status).toBe(204);
+
+    const convs = await db
+      .select({ id: schema.convConversations.id })
+      .from(schema.convConversations)
+      .where(
+        and(
+          eq(schema.convConversations.orgId, orgId),
+          sql`${schema.convConversations.metadata}->>'threllCallId' = ${callId}`,
+        ),
+      );
+    expect(convs.length).toBe(1);
+
+    const msgs = await db
+      .select({ body: schema.convMessages.body })
+      .from(schema.convMessages)
+      .where(eq(schema.convMessages.conversationId, convs[0]!.id));
+    expect(msgs.length).toBe(1);
+  });
+
   it('skips non-final transcripts', async () => {
     const callId = 'call_threll_partial';
     await postEvent({
@@ -617,6 +652,75 @@ const skipReason = TEST_URL
     expect(threllCall.recordingAvailable).toBe(true);
     expect(threllCall.analysis).toBe('Resolved.');
     expect(threllCall.endedReason).toBe('completed');
+  });
+
+  it('emits conversation.status_changed on call.ended so operator bridges see the auto-close', async () => {
+    const callId = 'call_threll_end_status_event';
+    await postEvent({
+      type: 'call.transcript',
+      data: { callId, role: 'user', text: 'That is all, thanks', isFinal: true, turnIndex: 0 },
+    });
+    await postEvent({
+      type: 'call.ended',
+      data: { callId, status: 'completed', recordingAvailable: false, analysis: null },
+    });
+
+    const [conv] = await db
+      .select({ id: schema.convConversations.id, status: schema.convConversations.status })
+      .from(schema.convConversations)
+      .where(
+        and(
+          eq(schema.convConversations.orgId, orgId),
+          sql`${schema.convConversations.metadata}->>'threllCallId' = ${callId}`,
+        ),
+      )
+      .limit(1);
+    expect(conv!.status).toBe('closed');
+
+    const events = await db
+      .select({ type: schema.events.type })
+      .from(schema.events)
+      .where(
+        and(
+          eq(schema.events.orgId, orgId),
+          sql`${schema.events.payload}->>'conversationId' = ${conv!.id}`,
+        ),
+      );
+    expect(events.map((e) => e.type)).toContain('conversation.status_changed');
+  });
+
+  it('enqueues the CRM contact-extraction pass when a voice call auto-closes', async () => {
+    const callId = 'call_threll_end_curator_job';
+    await postEvent({
+      type: 'call.transcript',
+      data: { callId, role: 'user', text: 'I am Ada, ada@example.com', isFinal: true, turnIndex: 0 },
+    });
+    await postEvent({
+      type: 'call.ended',
+      data: { callId, status: 'completed', recordingAvailable: false, analysis: null },
+    });
+
+    const [conv] = await db
+      .select({ id: schema.convConversations.id })
+      .from(schema.convConversations)
+      .where(
+        and(
+          eq(schema.convConversations.orgId, orgId),
+          sql`${schema.convConversations.metadata}->>'threllCallId' = ${callId}`,
+        ),
+      )
+      .limit(1);
+
+    const jobs = await db
+      .select({ jobUri: schema.curatorJobs.jobUri })
+      .from(schema.curatorJobs)
+      .where(
+        and(
+          eq(schema.curatorJobs.orgId, orgId),
+          eq(schema.curatorJobs.dedupeKey, `crm-contact-extract:conv:${conv!.id}`),
+        ),
+      );
+    expect(jobs.map((j) => j.jobUri)).toContain('skill://crm/extract-contact-from-message');
   });
 });
 

--- a/packages/backend-core/src/modules/conv/vapi/vapi-adapter.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-adapter.ts
@@ -33,6 +33,7 @@ import {
   verifyVapiWebhookSecret,
 } from './vapi-client.service.ts';
 import { findOrCreateContactByPhone } from '../contact-by-phone.ts';
+import { ConvService } from '../conv.service.ts';
 import { jsonbToStored } from './vapi.service.ts';
 import { VapiToolBridge, type VapiToolCall } from './vapi-tool-bridge.ts';
 import {
@@ -41,6 +42,10 @@ import {
   composeVoiceSystemPrompt,
   type ChatMessageSeed,
 } from './vapi-assistant.ts';
+
+interface ConversationStatusWriter {
+  changeStatus(input: { id: string; status: 'closed' }): Promise<unknown>;
+}
 
 interface VapiServerMessage {
   type: string;
@@ -81,6 +86,7 @@ export class VapiAdapter implements ChannelAdapter {
     @Inject(VapiClientService) private readonly client: VapiClientService,
     @Inject(WebhookDispatcher) private readonly webhooks: WebhookDispatcher,
     @Inject(VapiToolBridge) private readonly tools: VapiToolBridge,
+    @Inject(ConvService) private readonly conv: ConversationStatusWriter,
   ) {}
 
   readonly inbound: InboundMode = {
@@ -517,10 +523,10 @@ export class VapiAdapter implements ChannelAdapter {
         .update(schema.convConversations)
         .set({
           metadata: nextMeta,
-          status: 'closed',
           updatedAt: new Date(),
         })
         .where(eq(schema.convConversations.id, conversation.id));
+      await this.conv.changeStatus({ id: conversation.id, status: 'closed' });
       await this.webhooks.emit({
         type: 'conversation.voice.call_ended',
         payload: {

--- a/packages/db/drizzle/0065_conv_messages_threll_turn_uq.sql
+++ b/packages/db/drizzle/0065_conv_messages_threll_turn_uq.sql
@@ -1,0 +1,21 @@
+DO $$
+BEGIN
+  PERFORM set_config('app.bypass_rls', 'on', true);
+
+  -- Threll has redelivered whole call transcripts before this fix landed,
+  -- storing each turn twice. Keep the earliest copy of each turn, drop the rest.
+  DELETE FROM conv_messages cm
+  USING (
+    SELECT id, row_number() OVER (
+      PARTITION BY conversation_id, (metadata ->> 'threllCallId'), (metadata ->> 'voiceTurnIndex'), (metadata ->> 'threllRole')
+      ORDER BY created_at, id
+    ) AS rn
+    FROM conv_messages
+    WHERE (metadata ->> 'threllCallId') IS NOT NULL
+  ) dup
+  WHERE cm.id = dup.id AND dup.rn > 1;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "conv_messages_threll_turn_uq"
+  ON "conv_messages" ("conversation_id", (("metadata" ->> 'threllCallId')), (("metadata" ->> 'voiceTurnIndex')), (("metadata" ->> 'threllRole')))
+  WHERE ("metadata" ->> 'threllCallId') IS NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1785850742440,
       "tag": "0064_cms_entry_translation_groups",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1785923150369,
+      "tag": "0065_conv_messages_threll_turn_uq",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Two bugs surfaced while testing the Threll voice channel against a real inbound phone call. Both were diagnosed from the live conversation and call data, not just the symptoms.

## 1. Every transcript turn was stored twice

Threll redelivers the **full** call transcript as a second, out-of-order burst of `call.transcript` events a few seconds after the live turns already streamed in — with nothing in the payload distinguishing the redelivery from the original. `ThrellAdapter.handleTranscript` had no idempotency guard, so each redelivered turn became a fresh `conv_messages` row, and the Slack bridge dutifully mirrored a second copy of the whole conversation.

The observed call stored turns 0–12, then all 13 again inside a ~7s window.

**Fix:** dedupe on insert against a new partial unique index on `(conversation_id, threllCallId, voiceTurnIndex, threllRole)`. The insert moves to raw SQL with `ON CONFLICT … DO NOTHING`, mirroring the conversation-level dedup already in this file, so a redelivered turn is dropped without emitting a duplicate `conversation.message.received`. The migration also collapses turns already duplicated on existing deploys, keeping the earliest copy of each.

## 2. A voice call that auto-closed still looked open everywhere but the dashboard

`handleEnded` did close the conversation — but with a raw `UPDATE` that set `status: 'closed'` directly, emitting only `conversation.voice.call_ended`. That event is in no operator bridge's subscription list (`SLACK_MIRRORED_EVENT_TYPES`) and has no case in the bridge's switch, so:

- `conversation.status_changed` never fired, and the Slack thread parent kept rendering the open state with a **"Close"** button indefinitely. Clicking it is what finally made the thread show as resolved — which reads exactly like "the conversation wasn't auto-closed".
- The `skill://crm/extract-contact-from-message` pass that `changeStatus` enqueues on every other close never ran for voice — the channel most likely to have a name or email volunteered out loud.
- `needsHumanAttention` / `handoverResolvedAt` were never cleared and the runner lease was never released.

**Fix:** both `ThrellAdapter` and `VapiAdapter` (same bug, same shape) now write the call metadata and then route the status transition through `ConvService.changeStatus`, so an auto-close is indistinguishable from a manual one. Injected behind a narrow `ConversationStatusWriter` interface with `@Inject(ConvService)`, per the repo's no-double-cast convention — no DI cycle, `ConvService` doesn't depend on adapters.

## Verification

- Full `backend-core` suite: **1432 passed / 116 files**, including two new tests asserting `conversation.status_changed` and the curator job now land on a Threll auto-close, plus one for redelivered-turn dedup.
- Migration smoke-tested against a scratch DB **already at 0064** and seeded with the exact production duplicate pattern: the backfill kept the earliest copy of each turn, left non-Threll messages untouched, and the unique index built cleanly on top of previously-violating rows. The `ON CONFLICT` arbiter was then exercised as the non-superuser `munin_app` role — redelivered turn dropped, genuinely new turn inserted.
- `_journal.json` timestamp strictly increases (`migrations-journal.test.ts` 4/4); typecheck + eslint clean.

## Known limitations (pre-existing, not addressed here)

- Dedup keys on `voiceTurnIndex`, which `handleTranscript` falls back to deriving from `COUNT(*)` when Threll omits it. That count grows between the original and the redelivery, so the fallback yields a different index and a duplicate would still land. The observed call sends `turnIndex`, so it's covered in practice; a content hash would close the hole properly.
- `handleEnded` can still create-then-close a phantom conversation for a `callId` Munin never saw, via `resolveConversation` → `findOrCreateConversation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)