### PR TITLE
fix(conv): gate the voice tool list by connector state and channel kind

### DIFF
--- a/.changeset/voice-tool-list-connector-and-channel-gating.md
+++ b/.changeset/voice-tool-list-connector-and-channel-gating.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/mcp-toolkit': minor
+---
+
+Gate the voice tool list a Threll or Vapi call gets by connector state and channel appropriateness.
+
+Every voice call — Threll phone calls, Threll web-widget voice, Vapi — built its tool list from the full `self_service` registry with no filtering. Two consequences: `commerce_*`/`bookings_*` tools were offered to the voice agent even when the org had never configured a commerce or bookings connector connection, and `conv_request_human` (an async "flag this conversation for a teammate to review later" tool) was offered on live calls where it can't actually pull a human into the call — `conv_request_callback`, which places a real outbound call, is the voice-appropriate escalation.
+
+`@McpTool` gains `excludeChannelKinds`, and `McpToolRegistry.list()` takes an optional `{ channelKind }` filter; `conv_request_human` now sets `excludeChannelKinds: ['voice']`. A new `VoiceSelfServiceToolsService` — shared by `ThrellToolBridge` and `VapiToolBridge`, so a future voice vendor picks up the same behavior for free — additionally drops connector-backed tools per-request when `ConnectorsService.listActiveDomains` reports no active connection for their domain. Both bridges' `dispatch()` route through the same service's `isCallable`, so a channel-excluded tool is rejected even when a client calls it by name outside the advertised list.
+
+`listActiveDomains` resolves every domain in one indexed read on the caller's executor. `WidgetVoiceService.startSession` builds its tool list inside an open transaction, so the check has to reuse that transaction: acquiring a second pool connection while the first is held deadlocks the pool once concurrent voice starts reach `MUNIN_DB_POOL_MAX` (default 10), since no outer transaction can commit until an inner connection it will never be granted frees up. The domain→tool-prefix map is keyed by `ConnectorDomain`, so adding a third connector domain is a compile error here until it is gated too.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -4147,6 +4147,208 @@
     }
   },
   {
+    "name": "connectors_list_vendors",
+    "title": "Connectors: List supported vendors",
+    "description": "List the third-party systems Munin can connect to, grouped by domain (commerce, bookings) with the config fields each vendor requires. Use it to see what credentials are needed before creating a connection.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "connectors:read"
+    ],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "connectors_list_connections",
+    "title": "Connectors: List connections",
+    "description": "List this org’s connections to third-party systems with domain, non-secret settings, active state, and the result of the last credential test. Secrets are never returned.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "connectors:read"
+    ],
+    "danger": null,
+    "readOnly": true,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "connectors_create_connection",
+    "title": "Connectors: Create a connection",
+    "description": "Create a connection to a third-party system. `config` takes the vendor’s non-secret fields only — connectors_list_vendors returns the exact fields and marks which are secret. Secret fields are rejected here: the connection is created pending and the response includes a one-time link for a human to enter the secrets in the dashboard. The vendor determines the domain (commerce, bookings). Connection names must be unique within the org.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "connectors:write"
+    ],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "config": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "vendor",
+        "name"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "connectors_request_credentials",
+    "title": "Connectors: Request a credential link",
+    "description": "Return a one-time link a human opens to enter a connection’s secret credentials in the dashboard, so the secret is never pasted into a conversation. Use it for a pending connection created without its secret. The link expires after 24 hours.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "connectors:write"
+    ],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "connectionId": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "connectionId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "connectors_update_connection",
+    "title": "Connectors: Update a connection",
+    "description": "Rename, activate/deactivate, or reconfigure a connection. When passing `config`, supply the full non-secret vendor config; the stored secret values are kept. Secret fields are rejected here — to rotate a secret, delete the connection and create it again, entering the new secret through the credential link.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "connectors:write"
+    ],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "connectionId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "config": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "active": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "connectionId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "connectors_delete_connection",
+    "title": "Connectors: Delete a connection",
+    "description": "Delete a connection and its stored credentials. Lookups through this connection stop working immediately.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "connectors:write"
+    ],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "connectionId": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "connectionId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "connectors_test_connection",
+    "title": "Connectors: Test a connection’s credentials",
+    "description": "Verify a connection’s stored credentials against the vendor with a read-only probe (no external data is changed). Records the result on the connection.",
+    "audiences": [
+      "admin"
+    ],
+    "scopes": [
+      "connectors:write"
+    ],
+    "danger": "destructive",
+    "readOnly": false,
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "connectionId": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "connectionId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "crm_list_contacts",
     "title": "CRM: List contacts",
     "description": "List contacts in your org, newest-updated first. Filter by company or tag.",
@@ -8470,208 +8672,6 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {},
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "connectors_list_vendors",
-    "title": "Connectors: List supported vendors",
-    "description": "List the third-party systems Munin can connect to, grouped by domain (commerce, bookings) with the config fields each vendor requires. Use it to see what credentials are needed before creating a connection.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "connectors:read"
-    ],
-    "danger": null,
-    "readOnly": true,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "connectors_list_connections",
-    "title": "Connectors: List connections",
-    "description": "List this org’s connections to third-party systems with domain, non-secret settings, active state, and the result of the last credential test. Secrets are never returned.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "connectors:read"
-    ],
-    "danger": null,
-    "readOnly": true,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "connectors_create_connection",
-    "title": "Connectors: Create a connection",
-    "description": "Create a connection to a third-party system. `config` takes the vendor’s non-secret fields only — connectors_list_vendors returns the exact fields and marks which are secret. Secret fields are rejected here: the connection is created pending and the response includes a one-time link for a human to enter the secrets in the dashboard. The vendor determines the domain (commerce, bookings). Connection names must be unique within the org.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "connectors:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 32
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        },
-        "config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
-          "additionalProperties": {}
-        }
-      },
-      "required": [
-        "vendor",
-        "name"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "connectors_request_credentials",
-    "title": "Connectors: Request a credential link",
-    "description": "Return a one-time link a human opens to enter a connection’s secret credentials in the dashboard, so the secret is never pasted into a conversation. Use it for a pending connection created without its secret. The link expires after 24 hours.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "connectors:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "connectionId": {
-          "type": "string",
-          "minLength": 1
-        }
-      },
-      "required": [
-        "connectionId"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "connectors_update_connection",
-    "title": "Connectors: Update a connection",
-    "description": "Rename, activate/deactivate, or reconfigure a connection. When passing `config`, supply the full non-secret vendor config; the stored secret values are kept. Secret fields are rejected here — to rotate a secret, delete the connection and create it again, entering the new secret through the credential link.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "connectors:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "connectionId": {
-          "type": "string",
-          "minLength": 1
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        },
-        "config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
-          "additionalProperties": {}
-        },
-        "active": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "connectionId"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "connectors_delete_connection",
-    "title": "Connectors: Delete a connection",
-    "description": "Delete a connection and its stored credentials. Lookups through this connection stop working immediately.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "connectors:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "connectionId": {
-          "type": "string",
-          "minLength": 1
-        }
-      },
-      "required": [
-        "connectionId"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "connectors_test_connection",
-    "title": "Connectors: Test a connection’s credentials",
-    "description": "Verify a connection’s stored credentials against the vendor with a read-only probe (no external data is changed). Records the result on the connection.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "connectors:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "connectionId": {
-          "type": "string",
-          "minLength": 1
-        }
-      },
-      "required": [
-        "connectionId"
-      ],
       "additionalProperties": false
     }
   },

--- a/packages/backend-core/src/modules/connectors/connectors.service.test.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.test.ts
@@ -467,6 +467,51 @@ class FakeAdapter implements ConnectorAdapter {
     });
   });
 
+  describe('listActiveDomains', () => {
+    const ALL: ConnectorDomain[] = ['commerce', 'bookings'];
+
+    it('reports only domains that currently have an active connection', async () => {
+      const svc = new ConnectorsService(new ConnectorRegistry([shopAdapter]), undefined, db);
+
+      expect([...(await svc.listActiveDomains(orgId, ALL))]).toEqual([]);
+
+      const shop = await createConnection('fakeshop', 'Main store');
+      expect([...(await svc.listActiveDomains(orgId, ALL))]).toEqual(['commerce']);
+
+      await createConnection('fakedesk', 'Front desk');
+      expect([...(await svc.listActiveDomains(orgId, ALL))].sort()).toEqual([
+        'bookings',
+        'commerce',
+      ]);
+
+      await run(() => connectors.updateConnection({ connectionId: shop.id, active: false }));
+      expect([...(await svc.listActiveDomains(orgId, ALL))]).toEqual(['bookings']);
+    });
+
+    it('never reports a domain the caller did not ask about', async () => {
+      await createConnection('fakedesk', 'Front desk');
+      const svc = new ConnectorsService(new ConnectorRegistry([shopAdapter]), undefined, db);
+
+      expect([...(await svc.listActiveDomains(orgId, ['commerce']))]).toEqual([]);
+      expect([...(await svc.listActiveDomains(orgId, []))]).toEqual([]);
+    });
+
+    it('does not leak across orgs', async () => {
+      await createConnection('fakeshop', 'Main store');
+      const svc = new ConnectorsService(new ConnectorRegistry([shopAdapter]), undefined, db);
+
+      const [otherOrg] = await db
+        .insert(schema.orgs)
+        .values({ name: 'Other listActiveDomains Org' })
+        .returning();
+
+      expect([...(await svc.listActiveDomains(otherOrg!.id, ALL))]).toEqual([]);
+
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      await db.delete(schema.orgs).where(sql`id = ${otherOrg!.id}`);
+    });
+  });
+
   describe('RLS', () => {
     it('lets an end-user context read connections but not write them', async () => {
       const dto = await createConnection('fakeshop', 'Main store');

--- a/packages/backend-core/src/modules/connectors/connectors.service.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { sql } from 'drizzle-orm';
 import { schema, type Db, type Tx } from '@getmunin/db';
 import {
@@ -109,6 +109,25 @@ export class ConnectorsService {
       .from(schema.connectorConnections)
       .orderBy(schema.connectorConnections.createdAt);
     return rows.map((row) => this.toDto(row));
+  }
+
+  async listActiveDomains(
+    orgId: string,
+    domains: readonly ConnectorDomain[],
+    db?: Db | Tx,
+  ): Promise<Set<ConnectorDomain>> {
+    if (domains.length === 0) return new Set();
+    const rows = await (db ?? this.requireRootDb())
+      .selectDistinct({ domain: schema.connectorConnections.domain })
+      .from(schema.connectorConnections)
+      .where(
+        and(
+          eq(schema.connectorConnections.orgId, orgId),
+          inArray(schema.connectorConnections.domain, [...domains]),
+          eq(schema.connectorConnections.active, true),
+        ),
+      );
+    return new Set(rows.map((r) => r.domain as ConnectorDomain));
   }
 
   async createConnection(

--- a/packages/backend-core/src/modules/conv/channels/voice-self-service-tools.service.test.ts
+++ b/packages/backend-core/src/modules/conv/channels/voice-self-service-tools.service.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { Audience } from '@getmunin/core';
+import type { RegisteredMcpTool } from '@getmunin/mcp-toolkit';
+import { VoiceSelfServiceToolsService } from './voice-self-service-tools.service.ts';
+import type { ConnectorDomain } from '../../connectors/connector.ts';
+
+function tool(name: string, excludeChannelKinds?: readonly string[]): RegisteredMcpTool {
+  return {
+    meta: {
+      name,
+      description: name,
+      audiences: ['self_service'],
+      scopes: [],
+      input: z.object({}),
+      excludeChannelKinds,
+    },
+    handler: () => null,
+    inputJsonSchema: { type: 'object' },
+  };
+}
+
+function fakeRegistry(tools: RegisteredMcpTool[]) {
+  return {
+    list: (_audience?: Audience, opts?: { channelKind?: string }) =>
+      opts?.channelKind
+        ? tools.filter((t) => !t.meta.excludeChannelKinds?.includes(opts.channelKind!))
+        : tools,
+  };
+}
+
+function fakeConnectors(activeDomains: ConnectorDomain[]) {
+  const asked: Array<readonly ConnectorDomain[]> = [];
+  return {
+    asked,
+    listActiveDomains: (_orgId: string, domains: readonly ConnectorDomain[]) => {
+      asked.push(domains);
+      return Promise.resolve(new Set(domains.filter((d) => activeDomains.includes(d))));
+    },
+  };
+}
+
+describe('VoiceSelfServiceToolsService', () => {
+  it('drops connector-backed tools when the org has no active connection for that domain', async () => {
+    const tools = [
+      tool('kb_search'),
+      tool('commerce_list_my_orders'),
+      tool('bookings_list_my_bookings'),
+    ];
+    const connectors = fakeConnectors(['commerce']);
+    const svc = new VoiceSelfServiceToolsService(fakeRegistry(tools), connectors);
+
+    const result = await svc.list('org_1');
+
+    expect(result.map((t) => t.meta.name)).toEqual(['kb_search', 'commerce_list_my_orders']);
+  });
+
+  it('keeps connector-backed tools when the domain has an active connection', async () => {
+    const tools = [tool('commerce_list_my_orders'), tool('bookings_list_my_bookings')];
+    const connectors = fakeConnectors(['commerce', 'bookings']);
+    const svc = new VoiceSelfServiceToolsService(fakeRegistry(tools), connectors);
+
+    const result = await svc.list('org_1');
+
+    expect(result.map((t) => t.meta.name)).toEqual([
+      'commerce_list_my_orders',
+      'bookings_list_my_bookings',
+    ]);
+  });
+
+  it('excludes voice-inappropriate tools via the registry channel-kind filter', async () => {
+    const tools = [tool('conv_request_human', ['voice']), tool('conv_request_callback')];
+    const svc = new VoiceSelfServiceToolsService(fakeRegistry(tools), fakeConnectors([]));
+
+    const result = await svc.list('org_1');
+
+    expect(result.map((t) => t.meta.name)).toEqual(['conv_request_callback']);
+  });
+
+  it('only checks connector domains that are actually present in the candidate list', async () => {
+    const tools = [tool('kb_search'), tool('bookings_list_my_bookings')];
+    const connectors = fakeConnectors([]);
+    const svc = new VoiceSelfServiceToolsService(fakeRegistry(tools), connectors);
+
+    await svc.list('org_1');
+
+    expect(connectors.asked).toEqual([['bookings']]);
+  });
+
+  it('treats a connector-backed tool as callable only when the channel allows it', () => {
+    const svc = new VoiceSelfServiceToolsService(fakeRegistry([]), fakeConnectors([]));
+
+    expect(svc.isCallable(tool('conv_request_callback'))).toBe(true);
+    expect(svc.isCallable(tool('conv_request_human', ['voice']))).toBe(false);
+    expect(svc.isCallable(tool('conv_request_human', ['email']))).toBe(true);
+  });
+});

--- a/packages/backend-core/src/modules/conv/channels/voice-self-service-tools.service.ts
+++ b/packages/backend-core/src/modules/conv/channels/voice-self-service-tools.service.ts
@@ -1,0 +1,57 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { Audience } from '@getmunin/core';
+import type { Db, Tx } from '@getmunin/db';
+import type { RegisteredMcpTool } from '@getmunin/mcp-toolkit';
+import { McpRegistryService } from '../../../mcp/mcp.registry.ts';
+import { ConnectorsService } from '../../connectors/connectors.service.ts';
+import type { ConnectorDomain } from '../../connectors/connector.ts';
+
+export const VOICE_CHANNEL_KIND = 'voice';
+
+const TOOL_PREFIX_BY_DOMAIN: Record<ConnectorDomain, string> = {
+  commerce: 'commerce_',
+  bookings: 'bookings_',
+};
+
+const CONNECTOR_DOMAINS = Object.keys(TOOL_PREFIX_BY_DOMAIN) as ConnectorDomain[];
+
+interface ToolLister {
+  list(audience?: Audience, opts?: { channelKind?: string }): RegisteredMcpTool[];
+}
+
+interface ConnectorDomainReader {
+  listActiveDomains(
+    orgId: string,
+    domains: readonly ConnectorDomain[],
+    db?: Db | Tx,
+  ): Promise<Set<ConnectorDomain>>;
+}
+
+function domainOf(toolName: string): ConnectorDomain | null {
+  return CONNECTOR_DOMAINS.find((d) => toolName.startsWith(TOOL_PREFIX_BY_DOMAIN[d])) ?? null;
+}
+
+@Injectable()
+export class VoiceSelfServiceToolsService {
+  constructor(
+    @Inject(McpRegistryService) private readonly registry: ToolLister,
+    @Inject(ConnectorsService) private readonly connectors: ConnectorDomainReader,
+  ) {}
+
+  async list(orgId: string, db?: Db | Tx): Promise<RegisteredMcpTool[]> {
+    const candidates = this.registry.list('self_service', { channelKind: VOICE_CHANNEL_KIND });
+    const needed = CONNECTOR_DOMAINS.filter((domain) =>
+      candidates.some((t) => t.meta.name.startsWith(TOOL_PREFIX_BY_DOMAIN[domain])),
+    );
+    const active = await this.connectors.listActiveDomains(orgId, needed, db);
+
+    return candidates.filter((t) => {
+      const domain = domainOf(t.meta.name);
+      return !domain || active.has(domain);
+    });
+  }
+
+  isCallable(tool: RegisteredMcpTool): boolean {
+    return !tool.meta.excludeChannelKinds?.includes(VOICE_CHANNEL_KIND);
+  }
+}

--- a/packages/backend-core/src/modules/conv/conv.module.ts
+++ b/packages/backend-core/src/modules/conv/conv.module.ts
@@ -22,6 +22,8 @@ import { ChannelAdminTools } from './channels/channel-admin.tools.ts';
 import { ChannelCredentialService } from './channels/channel-credential.service.ts';
 import { ChannelCredentialTools } from './channels/channel-credential.tools.ts';
 import { CredentialHandoffModule } from '../credential-handoff/credential-handoff.module.ts';
+import { ConnectorsModule } from '../connectors/connectors.module.ts';
+import { VoiceSelfServiceToolsService } from './channels/voice-self-service-tools.service.ts';
 import { CredentialTargetRegistry } from '../credential-handoff/credential-target.ts';
 import { VapiAdminProvider } from './vapi/vapi-admin.provider.ts';
 import { VapiOutreachCaller } from './vapi/vapi-outreach-caller.ts';
@@ -65,7 +67,14 @@ import { WidgetAdminTools } from './widget/widget.tools.ts';
 import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
 
 @Module({
-  imports: [CuratorModule, McpModule, RealtimeModule, PublicThrottleModule, CredentialHandoffModule],
+  imports: [
+    CuratorModule,
+    McpModule,
+    RealtimeModule,
+    PublicThrottleModule,
+    CredentialHandoffModule,
+    ConnectorsModule,
+  ],
   controllers: [WidgetController, ChannelWebhookController],
   providers: [
     ConvService,
@@ -91,6 +100,7 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
     TwilioSmsService,
     TwilioSmsAdapter,
     TwilioSmsAdminService,
+    VoiceSelfServiceToolsService,
     VapiClientService,
     VapiService,
     VapiAdapter,

--- a/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.self-service.tools.ts
@@ -23,6 +23,7 @@ export class ConvSelfServiceTools {
     input: RequestMyHandoverInput,
     readOnlyHint: false,
     destructiveHint: true,
+    excludeChannelKinds: ['voice'],
   })
   requestMyHandover(args: z.infer<typeof RequestMyHandoverInput>) {
     return this.conv.requestHandover({ ...args, postSystemNote: false });

--- a/packages/backend-core/src/modules/conv/threll/threll-adapter.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-adapter.ts
@@ -199,7 +199,8 @@ export class ThrellAdapter implements ChannelAdapter {
 
       const deliveryUrl = buildWebhookUrl(channel.id);
       const tools = deliveryUrl
-        ? this.tools.buildToolList({
+        ? await this.tools.buildToolList({
+            orgId: channel.orgId,
             deliveryUrl,
             signingSecret: await this.client.loadSecret(jsonbToStored(channel.config).encryptedWebhookSecret),
           })

--- a/packages/backend-core/src/modules/conv/threll/threll-tool-bridge.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-tool-bridge.ts
@@ -6,11 +6,12 @@ import {
   withContext,
   type RequestContext,
 } from '@getmunin/core';
-import type { Db } from '@getmunin/db';
+import type { Db, Tx } from '@getmunin/db';
 import { DB } from '../../../common/db/db.module.ts';
 import { McpRegistryService } from '../../../mcp/mcp.registry.ts';
 import { applyTenancyGUCs } from '../../../common/tenancy/tenancy.interceptor.ts';
 import { SELF_SERVICE_SCOPES } from '../../../control/delegated-token.controller.ts';
+import { VoiceSelfServiceToolsService } from '../channels/voice-self-service-tools.service.ts';
 
 export interface ThrellExternalToolSpec {
   name: string;
@@ -34,13 +35,17 @@ export class ThrellToolBridge {
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(McpRegistryService) private readonly registry: McpRegistryService,
+    @Inject(VoiceSelfServiceToolsService) private readonly voiceTools: VoiceSelfServiceToolsService,
   ) {}
 
-  buildToolList(opts: {
+  async buildToolList(opts: {
+    orgId: string;
     deliveryUrl: string;
     signingSecret: string;
-  }): ThrellExternalToolSpec[] {
-    return this.registry.list('self_service').map((t) => ({
+    db?: Db | Tx;
+  }): Promise<ThrellExternalToolSpec[]> {
+    const tools = await this.voiceTools.list(opts.orgId, opts.db);
+    return tools.map((t) => ({
       name: t.meta.name,
       description: t.meta.description,
       inputSchema: sanitizeJsonSchema(t.inputJsonSchema as Record<string, unknown>),
@@ -59,6 +64,9 @@ export class ThrellToolBridge {
     const tool = this.registry.get(name);
     if (!tool) return { ok: false, error: `unknown_tool:${name}` };
     if (!tool.meta.audiences.includes('self_service')) {
+      return { ok: false, error: `tool_not_available:${name}` };
+    }
+    if (!this.voiceTools.isCallable(tool)) {
       return { ok: false, error: `tool_not_available:${name}` };
     }
 

--- a/packages/backend-core/src/modules/conv/vapi/vapi-adapter.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-adapter.ts
@@ -234,7 +234,7 @@ export class VapiAdapter implements ChannelAdapter {
       const inlineAssistant = buildInlineAssistantConfig({
         baseConfig: fetched.config,
         messages,
-        tools: this.tools.buildToolList(),
+        tools: await this.tools.buildToolList(channel.orgId),
       });
 
       const body = JSON.stringify({

--- a/packages/backend-core/src/modules/conv/vapi/vapi-tool-bridge.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-tool-bridge.ts
@@ -6,11 +6,12 @@ import {
   withContext,
   type RequestContext,
 } from '@getmunin/core';
-import type { Db } from '@getmunin/db';
+import type { Db, Tx } from '@getmunin/db';
 import { DB } from '../../../common/db/db.module.ts';
 import { McpRegistryService } from '../../../mcp/mcp.registry.ts';
 import { applyTenancyGUCs } from '../../../common/tenancy/tenancy.interceptor.ts';
 import { SELF_SERVICE_SCOPES } from '../../../control/delegated-token.controller.ts';
+import { VoiceSelfServiceToolsService } from '../channels/voice-self-service-tools.service.ts';
 
 export interface VapiFunctionTool {
   type: 'function';
@@ -41,10 +42,12 @@ export class VapiToolBridge {
   constructor(
     @Inject(DB) private readonly db: Db,
     @Inject(McpRegistryService) private readonly registry: McpRegistryService,
+    @Inject(VoiceSelfServiceToolsService) private readonly voiceTools: VoiceSelfServiceToolsService,
   ) {}
 
-  buildToolList(): VapiFunctionTool[] {
-    return this.registry.list('self_service').map((t) => ({
+  async buildToolList(orgId: string, db?: Db | Tx): Promise<VapiFunctionTool[]> {
+    const tools = await this.voiceTools.list(orgId, db);
+    return tools.map((t) => ({
       type: 'function',
       function: {
         name: t.meta.name,
@@ -73,6 +76,10 @@ export class VapiToolBridge {
         continue;
       }
       if (!tool.meta.audiences.includes('self_service')) {
+        results.push({ toolCallId: id, error: `tool_not_available:${name}` });
+        continue;
+      }
+      if (!this.voiceTools.isCallable(tool)) {
         results.push({ toolCallId: id, error: `tool_not_available:${name}` });
         continue;
       }

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
@@ -172,7 +172,12 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
         const webhookSecret = await this.threll.loadSecret(threllConfig.encryptedWebhookSecret);
         const deliveryUrl = buildVoiceWebhookUrl(channel.id);
         const externalTools = deliveryUrl
-          ? this.threllToolBridge.buildToolList({ deliveryUrl, signingSecret: webhookSecret })
+          ? await this.threllToolBridge.buildToolList({
+              orgId,
+              deliveryUrl,
+              signingSecret: webhookSecret,
+              db: tx,
+            })
           : [];
         const instructions = openerInstruction
           ? `${systemPrompt}\n\n${openerInstruction}`
@@ -242,7 +247,7 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
       const inlineAssistant = buildInlineAssistantConfig({
         baseConfig: fetched.config,
         messages: seededMessages,
-        tools: this.toolBridge.buildToolList(),
+        tools: await this.toolBridge.buildToolList(orgId, tx),
       });
       this.logger.log(
         `voice/start convId=${conv.id} vendor=vapi seededMessages=${seededMessages.length}`,

--- a/packages/mcp-toolkit/src/decorator.ts
+++ b/packages/mcp-toolkit/src/decorator.ts
@@ -11,6 +11,7 @@ export interface McpToolMeta<TInput extends z.ZodObject = z.ZodObject> {
   title?: string;
   readOnlyHint?: boolean;
   destructiveHint?: boolean;
+  excludeChannelKinds?: readonly string[];
   _meta?: Record<string, unknown>;
 }
 

--- a/packages/mcp-toolkit/src/registry.test.ts
+++ b/packages/mcp-toolkit/src/registry.test.ts
@@ -34,6 +34,20 @@ describe('McpToolRegistry', () => {
     expect(r.list().map((t) => t.meta.name)).toHaveLength(3);
   });
 
+  it('filters list by channel kind exclusion', () => {
+    const r = new McpToolRegistry();
+    r.register(meta('voice_and_chat', ['self_service']), () => 'a');
+    r.register(
+      { ...meta('chat_only', ['self_service']), excludeChannelKinds: ['voice'] },
+      () => 'b',
+    );
+
+    expect(r.list('self_service').map((t) => t.meta.name)).toEqual(['voice_and_chat', 'chat_only']);
+    expect(r.list('self_service', { channelKind: 'voice' }).map((t) => t.meta.name)).toEqual([
+      'voice_and_chat',
+    ]);
+  });
+
   it('generates JSON schema from zod input', () => {
     const r = new McpToolRegistry();
     r.register(

--- a/packages/mcp-toolkit/src/registry.ts
+++ b/packages/mcp-toolkit/src/registry.ts
@@ -20,10 +20,14 @@ export class McpToolRegistry {
     this.byName.set(meta.name, { meta, handler, inputJsonSchema });
   }
 
-  list(audience?: Audience): RegisteredMcpTool[] {
-    const all = Array.from(this.byName.values());
-    if (!audience) return all;
-    return all.filter((t) => t.meta.audiences.includes(audience));
+  list(audience?: Audience, opts?: { channelKind?: string }): RegisteredMcpTool[] {
+    let all = Array.from(this.byName.values());
+    if (audience) all = all.filter((t) => t.meta.audiences.includes(audience));
+    if (opts?.channelKind) {
+      const channelKind = opts.channelKind;
+      all = all.filter((t) => !t.meta.excludeChannelKinds?.includes(channelKind));
+    }
+    return all;
   }
 
   get(name: string): RegisteredMcpTool | undefined {


### PR DESCRIPTION
Reported from a live Threll call: the agent was offered `bookings_*` and `commerce_*` tools for an org that has never configured either connector, plus `conv_request_human`, which does nothing useful mid-call.

Both trace to one line. `ThrellToolBridge.buildToolList` (and its Vapi twin) built the call's tool list from `registry.list('self_service')` with no further filtering, so every voice call got the entire end-user surface regardless of what the org had set up or what the channel can actually do.

## What changed

**Channel-kind exclusion.** `@McpTool` gains `excludeChannelKinds`, and `McpToolRegistry.list()` takes an optional `{ channelKind }`. `conv_request_human` sets `excludeChannelKinds: ['voice']` — it flags a conversation for a teammate to review *later* and optionally drafts a reply for them to send, which is meaningless on a synchronous call. `conv_request_callback` stays, and is the real voice escalation: it places an outbound call.

**Connector-state gating.** New `VoiceSelfServiceToolsService` drops connector-backed tools when the org has no active connection for their domain, via `ConnectorsService.listActiveDomains`. This covers all 10 connector-backed end-user tools, including the non-`_my_` ones (`commerce_search_products`, `bookings_check_availability`).

**One place, so future vendors inherit it.** Both `ThrellToolBridge` and `VapiToolBridge` — covering all three voice paths (Threll phone, Threll web-widget voice, Vapi) — route list-building *and* `dispatch()` through this service. `dispatch()` uses its `isCallable`, so an excluded tool is rejected even if a client calls it by name outside the advertised list. A new voice vendor gets both filters by using the same service.

## Two things worth a reviewer's attention

**The connector check must reuse the caller's transaction.** `WidgetVoiceService.startSession` builds its tool list inside an open transaction. My first cut opened its own transaction per domain, so each voice start held one pooled connection while demanding two more. `MUNIN_DB_POOL_MAX` is unset by default → postgres.js caps at 10, and once concurrent voice starts saturate the pool no outer transaction can commit until an inner connection it will never be granted frees up: a hard deadlock. `listActiveDomains` is now a single indexed read that accepts the caller's executor, and `widget-voice` passes its `tx`. The `set_config('app.bypass_rls', ...)` I had added was also redundant — the `DB` provider is `serviceRole: true`, which sets that GUC at connection level.

**Adding a third connector domain is now a compile error until it's gated.** The domain→tool-prefix map is `Record<ConnectorDomain, string>`, so a future `invoices` domain can't silently leak its tools back into voice the way `commerce`/`bookings` just did.

## Note on the diff

`docs-fixtures/mcp-tools.json` shows the 7 `connectors_*` entries moving position. That is pure reordering, no content change: importing `ConnectorsModule` into `ConvModule` changes Nest's module instantiation order, which changes `DiscoveryService`'s walk order. `excludeChannelKinds` is internal and correctly does not appear in the public catalog; `openapi.json` regenerated with no diff.

## Testing

- `pnpm typecheck` — 31/31 packages
- backend-core: 1437 tests / 117 files pass; mcp-toolkit: 76 pass
- `eslint src` clean in both packages
- New coverage: `listActiveDomains` (active/inactive/deactivated, unasked domains, cross-org isolation), `VoiceSelfServiceToolsService` (connector gating, voice exclusion, only-query-needed-domains, `isCallable`), and registry channel-kind filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)