### PR TITLE
fix(dashboard): move conversation drawer send button to the left

### DIFF
--- a/packages/dashboard-pages/src/components/dashboard/inbox-conv-drawers.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-conv-drawers.tsx
@@ -324,21 +324,7 @@ export function FullConvDrawer({
             placeholder={t('replyPlaceholder')}
             className="w-full rounded-input border-[1px] border-rule-soft bg-paper px-3 py-2 text-base md:text-sm outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt dark:bg-card dark:border-rule-on-dark"
           />
-          <div className="mt-3 flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              {!claimed ? (
-                <Button size="sm" onClick={onTakeOver} disabled={pending} pending={pending}>
-                  {t('takeOver')}
-                </Button>
-              ) : (
-                <Button size="sm" variant="outline" onClick={onRelease} disabled={pending}>
-                  <Unplug className="size-3.5" /> {t('release')}
-                </Button>
-              )}
-              <Button size="sm" variant="ghost" onClick={onCloseConv} disabled={pending}>
-                {t('closeConv')}
-              </Button>
-            </div>
+          <div className="mt-3 flex items-center gap-2">
             <Button
               size="sm"
               variant="accent"
@@ -347,6 +333,18 @@ export function FullConvDrawer({
               pending={pending}
             >
               {actionError?.type === 'send' ? t('retryAction.send') : t('send')}
+            </Button>
+            {!claimed ? (
+              <Button size="sm" onClick={onTakeOver} disabled={pending} pending={pending}>
+                {t('takeOver')}
+              </Button>
+            ) : (
+              <Button size="sm" variant="outline" onClick={onRelease} disabled={pending}>
+                <Unplug className="size-3.5" /> {t('release')}
+              </Button>
+            )}
+            <Button size="sm" variant="ghost" onClick={onCloseConv} disabled={pending}>
+              {t('closeConv')}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- The conversation drawer's footer (`FullConvDrawer`) split its Send button off into a `justify-between` sibling instead of grouping it with Take Over/Release/Close Conversation, stranding it at the far right where it collides with the chat widget bubble.
- Every other dashboard drawer footer (KB, CMS, CRM, Outreach, Feedback, and the sibling `SimplifiedConvDrawer` in the same file) keeps the primary action first inside one left-aligned button group.
- Reordered the footer so Send renders first, in the same `flex gap-2` group as the other actions — matching the shared convention and no longer overlapping the widget.

## Test plan
- [x] `pnpm -F @getmunin/dashboard-pages lint`-equivalent (ran via lint-staged/eslint --fix on commit)
- [ ] Visually confirm in the dashboard that opening a conversation drawer shows Send on the left, no longer colliding with the chat widget bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)