### PR TITLE
fix(oauth): advertise offline_access so Claude Code can authenticate

### DIFF
--- a/.changeset/olive-jars-smile.md
+++ b/.changeset/olive-jars-smile.md
@@ -1,0 +1,19 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Advertise `offline_access` in the protected-resource metadata so Claude Code can authenticate.
+
+`/.well-known/oauth-protected-resource` listed only the Munin permission scopes. The MCP SDK
+uses that list verbatim as the `scope` of its dynamic client registration (SEP-835 scope
+selection), so the resulting OAuth client was stored without `offline_access`. Claude Code then
+requested `offline_access` at `/auth/oauth2/authorize` to obtain a refresh token, and Better
+Auth validates the requested scopes against the *client's* registered scopes before falling back
+to the server-wide list — so the browser landed on `invalid_scope: The following scopes are
+invalid: offline_access`. claude.ai was unaffected because it registers without a `scope`, which
+defaults the client to the full server-wide list.
+
+The two metadata documents now derive from one source: `STANDARD_OIDC_SCOPES`,
+`SUPPORTED_AUTH_SCOPES` and the new `RESOURCE_ADVERTISED_SCOPES` all live in
+`oauth.constants.ts`, and a test asserts the resource metadata never advertises a scope the
+authorization server would reject.

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -5,16 +5,15 @@ import { oauthProvider } from '@better-auth/oauth-provider';
 import { schema, type Db } from '@getmunin/db';
 import { readMembershipsForUser } from '@getmunin/core';
 import {
-  SUPPORTED_SCOPES as MUNIN_SUPPORTED_SCOPES,
+  STANDARD_OIDC_SCOPES,
+  SUPPORTED_AUTH_SCOPES,
   mcpResourceUrl,
 } from '../oauth/oauth.constants.ts';
 import { authCookiePrefix } from './auth-cookies.ts';
 
 type BetterAuthInstance = ReturnType<typeof betterAuth>;
 
-export const STANDARD_OIDC_SCOPES = ['openid', 'profile', 'email', 'offline_access'] as const;
-
-export const SUPPORTED_AUTH_SCOPES = [...STANDARD_OIDC_SCOPES, ...MUNIN_SUPPORTED_SCOPES] as const;
+export { STANDARD_OIDC_SCOPES, SUPPORTED_AUTH_SCOPES };
 
 export interface SignupHookUser {
   id: string;

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -147,6 +147,7 @@ export { OAuthModule } from './oauth/oauth.module.ts';
 export {
   MCP_RESOURCE_PATH,
   SUPPORTED_SCOPES,
+  RESOURCE_ADVERTISED_SCOPES,
   type SupportedScope,
   mcpResourceUrl,
   authorizationServerUrl,

--- a/packages/backend-core/src/oauth/oauth-as-alias.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-as-alias.controller.ts
@@ -1,6 +1,6 @@
 import { Get, Header } from '@nestjs/common';
 import { PublicController } from '../common/auth/auth.guard.ts';
-import { authorizationServerUrl, SUPPORTED_SCOPES } from './oauth.constants.ts';
+import { authorizationServerUrl, SUPPORTED_AUTH_SCOPES } from './oauth.constants.ts';
 
 interface AuthorizationServerMetadata {
   issuer: string;
@@ -45,7 +45,7 @@ export class OAuthAsAliasController {
         'none',
       ],
       code_challenge_methods_supported: ['S256'],
-      scopes_supported: ['openid', 'profile', 'email', 'offline_access', ...SUPPORTED_SCOPES],
+      scopes_supported: SUPPORTED_AUTH_SCOPES,
       resource_indicators_supported: true,
       authorization_response_iss_parameter_supported: true,
     };

--- a/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { OAuthResourceController } from './oauth-resource.controller.ts';
-import { SUPPORTED_SCOPES } from './oauth.constants.ts';
+import { RESOURCE_ADVERTISED_SCOPES, SUPPORTED_AUTH_SCOPES } from './oauth.constants.ts';
 
 describe('OAuthResourceController', () => {
   let originalUrl: string | undefined;
@@ -22,7 +22,7 @@ describe('OAuthResourceController', () => {
       resource_name: 'Munin',
       resource_logo_uri: 'https://api.example.test/icon.png',
       authorization_servers: ['https://api.example.test'],
-      scopes_supported: SUPPORTED_SCOPES,
+      scopes_supported: RESOURCE_ADVERTISED_SCOPES,
       bearer_methods_supported: ['header'],
       resource_documentation: 'https://api.example.test/docs',
       resource_indicators_supported: true,
@@ -56,5 +56,17 @@ describe('OAuthResourceController', () => {
     expect(meta.scopes_supported).toContain('kb:read');
     expect(meta.scopes_supported).toContain('conv:write');
     expect(meta.bearer_methods_supported).toEqual(['header']);
+  });
+
+  it('advertises offline_access so dynamically registered clients may request refresh tokens', () => {
+    const meta = new OAuthResourceController().metadata();
+    expect(meta.scopes_supported).toContain('offline_access');
+  });
+
+  it('advertises no scope the authorization server would reject', () => {
+    const meta = new OAuthResourceController().metadata();
+    for (const scope of meta.scopes_supported) {
+      expect(SUPPORTED_AUTH_SCOPES).toContain(scope);
+    }
   });
 });

--- a/packages/backend-core/src/oauth/oauth-resource.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.ts
@@ -4,7 +4,7 @@ import {
   authorizationServerUrl,
   mcpResourceOrigin,
   mcpResourceUrl,
-  SUPPORTED_SCOPES,
+  RESOURCE_ADVERTISED_SCOPES,
 } from './oauth.constants.ts';
 
 interface ProtectedResourceMetadata {
@@ -29,7 +29,7 @@ export class OAuthResourceController {
       resource_name: 'Munin',
       resource_logo_uri: `${mcpResourceOrigin()}/icon.png`,
       authorization_servers: [authorizationServerUrl()],
-      scopes_supported: SUPPORTED_SCOPES,
+      scopes_supported: RESOURCE_ADVERTISED_SCOPES,
       bearer_methods_supported: ['header'],
       resource_documentation: `${authorizationServerUrl()}/docs`,
       resource_indicators_supported: true,

--- a/packages/backend-core/src/oauth/oauth.constants.ts
+++ b/packages/backend-core/src/oauth/oauth.constants.ts
@@ -33,6 +33,12 @@ export const SUPPORTED_SCOPES = [
 
 export type SupportedScope = (typeof SUPPORTED_SCOPES)[number];
 
+export const STANDARD_OIDC_SCOPES = ['openid', 'profile', 'email', 'offline_access'] as const;
+
+export const SUPPORTED_AUTH_SCOPES = [...STANDARD_OIDC_SCOPES, ...SUPPORTED_SCOPES] as const;
+
+export const RESOURCE_ADVERTISED_SCOPES = ['offline_access', ...SUPPORTED_SCOPES] as const;
+
 const DEFAULT_MCP_URL = 'http://localhost:3001/mcp';
 
 export function mcpResourceUrl(): string {


### PR DESCRIPTION
Adding `mcp.getmunin.com` as a connector in Claude Code fails at the OAuth callback with:

```
invalid_scope: The following scopes are invalid: offline_access
```

It works from claude.ai, which is what made this look like a client bug. It isn't.

## Cause

1. `/.well-known/oauth-protected-resource` advertised `scopes_supported` as the 27 Munin permission scopes, **without `offline_access`**.
2. The MCP SDK's scope selection (SEP-835, `client/auth.js`) resolves `scope = wwwAuthenticateScope || prm.scopes_supported.join(' ') || clientMetadata.scope` and uses that value **verbatim as the `scope` of its dynamic client registration**. So the `oauthClient` row Claude Code created was stored without `offline_access`.
3. Claude Code then requests `offline_access` at `/auth/oauth2/authorize` to get a refresh token.
4. Better Auth validates the requested scopes against `client.scopes ?? opts.scopes` — the *client's* registered list wins, and it lacks the scope. Rejected before the session check, so it never even reaches login.

claude.ai is unaffected because it registers **without** a `scope` field, and Better Auth then defaults the client to the full server-wide list (`auth-factory.ts`), which does include `offline_access`.

Reproduced against prod:

```
# client registered with the PRM scope list
authorize + offline_access -> ?error=invalid_scope&error_description=The+following+scopes+are+invalid%3A+offline_access
authorize - offline_access -> 302 https://app.getmunin.com/login?...    # normal

# client registered with offline_access in its scope
authorize + offline_access -> 302 https://app.getmunin.com/login?...    # normal
```

## Fix

`RESOURCE_ADVERTISED_SCOPES = ['offline_access', ...SUPPORTED_SCOPES]` now backs the resource metadata.

The underlying defect was drift between two hand-maintained scope lists, so they now share a source: `STANDARD_OIDC_SCOPES` and `SUPPORTED_AUTH_SCOPES` moved into `oauth.constants.ts` (re-exported from `auth-factory.ts`, public API unchanged), and the AS-alias document builds from `SUPPORTED_AUTH_SCOPES` instead of a hand-written copy of it.

`offline_access` grants no additional data access — it is the single flag `@better-auth/oauth-provider` consults to decide whether to mint a refresh token. Without it a connector's access token dies after an hour and the user must redo the full browser flow. The consent page already hides the scope (`HIDDEN_SCOPES`), so there is no UI change.

## Tests

Two added to `oauth-resource.controller.test.ts`:

- `offline_access` is advertised.
- Every scope in the resource metadata is one `SUPPORTED_AUTH_SCOPES` accepts — the invariant whose violation caused this.

`vitest` on the oauth + auth suites: 19 passed.

## After deploy

Existing Claude Code connectors are already registered under a client without `offline_access`; that row won't be re-registered. Remove and re-add the connector once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
