### PR TITLE
fix(dashboard): stop the API-key copy button resizing on click

### DIFF
--- a/.changeset/copy-key-icon-button.md
+++ b/.changeset/copy-key-icon-button.md
@@ -1,0 +1,16 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Make the API-key reveal dialog's copy control a fixed-size icon button.
+
+The button was labelled "Copy to clipboard" and collapsed to a bare `✓` on success, so it shrank
+from ~340px to ~70px on click and the key field snapped wider underneath it. It is now a square
+icon button that swaps the copy glyph for a green check, with the label moved to
+`title`/`aria-label` and an `aria-live` region announcing "Copied" — no reflow, and the key gets
+the reclaimed width.
+
+The key field is pinned to `h-9` to match the button exactly; it previously derived a 34px height
+from `py-2` and sat 2px short. Moving the value into a `truncate` span means the field is no
+longer its own overflow container, so it also carries `min-w-0 overflow-hidden` — without that it
+cannot shrink below the key's intrinsic width and pushes the button outside the dialog.

--- a/packages/dashboard-pages/src/pages/api-keys.tsx
+++ b/packages/dashboard-pages/src/pages/api-keys.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
-import { Copy } from 'lucide-react';
+import { Check, Copy } from 'lucide-react';
 import { useFormatter, useTranslations } from 'next-intl';
 import { api } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
@@ -325,6 +325,7 @@ function MintKeyDialog({
 }
 
 function KeyReveal({ value, copyLabel }: { value: string; copyLabel: string }) {
+  const tCommon = useTranslations('common');
   const [copied, setCopied] = useState(false);
   function copy() {
     void navigator.clipboard.writeText(value).then(() => {
@@ -332,15 +333,29 @@ function KeyReveal({ value, copyLabel }: { value: string; copyLabel: string }) {
       setTimeout(() => setCopied(false), 1500);
     });
   }
+  const label = copied ? tCommon('copied') : copyLabel;
   return (
     <div className="flex items-center gap-2">
-      <code className="flex-1 truncate border-[1px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary px-3 py-2 font-mono text-xs text-ink dark:text-foreground">
-        {value}
+      <code className="flex h-9 min-w-0 flex-1 items-center overflow-hidden border-[1px] border-rule-soft dark:border-rule-on-dark bg-paper-deep dark:bg-secondary px-3 font-mono text-xs text-ink dark:text-foreground">
+        <span className="min-w-0 truncate">{value}</span>
       </code>
-      <Button variant="outline" size="sm" onClick={copy} className="gap-1.5">
-        <Copy className="size-3.5" />
-        {copied ? '✓' : copyLabel}
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={copy}
+        title={label}
+        aria-label={label}
+        className="shrink-0"
+      >
+        {copied ? (
+          <Check className="size-4 text-emerald-600 dark:text-emerald-400" />
+        ) : (
+          <Copy className="size-4" />
+        )}
       </Button>
+      <span aria-live="polite" className="sr-only">
+        {copied ? tCommon('copied') : ''}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
The copy control in the API-key reveal dialog was a labelled `Copy to clipboard` button that collapsed to a bare `✓` once clicked — roughly 340px down to 70px — so the key field snapped wider the instant you interacted with it.

It is now a fixed-size icon button. The glyph swaps (`Copy` → green `Check`), the geometry does not.

### Changes

- **No reflow on copy.** `size="icon"` + `shrink-0`, so both states occupy the same square.
- **Accessibility improved rather than traded away.** The `copyClipboard` message moves to `title`/`aria-label` (the string is still used, no message churn), and an `aria-live="polite"` region announces "Copied" — the old bare `✓` announced nothing.
- **Field and button align exactly.** The field derived a 34px height from `py-2` + borders against the button's 36px `size-9`; it is now pinned to `h-9`. I sized the field to the button rather than stretching the button, because layering `h-auto` over the `size-9` variant would put the outcome at the mercy of `tailwind-merge`'s conflict groups (`size-*` conflicts with both `w-*` and `h-*`) instead of anything readable in the source.
- **Field can still shrink.** Wrapping the value in a `truncate` span means the `<code>` is no longer its own overflow container, so its `min-width:auto` resolves to the key's intrinsic width. Without the added `min-w-0 overflow-hidden` it pushes the button outside the dialog.

Side benefit: the truncated key gets the ~270px the label used to eat, so more of it is visible before the ellipsis.

### Not in scope

Six other copy affordances (`components/copyable-secret.tsx`, `pages/channels.tsx` ×4, `pages/trackers.tsx` ×2, `components/dashboard/get-started.tsx`) swap "Copy" ↔ "Copied", so they shift a few pixels rather than ~270. Two of them share this field's height mismatch, and one pairs the copy button with a labelled "Regenerate" button — converting those is a composition decision, so it is left out of a fix PR.

### Testing

Typecheck and eslint clean.

Visually checked in the local dashboard at `/en/dashboard/settings/api-keys` up to and including the `h-9` alignment: the icon button holds its size across the copy → check cycle, and the two elements line up flush.

**The final `min-w-0 overflow-hidden` change has not been visually confirmed** — the fix was authored in response to the overflow it corrects (the button escaping the dialog's right edge), but the local dev server was lost to an unrelated port conflict before it could be reloaded. The reasoning is standard flexbox `min-width:auto` behaviour and typecheck/lint pass, but a reviewer should mint a key and confirm the row stays inside the dialog before merging.