### PR TITLE
fix(auth): route unfinished onboarding straight to setup

### DIFF
--- a/.changeset/setup-aware-post-auth-redirect.md
+++ b/.changeset/setup-aware-post-auth-redirect.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Send a freshly signed-up or signed-in owner straight to onboarding instead of routing them through the dashboard first.
+
+`SignupForm` and `LoginForm` always pushed `/dashboard` (the `safeRedirect` fallback), and the need for onboarding was only discovered afterwards by `useDashboardGate` — two client-side API calls plus a route-bundle load later. The browser therefore sat on `/dashboard` for hundreds of milliseconds, and for seconds when the `/setup` route still had to be built, which read as "signup dropped me on the dashboard and a reload fixed it". Both forms now resolve the destination before navigating.
+
+`resolvePostAuthDestination` falls back to `/dashboard` whenever the setup state can't be established (either read failing, no membership, a non-admin member), so `useDashboardGate` remains the backstop rather than being replaced. An explicit `?redirect=` target — invitations, deep links, the OAuth authorize resume — still wins over the setup check.

--- a/apps/web/lib/setup-gate.test.ts
+++ b/apps/web/lib/setup-gate.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasSessionCookie,
+  isSetupGatedPath,
+  isSetupIncomplete,
+  setupPathFor,
+  type MembershipDto,
+} from './setup-gate';
+
+function membership(overrides: Partial<MembershipDto> = {}): MembershipDto {
+  return { orgId: 'org_1', name: 'Acme', role: 'owner', isDefault: true, ...overrides };
+}
+
+describe('isSetupGatedPath', () => {
+  it('gates the dashboard root of every supported locale', () => {
+    expect(isSetupGatedPath('/en/dashboard')).toBe(true);
+    expect(isSetupGatedPath('/nb/dashboard')).toBe(true);
+    expect(isSetupGatedPath('/en/dashboard/')).toBe(true);
+  });
+
+  it('leaves dashboard subpages to the client-side gate', () => {
+    expect(isSetupGatedPath('/en/dashboard/settings')).toBe(false);
+    expect(isSetupGatedPath('/en/dashboard/account')).toBe(false);
+    expect(isSetupGatedPath('/en/dashboard/oauth/consent')).toBe(false);
+  });
+
+  it('ignores paths that only look like the dashboard root', () => {
+    expect(isSetupGatedPath('/dashboard')).toBe(false);
+    expect(isSetupGatedPath('/de/dashboard')).toBe(false);
+    expect(isSetupGatedPath('/en/dashboards')).toBe(false);
+    expect(isSetupGatedPath('/en/setup')).toBe(false);
+    expect(isSetupGatedPath('/en/login')).toBe(false);
+  });
+});
+
+describe('setupPathFor', () => {
+  it('keeps the locale prefix of the request', () => {
+    expect(setupPathFor('/en/dashboard')).toBe('/en/setup');
+    expect(setupPathFor('/nb/dashboard')).toBe('/nb/setup');
+    expect(setupPathFor('/en/dashboard/')).toBe('/en/setup');
+  });
+});
+
+describe('hasSessionCookie', () => {
+  it('detects the session cookie whatever prefix it carries', () => {
+    expect(hasSessionCookie('better-auth.session_token=abc')).toBe(true);
+    expect(hasSessionCookie('__Secure-better-auth.session_token=abc; munin_locale=en')).toBe(true);
+  });
+
+  it('is false without one', () => {
+    expect(hasSessionCookie('')).toBe(false);
+    expect(hasSessionCookie('munin_locale=en')).toBe(false);
+  });
+});
+
+describe('isSetupIncomplete', () => {
+  it('is true for an owner whose org has no name', () => {
+    expect(isSetupIncomplete({ providerConfigured: true }, [membership({ name: '' })])).toBe(true);
+    expect(isSetupIncomplete({ providerConfigured: true }, [membership({ name: '   ' })])).toBe(true);
+  });
+
+  it('is true for an owner with no LLM provider configured', () => {
+    expect(isSetupIncomplete({ providerConfigured: false }, [membership()])).toBe(true);
+  });
+
+  it('is true for an admin, not just an owner', () => {
+    expect(
+      isSetupIncomplete({ providerConfigured: true }, [membership({ role: 'admin', name: '' })]),
+    ).toBe(true);
+  });
+
+  it('is false once the org is named and a provider is configured', () => {
+    expect(isSetupIncomplete({ providerConfigured: true }, [membership()])).toBe(false);
+  });
+
+  it('never redirects a non-admin member', () => {
+    expect(
+      isSetupIncomplete({ providerConfigured: false }, [membership({ role: 'member', name: '' })]),
+    ).toBe(false);
+    expect(
+      isSetupIncomplete({ providerConfigured: false }, [membership({ role: 'weird', name: '' })]),
+    ).toBe(false);
+  });
+
+  it('falls through when either read failed or returned nothing', () => {
+    expect(isSetupIncomplete(null, [membership({ name: '' })])).toBe(false);
+    expect(isSetupIncomplete({ providerConfigured: false }, null)).toBe(false);
+    expect(isSetupIncomplete({ providerConfigured: false }, [])).toBe(false);
+  });
+
+  it('reads the default membership rather than the first row', () => {
+    const rows = [
+      membership({ orgId: 'org_other', name: 'Named', isDefault: false }),
+      membership({ orgId: 'org_active', name: '', isDefault: true }),
+    ];
+    expect(isSetupIncomplete({ providerConfigured: true }, rows)).toBe(true);
+  });
+});

--- a/apps/web/lib/setup-gate.ts
+++ b/apps/web/lib/setup-gate.ts
@@ -1,0 +1,39 @@
+import { SUPPORTED_LOCALES } from '../i18n/locales';
+
+const DASHBOARD_ROOT = new RegExp(`^/(?:${SUPPORTED_LOCALES.join('|')})/dashboard/?$`);
+
+export interface MembershipDto {
+  orgId: string;
+  name: string;
+  role: string;
+  isDefault: boolean;
+}
+
+export interface AgentConfigStatusDto {
+  providerConfigured: boolean;
+}
+
+export function isSetupGatedPath(pathname: string): boolean {
+  return DASHBOARD_ROOT.test(pathname);
+}
+
+export function setupPathFor(pathname: string): string {
+  return pathname.replace(/\/dashboard\/?$/, '/setup');
+}
+
+export function hasSessionCookie(cookieHeader: string): boolean {
+  return cookieHeader.includes('session_token');
+}
+
+export function isSetupIncomplete(
+  config: AgentConfigStatusDto | null,
+  memberships: MembershipDto[] | null,
+): boolean {
+  if (!config || !memberships) return false;
+
+  const active = memberships.find((m) => m.isDefault) ?? memberships[0] ?? null;
+  if (!active) return false;
+  if (active.role !== 'owner' && active.role !== 'admin') return false;
+
+  return !config.providerConfigured || active.name.trim().length === 0;
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,7 +1,58 @@
 import createMiddleware from 'next-intl/middleware';
+import { NextResponse, type NextRequest } from 'next/server';
 import { routing } from './i18n/routing';
+import {
+  hasSessionCookie,
+  isSetupGatedPath,
+  isSetupIncomplete,
+  setupPathFor,
+  type AgentConfigStatusDto,
+  type MembershipDto,
+} from './lib/setup-gate';
 
-export default createMiddleware(routing);
+const handleIntl = createMiddleware(routing);
+
+const API_URL = (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
+const SETUP_STATUS_TIMEOUT_MS = 1500;
+
+async function fetchWithCookies<T>(path: string, cookie: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${API_URL}${path}`, {
+      headers: { cookie },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(SETUP_STATUS_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn('[proxy] setup-status fetch failed', path, err);
+    return null;
+  }
+}
+
+async function setupIncompleteFor(cookie: string): Promise<boolean> {
+  const [config, memberships] = await Promise.all([
+    fetchWithCookies<AgentConfigStatusDto>('/v1/agent-config', cookie),
+    fetchWithCookies<MembershipDto[]>('/v1/me/memberships', cookie),
+  ]);
+  return isSetupIncomplete(config, memberships);
+}
+
+export default async function proxy(request: NextRequest): Promise<NextResponse> {
+  const response = handleIntl(request);
+  if (response.headers.get('location')) return response;
+
+  const { pathname } = request.nextUrl;
+  if (!isSetupGatedPath(pathname)) return response;
+
+  const cookie = request.headers.get('cookie') ?? '';
+  if (!hasSessionCookie(cookie)) return response;
+  if (!(await setupIncompleteFor(cookie))) return response;
+
+  const url = request.nextUrl.clone();
+  url.pathname = setupPathFor(pathname);
+  return NextResponse.redirect(url);
+}
 
 export const config = {
   matcher: ['/((?!api|_next|_vercel|.*\\..*).*)'],

--- a/packages/dashboard-pages/src/auth/setup-status.test.ts
+++ b/packages/dashboard-pages/src/auth/setup-status.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  isSetupIncomplete,
+  resolvePostAuthDestination,
+  type MembershipDto,
+} from './setup-status';
+import { api } from '../api';
+
+vi.mock('../api', () => ({ api: vi.fn() }));
+
+const apiMock = vi.mocked(api);
+
+function membership(overrides: Partial<MembershipDto> = {}): MembershipDto {
+  return { orgId: 'org_1', name: 'Acme', role: 'owner', isDefault: true, ...overrides };
+}
+
+function respondWith(
+  config: { providerConfigured: boolean } | Error,
+  memberships: MembershipDto[] | Error,
+): void {
+  apiMock.mockImplementation((path: string) => {
+    if (path === '/v1/agent-config') {
+      return config instanceof Error ? Promise.reject(config) : Promise.resolve(config);
+    }
+    if (path === '/v1/me/memberships') {
+      return memberships instanceof Error
+        ? Promise.reject(memberships)
+        : Promise.resolve(memberships);
+    }
+    throw new Error(`unexpected path ${path}`);
+  });
+}
+
+describe('isSetupIncomplete', () => {
+  it('is true for an owner whose org has no name', () => {
+    expect(isSetupIncomplete({ providerConfigured: true }, [membership({ name: '' })])).toBe(true);
+    expect(isSetupIncomplete({ providerConfigured: true }, [membership({ name: '  ' })])).toBe(true);
+  });
+
+  it('is true for an owner with no LLM provider configured', () => {
+    expect(isSetupIncomplete({ providerConfigured: false }, [membership()])).toBe(true);
+  });
+
+  it('is true for an admin, not just an owner', () => {
+    expect(
+      isSetupIncomplete({ providerConfigured: true }, [membership({ role: 'admin', name: '' })]),
+    ).toBe(true);
+  });
+
+  it('is false once the org is named and a provider is configured', () => {
+    expect(isSetupIncomplete({ providerConfigured: true }, [membership()])).toBe(false);
+  });
+
+  it('never diverts a non-admin member', () => {
+    expect(
+      isSetupIncomplete({ providerConfigured: false }, [membership({ role: 'member', name: '' })]),
+    ).toBe(false);
+  });
+
+  it('falls through when either read failed or returned nothing', () => {
+    expect(isSetupIncomplete(null, [membership({ name: '' })])).toBe(false);
+    expect(isSetupIncomplete({ providerConfigured: false }, null)).toBe(false);
+    expect(isSetupIncomplete({ providerConfigured: false }, [])).toBe(false);
+  });
+
+  it('reads the default membership rather than the first row', () => {
+    expect(
+      isSetupIncomplete({ providerConfigured: true }, [
+        membership({ orgId: 'org_other', name: 'Named', isDefault: false }),
+        membership({ orgId: 'org_active', name: '', isDefault: true }),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe('resolvePostAuthDestination', () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+  });
+
+  it('sends a fresh owner to onboarding', async () => {
+    respondWith({ providerConfigured: false }, [membership({ name: '' })]);
+    await expect(resolvePostAuthDestination('/dashboard')).resolves.toBe('/setup');
+  });
+
+  it('sends a set-up owner to the fallback', async () => {
+    respondWith({ providerConfigured: true }, [membership()]);
+    await expect(resolvePostAuthDestination('/dashboard')).resolves.toBe('/dashboard');
+  });
+
+  it('keeps a non-default fallback when setup is complete', async () => {
+    respondWith({ providerConfigured: true }, [membership()]);
+    await expect(resolvePostAuthDestination('/dashboard/settings')).resolves.toBe(
+      '/dashboard/settings',
+    );
+  });
+
+  it('falls back when the agent-config read fails', async () => {
+    respondWith(new Error('boom'), [membership({ name: '' })]);
+    await expect(resolvePostAuthDestination('/dashboard')).resolves.toBe('/dashboard');
+  });
+
+  it('falls back when the memberships read fails', async () => {
+    respondWith({ providerConfigured: false }, new Error('boom'));
+    await expect(resolvePostAuthDestination('/dashboard')).resolves.toBe('/dashboard');
+  });
+});

--- a/packages/dashboard-pages/src/auth/setup-status.ts
+++ b/packages/dashboard-pages/src/auth/setup-status.ts
@@ -1,0 +1,37 @@
+import { api } from '../api';
+
+export interface MembershipDto {
+  orgId: string;
+  name: string;
+  role: string;
+  isDefault: boolean;
+}
+
+export interface AgentConfigStatusDto {
+  providerConfigured: boolean;
+}
+
+export function isSetupIncomplete(
+  config: AgentConfigStatusDto | null,
+  memberships: MembershipDto[] | null,
+): boolean {
+  if (!config || !memberships) return false;
+
+  const active = memberships.find((m) => m.isDefault) ?? memberships[0] ?? null;
+  if (!active) return false;
+  if (active.role !== 'owner' && active.role !== 'admin') return false;
+
+  return !config.providerConfigured || active.name.trim().length === 0;
+}
+
+export async function resolvePostAuthDestination(fallback: string): Promise<string> {
+  try {
+    const [config, memberships] = await Promise.all([
+      api<AgentConfigStatusDto>('/v1/agent-config'),
+      api<MembershipDto[]>('/v1/me/memberships'),
+    ]);
+    return isSetupIncomplete(config, memberships) ? '/setup' : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/login-form.tsx
@@ -13,6 +13,7 @@ import {
   socialCallbackUrl,
   absoluteCallbackUrl,
 } from '../../auth/post-signin-redirect';
+import { resolvePostAuthDestination } from '../../auth/setup-status';
 import { AuthShell, AuthHeading, AuthSubheading, AuthFootnote, AuthDivider } from './auth-shell';
 import { AuthEpigraph } from './auth-epigraph';
 import { ErrorAlert } from './error-alert';
@@ -90,7 +91,7 @@ export function LoginForm({ providers, footer }: LoginFormProps) {
         window.location.assign(oauthResume);
         return;
       }
-      router.push(redirectTo);
+      router.push(redirectRaw ? redirectTo : await resolvePostAuthDestination(redirectTo));
     } catch (err) {
       turnstileRef.current?.reset();
       setError({

--- a/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/signup-form.tsx
@@ -13,6 +13,7 @@ import {
   hasOauthAuthorizeParams,
   socialCallbackUrl,
 } from '../../auth/post-signin-redirect';
+import { resolvePostAuthDestination } from '../../auth/setup-status';
 import {
   AuthShell,
   AuthHeading,
@@ -110,7 +111,7 @@ export function SignupForm({ providers, footer }: SignupFormProps) {
         router.push(`/setup?${params.toString()}`);
         return;
       }
-      router.push(redirectTo);
+      router.push(redirectRaw ? redirectTo : await resolvePostAuthDestination(redirectTo));
     } catch (err) {
       turnstileRef.current?.reset();
       setError(translateError(err) || tCommon('networkError'));


### PR DESCRIPTION
## Problem

Signing up landed on `/dashboard` and only *then* discovered onboarding was pending. `SignupForm` and `LoginForm` always pushed the `safeRedirect` fallback, and `useDashboardGate` worked it out afterwards from two client-side API reads plus a route-bundle load. Measured on a live rig, `/dashboard` stayed on screen for **~3.0s** cold (dominated by building the `/setup` route) and ~100ms warm — which reads as "signup dropped me on the dashboard, and reloading fixed it". The reload only *seemed* to fix it: it re-ran the same gate with everything warm.

The backend was never at fault — the membership row exists before the signup response returns (better-auth awaits `databaseHooks.user.create.after`), and `/v1/me/memberships` answered `200 [{"name":"","role":"owner"}]` 19ms after signup.

## Change

Two layers, both failing open to the existing gate:

- **`resolvePostAuthDestination`** (`packages/dashboard-pages/src/auth/setup-status.ts`) — both auth forms resolve the destination before navigating. This lives in `dashboard-pages`, which `apps/web-cloud` already consumes, so **cloud gets the fix from the version bump with no change of its own**. An explicit `?redirect=` target (invitations, deep links) and the OAuth authorize resume still win.
- **`apps/web/proxy.ts`** — a hard `307` for the dashboard root when the caller is an owner/admin with an unnamed org or no LLM provider, so a bookmark or typed URL never renders the dashboard either. A page-level `redirect()` cannot do this: Next 16 serves the prerendered shell with `200` (`x-nextjs-prerender: 1`) and defers the redirect to the client, so `/dashboard` still commits. `export const dynamic = 'force-dynamic'` doesn't change that.

Unknown state is never treated as incomplete — a failed read, a missing membership, or a non-admin member all fall through, and the proxy bounds its reads at 1500ms. `useDashboardGate` stays the backstop rather than being replaced.

## Verification

Against a live backend + web (scratch DB, real signup through Chrome):

| case | result |
|---|---|
| browser signup | `/en/signup` → `/en/setup`; `/dashboard` never commits (was: dashboard at 1963ms, setup at 5017ms) |
| browser login, onboarding pending | → `/en/setup` |
| forms alone, proxy reverted (= what cloud gets) | → `/en/setup`, no `/dashboard` request |
| `GET /en/dashboard` doc + RSC | `307 → /en/setup` |
| `/nb/dashboard?client_id=…&response_type=code` | `307 → /nb/setup?client_id=…&response_type=code` |
| dashboard subpages, anonymous, `role=member` | `200`, untouched |
| after finishing onboarding | `/dashboard` served, no ping-pong |

Unit tests cover the decision logic on both sides: path matching per locale, lookalike paths, cookie detection with/without the `__Secure-` prefix, unnamed org, unconfigured provider, admin vs owner vs member, either read failing, empty membership list, and `isDefault` winning over row order.

`web` 13 passed · `dashboard-pages` 51 passed · eslint clean · tsc clean · playwright 6 passed.

## Follow-ups (not in this PR)

- **Confirm on dev/staging** that `/dashboard` returns `307` there. Localhost shares a host between web and api, so cookie forwarding across `app.` → `api.` is the one assumption these tests can't exercise. It fails open, so a miss means the old behaviour, not a break.
- **Cloud's own `proxy.ts`** is now optional — only the bookmark case. Note it rewrites `Location` from `x-forwarded-host`/`x-forwarded-proto`, so a redirect there needs the same treatment.
- Only the dashboard **root** is proxy-gated; deep links keep the client-gate path, which costs 2 API calls per navigation if extended to the whole subtree.
- `isSetupIncomplete` is deliberately duplicated between `apps/web/lib/setup-gate.ts` and the shared module, because middleware can't safely import the `dashboard-pages` root barrel (it's full of `'use client'` components). Consolidating means adding a `./setup-status` export subpath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
