### PR TITLE
fix(dashboard-pages): stop bare cards clipping the input focus ring

### DIFF
--- a/.changeset/bare-card-focus-ring-clip.md
+++ b/.changeset/bare-card-focus-ring-clip.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Stop the onboarding wizard clipping the focus ring on its inputs.
+
+`Card` carries `overflow-hidden`, and `BARE_CARD` — which turns a card into a plain layout wrapper for the wizard — dropped the border, background and padding but kept the clip. With `px-0` in bare mode the input is exactly as wide as the card, so the focused input's `ring-1` box-shadow, which paints outside the border box, was cut off on the left and right while the top and bottom kept their full 2px. The effect was a focus outline that looked thinner on the vertical edges than the horizontal ones.
+
+Bare cards clip nothing intentionally, so `BARE_CARD` now sets `overflow-visible`. This covers the workspace name, provider API key, models and website import steps.

--- a/packages/dashboard-pages/src/components/agent-config/types.ts
+++ b/packages/dashboard-pages/src/components/agent-config/types.ts
@@ -50,7 +50,8 @@ export const PROVIDER_PRESETS = [
 
 export type PresetId = (typeof PROVIDER_PRESETS)[number]['id'];
 
-export const BARE_CARD = 'border-0 bg-transparent py-0 dark:border-0 dark:bg-transparent';
+export const BARE_CARD =
+  'border-0 bg-transparent py-0 overflow-visible dark:border-0 dark:bg-transparent';
 
 export function presetForUrl(url: string): PresetId {
   const match = PROVIDER_PRESETS.find((p) => p.url === url);


### PR DESCRIPTION
Independent of #747/#748 — branched off `main`, one-line CSS change, safe to merge in any order.

## Problem

In the onboarding wizard the focused input's outline looks thinner on the left and right than on the top and bottom.

`Card` sets `overflow-hidden` (`packages/ui/src/components/card.tsx:15`). `BARE_CARD` turns a card into a plain layout wrapper for the wizard — dropping border, background and padding — but kept that clip, and bare mode also sets `px-0` on the content, so the input is exactly as wide as the card. The focused input paints a 1px border **plus** a 1px `ring`, and a ring is a box-shadow drawn *outside* the border box, so its left and right edges were clipped. Top and bottom survived because the label above and hint below leave room.

## Measured, not guessed

Probed in Chrome on the real wizard, walking up from `#orgName`:

```
focus ring box-shadow: rgb(0, 102, 255) 0px 0px 0px 1px
border-color:          rgb(0, 102, 255)
clipping ancestors:    [{ el: "div[data-slot=card]", overflow: "hidden/hidden",
                          leftGap: 0, rightGap: 0 }]
```

`leftGap: 0, rightGap: 0` is the whole bug — the clip boundary sits exactly on the input's border box. After the change: `clipping ancestors: []`, and a 3× screenshot of the corner shows the vertical stroke matching the horizontal one instead of being half its width.

## Fix

`BARE_CARD` now sets `overflow-visible`. Bare cards clip nothing on purpose — no border, no background, no rounded corners — and I checked the four consumers (`org-name`, `provider`, `models`, `website-import`) for children that relied on the parent clip; the only rounded element is a `rounded-full` badge that clips itself. All four steps share the constant, so all four inputs are fixed by this.

`dashboard-pages` 39 tests pass, eslint and tsc clean. No test added: the change is a class constant, and asserting the constant contains the class would only restate the diff — the repo has no visual-regression suite, so the browser probe above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
