### PR TITLE
fix(docs-pages): resolve dashboard links against NEXT_PUBLIC_APP_URL

### DIFF
--- a/.changeset/docs-dashboard-links-app-url.md
+++ b/.changeset/docs-dashboard-links-app-url.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/docs-pages': patch
+---
+
+fix(docs-pages): resolve dashboard links against `NEXT_PUBLIC_APP_URL` instead of assuming same-origin
+
+The six links into `/dashboard/settings/api-keys` — the "Get a key →" button in the docs topbar plus the inline "Settings → API keys" links in the five `connect-*` guides — used the next-intl `Link`, which localizes the href against the *current* app. In OSS that is correct: `apps/web` serves `/[locale]/docs` and `/[locale]/dashboard` from one origin. On the cloud marketing site it is not — there is no dashboard route there, so every one of the 66 built docs pages carried a dead `/en/dashboard/settings/api-keys`, the topbar button included.
+
+New `DashboardLink` component keeps the relative, locale-prefixed `Link` when `NEXT_PUBLIC_APP_URL` is unset (OSS, same-origin) and emits a plain `<a>` at `${NEXT_PUBLIC_APP_URL}${href}` when it is set. It has to be a plain anchor in that case: next-intl's `Link` would localize an absolute cross-origin href rather than pass it through. The unprefixed target is fine on the app side — `apps/web/proxy.ts` runs the next-intl middleware with `localePrefix: 'always'`, so `/dashboard/...` redirects to the visitor's negotiated locale.
+
+`NEXT_PUBLIC_APP_URL` is the existing convention on the consuming side (`marketing-cloud/lib/links.ts`, already baked into the marketing deploy for dev and prod), so no new configuration is needed — only the dependency bump.

--- a/packages/docs-pages/src/_components/dashboard-link.tsx
+++ b/packages/docs-pages/src/_components/dashboard-link.tsx
@@ -1,0 +1,23 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { Link } from '../i18n-navigation';
+
+const APP_URL = (process.env.NEXT_PUBLIC_APP_URL ?? '').replace(/\/+$/, '');
+
+export function DashboardLink({
+  href,
+  children,
+  ...rest
+}: Omit<ComponentProps<'a'>, 'href'> & { href: string; children: ReactNode }) {
+  if (!APP_URL) {
+    return (
+      <Link href={href} {...rest}>
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <a href={`${APP_URL}${href}`} {...rest}>
+      {children}
+    </a>
+  );
+}

--- a/packages/docs-pages/src/_components/docs-shell.tsx
+++ b/packages/docs-pages/src/_components/docs-shell.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { Link, usePathname } from '../i18n-navigation';
 import { useEffect, useRef, type ReactNode } from 'react';
 import { DocsSearch, type SearchIndex } from './search';
+import { DashboardLink } from './dashboard-link';
 
 export function DocsShell({
   children,
@@ -47,9 +48,9 @@ export function DocsShell({
         <div className="sep" aria-hidden />
         <div className="org-name">Munin developer portal</div>
         <div className="spacer" />
-        <Link className="docs-btn primary" href="/dashboard/settings/api-keys">
+        <DashboardLink className="docs-btn primary" href="/dashboard/settings/api-keys">
           Get a key →
-        </Link>
+        </DashboardLink>
       </header>
 
       <nav className="docs-switcher">

--- a/packages/docs-pages/src/guides/connect-chatgpt/page.tsx
+++ b/packages/docs-pages/src/guides/connect-chatgpt/page.tsx
@@ -1,5 +1,6 @@
 import { Link } from '../../i18n-navigation';
 import { GuidesSidebar } from '../../_components/guides-sidebar';
+import { DashboardLink } from '../../_components/dashboard-link';
 
 export const metadata = {
   title: 'Munin · Connect ChatGPT over MCP',
@@ -46,7 +47,7 @@ export default function ConnectChatGPT() {
         </h2>
         <p className="tag-blurb">
           From the dashboard, go to{' '}
-          <Link href="/dashboard/settings/api-keys">Settings → API keys</Link> and create one.
+          <DashboardLink href="/dashboard/settings/api-keys">Settings → API keys</DashboardLink> and create one.
           Scope it to what ChatGPT should be allowed to do. The token starts with{' '}
           <code>mn_admin_</code> and is shown once.
         </p>

--- a/packages/docs-pages/src/guides/connect-claude/page.tsx
+++ b/packages/docs-pages/src/guides/connect-claude/page.tsx
@@ -1,5 +1,6 @@
 import { Link } from '../../i18n-navigation';
 import { GuidesSidebar } from '../../_components/guides-sidebar';
+import { DashboardLink } from '../../_components/dashboard-link';
 
 export const metadata = {
   title: 'Munin · Connect Claude over MCP',
@@ -44,7 +45,7 @@ export default function ConnectClaude() {
           1 · Mint an API key
         </h2>
         <p className="tag-blurb">
-          In the dashboard, go to <Link href="/dashboard/settings/api-keys">Settings → API keys</Link>{' '}
+          In the dashboard, go to <DashboardLink href="/dashboard/settings/api-keys">Settings → API keys</DashboardLink>{' '}
           and create a key. Scope it to what Claude should be allowed to do — read-only KB access,
           full CRM write, or everything. The token starts with <code>mn_admin_</code>. You&rsquo;ll
           only see it once.

--- a/packages/docs-pages/src/guides/connect-gemini/page.tsx
+++ b/packages/docs-pages/src/guides/connect-gemini/page.tsx
@@ -1,5 +1,6 @@
 import { Link } from '../../i18n-navigation';
 import { GuidesSidebar } from '../../_components/guides-sidebar';
+import { DashboardLink } from '../../_components/dashboard-link';
 
 export const metadata = {
   title: 'Munin · Connect Gemini over MCP',
@@ -35,7 +36,7 @@ export default function ConnectGemini() {
         </h2>
         <p className="tag-blurb">
           From the dashboard, go to{' '}
-          <Link href="/dashboard/settings/api-keys">Settings → API keys</Link>. Pick scopes that
+          <DashboardLink href="/dashboard/settings/api-keys">Settings → API keys</DashboardLink>. Pick scopes that
           match what Gemini should be allowed to do. The token starts with <code>mn_admin_</code>{' '}
           and is shown once.
         </p>

--- a/packages/docs-pages/src/guides/connect-hermes/page.tsx
+++ b/packages/docs-pages/src/guides/connect-hermes/page.tsx
@@ -1,5 +1,6 @@
 import { Link } from '../../i18n-navigation';
 import { GuidesSidebar } from '../../_components/guides-sidebar';
+import { DashboardLink } from '../../_components/dashboard-link';
 
 export const metadata = {
   title: 'Munin · Connect Hermes Agent over MCP',
@@ -35,7 +36,7 @@ export default function ConnectHermes() {
         </h2>
         <p className="tag-blurb">
           In the dashboard, go to{' '}
-          <Link href="/dashboard/settings/api-keys">Settings → API keys</Link> and create a key.
+          <DashboardLink href="/dashboard/settings/api-keys">Settings → API keys</DashboardLink> and create a key.
           Pick scopes that match what Hermes should be allowed to do — read-only KB for an
           answer-bot, full CRM write for a sales agent. The token starts with{' '}
           <code>mn_admin_</code> and is shown once.

--- a/packages/docs-pages/src/guides/connect-openclaw/page.tsx
+++ b/packages/docs-pages/src/guides/connect-openclaw/page.tsx
@@ -1,5 +1,6 @@
 import { Link } from '../../i18n-navigation';
 import { GuidesSidebar } from '../../_components/guides-sidebar';
+import { DashboardLink } from '../../_components/dashboard-link';
 
 export const metadata = {
   title: 'Munin · Connect OpenClaw over MCP',
@@ -35,7 +36,7 @@ export default function ConnectOpenClaw() {
         </h2>
         <p className="tag-blurb">
           In the dashboard, go to{' '}
-          <Link href="/dashboard/settings/api-keys">Settings → API keys</Link> and create a key.
+          <DashboardLink href="/dashboard/settings/api-keys">Settings → API keys</DashboardLink> and create a key.
           Scope it to what OpenClaw should be allowed to do — read-only KB, full CRM write, or
           everything. The token starts with <code>mn_admin_</code> and is shown once.
         </p>


### PR DESCRIPTION
## What

The docs portal has six links into `/dashboard/settings/api-keys` — the **"Get a key →"** button in the topbar (`_components/docs-shell.tsx:50`) and the inline *"Settings → API keys"* links in the five `connect-*` guides. All six used the next-intl `Link`, which localizes the href against whichever app is rendering.

In OSS that's correct: `apps/web` serves `/[locale]/docs` and `/[locale]/dashboard` from a single origin, so it resolves. On the cloud marketing site it isn't — `marketing-cloud/app/[locale]/` has only `(marketing)/` and `docs/`, no dashboard. Every one of the **66 built docs pages** shipped a dead `/en/dashboard/settings/api-keys`, the topbar button included, so it's on every page of the developer portal rather than a stray link in one guide.

## How

New `DashboardLink` component:

- `NEXT_PUBLIC_APP_URL` unset → unchanged behaviour, the relative locale-prefixed next-intl `Link`. OSS same-origin keeps working.
- set → a plain `<a>` at `${NEXT_PUBLIC_APP_URL}${href}`.

It has to be a plain anchor in the second case: next-intl's `Link` localizes an absolute cross-origin href rather than passing it through. Default is empty string, not a localhost URL, so relative stays the fallback.

This follows the idiom the package already uses for `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_MCP_URL`, and matches the consuming convention on the cloud side (`marketing-cloud/lib/links.ts` → `APP_URL`, 12 call sites).

## Checks worth noting

Two things that could have made this a non-fix, both verified:

- **The absolute target is unprefixed**, which would 404 against a `localePrefix: 'always'` app. It doesn't — `apps/web/proxy.ts` runs the next-intl middleware under a matcher that covers `/dashboard/*`, so it redirects to the negotiated locale. Known side effect: with `localeDetection: true`, a Norwegian visitor on `/en/docs` may land on `/nb/dashboard/...`.
- **Whether cloud needs new config.** It doesn't. `NEXT_PUBLIC_APP_URL` is already in `munin-cloud/.env.example` and baked into the marketing deploy — `https://app.getmunin.com` for prod, `https://app.dev.getmunin.com` for dev. The cloud side is just the `@getmunin/docs-pages` bump through the normal release pipeline.

## Notes

Changeset lists only `@getmunin/docs-pages` — nothing here touches `apps/web`, so no ignored/published mixing. `typecheck` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)