### PR TITLE
fix(dashboard): show the topbar left slot on mobile

### DIFF
--- a/.changeset/mobile-topbar-left-slot.md
+++ b/.changeset/mobile-topbar-left-slot.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Render `DashboardTopbar`'s `leftSlot` on mobile. The slot lived in a `hidden md:flex` container, so cloud's org switcher was unreachable below the `md` breakpoint — the topbar showed the centered brand label instead, with no way to switch orgs on a phone. The slot now renders at every width and replaces the brand label (as it already did on desktop); the centered mobile brand is kept only when no slot is supplied. Topbar gaps tighten to `gap-2` under `md` so a switcher fits next to the logo.

--- a/packages/dashboard-pages/src/components/munin-topbar.tsx
+++ b/packages/dashboard-pages/src/components/munin-topbar.tsx
@@ -29,7 +29,7 @@ export function DashboardTopbar({
   settingsLabel,
 }: DashboardTopbarProps) {
   return (
-    <header className={`${topbarChromeBase} flex h-14 items-stretch gap-6 px-4 md:px-10`}>
+    <header className={`${topbarChromeBase} flex h-14 items-stretch gap-2 px-4 md:gap-6 md:px-10`}>
       <Link
         href={brandHref}
         className="flex items-center gap-1 self-center text-ink dark:text-foreground"
@@ -42,15 +42,19 @@ export function DashboardTopbar({
 
       <span className="my-auto hidden h-5 w-px bg-rule-soft md:block dark:bg-rule-on-dark" aria-hidden />
 
-      <div className="hidden items-center gap-3 self-center md:flex">
-        {leftSlot ?? (
-          <span className="text-[13px] font-medium text-ink dark:text-foreground">{brand}</span>
-        )}
-      </div>
+      {leftSlot ? (
+        <div className="flex min-w-0 items-center gap-3 self-center">{leftSlot}</div>
+      ) : (
+        <>
+          <div className="hidden items-center gap-3 self-center md:flex">
+            <span className="text-[13px] font-medium text-ink dark:text-foreground">{brand}</span>
+          </div>
 
-      <div className="pointer-events-none absolute inset-x-0 top-0 flex h-14 items-center justify-center md:hidden">
-        <span className="text-[13px] font-medium text-ink dark:text-foreground">{brand}</span>
-      </div>
+          <div className="pointer-events-none absolute inset-x-0 top-0 flex h-14 items-center justify-center md:hidden">
+            <span className="text-[13px] font-medium text-ink dark:text-foreground">{brand}</span>
+          </div>
+        </>
+      )}
 
       <div className="ml-auto flex items-center self-center">
         <Link


### PR DESCRIPTION
## Problem

The org switcher can't be opened on the mobile dashboard — it isn't clipped or unclickable, it was never rendered.

Cloud injects `<OrgSwitcher>` as `leftSlot` on `DashboardShell` (`munin-cloud/apps/web-cloud/app/[locale]/dashboard/layout.tsx`), and `DashboardTopbar` put that slot inside a `hidden … md:flex` container, with a separate absolutely-centered brand label for `md:hidden`. Below the `md` breakpoint you got the static brand text and no switcher at all — no way to change org on a phone.

## Fix

`packages/dashboard-pages/src/components/munin-topbar.tsx`:

- When `leftSlot` is provided it renders at every width (`min-w-0` so the switcher's own truncation works) and replaces the brand label — which is already what it did on desktop.
- The centered mobile brand now renders only when no slot is supplied, so OSS single-tenant (`apps/web` passes no `leftSlot`) is visually unchanged.
- Header gap drops to `gap-2` under `md` (`md:gap-6` unchanged) so a switcher fits beside the logo. On the no-slot mobile path the brand is absolutely positioned, so that gap doesn't affect it.

## Testing

Verified locally against the real cloud switcher markup: ran the OSS dashboard with a stand-in `leftSlot` using the same classes as cloud's `OrgSwitcher` (`max-w-[180px]` truncating label, `w-72` dropdown). At ~375px the org name now sits beside the logo and the dropdown opens and is clickable; at ≥768px the desktop topbar is unchanged. The scaffolding is not part of this PR. Typecheck and lint pass for the package.

## Notes

- Takes effect in cloud on the next `@getmunin/*` bump; nothing in munin-cloud needs editing.
- Out of scope: settings pages have no switcher at any width — `SettingsTopbar` takes no `leftSlot`. Pre-existing on desktop too, so it reads as a separate product decision rather than this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)