### PR TITLE
fix(analytics): let identify adopt anonymous widget identities

### DIFF
--- a/.changeset/anon-identity-provisional.md
+++ b/.changeset/anon-identity-provisional.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Treat anonymous and phone-derived identities as provisional when resolving `identify`
+
+`identify` refused to adopt an `end_users` row whose `external_id` was an `anon:<session>` key, because only `email:` prefixes and `NULL` counted as provisional. Those anon keys are throwaway widget-session ids, not real identities — and the chat widget stamps the visitor's email onto them through visitor enrichment, so they routinely hold an address.
+
+The result: a visitor who chatted with the widget and later signed in hit the conflict branch instead of the adoption branch. `identify` created a second row with no email, logged `identify.email_conflict`, and did so on every subsequent call — the web journey could never join the email identity, which is the exact split this feature exists to close. `phone:` keys had the same gap.
+
+Both prefixes are now provisional alongside `email:`, so the anonymous row is promoted in place to the caller's real external id: the row id never changes, everything already attached to it stays attached, and the throwaway key is retired as a side effect. Existing rows heal on the next identify; no migration required.
+
+Note that migration `0069`'s keeper ordering shares the blind spot — it ranks `anon:` as a real id when choosing which duplicate survives — so a deploy that merged duplicates may have kept an anon-keyed row. That is cosmetic rather than harmful: the merge itself repointed every reference correctly, and the first identify after this fix promotes the key.

--- a/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
+++ b/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
@@ -1258,6 +1258,51 @@ const skipReason = TEST_URL
     );
   }, 30_000);
 
+  it('adopts an anonymous widget identity that already carries the address', async () => {
+    const minted = await mintIdentityTracker('anon-adopt tracker');
+    const email = 'anon.holder@example.no';
+
+    const [anon] = await db
+      .insert(schema.endUsers)
+      .values({
+        orgId,
+        externalId: `anon:${'sess-' + Math.abs(orgId.length * 7919)}`,
+        email,
+        name: 'Kjell (widget session)',
+      })
+      .returning({ id: schema.endUsers.id });
+
+    const visitorId = 'visitor-anon-adopt';
+    const externalId = 'axo-anon-1';
+    const res = await postIdentify(minted.trackerKey, {
+      visitorId,
+      externalId,
+      email,
+      userHash: signHmac(
+        identityHashPayload({ externalId, visitorId, email }),
+        minted.identityVerificationSecret,
+      ),
+    });
+    expect(res.status).toBe(204);
+
+    await waitFor(async () => {
+      const rows = await db
+        .select({ id: schema.endUsers.id })
+        .from(schema.endUsers)
+        .where(sql`org_id = ${orgId} AND external_id = ${externalId}`)
+        .limit(1);
+      return rows.length > 0;
+    });
+
+    const holders = await db
+      .select({ id: schema.endUsers.id, externalId: schema.endUsers.externalId })
+      .from(schema.endUsers)
+      .where(sql`org_id = ${orgId} AND lower(email) = ${email}`);
+    expect(holders).toHaveLength(1);
+    expect(holders[0]!.id).toBe(anon!.id);
+    expect(holders[0]!.externalId).toBe(externalId);
+  }, 30_000);
+
   it('identify with a signed email converges on the identity the email channel already created', async () => {
     const minted = await mintIdentityTracker('email-trait tracker');
     const email = 'kari.nordmann@example.no';

--- a/packages/backend-core/src/modules/analytics/visitor-identity.ts
+++ b/packages/backend-core/src/modules/analytics/visitor-identity.ts
@@ -19,8 +19,10 @@ export function normalizeIdentityEmail(email: string | null | undefined): string
   return trimmed ? trimmed : null;
 }
 
+const SYNTHETIC_ID_PREFIXES = ['email:', 'phone:', 'anon:'];
+
 function isProvisionalIdentity(externalId: string | null): boolean {
-  return externalId === null || externalId.startsWith('email:');
+  return externalId === null || SYNTHETIC_ID_PREFIXES.some((p) => externalId.startsWith(p));
 }
 
 async function findByExternalId(tx: Tx | Db, orgId: string, externalId: string) {


### PR DESCRIPTION
Found while confirming the prod outcome of #770/#772: both surviving `end_users` rows for one address were keyed `anon:<uuid>`, and identify would never adopt them.

## The bug

```ts
function isProvisionalIdentity(externalId: string | null): boolean {
  return externalId === null || externalId.startsWith('email:');   // anon: / phone: missing
}
```

`anon:<session>` keys are throwaway widget-session identities — and the chat widget stamps the visitor's email onto them through visitor enrichment, so they routinely hold a real address. Treating them as established identities meant `resolveIdentifiedEndUser` took the **conflict** branch: a second row with no email, an `identify.email_conflict` log line, and the same outcome on every subsequent call.

So a visitor who chatted with the widget and later signed in could never join their web journey to the identity holding their address — the exact split the signed-email trait exists to close. `phone:` keys had the same gap.

## The fix

`anon:` and `phone:` are provisional alongside `email:`, so the row is promoted in place to the caller's real external id. The row id never changes, everything attached stays attached, and the throwaway key is retired as a side effect. Existing rows heal on the next identify — no migration.

Adopting an anonymous session under a *signed, verified* email is the same thing the widget's own `claimAnonymousIdentityInTx` does when an anonymous chatter signs in, so this restores symmetry rather than inventing a new behaviour.

## Test

The regression test seeds the shape observed in production — an `anon:`-keyed row already carrying the address — and asserts the row is adopted rather than duplicated. Verified it **fails against the previous predicate**:

```
AssertionError: expected 'anon:sess-205894' to be 'axo-anon-1'
```

analytics + conv suites: 399 passing.

## Known cosmetic gap, not fixed here

Migration `0069`'s keeper ordering shares the blind spot (`external_id NOT LIKE 'email:%'` ranks `anon:` as real), so a deploy that merged duplicates may have kept an anon-keyed row. The merge itself repointed every reference correctly, and the first identify after this fix promotes the key — so a corrective migration would be churn for no behavioural gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiRhcZUpZ3u538xCioS8dv