### PR TITLE
fix(agent): stop a provider 429 burst from looking like an outage

### DIFF
--- a/.changeset/agent-429-retry-and-drain-stagger.md
+++ b/.changeset/agent-429-retry-and-drain-stagger.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/agent-runtime': patch
+'@getmunin/agent-host': patch
+---
+
+Retry provider 429s with jittered backoff, and stagger curator drains across orgs
+
+A hosted deploy put every org's agent runner on one shared provider key and one shared per-minute token budget. When the backend container respawned, all runners reconnected to the realtime bus inside the same second and each immediately drained its curator queue. Individual curator jobs cost 15k–85k tokens, so a handful of concurrent drains blew straight through the provider's tokens-per-minute quota and came back `429 INSUFFICIENT QUOTA`.
+
+Two things then made a one-second burst look like an outage. `openAiCompatibleProvider` surfaced the first 429 as a `ProviderError`, and `AgentHealthService` opened an `llm_provider` alert on it — which only resolves on a later *success*, so the dashboard's "agent runner offline — provider rate limit hit" banner stayed up for hours after the provider had recovered. Four orgs sat degraded that way with no further failing traffic.
+
+`openAiCompatibleProvider` now retries a 429 up to four times before raising, waiting `500ms · 2^attempt` (capped at 15s), never less than a `Retry-After` header asks for, and multiplied by a random 1–2× jitter so concurrent callers don't retry in lockstep. Every caller inherits this: chat, curator jobs, and any host-supplied provider that wraps the built-in one. Other statuses are untouched — a 401 or 404 still fails on the first attempt, since retrying a bad key or a missing model only delays the real signal.
+
+`AgentHostRunner` now routes the on-connect curator drain through a shared scheduler that spaces drains 5s apart, so a twelve-org boot spreads over a minute instead of firing at `t=0`. A single reconnect after the spacing window has passed is not delayed at all, and a runner that stops with a drain still pending cancels it.

--- a/.changeset/anon-identity-provisional.md
+++ b/.changeset/anon-identity-provisional.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Treat anonymous and phone-derived identities as provisional when resolving `identify`
+
+`identify` refused to adopt an `end_users` row whose `external_id` was an `anon:<session>` key, because only `email:` prefixes and `NULL` counted as provisional. Those anon keys are throwaway widget-session ids, not real identities — and the chat widget stamps the visitor's email onto them through visitor enrichment, so they routinely hold an address.
+
+The result: a visitor who chatted with the widget and later signed in hit the conflict branch instead of the adoption branch. `identify` created a second row with no email, logged `identify.email_conflict`, and did so on every subsequent call — the web journey could never join the email identity, which is the exact split this feature exists to close. `phone:` keys had the same gap.
+
+Both prefixes are now provisional alongside `email:`, so the anonymous row is promoted in place to the caller's real external id: the row id never changes, everything already attached to it stays attached, and the throwaway key is retired as a side effect. Existing rows heal on the next identify; no migration required.
+
+Note that migration `0069`'s keeper ordering shares the blind spot — it ranks `anon:` as a real id when choosing which duplicate survives — so a deploy that merged duplicates may have kept an anon-keyed row. That is cosmetic rather than harmful: the merge itself repointed every reference correctly, and the first identify after this fix promotes the key.

--- a/.changeset/curator-drain-and-sweep-spread.md
+++ b/.changeset/curator-drain-and-sweep-spread.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/agent-host': patch
+---
+
+Drain the curator queue to empty, and spread scheduled sweeps across the fleet
+
+A curator backlog could sit untouched for hours and then run all at once. Two causes, both fixed here.
+
+`triggerPoll` drops a trigger while a poll is already in flight, and `pollOnce` claimed exactly one job per trigger. So when the scheduler enqueued four sweeps for an org in the same second, four `curator_job.pending` events arrived, the first started a poll, and the other three were swallowed — one job ran and the rest waited for something to poll again. Nothing does, until the next realtime reconnect. In practice that meant a restart: jobs enqueued at 00:00 were observed starting at 06:38 the same morning, still on `attempt 1/5`, for every org at once.
+
+The poll loop now keeps claiming until the queue comes back empty (`drainCuratorQueue`), so a burst of enqueues drains steadily instead of pooling. It re-checks `beforeGenerate` between jobs, so a host that revokes permission mid-drain — a quota gate, a rate limiter — is honoured on the next job rather than after the whole backlog. It stops early on a provider error, since the next job would only fail the same way, and pauses after 25 jobs so one org's backlog can't monopolise a shared provider; the remainder is re-queued behind the other orgs.
+
+The other cause is the scheduler itself: `runSweep` walked every org and enqueued with the same `next_attempt_at`, so an entire fleet's weekly sweep landed on one instant. Sweeps now spread their enqueues over a window that scales with fleet size (60s per org, capped at 4h) — a single-org deployment is unaffected, a 100-org fleet spreads over ~99 minutes. Retry backoff in `fail()` gained the same treatment: it was `30s · 2^attempts` with no jitter, so jobs that failed together retried together forever. It is now multiplied by a random 1–2×.

--- a/packages/agent-host/src/curator-drain.test.ts
+++ b/packages/agent-host/src/curator-drain.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { drainCuratorQueue } from './curator-drain.ts';
+
+function harness(options: {
+  queue: string[];
+  admit?: () => Promise<boolean>;
+  execute?: (job: string) => Promise<boolean>;
+  maxJobs?: number;
+  stopAfter?: number;
+  claimThrows?: boolean;
+}): {
+  run: () => ReturnType<typeof drainCuratorQueue<string>>;
+  executed: string[];
+  claims: () => number;
+} {
+  const executed: string[] = [];
+  let claims = 0;
+  let stopped = false;
+  const run = (): ReturnType<typeof drainCuratorQueue<string>> =>
+    drainCuratorQueue<string>({
+      admit: options.admit ?? (() => Promise.resolve(true)),
+      claim: () => {
+        claims += 1;
+        if (options.claimThrows) return Promise.reject(new Error('claim boom'));
+        const next = options.queue.shift();
+        return Promise.resolve(next ? [next] : []);
+      },
+      execute: async (job) => {
+        executed.push(job);
+        if (options.stopAfter !== undefined && executed.length >= options.stopAfter) stopped = true;
+        return options.execute ? await options.execute(job) : false;
+      },
+      maxJobs: options.maxJobs ?? 25,
+      isStopped: () => stopped,
+      onClaimError: () => {},
+    });
+  return { run, executed, claims: () => claims };
+}
+
+describe('drainCuratorQueue', () => {
+  it('keeps claiming until the queue is empty instead of stopping after one job', async () => {
+    const h = harness({ queue: ['a', 'b', 'c'] });
+    await expect(h.run()).resolves.toBe('empty');
+    expect(h.executed).toEqual(['a', 'b', 'c']);
+    expect(h.claims()).toBe(4);
+  });
+
+  it('returns empty without executing anything when the queue is already drained', async () => {
+    const h = harness({ queue: [] });
+    await expect(h.run()).resolves.toBe('empty');
+    expect(h.executed).toEqual([]);
+  });
+
+  it('stops immediately when the generate gate denies', async () => {
+    const h = harness({ queue: ['a', 'b'], admit: () => Promise.resolve(false) });
+    await expect(h.run()).resolves.toBe('suppressed');
+    expect(h.executed).toEqual([]);
+  });
+
+  it('re-checks the gate between jobs so a mid-drain quota stop is honoured', async () => {
+    let calls = 0;
+    const h = harness({
+      queue: ['a', 'b', 'c'],
+      admit: () => {
+        calls += 1;
+        return Promise.resolve(calls <= 2);
+      },
+    });
+    await expect(h.run()).resolves.toBe('suppressed');
+    expect(h.executed).toEqual(['a', 'b']);
+  });
+
+  it('abandons the rest of the queue when a job fails against the provider', async () => {
+    const h = harness({ queue: ['a', 'b', 'c'], execute: (job) => Promise.resolve(job === 'b') });
+    await expect(h.run()).resolves.toBe('provider_unhealthy');
+    expect(h.executed).toEqual(['a', 'b']);
+  });
+
+  it('pauses once the per-drain job budget is spent', async () => {
+    const h = harness({ queue: ['a', 'b', 'c', 'd'], maxJobs: 2 });
+    await expect(h.run()).resolves.toBe('paused');
+    expect(h.executed).toEqual(['a', 'b']);
+  });
+
+  it('stops when the worker is torn down mid-drain', async () => {
+    const h = harness({ queue: ['a', 'b', 'c'], stopAfter: 1 });
+    await expect(h.run()).resolves.toBe('empty');
+    expect(h.executed).toEqual(['a']);
+  });
+
+  it('reports a failed claim rather than spinning', async () => {
+    const h = harness({ queue: ['a'], claimThrows: true });
+    await expect(h.run()).resolves.toBe('claim_failed');
+    expect(h.claims()).toBe(1);
+  });
+});

--- a/packages/agent-host/src/curator-drain.ts
+++ b/packages/agent-host/src/curator-drain.ts
@@ -1,0 +1,36 @@
+export type DrainOutcome = 'empty' | 'suppressed' | 'claim_failed' | 'provider_unhealthy' | 'paused';
+
+export interface DrainOptions<Job> {
+  admit: () => Promise<boolean>;
+  claim: () => Promise<Job[]>;
+  execute: (job: Job) => Promise<boolean>;
+  maxJobs: number;
+  isStopped: () => boolean;
+  onClaimError: (err: unknown) => void;
+}
+
+export async function drainCuratorQueue<Job>(opts: DrainOptions<Job>): Promise<DrainOutcome> {
+  let drained = 0;
+  while (!opts.isStopped()) {
+    if (!(await opts.admit())) return 'suppressed';
+
+    let jobs: Job[];
+    try {
+      jobs = await opts.claim();
+    } catch (err) {
+      opts.onClaimError(err);
+      return 'claim_failed';
+    }
+    if (jobs.length === 0) return 'empty';
+
+    for (const job of jobs) {
+      if (opts.isStopped()) return 'empty';
+      const providerFailed = await opts.execute(job);
+      if (providerFailed) return 'provider_unhealthy';
+      drained += 1;
+    }
+
+    if (drained >= opts.maxJobs) return 'paused';
+  }
+  return 'empty';
+}

--- a/packages/agent-host/src/drain-scheduler.test.ts
+++ b/packages/agent-host/src/drain-scheduler.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDrainScheduler } from './drain-scheduler.ts';
+
+describe('createDrainScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('spaces out drains enqueued in the same tick instead of running them all at once', () => {
+    const scheduler = createDrainScheduler(5_000, () => Date.now());
+    const ran: string[] = [];
+    for (const id of ['a', 'b', 'c']) scheduler.enqueue(() => ran.push(id));
+
+    vi.advanceTimersByTime(0);
+    expect(ran).toEqual(['a']);
+
+    vi.advanceTimersByTime(5_000);
+    expect(ran).toEqual(['a', 'b']);
+
+    vi.advanceTimersByTime(5_000);
+    expect(ran).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not delay a lone drain that arrives after the spacing window has passed', () => {
+    const scheduler = createDrainScheduler(5_000, () => Date.now());
+    const ran: string[] = [];
+    scheduler.enqueue(() => ran.push('first'));
+    vi.advanceTimersByTime(60_000);
+
+    scheduler.enqueue(() => ran.push('second'));
+    vi.advanceTimersByTime(0);
+    expect(ran).toEqual(['first', 'second']);
+  });
+
+  it('cancel prevents a pending drain from running', () => {
+    const scheduler = createDrainScheduler(5_000, () => Date.now());
+    const ran: string[] = [];
+    scheduler.enqueue(() => ran.push('a'));
+    const cancel = scheduler.enqueue(() => ran.push('b'));
+    cancel();
+
+    vi.advanceTimersByTime(30_000);
+    expect(ran).toEqual(['a']);
+  });
+});

--- a/packages/agent-host/src/drain-scheduler.ts
+++ b/packages/agent-host/src/drain-scheduler.ts
@@ -1,0 +1,19 @@
+export interface DrainScheduler {
+  enqueue(run: () => void): () => void;
+}
+
+export function createDrainScheduler(
+  spacingMs: number,
+  now: () => number = Date.now,
+): DrainScheduler {
+  let nextAt = 0;
+  return {
+    enqueue(run) {
+      const current = now();
+      const at = Math.max(current, nextAt);
+      nextAt = at + spacingMs;
+      const timer = setTimeout(run, at - current);
+      return () => clearTimeout(timer);
+    },
+  };
+}

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -56,6 +56,7 @@ import { ReplicaLockManager } from './replica-lock.ts';
 import { runWebImportJob } from './web-import.handler.ts';
 import { AgentHealthService } from './agent-health.service.ts';
 import { createMeteringProvider } from './usage-metering.ts';
+import { createDrainScheduler, type DrainScheduler } from './drain-scheduler.ts';
 
 interface TaskHandlerContext {
   job: CuratorJob;
@@ -79,6 +80,7 @@ const CURATOR_LEASE_SECONDS = 600;
 const CURATOR_MAX_SCHEDULED_DELAY_MS = 24 * 60 * 60 * 1000;
 const CONVERSATION_SWEEP_LIMIT = 50;
 const CURATOR_MAX_TOOL_ITERATIONS = 16;
+const CURATOR_DRAIN_SPACING_MS = 5_000;
 
 const BASE_END_USER_AGENT_SCOPES: readonly string[] = [
   'conv:read',
@@ -161,6 +163,9 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
   private readonly holderId: string;
   private readonly lockManager: ReplicaLockManager | null;
   private readonly options?: AgentHostRunnerOptions;
+  private readonly drainScheduler: DrainScheduler = createDrainScheduler(
+    CURATOR_DRAIN_SPACING_MS,
+  );
 
   constructor(
     @Inject(AGENT_CONFIG_REPOSITORY) private readonly repo: AgentConfigRepository,
@@ -737,6 +742,17 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       );
     };
 
+    let cancelDrain: (() => void) | null = null;
+    const scheduleDrain = (): void => {
+      if (cancelDrain) return;
+      cancelDrain = this.drainScheduler.enqueue(() => {
+        cancelDrain = null;
+        if (stopped) return;
+        log.info('realtime connected — draining queue');
+        triggerPoll();
+      });
+    };
+
     return {
       onPending(event) {
         if (stopped) return;
@@ -757,11 +773,12 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       },
       onConnected() {
         if (stopped) return;
-        log.info('realtime connected — draining queue');
-        triggerPoll();
+        scheduleDrain();
       },
       async stop() {
         stopped = true;
+        cancelDrain?.();
+        cancelDrain = null;
         for (const t of scheduledByJob.values()) clearTimeout(t);
         scheduledByJob.clear();
         await Promise.allSettled([...inFlight]);

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -57,6 +57,7 @@ import { runWebImportJob } from './web-import.handler.ts';
 import { AgentHealthService } from './agent-health.service.ts';
 import { createMeteringProvider } from './usage-metering.ts';
 import { createDrainScheduler, type DrainScheduler } from './drain-scheduler.ts';
+import { drainCuratorQueue } from './curator-drain.ts';
 
 interface TaskHandlerContext {
   job: CuratorJob;
@@ -81,6 +82,7 @@ const CURATOR_MAX_SCHEDULED_DELAY_MS = 24 * 60 * 60 * 1000;
 const CONVERSATION_SWEEP_LIMIT = 50;
 const CURATOR_MAX_TOOL_ITERATIONS = 16;
 const CURATOR_DRAIN_SPACING_MS = 5_000;
+const CURATOR_DRAIN_MAX_JOBS = 25;
 
 const BASE_END_USER_AGENT_SCOPES: readonly string[] = [
   'conv:read',
@@ -577,7 +579,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     const smartModel = opts.smartModel;
     const fastModel = opts.fastModel;
 
-    const executeOne = async (job: CuratorJob): Promise<void> => {
+    const executeOne = async (job: CuratorJob): Promise<boolean> => {
       log.info(`running ${job.jobUri} for ${job.id} (attempt ${job.attempts}/${job.maxAttempts})`);
       let result: SkillPassResult;
       const jobMcp = openAdminAgentMcpClient({
@@ -643,7 +645,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
         await opts.rest
           .failCuratorJob(job.id, { error: message })
           .catch((e) => log.error(`fail-report failed: ${describe(e)}`));
-        return;
+        return false;
       }
 
       if (result.ok) {
@@ -663,7 +665,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
             { orgId: opts.orgId },
           ).catch((e) => log.warn(`recordSuccess failed: ${describe(e)}`));
         }
-        return;
+        return false;
       }
 
       const retryable =
@@ -690,45 +692,54 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       await opts.rest
         .failCuratorJob(job.id, failBody)
         .catch((e) => log.error(`fail-report failed: ${describe(e)}`));
+      return result.skipped === 'provider_error';
+    };
+
+    const admit = async (): Promise<boolean> => {
+      if (!this.options?.beforeGenerate) return true;
+      const verdict = await runWithServiceContext(
+        this.db,
+        opts.id,
+        () =>
+          this.options!.beforeGenerate!({
+            orgId: opts.orgId,
+            config: opts.config,
+            managed: opts.managed,
+            trigger: 'scheduled',
+          }),
+        { orgId: opts.orgId },
+      ).catch((err): { allowed: boolean; reason?: string } => {
+        log.warn(`beforeGenerate failed, proceeding: ${describe(err)}`);
+        return { allowed: true };
+      });
+      if (!verdict.allowed) {
+        log.info(`scheduled work suppressed: ${verdict.reason ?? 'gate denied'}`);
+        return false;
+      }
+      return true;
     };
 
     const pollOnce = async (): Promise<void> => {
       if (stopped) return;
-      if (this.options?.beforeGenerate) {
-        const verdict = await runWithServiceContext(
-          this.db,
-          opts.id,
-          () =>
-            this.options!.beforeGenerate!({
-              orgId: opts.orgId,
-              config: opts.config,
-              managed: opts.managed,
-              trigger: 'scheduled',
-            }),
-          { orgId: opts.orgId },
-        ).catch((err): { allowed: boolean; reason?: string } => {
-          log.warn(`beforeGenerate failed, proceeding: ${describe(err)}`);
-          return { allowed: true };
-        });
-        if (!verdict.allowed) {
-          log.info(`scheduled work suppressed: ${verdict.reason ?? 'gate denied'}`);
-          return;
-        }
+      const outcome = await drainCuratorQueue<CuratorJob>({
+        admit,
+        claim: () =>
+          opts.rest.claimCuratorJobs({
+            holder: this.holderId,
+            limit: 1,
+            leaseSeconds: CURATOR_LEASE_SECONDS,
+          }),
+        execute: executeOne,
+        maxJobs: CURATOR_DRAIN_MAX_JOBS,
+        isStopped: () => stopped,
+        onClaimError: (err) => log.warn(`claim failed: ${describe(err)}`),
+      });
+      if (outcome === 'paused') {
+        log.info(`drained ${CURATOR_DRAIN_MAX_JOBS} jobs — re-queueing the rest behind other orgs`);
+        scheduleDrain('batch limit');
       }
-      let jobs: CuratorJob[];
-      try {
-        jobs = await opts.rest.claimCuratorJobs({
-          holder: this.holderId,
-          limit: 1,
-          leaseSeconds: CURATOR_LEASE_SECONDS,
-        });
-      } catch (err) {
-        log.warn(`claim failed: ${describe(err)}`);
-        return;
-      }
-      for (const job of jobs) {
-        if (stopped) break;
-        await executeOne(job);
+      if (outcome === 'provider_unhealthy') {
+        log.warn('provider unhealthy — leaving the rest of the queue for the next drain');
       }
     };
 
@@ -743,12 +754,12 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
     };
 
     let cancelDrain: (() => void) | null = null;
-    const scheduleDrain = (): void => {
+    const scheduleDrain = (reason: string): void => {
       if (cancelDrain) return;
       cancelDrain = this.drainScheduler.enqueue(() => {
         cancelDrain = null;
         if (stopped) return;
-        log.info('realtime connected — draining queue');
+        log.info(`draining queue (${reason})`);
         triggerPoll();
       });
     };
@@ -773,7 +784,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
       },
       onConnected() {
         if (stopped) return;
-        scheduleDrain();
+        scheduleDrain('realtime connected');
       },
       async stop() {
         stopped = true;

--- a/packages/agent-runtime/src/providers/openai-compatible.test.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import * as core from '@getmunin/core';
 import {
+  parseRetryAfterMs,
+  rateLimitRetryDelayMs,
   shouldEnablePromptCache,
   withSystemPromptCache,
   withToolsCache,
@@ -97,6 +99,125 @@ describe('openAiCompatibleProvider request body', () => {
     expect(messages[0]?.content).toBe('sys');
     const tools = captured.body?.tools as Array<Record<string, unknown>>;
     expect(tools[0]?.cache_control).toBeUndefined();
+  });
+});
+
+describe('openAiCompatibleProvider rate-limit retries', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function stubSafeFetchSequence(
+    responses: Array<{ status: number; body: unknown; retryAfter?: string }>,
+  ): ReturnType<typeof vi.fn> {
+    let call = 0;
+    const fn = vi.fn(() => {
+      const out = responses[Math.min(call, responses.length - 1)]!;
+      call += 1;
+      return Promise.resolve({
+        ok: out.status >= 200 && out.status < 300,
+        status: out.status,
+        headers: { get: (name: string) => (name === 'retry-after' ? (out.retryAfter ?? null) : null) },
+        json: () => Promise.resolve(out.body),
+        text: () =>
+          Promise.resolve(typeof out.body === 'string' ? out.body : JSON.stringify(out.body)),
+      });
+    });
+    vi.spyOn(core, 'safeFetch').mockImplementation(fn as unknown as typeof core.safeFetch);
+    return fn;
+  }
+
+  const okBody = {
+    choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+
+  const call = (): Promise<unknown> =>
+    openAiCompatibleProvider({
+      config: {
+        provider: { baseUrl: 'https://api.scaleway.ai/v1', apiKey: 'k' },
+        model: 'gpt-oss-120b',
+        systemPrompt: 'sys',
+      },
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: [],
+    });
+
+  it('retries a 429 and resolves without surfacing a provider error', async () => {
+    vi.useFakeTimers();
+    const fetchStub = stubSafeFetchSequence([
+      { status: 429, body: { error: 'INSUFFICIENT QUOTA' }, retryAfter: '1' },
+      { status: 200, body: okBody },
+    ]);
+
+    const pending = call();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(pending).resolves.toMatchObject({ finishReason: 'stop' });
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after the retry budget and throws provider_rate_limit', async () => {
+    vi.useFakeTimers();
+    const fetchStub = stubSafeFetchSequence([
+      { status: 429, body: { error: 'INSUFFICIENT QUOTA' } },
+    ]);
+
+    const pending = call().catch((err: unknown) => err);
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    const err = await pending;
+    expect(err).toMatchObject({ name: 'ProviderError', code: 'provider_rate_limit', status: 429 });
+    expect(fetchStub).toHaveBeenCalledTimes(5);
+  });
+
+  it('does not retry a non-429 failure', async () => {
+    const fetchStub = stubSafeFetchSequence([{ status: 401, body: { error: 'User not found.' } }]);
+
+    const err = await call().catch((e: unknown) => e);
+    expect(err).toMatchObject({ name: 'ProviderError', code: 'provider_auth' });
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('rateLimitRetryDelayMs', () => {
+  it('grows exponentially across attempts', () => {
+    const half = (): number => 0;
+    expect(rateLimitRetryDelayMs(null, 0, half)).toBe(500);
+    expect(rateLimitRetryDelayMs(null, 1, half)).toBe(1_000);
+    expect(rateLimitRetryDelayMs(null, 2, half)).toBe(2_000);
+  });
+
+  it('jitters so that concurrent callers do not retry in lockstep', () => {
+    expect(rateLimitRetryDelayMs(null, 0, () => 0)).toBe(500);
+    expect(rateLimitRetryDelayMs(null, 0, () => 1)).toBe(1_000);
+  });
+
+  it('never waits less than the provider asked for', () => {
+    expect(rateLimitRetryDelayMs('3', 0, () => 0)).toBe(3_000);
+  });
+
+  it('caps the wait', () => {
+    expect(rateLimitRetryDelayMs('600', 4, () => 1)).toBe(15_000);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('reads delay-seconds', () => {
+    expect(parseRetryAfterMs('2')).toBe(2_000);
+  });
+
+  it('reads an HTTP date', () => {
+    const at = new Date(Date.now() + 4_000).toUTCString();
+    const ms = parseRetryAfterMs(at);
+    expect(ms).toBeGreaterThan(2_000);
+    expect(ms).toBeLessThanOrEqual(5_000);
+  });
+
+  it('returns null for a missing or unparseable header', () => {
+    expect(parseRetryAfterMs(null)).toBeNull();
+    expect(parseRetryAfterMs('soon')).toBeNull();
   });
 });
 

--- a/packages/agent-runtime/src/providers/openai-compatible.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.ts
@@ -17,6 +17,10 @@ interface OpenAIResponse {
 
 const CACHE_CONTROL = { type: 'ephemeral' } as const;
 
+const RATE_LIMIT_MAX_RETRIES = 4;
+const RATE_LIMIT_BASE_DELAY_MS = 500;
+const RATE_LIMIT_MAX_DELAY_MS = 15_000;
+
 export const openAiCompatibleProvider: Provider = async ({
   config,
   messages,
@@ -39,14 +43,11 @@ export const openAiCompatibleProvider: Provider = async ({
     body.response_format = { type: 'json_object' };
   }
 
-  const res = await safeFetch(url, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      authorization: `Bearer ${config.provider.apiKey}`,
-    },
+  const res = await postChatCompletion({
+    url,
+    apiKey: config.provider.apiKey,
     body: JSON.stringify(body),
-    signal: abortSignal,
+    abortSignal,
   });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
@@ -77,6 +78,69 @@ export const openAiCompatibleProvider: Provider = async ({
     finishReason,
   };
 };
+
+async function postChatCompletion(args: {
+  url: string;
+  apiKey: string;
+  body: string;
+  abortSignal?: AbortSignal;
+}): Promise<Awaited<ReturnType<typeof safeFetch>>> {
+  for (let attempt = 0; ; attempt++) {
+    const res = await safeFetch(args.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${args.apiKey}`,
+      },
+      body: args.body,
+      signal: args.abortSignal,
+    });
+    if (res.status !== 429 || attempt >= RATE_LIMIT_MAX_RETRIES) return res;
+    const retryAfter = res.headers.get('retry-after');
+    await sleep(rateLimitRetryDelayMs(retryAfter, attempt), args.abortSignal);
+  }
+}
+
+export function rateLimitRetryDelayMs(
+  retryAfter: string | null,
+  attempt: number,
+  random: () => number = Math.random,
+): number {
+  const backoff = Math.min(RATE_LIMIT_BASE_DELAY_MS * 2 ** attempt, RATE_LIMIT_MAX_DELAY_MS);
+  const requested = parseRetryAfterMs(retryAfter);
+  const wait = requested === null ? backoff : Math.max(requested, backoff);
+  return Math.min(RATE_LIMIT_MAX_DELAY_MS, Math.round(wait * (1 + random())));
+}
+
+export function parseRetryAfterMs(retryAfter: string | null): number | null {
+  if (!retryAfter) return null;
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const at = Date.parse(retryAfter);
+  return Number.isFinite(at) ? Math.max(0, at - Date.now()) : null;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortReason(signal));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(abortReason(signal));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function abortReason(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error ? signal.reason : new Error('aborted');
+}
 
 export type ProviderErrorCode =
   | 'provider_auth'

--- a/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
+++ b/packages/backend-core/src/modules/analytics/analytics-tracker.integration.test.ts
@@ -1258,6 +1258,51 @@ const skipReason = TEST_URL
     );
   }, 30_000);
 
+  it('adopts an anonymous widget identity that already carries the address', async () => {
+    const minted = await mintIdentityTracker('anon-adopt tracker');
+    const email = 'anon.holder@example.no';
+
+    const [anon] = await db
+      .insert(schema.endUsers)
+      .values({
+        orgId,
+        externalId: `anon:${'sess-' + Math.abs(orgId.length * 7919)}`,
+        email,
+        name: 'Kjell (widget session)',
+      })
+      .returning({ id: schema.endUsers.id });
+
+    const visitorId = 'visitor-anon-adopt';
+    const externalId = 'axo-anon-1';
+    const res = await postIdentify(minted.trackerKey, {
+      visitorId,
+      externalId,
+      email,
+      userHash: signHmac(
+        identityHashPayload({ externalId, visitorId, email }),
+        minted.identityVerificationSecret,
+      ),
+    });
+    expect(res.status).toBe(204);
+
+    await waitFor(async () => {
+      const rows = await db
+        .select({ id: schema.endUsers.id })
+        .from(schema.endUsers)
+        .where(sql`org_id = ${orgId} AND external_id = ${externalId}`)
+        .limit(1);
+      return rows.length > 0;
+    });
+
+    const holders = await db
+      .select({ id: schema.endUsers.id, externalId: schema.endUsers.externalId })
+      .from(schema.endUsers)
+      .where(sql`org_id = ${orgId} AND lower(email) = ${email}`);
+    expect(holders).toHaveLength(1);
+    expect(holders[0]!.id).toBe(anon!.id);
+    expect(holders[0]!.externalId).toBe(externalId);
+  }, 30_000);
+
   it('identify with a signed email converges on the identity the email channel already created', async () => {
     const minted = await mintIdentityTracker('email-trait tracker');
     const email = 'kari.nordmann@example.no';

--- a/packages/backend-core/src/modules/analytics/visitor-identity.ts
+++ b/packages/backend-core/src/modules/analytics/visitor-identity.ts
@@ -19,8 +19,10 @@ export function normalizeIdentityEmail(email: string | null | undefined): string
   return trimmed ? trimmed : null;
 }
 
+const SYNTHETIC_ID_PREFIXES = ['email:', 'phone:', 'anon:'];
+
 function isProvisionalIdentity(externalId: string | null): boolean {
-  return externalId === null || externalId.startsWith('email:');
+  return externalId === null || SYNTHETIC_ID_PREFIXES.some((p) => externalId.startsWith(p));
 }
 
 async function findByExternalId(tx: Tx | Db, orgId: string, externalId: string) {

--- a/packages/backend-core/src/modules/curator/curator-jobs.service.ts
+++ b/packages/backend-core/src/modules/curator/curator-jobs.service.ts
@@ -26,6 +26,11 @@ export type CuratorJobStatus = (typeof CURATOR_JOB_STATUSES)[number];
 
 const BACKOFF_BASE_MS = 30_000;
 
+export function jitteredBackoffMs(attempts: number, random: () => number = Math.random): number {
+  const base = BACKOFF_BASE_MS * Math.pow(2, Math.max(0, attempts - 1));
+  return Math.round(base * (1 + random()));
+}
+
 export interface CuratorJobDto {
   id: string;
   orgId: string;
@@ -253,7 +258,7 @@ export class CuratorJobsService {
         : reachedMax
           ? 'dead'
           : 'pending';
-    const backoffMs = BACKOFF_BASE_MS * Math.pow(2, Math.max(0, current.attempts - 1));
+    const backoffMs = jitteredBackoffMs(current.attempts);
     const nextAt = status === 'pending' ? new Date(Date.now() + backoffMs) : current.nextAttemptAt;
 
     const [row] = await ctx.db

--- a/packages/backend-core/src/modules/curator/curator-scheduler.service.ts
+++ b/packages/backend-core/src/modules/curator/curator-scheduler.service.ts
@@ -34,6 +34,14 @@ interface SweepDef {
   dedupeKey: string;
 }
 
+const SWEEP_SPREAD_SECONDS_PER_ORG = 60;
+const SWEEP_SPREAD_MAX_SECONDS = 4 * 60 * 60;
+
+export function sweepSpreadSeconds(orgCount: number): number {
+  const span = Math.max(orgCount - 1, 0) * SWEEP_SPREAD_SECONDS_PER_ORG;
+  return Math.min(span, SWEEP_SPREAD_MAX_SECONDS);
+}
+
 @Injectable()
 export class CuratorSchedulerService implements OnModuleInit {
   private readonly logger = new Logger(CuratorSchedulerService.name);
@@ -122,9 +130,16 @@ export class CuratorSchedulerService implements OnModuleInit {
       .from(schema.orgs);
     if (orgs.length === 0) return;
 
+    const spreadSeconds = sweepSpreadSeconds(orgs.length);
+    if (spreadSeconds > 0) {
+      this.logger.log(
+        `${sweep.name} spreading ${orgs.length} orgs over ${Math.round(spreadSeconds / 60)} min`,
+      );
+    }
+
     for (const org of orgs) {
       try {
-        await this.enqueueAsOrg(org.id, sweep);
+        await this.enqueueAsOrg(org.id, sweep, Math.floor(Math.random() * spreadSeconds));
       } catch (err) {
         this.logger.warn(
           `${sweep.name} enqueue failed for org ${org.id}: ${describe(err)}`,
@@ -133,7 +148,11 @@ export class CuratorSchedulerService implements OnModuleInit {
     }
   }
 
-  private async enqueueAsOrg(orgId: string, sweep: SweepDef): Promise<void> {
+  private async enqueueAsOrg(
+    orgId: string,
+    sweep: SweepDef,
+    delaySeconds: number,
+  ): Promise<void> {
     await this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.bypass_rls', 'off', true)`);
       await tx.execute(sql`SELECT set_config('app.org_id', ${orgId}, true)`);
@@ -146,6 +165,7 @@ export class CuratorSchedulerService implements OnModuleInit {
           userPrompt: sweep.userPrompt,
           sourceEventType: `scheduler.${sweep.name}`,
           dedupeKey: sweep.dedupeKey,
+          delaySeconds,
         });
         if (result.alreadyPending) {
           this.logger.log(

--- a/packages/backend-core/src/modules/curator/curator-scheduler.test.ts
+++ b/packages/backend-core/src/modules/curator/curator-scheduler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SchedulerRegistry } from '@nestjs/schedule';
-import { CuratorSchedulerService } from './curator-scheduler.service.ts';
+import { CuratorSchedulerService, sweepSpreadSeconds } from './curator-scheduler.service.ts';
+import { jitteredBackoffMs } from './curator-jobs.service.ts';
 
 describe('CuratorSchedulerService.onModuleInit', () => {
   beforeEach(() => {
@@ -66,5 +67,39 @@ describe('CuratorSchedulerService.onModuleInit', () => {
     const { svc, registry } = build();
     svc.onModuleInit();
     expect([...registry.getCronJobs().keys()]).toHaveLength(0);
+  });
+});
+
+describe('sweepSpreadSeconds', () => {
+  it('does not delay a single-org deployment', () => {
+    expect(sweepSpreadSeconds(0)).toBe(0);
+    expect(sweepSpreadSeconds(1)).toBe(0);
+  });
+
+  it('widens the window as the fleet grows', () => {
+    expect(sweepSpreadSeconds(13)).toBe(720);
+    expect(sweepSpreadSeconds(100)).toBe(5_940);
+  });
+
+  it('caps the window at four hours', () => {
+    expect(sweepSpreadSeconds(10_000)).toBe(4 * 60 * 60);
+  });
+});
+
+describe('jitteredBackoffMs', () => {
+  it('grows exponentially with attempts', () => {
+    const none = (): number => 0;
+    expect(jitteredBackoffMs(1, none)).toBe(30_000);
+    expect(jitteredBackoffMs(2, none)).toBe(60_000);
+    expect(jitteredBackoffMs(3, none)).toBe(120_000);
+  });
+
+  it('spreads jobs that failed together across a 1-2x window', () => {
+    expect(jitteredBackoffMs(1, () => 0)).toBe(30_000);
+    expect(jitteredBackoffMs(1, () => 1)).toBe(60_000);
+  });
+
+  it('never returns less than the base delay', () => {
+    expect(jitteredBackoffMs(0, () => 0)).toBe(30_000);
   });
 });


### PR DESCRIPTION
## Why

Hosted Munin runs every managed org's agent against one shared provider key and one shared per-minute token budget. A production incident this morning made four orgs show *"agent runner offline — provider rate limit hit"* for hours, from a burst that lasted one second.

Timeline from prod logs:

```
08-16 00:00:00  ~30 curator jobs enqueued+started across 13 orgs, same second
                (daily follow-up cron + three weekly sweeps coincided)
08-16 06:38:00  container respawn; every runner reconnects and drains at once
                jobs still on attempt 1/5 — enqueued at midnight, never polled
08-16 06:38:06  429 INSUFFICIENT QUOTA: "You exceeded your current quota of
                tokens per minute"  ×6 orgs
                → agent-health degraded (provider_rate_limit) ×4, never recovered
```

Measured provider ceiling is 200k tokens/min org-wide; individual curator jobs cost 15k–85k tokens (`tokens=85142` in the logs), so a handful of concurrent drains exceeds it.

Four independent defects, each fixed here.

## What

**1. A single 429 flipped agent health.** `openAiCompatibleProvider` surfaced the first 429 as a `ProviderError`; `AgentHealthService` opened an `llm_provider` alert, which only resolves on a later *success* — so with no further traffic the banner outlived the burst indefinitely. The provider now retries a 429 up to 4× with `500ms · 2^attempt` (capped 15s), floored at `Retry-After`, times a random 1–2× jitter so concurrent callers don't retry in lockstep. Other statuses are untouched: a 401 or a missing model still fails on the first attempt.

**2. The curator queue only drained on reconnect.** `triggerPoll` drops a trigger while a poll is in flight, and `pollOnce` claimed exactly one job. Four enqueues in one second → four events → one job runs, three sit pending with nothing scheduled to pick them up. That's why midnight's jobs were still `attempt 1/5` at 06:38. The loop now claims until empty, re-checks `beforeGenerate` between jobs, stops early on a provider error, and pauses after 25 jobs so one org's backlog can't monopolise a shared provider.

**3. The scheduler fanned out to the whole fleet on one instant.** `runSweep` enqueued every org with the same `next_attempt_at`. Sweeps now spread over 60s per org, capped at 4h — single-org deployments unaffected (spread = 0), a 100-org fleet spreads over ~99 min.

**4. Retry backoff had no jitter.** `30s · 2^attempts` meant jobs that failed together retried together, forever. Now ×1–2 random.

Plus a shared drain scheduler that spaces on-connect drains 5s apart, as a backstop for the reconnect case.

## Tests

New: `curator-drain.test.ts` (8), `drain-scheduler.test.ts` (3), provider retry/backoff/`Retry-After` parsing (10), `sweepSpreadSeconds` + `jitteredBackoffMs` (6). `agent-host` 113 pass, `agent-runtime` 374 pass, typecheck + eslint clean on all three packages.

## Not in scope

Admission control on the shared token budget — spacing starts helps a burst, but at ~100 orgs the fleet needs a cross-replica token gate (the `beforeGenerate` seam is ready for it) and a raised provider quota. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhaGswtoVx7nowaQw8Qm3C