### PR TITLE
fix(dashboard): place the email channel dialog's submit error above the footer

### DIFF
--- a/.changeset/pinned-email-channel-form-error.md
+++ b/.changeset/pinned-email-channel-form-error.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Pin the submit error in the email channel dialog to the footer instead of leaving it in the gap below the scroll area.
+
+The email channel dialog is the only one that scrolls an inner region rather than the whole popup, so its `FormError` rendered as a detached inset box wedged between the scroll container and the footer — misaligned against both neighbours' negative-margin bleeds, and with no spacing from the fields above. `FormError` now takes a `pinned` variant that drops the box for a `rule-soft` separator inset to the content width, on the same 16px/16px rhythm as the rule under the dialog header, so the error reads as a continuation of the form rather than a third structural zone competing with the footer plinth. It stays visible regardless of scroll position. Also raises the destructive fill of the boxed variant in dark mode, where 5% of `#d96a6a` over the card background was effectively invisible.

--- a/packages/dashboard-pages/src/components/form-error.tsx
+++ b/packages/dashboard-pages/src/components/form-error.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { cn } from '@getmunin/ui';
+
 import { ApiError } from '../api';
 
 export interface FormErrorDetail {
@@ -11,11 +13,22 @@ export function toFormError(err: unknown, message: string): FormErrorDetail {
   return { message, requestId: err instanceof ApiError ? err.requestId : null };
 }
 
-export function FormError({ detail }: { detail: FormErrorDetail }) {
+export function FormError({
+  detail,
+  pinned = false,
+}: {
+  detail: FormErrorDetail;
+  pinned?: boolean;
+}) {
   return (
     <div
       role="alert"
-      className="space-y-1 border-[1px] border-destructive/40 bg-destructive/5 px-3.5 py-3"
+      className={cn(
+        'space-y-1',
+        pinned
+          ? 'my-4 border-t-[1px] border-rule-soft pt-4 dark:border-rule-on-dark'
+          : 'border-[1px] border-destructive/40 bg-destructive/5 px-3.5 py-3 dark:bg-destructive/10',
+      )}
     >
       <p className="text-sm leading-snug text-destructive">{detail.message}</p>
       {detail.requestId && (

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -1576,8 +1576,8 @@ function EmailChannelDialog({
           </fieldset>
           </div>
 
-          {submitError && <FormError detail={submitError} />}
-          <DialogFooter className={dialogFooterClass}>
+          {submitError && <FormError detail={submitError} pinned />}
+          <DialogFooter className={cn(dialogFooterClass, submitError && 'mt-0')}>
             <Button
               type="button"
               variant="outline"


### PR DESCRIPTION
## What

The email channel dialog is the only one in the dashboard that scrolls an *inner* region (`DialogContent` is `flex max-h-[90vh] flex-col`, with a nested `overflow-y-auto` body) rather than scrolling the whole popup like the other nine. Its `FormError` was rendered outside that scroll container, so a save failure produced a detached inset box floating in the gap between the scroll area and the footer — inset while both of its neighbours bleed to the popup edge with negative margins, and with no top spacing since it fell outside the body's `gap-4`.

## Change

`FormError` gains a `pinned` variant. Instead of the bordered box, it draws a `rule-soft` separator inset to the content width — the same treatment as the rule under `DialogHeader` — on a matching 16px/16px rhythm:

```
│  ▓ fields, scrolling             ▒ │
│                                    │  ← 16
│  ──────────────────────────────    │  ← rule-soft, inset, matches header
│                                    │  ← 16
│  Internal server error             │
│  request_id e3738430-…             │
│                                    │  ← 16
├────────────────────────────────────┤
│                [Avbryt]  [Lagre ↵] │
```

The error now reads as a continuation of the form rather than a third structural zone competing with the footer plinth, and it stays visible no matter where the body is scrolled — which matters here precisely because this dialog is tall enough that an in-flow error can render below the fold on submit.

The default (unpinned) branch is unchanged apart from raising the destructive fill in dark mode, where 5% of `#d96a6a` over the card background was effectively invisible. `trackers.tsx` and the other channel dialogs render exactly as before.

## Notes

- Only `EmailChannelDialog` opts into `pinned`; the other dialogs don't need it, since scrolling the whole popup already keeps the error adjacent to the footer.
- No new i18n keys — messages still come through `translate(err)` / `toFormError`.
- Not addressed here: the error in the screenshot above is a bare `ZodError` escaping the save handler as a 500. That's a separate validation bug on the backend (it should be a coded `BadRequestException`, ideally routed to the offending field) and is worth its own PR.

## Test plan

- [x] `pnpm -F @getmunin/dashboard-pages typecheck`
- [x] Verified in local dev: triggered a failing save in the Edit email channel dialog and confirmed the separator aligns with the header rule and the spacing matches
- [ ] Spot-check one unpinned dialog (e.g. Add tracker) for no visual change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiRhcZUpZ3u538xCioS8dv