### PR TITLE
fix(conv): map unparseable stored channel configs to a coded 500

### DIFF
--- a/.changeset/email-channel-config-parse-error.md
+++ b/.changeset/email-channel-config-parse-error.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+Explain — and repair — an email channel whose stored config can't be parsed, instead of answering every save with a bare 500.
+
+`jsonbToStored` parsed `conv_channels.config` with a bare `.parse()`, so a row whose saved config doesn't satisfy `StoredEmailChannelConfigSchema` threw a raw `ZodError` out of the handler. Nest turned that into an uninformative `Internal server error`, and because `updateChannel` parses the *existing* row before merging, the channel became uneditable: every attempt to fix it through the dashboard failed on the very thing the operator was trying to repair.
+
+`jsonbToStored` now throws a `BadRequestException` carrying `code: 'conv_channel_config_invalid'`, the offending field paths, and a message that says what to do — so the dashboard shows a translated explanation and agents get a machine-readable string. More importantly, `updateChannel` now falls back to building the config from the submitted input when the stored one won't parse, so saving a complete configuration repairs the row rather than bouncing off it.

--- a/.changeset/email-channel-config-parse-error.md
+++ b/.changeset/email-channel-config-parse-error.md
@@ -3,8 +3,12 @@
 '@getmunin/dashboard-pages': patch
 ---
 
-Explain — and repair — an email channel whose stored config can't be parsed, instead of answering every save with a bare 500.
+Stop returning bare 500s when a channel's stored config can't be parsed, and let a full save repair it.
 
-`jsonbToStored` parsed `conv_channels.config` with a bare `.parse()`, so a row whose saved config doesn't satisfy `StoredEmailChannelConfigSchema` threw a raw `ZodError` out of the handler. Nest turned that into an uninformative `Internal server error`, and because `updateChannel` parses the *existing* row before merging, the channel became uneditable: every attempt to fix it through the dashboard failed on the very thing the operator was trying to repair.
+Every channel service parsed `conv_channels.config` with a bare `.parse()`, so a row that doesn't satisfy its stored schema threw a raw `ZodError` out of the handler and surfaced as an uninformative `Internal server error`. `ConvService.importConv` writes `config: {}` on every imported channel by design — the operator is told to "re-enter them on this server" — so the documented recovery path ran straight into this.
 
-`jsonbToStored` now throws a `BadRequestException` carrying `code: 'conv_channel_config_invalid'`, the offending field paths, and a message that says what to do — so the dashboard shows a translated explanation and agents get a machine-readable string. More importantly, `updateChannel` now falls back to building the config from the submitted input when the stored one won't parse, so saving a complete configuration repairs the row rather than bouncing off it.
+Stored configs now go through a shared `parseStoredConfig`, which throws a transport-free `ChannelConfigInvalidError` carrying `code: 'conv_channel_config_invalid'` and the offending field paths. A controller-scoped interceptor maps it to a **500** at the HTTP boundary: a corrupt stored config is a server-side fault the caller cannot fix by changing the request, which is the same split `nestjs-zod` makes between request validation (400) and server-side serialization failures (500). The MCP dispatcher already surfaces the message, so agents get the coded string and the dashboard translates via `code`. Applied to all five channel kinds — email, Vapi, Twilio, MessageBird and Threll.
+
+`EmailService.updateChannel` additionally falls back to building the config from the submitted input when the stored one won't parse, so saving a complete configuration repairs the row instead of bouncing off it. The vendor services deliberately do not get that fallback: their merges read `input.config?.x ?? prev.x`, so rebuilding from a partial input would silently drop settings — they surface the error instead.
+
+Separately, the four vendor admin providers parsed *incoming* config with a bare `ConfigSchema.parse(input.config)`, turning ordinary bad input into a 500 as well. That boundary is genuinely client-side, so it now throws a `400` naming the offending fields, matching the `validatePendingConfig` helper already sitting a few lines below each one.

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -1138,4 +1138,36 @@ interface OrgFixture {
       expect(Array.isArray(body)).toBe(true);
     });
   });
+
+  describe('channel with an unparseable stored config', () => {
+    it('answers 500 with a translatable code, not a bare Internal server error', async () => {
+      const [broken] = await db
+        .insert(schema.convChannels)
+        .values({
+          orgId: orgA.id,
+          type: 'email',
+          vendor: 'smtp',
+          name: 'cp-broken-config',
+          config: { addressing: { fromAddress: 'broken@example.test' } },
+        })
+        .returning();
+
+      const res = await fetch(`${baseUrl}/v1/conversations/channels/email/${broken!.id}/test`, {
+        method: 'POST',
+        headers: authHeaders(orgA.adminKey),
+      });
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as {
+        code: string;
+        message: string;
+        fieldErrors: Array<{ field: string; message: string }>;
+      };
+      expect(body.code).toBe('conv_channel_config_invalid');
+      expect(body.fieldErrors).toEqual([
+        expect.objectContaining({ field: 'outbound' }),
+      ]);
+      expect(body.message).toContain('conv_channel_config_invalid:');
+    });
+  });
 });

--- a/packages/backend-core/src/control/conv-channels.controller.ts
+++ b/packages/backend-core/src/control/conv-channels.controller.ts
@@ -14,6 +14,7 @@ import { createZodDto } from 'nestjs-zod';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
+import { ChannelConfigErrorInterceptor } from '../modules/conv/channels/stored-config.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 import { RoleGuard } from './role.guard.ts';
 import { RequireRole } from './role.decorator.ts';
@@ -91,7 +92,7 @@ interface ChannelListResponse {
 
 @Controller('v1/conversations/channels')
 @UseGuards(AuthGuard, ControlPlaneGuard, RoleGuard)
-@UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@UseInterceptors(TenancyInterceptor, AuditInterceptor, ChannelConfigErrorInterceptor)
 @RequireRole('owner', 'admin')
 export class ConvChannelsController {
   constructor(

--- a/packages/backend-core/src/modules/conv/channels/channel-admin.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-admin.ts
@@ -1,5 +1,17 @@
+import { BadRequestException } from '@nestjs/common';
 import { isSensitiveSchema } from '@getmunin/types';
 import type { z } from 'zod';
+
+export function parseVendorConfig<T extends z.ZodType>(
+  schema: T,
+  config: unknown,
+  vendor: string,
+): z.infer<T> {
+  const parsed = schema.safeParse(config);
+  if (parsed.success) return parsed.data;
+  const detail = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+  throw new BadRequestException(`conv_invalid: config for ${vendor}: ${detail}`);
+}
 
 export type ChannelAdminKind = 'voice' | 'sms';
 

--- a/packages/backend-core/src/modules/conv/channels/stored-config.test.ts
+++ b/packages/backend-core/src/modules/conv/channels/stored-config.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { HttpStatus, type CallHandler, type ExecutionContext } from '@nestjs/common';
+import { firstValueFrom, throwError } from 'rxjs';
+import { z } from 'zod';
+import {
+  ChannelConfigErrorInterceptor,
+  ChannelConfigInvalidError,
+  parseStoredConfig,
+  tryParseStoredConfig,
+} from './stored-config.ts';
+
+const Schema = z.object({
+  outbound: z.object({ provider: z.literal('smtp') }),
+});
+
+function runInterceptor(err: unknown): Promise<unknown> {
+  const interceptor = new ChannelConfigErrorInterceptor();
+  const next: CallHandler = { handle: () => throwError(() => err) };
+  return firstValueFrom(
+    interceptor.intercept({} as ExecutionContext, next) as ReturnType<CallHandler['handle']>,
+  );
+}
+
+describe('parseStoredConfig', () => {
+  it('names every distinct invalid path once', () => {
+    let thrown: unknown;
+    try {
+      parseStoredConfig(Schema, {}, 'email');
+    } catch (err) {
+      thrown = err;
+    }
+    const err = thrown as ChannelConfigInvalidError;
+    expect(err).toBeInstanceOf(ChannelConfigInvalidError);
+    expect(err.fieldErrors.map((fe) => fe.field)).toEqual(['outbound']);
+    expect(err.message).toContain("this email channel's saved settings are incomplete");
+  });
+
+  it('returns the parsed value when the config is valid', () => {
+    expect(parseStoredConfig(Schema, { outbound: { provider: 'smtp' } }, 'email').outbound.provider).toBe(
+      'smtp',
+    );
+  });
+});
+
+describe('tryParseStoredConfig', () => {
+  it('returns null rather than throwing', () => {
+    expect(tryParseStoredConfig(Schema, {})).toBeNull();
+  });
+});
+
+describe('ChannelConfigErrorInterceptor', () => {
+  it('maps a corrupt stored config to 500, since the caller cannot fix it by changing the request', async () => {
+    const err = await runInterceptor(new ChannelConfigInvalidError('email', [
+      { field: 'outbound', message: 'required' },
+    ])).catch((e: unknown) => e);
+
+    const mapped = err as { getStatus: () => number; getResponse: () => unknown };
+    expect(mapped.getStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(mapped.getResponse()).toMatchObject({
+      code: 'conv_channel_config_invalid',
+      fieldErrors: [{ field: 'outbound', message: 'required' }],
+    });
+  });
+
+  it('passes every other error through untouched', async () => {
+    const original = new Error('unrelated');
+    const err = await runInterceptor(original).catch((e: unknown) => e);
+    expect(err).toBe(original);
+  });
+});

--- a/packages/backend-core/src/modules/conv/channels/stored-config.ts
+++ b/packages/backend-core/src/modules/conv/channels/stored-config.ts
@@ -1,0 +1,71 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  InternalServerErrorException,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, catchError, throwError } from 'rxjs';
+import type { z } from 'zod';
+
+export class ChannelConfigInvalidError extends Error {
+  readonly code = 'conv_channel_config_invalid';
+  readonly fieldErrors: ReadonlyArray<{ field: string; message: string }>;
+
+  constructor(kind: string, fieldErrors: ReadonlyArray<{ field: string; message: string }>) {
+    const fields = fieldErrors.map((fe) => fe.field).join(', ');
+    super(
+      `conv_channel_config_invalid: this ${kind} channel's saved settings are incomplete (${fields}) — open the channel and save its settings again to repair it`,
+    );
+    this.fieldErrors = fieldErrors;
+  }
+}
+
+export function parseStoredConfig<T extends z.ZodType>(
+  schema: T,
+  json: Record<string, unknown>,
+  kind: string,
+): z.infer<T> {
+  const parsed = schema.safeParse(json);
+  if (parsed.success) return parsed.data;
+  throw new ChannelConfigInvalidError(kind, toFieldErrors(parsed.error));
+}
+
+export function tryParseStoredConfig<T extends z.ZodType>(
+  schema: T,
+  json: Record<string, unknown>,
+): z.infer<T> | null {
+  const parsed = schema.safeParse(json);
+  return parsed.success ? parsed.data : null;
+}
+
+function toFieldErrors(error: z.ZodError): Array<{ field: string; message: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ field: string; message: string }> = [];
+  for (const issue of error.issues) {
+    const field = issue.path.join('.') || 'config';
+    if (seen.has(field)) continue;
+    seen.add(field);
+    out.push({ field, message: issue.message });
+  }
+  return out;
+}
+
+@Injectable()
+export class ChannelConfigErrorInterceptor implements NestInterceptor {
+  intercept(_context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(
+      catchError((err: unknown) =>
+        throwError(() =>
+          err instanceof ChannelConfigInvalidError
+            ? new InternalServerErrorException({
+                message: err.message,
+                code: err.code,
+                fieldErrors: err.fieldErrors,
+              })
+            : err,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/backend-core/src/modules/conv/email/email.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email.integration.test.ts
@@ -470,6 +470,47 @@ class StubImapFetcher implements ImapFetcher {
     expect(convs).toHaveLength(1);
     expect(convs[0]!.agentMode).toBe('draft_only');
   }, 60_000);
+
+  it('saving a full config repairs a channel whose stored config lost its outbound block', async () => {
+    const [broken] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'email',
+        vendor: 'smtp',
+        name: 'Half-configured inbox',
+        config: { addressing: { fromAddress: 'half@acme.test' } },
+      })
+      .returning();
+
+    const rawResult = await withClient(adminKey, async (c) =>
+      c.callTool({
+        name: 'conv_configure_email_channel',
+        arguments: {
+          channelId: broken!.id,
+          name: 'Half-configured inbox',
+          config: {
+            addressing: { fromAddress: 'half@acme.test', fromName: 'Acme' },
+            outbound: { provider: 'mailer' },
+          },
+        },
+      }),
+    );
+    expect((rawResult as { isError?: boolean }).isError).toBeFalsy();
+
+    const repaired = parseToolResult<{
+      id: string;
+      config: { outbound: { provider: string } };
+    }>(rawResult);
+    expect(repaired.config.outbound.provider).toBe('mailer');
+
+    const rows = await db
+      .select()
+      .from(schema.convChannels)
+      .where(eq(schema.convChannels.id, broken!.id));
+    expect((rows[0]!.config as { outbound?: unknown }).outbound).toBeDefined();
+  }, 30_000);
+
 });
 
 async function waitFor(check: () => Promise<boolean>, timeoutMs = 2000): Promise<void> {

--- a/packages/backend-core/src/modules/conv/email/email.service.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email.service.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { jsonbToStored, tryJsonbToStored } from './email.service.ts';
+
+const COMPLETE: Record<string, unknown> = {
+  addressing: { fromAddress: 'hei@example.test', fromName: 'Support' },
+  outbound: {
+    provider: 'smtp',
+    host: 'smtp.example.test',
+    port: 587,
+    secure: false,
+    username: 'postmaster',
+    encryptedPassword: 'ciphertext',
+  },
+};
+
+const MISSING_OUTBOUND: Record<string, unknown> = {
+  addressing: { fromAddress: 'hei@example.test' },
+};
+
+describe('jsonbToStored', () => {
+  it('returns the parsed config when the stored shape is complete', () => {
+    expect(jsonbToStored(COMPLETE).outbound.provider).toBe('smtp');
+  });
+
+  it('throws a coded BadRequest naming the missing field rather than a raw ZodError', () => {
+    let thrown: unknown;
+    try {
+      jsonbToStored(MISSING_OUTBOUND);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BadRequestException);
+    const body = (thrown as BadRequestException).getResponse() as {
+      message: string;
+      code: string;
+      fields: string[];
+    };
+    expect(body.code).toBe('conv_channel_config_invalid');
+    expect(body.fields).toEqual(['outbound']);
+    expect(body.message).toContain('conv_channel_config_invalid:');
+  });
+});
+
+describe('tryJsonbToStored', () => {
+  it('returns null instead of throwing so a full save can rebuild the config', () => {
+    expect(tryJsonbToStored(MISSING_OUTBOUND)).toBeNull();
+    expect(tryJsonbToStored(COMPLETE)).not.toBeNull();
+  });
+});

--- a/packages/backend-core/src/modules/conv/email/email.service.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { BadRequestException } from '@nestjs/common';
+import { HttpException } from '@nestjs/common';
+import { ChannelConfigInvalidError } from '../channels/stored-config.ts';
 import { jsonbToStored, tryJsonbToStored } from './email.service.ts';
 
 const COMPLETE: Record<string, unknown> = {
@@ -23,22 +24,22 @@ describe('jsonbToStored', () => {
     expect(jsonbToStored(COMPLETE).outbound.provider).toBe('smtp');
   });
 
-  it('throws a coded BadRequest naming the missing field rather than a raw ZodError', () => {
+  it('throws a transport-free domain error naming the missing field', () => {
     let thrown: unknown;
     try {
       jsonbToStored(MISSING_OUTBOUND);
     } catch (err) {
       thrown = err;
     }
-    expect(thrown).toBeInstanceOf(BadRequestException);
-    const body = (thrown as BadRequestException).getResponse() as {
-      message: string;
-      code: string;
-      fields: string[];
-    };
-    expect(body.code).toBe('conv_channel_config_invalid');
-    expect(body.fields).toEqual(['outbound']);
-    expect(body.message).toContain('conv_channel_config_invalid:');
+    expect(thrown).toBeInstanceOf(ChannelConfigInvalidError);
+    const err = thrown as ChannelConfigInvalidError;
+    expect(err.code).toBe('conv_channel_config_invalid');
+    expect(err.fieldErrors.map((fe) => fe.field)).toEqual(['outbound']);
+    expect(err.message).toContain('conv_channel_config_invalid:');
+  });
+
+  it('does not couple stored-config failures to HTTP, since workers parse configs too', () => {
+    expect(() => jsonbToStored(MISSING_OUTBOUND)).not.toThrow(HttpException);
   });
 });
 

--- a/packages/backend-core/src/modules/conv/email/email.service.ts
+++ b/packages/backend-core/src/modules/conv/email/email.service.ts
@@ -365,8 +365,10 @@ export class EmailService {
     if (channel.type !== 'email') {
       throw new BadRequestException(`channel ${input.channelId} is not an email channel`);
     }
-    const prev = jsonbToStored(channel.config);
-    const merged = await this.mergeConfig(prev, input.config);
+    const prev = tryJsonbToStored(channel.config);
+    const merged = prev
+      ? await this.mergeConfig(prev, input.config)
+      : await this.toStored(input.config);
     const [row] = await ctx.db
       .update(schema.convChannels)
       .set({
@@ -539,7 +541,23 @@ export function storedToJsonb(stored: StoredEmailChannelConfig): Record<string, 
 }
 
 export function jsonbToStored(json: Record<string, unknown>): StoredEmailChannelConfig {
-  return StoredEmailChannelConfigSchema.parse(json);
+  const parsed = StoredEmailChannelConfigSchema.safeParse(json);
+  if (!parsed.success) throw invalidStoredConfig(parsed.error);
+  return parsed.data;
+}
+
+export function tryJsonbToStored(json: Record<string, unknown>): StoredEmailChannelConfig | null {
+  const parsed = StoredEmailChannelConfigSchema.safeParse(json);
+  return parsed.success ? parsed.data : null;
+}
+
+function invalidStoredConfig(error: z.ZodError): BadRequestException {
+  const fields = [...new Set(error.issues.map((issue) => issue.path.join('.') || 'config'))];
+  return new BadRequestException({
+    message: `conv_channel_config_invalid: this email channel's saved settings are incomplete (${fields.join(', ')}) — open the channel and save its settings again to repair it`,
+    code: 'conv_channel_config_invalid',
+    fields,
+  });
 }
 
 async function decryptString(tx: Db | Tx, ciphertext: string): Promise<string> {

--- a/packages/backend-core/src/modules/conv/email/email.service.ts
+++ b/packages/backend-core/src/modules/conv/email/email.service.ts
@@ -23,6 +23,7 @@ import {
   type SendLimits,
 } from '@getmunin/types';
 import { findOrCreateEndUserByEmail } from '../end-user-by-email.ts';
+import { parseStoredConfig, tryParseStoredConfig } from '../channels/stored-config.ts';
 
 export { EmailChannelConfigInput };
 export type { EmailChannelConfigInputT };
@@ -541,23 +542,11 @@ export function storedToJsonb(stored: StoredEmailChannelConfig): Record<string, 
 }
 
 export function jsonbToStored(json: Record<string, unknown>): StoredEmailChannelConfig {
-  const parsed = StoredEmailChannelConfigSchema.safeParse(json);
-  if (!parsed.success) throw invalidStoredConfig(parsed.error);
-  return parsed.data;
+  return parseStoredConfig(StoredEmailChannelConfigSchema, json, 'email');
 }
 
 export function tryJsonbToStored(json: Record<string, unknown>): StoredEmailChannelConfig | null {
-  const parsed = StoredEmailChannelConfigSchema.safeParse(json);
-  return parsed.success ? parsed.data : null;
-}
-
-function invalidStoredConfig(error: z.ZodError): BadRequestException {
-  const fields = [...new Set(error.issues.map((issue) => issue.path.join('.') || 'config'))];
-  return new BadRequestException({
-    message: `conv_channel_config_invalid: this email channel's saved settings are incomplete (${fields.join(', ')}) — open the channel and save its settings again to repair it`,
-    code: 'conv_channel_config_invalid',
-    fields,
-  });
+  return tryParseStoredConfig(StoredEmailChannelConfigSchema, json);
 }
 
 async function decryptString(tx: Db | Tx, ciphertext: string): Promise<string> {

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms-admin.provider.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
-import { describeConfigFields } from '../channels/channel-admin.ts';
+import { describeConfigFields, parseVendorConfig } from '../channels/channel-admin.ts';
 import type {
   ChannelAdminDto,
   ChannelAdminProvider,
@@ -26,7 +26,7 @@ export class MessageBirdSmsAdminProvider implements ChannelAdminProvider {
   constructor(@Inject(MessageBirdSmsAdminService) private readonly tools: MessageBirdSmsAdminService) {}
 
   configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
-    const config = ConfigSchema.parse(input.config);
+    const config = parseVendorConfig(ConfigSchema, input.config, 'messagebird');
     return this.tools.configure({ channelId: input.channelId, name: input.name, ...config });
   }
 

--- a/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.service.ts
+++ b/packages/backend-core/src/modules/conv/messagebird/messagebird-sms.service.ts
@@ -15,6 +15,7 @@ import { schema, type Db } from '@getmunin/db';
 import { z } from 'zod';
 import { DB } from '../../../common/db/db.module.ts';
 import { readPendingSetup } from '../channels/channel-admin.ts';
+import { parseStoredConfig } from '../channels/stored-config.ts';
 
 const REDACTED = '••••';
 
@@ -196,7 +197,7 @@ export function storedToJsonb(stored: StoredMessageBirdSmsConfig): Record<string
 }
 
 export function jsonbToStored(json: Record<string, unknown>): StoredMessageBirdSmsConfig {
-  return StoredMessageBirdSmsConfigSchema.parse(json);
+  return parseStoredConfig(StoredMessageBirdSmsConfigSchema, json, 'sms:messagebird');
 }
 
 async function encryptString(plaintext: string): Promise<string> {

--- a/packages/backend-core/src/modules/conv/threll/threll-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll-admin.provider.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
-import { describeConfigFields } from '../channels/channel-admin.ts';
+import { describeConfigFields, parseVendorConfig } from '../channels/channel-admin.ts';
 import type {
   ChannelAdminDto,
   ChannelAdminProvider,
@@ -35,7 +35,7 @@ export class ThrellAdminProvider implements ChannelAdminProvider {
   constructor(@Inject(ThrellAdminService) private readonly tools: ThrellAdminService) {}
 
   configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
-    const config = ConfigSchema.parse(input.config);
+    const config = parseVendorConfig(ConfigSchema, input.config, 'threll');
     return this.tools.configure({ channelId: input.channelId, name: input.name, ...config });
   }
 

--- a/packages/backend-core/src/modules/conv/threll/threll.service.ts
+++ b/packages/backend-core/src/modules/conv/threll/threll.service.ts
@@ -16,6 +16,7 @@ import {
   buildWebhookUrl,
   type ThrellWebhookSubscriptionSummary,
 } from './threll-client.service.ts';
+import { parseStoredConfig } from '../channels/stored-config.ts';
 
 const REDACTED = '••••';
 
@@ -267,7 +268,7 @@ export function storedToJsonb(stored: StoredThrellConfig): Record<string, unknow
 }
 
 export function jsonbToStored(json: Record<string, unknown>): StoredThrellConfig {
-  return StoredThrellConfigSchema.parse(json);
+  return parseStoredConfig(StoredThrellConfigSchema, json, 'voice:threll');
 }
 
 async function encryptString(plaintext: string): Promise<string> {

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms-admin.provider.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
-import { describeConfigFields } from '../channels/channel-admin.ts';
+import { describeConfigFields, parseVendorConfig } from '../channels/channel-admin.ts';
 import type {
   ChannelAdminDto,
   ChannelAdminProvider,
@@ -32,7 +32,7 @@ export class TwilioSmsAdminProvider implements ChannelAdminProvider {
   constructor(@Inject(TwilioSmsAdminService) private readonly tools: TwilioSmsAdminService) {}
 
   configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
-    const config = ConfigSchema.parse(input.config);
+    const config = parseVendorConfig(ConfigSchema, input.config, 'twilio');
     return this.tools.configure({ channelId: input.channelId, name: input.name, ...config });
   }
 

--- a/packages/backend-core/src/modules/conv/twilio/twilio-sms.service.ts
+++ b/packages/backend-core/src/modules/conv/twilio/twilio-sms.service.ts
@@ -15,6 +15,7 @@ import { schema, type Db } from '@getmunin/db';
 import { z } from 'zod';
 import { DB } from '../../../common/db/db.module.ts';
 import { readPendingSetup } from '../channels/channel-admin.ts';
+import { parseStoredConfig } from '../channels/stored-config.ts';
 
 const REDACTED = '••••';
 
@@ -225,7 +226,7 @@ export function storedToJsonb(stored: StoredTwilioSmsConfig): Record<string, unk
 }
 
 export function jsonbToStored(json: Record<string, unknown>): StoredTwilioSmsConfig {
-  return StoredTwilioSmsConfigSchema.parse(json);
+  return parseStoredConfig(StoredTwilioSmsConfigSchema, json, 'sms:twilio');
 }
 
 async function encryptString(plaintext: string): Promise<string> {

--- a/packages/backend-core/src/modules/conv/vapi/vapi-admin.provider.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi-admin.provider.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
-import { describeConfigFields } from '../channels/channel-admin.ts';
+import { describeConfigFields, parseVendorConfig } from '../channels/channel-admin.ts';
 import type {
   ChannelAdminDto,
   ChannelAdminProvider,
@@ -33,7 +33,7 @@ export class VapiAdminProvider implements ChannelAdminProvider {
   constructor(@Inject(VapiAdminService) private readonly tools: VapiAdminService) {}
 
   configure(input: ConfigureChannelInput): Promise<ChannelAdminDto> {
-    const config = ConfigSchema.parse(input.config);
+    const config = parseVendorConfig(ConfigSchema, input.config, 'vapi');
     return this.tools.configure({ channelId: input.channelId, name: input.name, ...config });
   }
 

--- a/packages/backend-core/src/modules/conv/vapi/vapi.service.ts
+++ b/packages/backend-core/src/modules/conv/vapi/vapi.service.ts
@@ -18,6 +18,7 @@ import { DB } from '../../../common/db/db.module.ts';
 import { asRecord } from '../channels/json-shape.ts';
 import { readPendingSetup } from '../channels/channel-admin.ts';
 import { VapiClientService, VAPI_WEBHOOK_SECRET_HEADER } from './vapi-client.service.ts';
+import { parseStoredConfig } from '../channels/stored-config.ts';
 
 const REDACTED = '••••';
 
@@ -324,7 +325,7 @@ export function storedToJsonb(stored: StoredVapiConfig): Record<string, unknown>
 }
 
 export function jsonbToStored(json: Record<string, unknown>): StoredVapiConfig {
-  return StoredVapiConfigSchema.parse(json);
+  return parseStoredConfig(StoredVapiConfigSchema, json, 'voice:vapi');
 }
 
 async function encryptString(plaintext: string): Promise<string> {

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1568,7 +1568,8 @@
     "cms_asset_too_large": "This file is too large to upload. The maximum size is 50 MB.",
     "cms_asset_upload_failed": "The file upload didn't finish. Check your connection and try again.",
     "cms_version_conflict": "This entry was changed elsewhere while you were editing. Reload it and try again.",
-    "agent_config_invalid_model": "Your AI provider no longer offers that model. Reload the page to refresh the list, then pick a model and save again."
+    "agent_config_invalid_model": "Your AI provider no longer offers that model. Reload the page to refresh the list, then pick a model and save again.",
+    "conv_channel_config_invalid": "This channel's saved settings are incomplete, so it can't be used yet. Open its settings, fill in what's missing and save to repair it."
   },
   "footer": {
     "privacy": "Privacy",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1568,7 +1568,8 @@
     "cms_asset_too_large": "Filen er for stor til å lastes opp. Maksstørrelsen er 50 MB.",
     "cms_asset_upload_failed": "Opplastingen ble ikke fullført. Sjekk tilkoblingen og prøv igjen.",
     "cms_version_conflict": "Oppføringen ble endret et annet sted mens du redigerte. Last den inn på nytt og prøv igjen.",
-    "agent_config_invalid_model": "KI-leverandøren tilbyr ikke denne modellen lenger. Last siden på nytt for å oppdatere listen, velg en modell og lagre igjen."
+    "agent_config_invalid_model": "KI-leverandøren tilbyr ikke denne modellen lenger. Last siden på nytt for å oppdatere listen, velg en modell og lagre igjen.",
+    "conv_channel_config_invalid": "Kanalen har ufullstendige innstillinger og kan ikke brukes ennå. Åpne innstillingene, fyll ut det som mangler og lagre for å reparere den."
   },
   "footer": {
     "privacy": "Personvern",


### PR DESCRIPTION
Follow-up to #787, which fixed *where* the error was drawn. This fixes the error itself — and the same defect in every other channel kind.

## The bug

Saving the Edit email channel dialog returned a bare `Internal server error`:

```
ERROR [ExceptionsHandler] ZodError: [
  { "code": "invalid_type", "expected": "object", "path": ["outbound"], … } ]
    at jsonbToStored (email.service.ts:371)
    at EmailService.updateChannel (email.service.ts:252)
```

Not the submitted input — the **stored row**. Every channel service parsed `conv_channels.config` with a bare `.parse()`, so a row that doesn't satisfy its stored schema threw a raw `ZodError` out of the handler. And because `updateChannel` parses the existing row *before* merging, the channel became uneditable: every attempt to fix it failed on exactly the thing the operator was trying to repair.

**This is reachable by design, not just by corruption.** `ConvService.importConv` (`conv.service.ts:1585`) writes `config: {}` for every imported channel — credentials can't travel between servers — and emits:

> `channel "…" imported without credentials — re-enter them on this server`

Follow that instruction and you hit the bug. The documented recovery path was broken by it.

## Why 500 and not 400

The first pass used `BadRequestException`. That was wrong: a corrupt stored config is a server-side fault the caller cannot fix by changing the request. It's the same split [`nestjs-zod`](https://github.com/BenLorantfy/nestjs-zod) makes in its own design — `ZodValidationException` → 400 for request parsing, `ZodSerializationException` → 500 for server-side data — and it matches the standard [4xx vs 5xx guidance](https://restcookbook.com/HTTP%20Methods/400-vs-500/). Misclassifying also distorts reliability metrics and invites retries that can never succeed.

`api.ts:69` handles `!res.ok` for any status, so a coded 500 body translates in the dashboard exactly as well as a 400 would have. Nothing was gained by the 400.

## Why a domain error rather than an HttpException

`jsonbToStored` is not HTTP-only. It runs in `email-adapter.ts:157,231` (outbound send, driven by `OutboundDeliveryWorker`), `widget-email-fallback.worker.ts:211` and `channel-reactivation.service.ts:48`. Throwing an HTTP exception there is meaningless.

So stored configs now go through a shared `parseStoredConfig` that throws a transport-free `ChannelConfigInvalidError` (code + field paths), and a controller-scoped interceptor maps it to a 500 at the HTTP boundary. This mirrors the `CmsInvalidError` / `CmsConflictError` pattern already used in `cms.service.ts` and mapped in `cms-drafts.controller.ts`.

The interceptor is scoped to `ConvChannelsController` rather than registered as a global `APP_FILTER`, because `apps/backend` already registers `SentryGlobalFilter` as a catch-all and global-filter precedence depends on registration order I'd rather not depend on. MCP needs no mapping at all — `dispatch.ts:176` already catches and surfaces `err.message`.

## Scope

Applied to all five channel kinds — **email, Vapi, Twilio, MessageBird, Threll** — which each had a byte-identical `jsonbToStored`.

`EmailService.updateChannel` additionally rebuilds from the submitted input when the stored config won't parse, so a complete save repairs the row. **The vendor services deliberately don't get that fallback**: their merges read `input.config?.x ?? prev.x`, so rebuilding from a partial input would silently drop settings. They surface the error instead.

Separately, the four vendor admin providers had the **inverse** defect — a bare `ConfigSchema.parse(input.config)` on *incoming* config, turning ordinary bad input into a 500. That boundary is genuinely client-side, so it now throws a `400` naming the offending fields, matching the `validatePendingConfig` helper already sitting a few lines below each one.

## Test plan

- [x] `stored-config.test.ts` (new): field extraction, `tryParseStoredConfig` returning null, interceptor maps to 500 with code + `fieldErrors`, and passes every other error through untouched
- [x] `email.service.test.ts` (new): domain error carries the code and field paths, and is **not** an `HttpException`
- [x] `email.integration.test.ts`: a channel row that lost `outbound` is repaired by a full save
- [x] `control-plane.integration.test.ts`: real HTTP request against a broken channel returns **500** with `code: 'conv_channel_config_invalid'` and `fieldErrors`
- [x] Both new integration tests verified to have teeth — removing the interceptor makes `body.code` `undefined`; removing the `updateChannel` fallback fails the repair test
- [x] `vitest run src/modules/conv src/control` — 47 files, 550 passed
- [x] `pnpm -F @getmunin/backend-core typecheck`, `pnpm -F @getmunin/dashboard-pages typecheck`

Note: `docs-pages` / `web` typecheck fail on this branch *and* on a clean tree with `Cannot find module '@getmunin/types'` — stale local dist, unrelated.

## Not addressed

`conv_create_channel` still accepts `config: z.record(z.string(), z.unknown())` for typed channels and writes it verbatim, which is one way these rows are born. Guarding it breaks 28 existing tests — `conv.service.test.ts` creates email channels with no config at all across 16 fixtures — so a config-less channel is an established internal state. Tightening that is a deliberate semantics change to a public MCP surface and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiRhcZUpZ3u538xCioS8dv