### PR TITLE
fix(auth): accept a registered MCP surface as a token audience

### DIFF
--- a/.changeset/mcp-surface-jwt-audience.md
+++ b/.changeset/mcp-surface-jwt-audience.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/core': minor
+'@getmunin/backend-core': minor
+---
+
+Accept a registered MCP surface as a token audience, and report which resource a JWT was actually issued for.
+
+Registering a surface made the authorization server issue tokens for `<origin><surface path>`, but nothing downstream would accept one. `acceptedJwtAudiences()` builds a fixed set from `NEXT_PUBLIC_MCP_URL` — the canonical URL, its trailing-slash variant, and the bare origin — so a JWT whose `aud` names a surface failed audience validation and `resolveOauthJwt` returned null. The request came back `401 invalid or expired credential` on the surface's own endpoint, with a `WWW-Authenticate` challenge pointing at metadata the client had already followed correctly. In other words: the moment a host registered a surface, every newly issued token for it was dead on arrival, while tokens issued before the surface existed kept working — a failure that appears only after a deploy, only for new connections, and looks like a credential problem rather than a configuration one.
+
+Registered surface paths now live in a small module registry in `@getmunin/core` (`registerMcpResourcePaths`, called by `McpSurfacesModule.forRoot` and by `AuthGuard` when surfaces are injected directly, so either wiring path is enough). Paths rather than URLs, resolved against the MCP origin on read, so the accepted set follows `NEXT_PUBLIC_MCP_URL` at call time instead of freezing whatever it was during module construction.
+
+`acceptedJwtAudiences()` unions those resources in, and `resolveOauthJwt` now reports `audience` as the resource the matched `aud` denotes rather than unconditionally the base: a surface audience is reported as itself, and every other accepted shape (bare origin, trailing slash, canonical) still folds onto the base resource exactly as before. That is what makes `AuthGuard`'s per-surface audience check real for JWT credentials — until now the guard compared against a value the resolver hardcoded, so a surface-scoped token was indistinguishable from a base one.
+
+Opaque OAuth access tokens are unchanged: `oauth_access_token` records no resource, so they continue to report the base audience, which the guard accepts on surface paths. Per-surface isolation therefore applies to JWT credentials only, and this is deliberate rather than an oversight — narrowing opaque tokens would need a schema column and a migration.

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -94,7 +94,9 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
     mcpResourceUrl(),
     mcpSurfaceAudiences(surfaces),
   );
-  const authScopes = [...SUPPORTED_AUTH_SCOPES, ...mcpSurfaceScopes(surfaces)];
+  const authScopes = Array.from(
+    new Set<string>([...SUPPORTED_AUTH_SCOPES, ...mcpSurfaceScopes(surfaces)]),
+  );
   const issuer = stripTrailingSlashes(opts.baseUrl);
 
   const socialProviders = buildSocialProviders(opts.socialProviders);

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -11,7 +11,11 @@ import {
   applyDecorators,
 } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
-import { CredentialResolver, type ResolvedCredential } from '@getmunin/core';
+import {
+  CredentialResolver,
+  registerMcpResourcePaths,
+  type ResolvedCredential,
+} from '@getmunin/core';
 import type { Db } from '@getmunin/db';
 import { DB } from '../db/db.module.ts';
 import { Reflector } from '@nestjs/core';
@@ -72,6 +76,7 @@ export class AuthGuard implements CanActivate {
   ) {
     this.resolver = new CredentialResolver(db);
     this.surfaces = resolveMcpSurfaces(surfaces);
+    registerMcpResourcePaths(this.surfaces.map((surface) => surface.path));
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/packages/backend-core/src/oauth/mcp-surfaces.module.test.ts
+++ b/packages/backend-core/src/oauth/mcp-surfaces.module.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { Module, type INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import type { AddressInfo } from 'node:net';
+import { mcpResourcePaths, resetMcpResourcePaths } from '@getmunin/core';
 import { McpSurfacesModule } from './mcp-surfaces.module.ts';
 import { OAuthResourceController } from './oauth-resource.controller.ts';
 import type { McpSurface } from './mcp-surface.ts';
@@ -50,5 +51,12 @@ describe('McpSurfacesModule', () => {
     expect(() =>
       McpSurfacesModule.forRoot([{ id: 'bad', path: '/v1/bad', resourceName: 'Bad', scopes: [] }]),
     ).toThrow(/below \/mcp/);
+  });
+
+  it('registers the surface with the token layer, which is what makes its audience acceptable', () => {
+    resetMcpResourcePaths();
+    expect(mcpResourcePaths()).not.toContain('/mcp/addon');
+    McpSurfacesModule.forRoot(SURFACES);
+    expect(mcpResourcePaths()).toContain('/mcp/addon');
   });
 });

--- a/packages/backend-core/src/oauth/mcp-surfaces.module.ts
+++ b/packages/backend-core/src/oauth/mcp-surfaces.module.ts
@@ -1,4 +1,5 @@
 import { Global, Module, type DynamicModule } from '@nestjs/common';
+import { registerMcpResourcePaths } from '@getmunin/core';
 import { ADDITIONAL_MCP_SURFACES, resolveMcpSurfaces, type McpSurface } from './mcp-surface.ts';
 
 @Global()
@@ -6,6 +7,7 @@ import { ADDITIONAL_MCP_SURFACES, resolveMcpSurfaces, type McpSurface } from './
 export class McpSurfacesModule {
   static forRoot(surfaces: readonly McpSurface[]): DynamicModule {
     const resolved = resolveMcpSurfaces(surfaces);
+    registerMcpResourcePaths(resolved.map((surface) => surface.path));
     return {
       module: McpSurfacesModule,
       providers: [{ provide: ADDITIONAL_MCP_SURFACES, useValue: resolved }],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,13 @@ export {
   type ResolvedCredential,
   readMembershipsForUser,
 } from './request/credentials.ts';
+export {
+  canonicalMcpResource,
+  mcpResourcePaths,
+  mcpResourceUrls,
+  registerMcpResourcePaths,
+  resetMcpResourcePaths,
+} from './request/mcp-resources.ts';
 
 export {
   hashSecret,

--- a/packages/core/src/request/mcp-resources.test.ts
+++ b/packages/core/src/request/mcp-resources.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  canonicalMcpResource,
+  mcpResourcePaths,
+  mcpResourceUrls,
+  registerMcpResourcePaths,
+  resetMcpResourcePaths,
+} from './mcp-resources.ts';
+import { acceptedJwtAudiences } from './oauth-jwt.ts';
+
+describe('registered MCP resources', () => {
+  let originalMcp: string | undefined;
+
+  beforeEach(() => {
+    originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+    resetMcpResourcePaths();
+  });
+
+  afterEach(() => {
+    resetMcpResourcePaths();
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+  });
+
+  it('registers nothing by default', () => {
+    expect(mcpResourcePaths()).toEqual([]);
+    expect(mcpResourceUrls()).toEqual([]);
+  });
+
+  it('normalizes and de-duplicates registered paths', () => {
+    registerMcpResourcePaths(['/mcp/media', 'mcp/media/', '/mcp/media']);
+    expect(mcpResourcePaths()).toEqual(['/mcp/media']);
+  });
+
+  it('hangs registered paths off the MCP origin, not its path', () => {
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+    registerMcpResourcePaths(['/mcp/media']);
+    expect(mcpResourceUrls()).toEqual(['https://mcp.example.test/mcp/media']);
+
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://api.example.test/mcp';
+    expect(mcpResourceUrls()).toEqual(['https://api.example.test/mcp/media']);
+  });
+
+  it('accepts a JWT audience naming a registered resource', () => {
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+    expect(acceptedJwtAudiences().has('https://mcp.example.test/mcp/media')).toBe(false);
+    registerMcpResourcePaths(['/mcp/media']);
+    expect(acceptedJwtAudiences().has('https://mcp.example.test/mcp/media')).toBe(true);
+    expect(acceptedJwtAudiences().has('https://mcp.example.test/mcp/media/')).toBe(true);
+  });
+
+  it('keeps rejecting an audience no surface claims', () => {
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+    registerMcpResourcePaths(['/mcp/media']);
+    expect(acceptedJwtAudiences().has('https://mcp.example.test/mcp/other')).toBe(false);
+    expect(acceptedJwtAudiences().has('https://evil.example.test/mcp/media')).toBe(false);
+  });
+
+  it('reports a registered resource audience as itself', () => {
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+    registerMcpResourcePaths(['/mcp/media']);
+    expect(canonicalMcpResource('https://mcp.example.test/mcp/media')).toBe(
+      'https://mcp.example.test/mcp/media',
+    );
+    expect(canonicalMcpResource('https://mcp.example.test/mcp/media/')).toBe(
+      'https://mcp.example.test/mcp/media',
+    );
+  });
+
+  it('folds every other accepted audience shape onto the base resource', () => {
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://api.example.test/mcp';
+    registerMcpResourcePaths(['/mcp/media']);
+    expect(canonicalMcpResource('https://api.example.test')).toBe('https://api.example.test/mcp');
+    expect(canonicalMcpResource('https://api.example.test/')).toBe('https://api.example.test/mcp');
+    expect(canonicalMcpResource('https://api.example.test/mcp')).toBe(
+      'https://api.example.test/mcp',
+    );
+  });
+});

--- a/packages/core/src/request/mcp-resources.ts
+++ b/packages/core/src/request/mcp-resources.ts
@@ -1,0 +1,51 @@
+import { stripTrailingSlashes } from '@getmunin/types';
+
+const registeredPaths = new Set<string>();
+
+export function registerMcpResourcePaths(paths: readonly string[]): void {
+  for (const raw of paths) {
+    const path = normalizeResourcePath(raw);
+    if (path) registeredPaths.add(path);
+  }
+}
+
+export function resetMcpResourcePaths(): void {
+  registeredPaths.clear();
+}
+
+export function mcpResourcePaths(): string[] {
+  return Array.from(registeredPaths);
+}
+
+export function mcpResourceBase(): string {
+  return stripTrailingSlashes(process.env.NEXT_PUBLIC_MCP_URL ?? 'http://localhost:3001/mcp');
+}
+
+export function mcpResourceUrls(): string[] {
+  const origin = mcpResourceOriginOrNull();
+  if (!origin) return [];
+  return mcpResourcePaths().map((path) => `${origin}${path}`);
+}
+
+export function canonicalMcpResource(audience: string): string {
+  const candidate = stripTrailingSlashes(audience);
+  for (const url of mcpResourceUrls()) {
+    if (candidate === url) return url;
+  }
+  return mcpResourceBase();
+}
+
+function mcpResourceOriginOrNull(): string | null {
+  try {
+    return new URL(mcpResourceBase()).origin;
+  } catch (err) {
+    console.warn('[mcp-resources] NEXT_PUBLIC_MCP_URL is not a parseable URL', { err });
+    return null;
+  }
+}
+
+function normalizeResourcePath(raw: string): string {
+  const trimmed = stripTrailingSlashes(raw.trim());
+  if (!trimmed) return '';
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}

--- a/packages/core/src/request/oauth-jwt.ts
+++ b/packages/core/src/request/oauth-jwt.ts
@@ -5,11 +5,11 @@ import { decodeProtectedHeader, importJWK, jwtVerify, type JWTPayload } from 'jo
 import { ActorIdentity } from './context.ts';
 import {
   gateOauthGrantsByRole,
-  oauthMcpResourceAudience,
   readMembershipsForUser,
   resolvePinnedMembership,
   type ResolvedCredential,
 } from './credentials.ts';
+import { canonicalMcpResource, mcpResourceUrls } from './mcp-resources.ts';
 import { stripTrailingSlashes } from '@getmunin/types';
 
 type VerifyKey = Awaited<ReturnType<typeof importJWK>>;
@@ -82,7 +82,8 @@ export async function resolveOauthJwtAccessToken(
     : typeof audClaim === 'string'
       ? [audClaim]
       : [];
-  if (!audiencesFromJwt.some((a) => isAcceptedJwtAudience(a))) return null;
+  const matchedAudience = audiencesFromJwt.find((a) => isAcceptedJwtAudience(a));
+  if (!matchedAudience) return null;
 
   const scopes =
     typeof payload['scope'] === 'string' ? payload['scope'].split(/\s+/).filter(Boolean) : [];
@@ -113,7 +114,7 @@ export async function resolveOauthJwtAccessToken(
   return {
     actor,
     expiresAt,
-    audience: oauthMcpResourceAudience(),
+    audience: canonicalMcpResource(matchedAudience),
   };
 }
 
@@ -168,6 +169,10 @@ export function acceptedJwtAudiences(): Set<string> {
     set.add(`${origin}/`);
   } catch (err) {
     console.warn('[credentials] publicUrl is not a parseable URL', { err });
+  }
+  for (const url of mcpResourceUrls()) {
+    set.add(url);
+    set.add(`${url}/`);
   }
   return set;
 }


### PR DESCRIPTION
Follow-up to #790, which is not shippable without this.

## The hole

#790 taught the authorization server to issue tokens for `<origin><surface path>`, but nothing downstream accepts one. `acceptedJwtAudiences()` in `@getmunin/core` builds a **fixed** set from `NEXT_PUBLIC_MCP_URL` — canonical URL, trailing-slash variant, bare origin — so a JWT whose `aud` names a surface fails audience validation and `resolveOauthJwt` returns `null`.

The surface endpoint then answers `401 invalid or expired credential` with a `WWW-Authenticate` challenge pointing at metadata the client had already followed correctly. Worse, the shape of the failure hides the cause: tokens issued *before* a surface was registered keep working (they carry the base audience), so this breaks only new connections, only after a deploy, and reads as a credential problem rather than a configuration one.

There's a second, quieter gap. `resolveOauthJwt` returns `audience: oauthMcpResourceAudience()` — the base resource from env, not the token's actual `aud`. So #790's per-surface guard check compared against a value the resolver hardcoded: correct code, constant input. Per-surface isolation was decorative for JWT credentials.

## The fix

- **`packages/core/src/request/mcp-resources.ts`** — a small module registry of registered surface paths. `registerMcpResourcePaths` is called by `McpSurfacesModule.forRoot` *and* by `AuthGuard` when surfaces are injected directly, so either wiring path is sufficient. Paths rather than URLs, resolved against the MCP origin on read, so the accepted set follows `NEXT_PUBLIC_MCP_URL` at call time instead of freezing whatever it was during module construction.
- **`acceptedJwtAudiences()`** unions those resources in (exact + trailing-slash). An audience no surface claims, or one on another host, is still rejected.
- **`resolveOauthJwt`** reports `audience` as the resource the matched `aud` denotes: a surface audience as itself, every other accepted shape (bare origin, trailing slash, canonical) folding onto the base resource exactly as before. That makes the guard's per-surface check real.

### Scope of the isolation claim

Opaque OAuth access tokens are unchanged — `oauth_access_token` records no resource, so they keep reporting the base audience, which the guard accepts on surface paths. Per-surface isolation therefore covers **JWT credentials only**. Deliberate: narrowing opaque tokens needs a schema column and a migration, and claude.ai-shaped clients are on the JWT path.

## Testing

- `packages/core/src/request/mcp-resources.test.ts` — registration/normalization/de-duplication, origin resolution under both `NEXT_PUBLIC_MCP_URL` shapes, surface audience accepted only once registered, foreign host and unclaimed path still rejected, and the canonicalization table (surface → itself, everything else → base).
- `mcp-surfaces.module.test.ts` — asserts the module actually populates the core registry, which is the seam that would otherwise silently not happen.
- `pnpm -F @getmunin/core test` 476 passed · `pnpm -F @getmunin/backend-core test` 1542 passed · `pnpm typecheck` 31/31 · eslint clean. (Counts from a run with the repo `.env` moved aside — see the note on #790.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
