### PR TITLE
fix(dashboard): drop the icon from the consent denial pane

### DIFF
--- a/.changeset/consent-denial-icon.md
+++ b/.changeset/consent-denial-icon.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Drop the circular warning icon from the consent denial pane.
+
+The pane already opens with a serif headline naming the resource that can't be authorized, so the icon above it restated the tone without adding information. Removing it leaves the headline as the first thing read; the surrounding `gap-4` column keeps the spacing it already had.

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -531,12 +531,6 @@ function BlockedPane({
       <IdentityCard clientInfo={clientInfo} clientId={clientId} displayName={displayName} />
 
       <div className="flex flex-col gap-4 px-7 py-8">
-        <div className="inline-flex h-11 w-11 items-center justify-center rounded-full border-[1px] border-rule-soft bg-paper-deep text-ink-soft">
-          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="9" />
-            <path d="M12 8v4M12 16h.01" />
-          </svg>
-        </div>
         <div className="font-serif text-[24px] tracking-[-0.01em] [overflow-wrap:anywhere]">
           {t.rich('blocked.panelTitle', {
             resource: () => <em className="not-italic italic">{denial.resourceName}</em>,


### PR DESCRIPTION
Removes the circular warning icon from `BlockedPane` on the OAuth consent screen.

The pane already opens with a serif headline naming the resource that can't be authorized ("Munin Media isn't available to this organization"), so the icon above it restated the tone without adding information. The surrounding `gap-4` column keeps the spacing it had.

Verified on dev before proposing this — the denial pane itself works end to end (non-entitled org → explanation + cancel button, instead of consent followed by an error inside the client).

`pnpm -F @getmunin/dashboard-pages typecheck` · `lint` · `test` (70 passed) all clean.

Committed from a `git worktree` with `--no-verify`, per the shared-checkout convention: another agent has uncommitted work in `~/Source/munin/munin`, and the worktree has no `node_modules` for the hooks to run. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
