### PR TITLE
feat(mcp): serve the MCP endpoint per organization at /mcp/o/<orgId>

### DIFF
--- a/.changeset/org-scoped-mcp-endpoints.md
+++ b/.changeset/org-scoped-mcp-endpoints.md
@@ -1,0 +1,24 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/core': minor
+---
+
+Serve the MCP endpoint per organization at `/mcp/o/<orgId>`, so one user can hold simultaneous connections to several organizations.
+
+MCP clients key a connection by its URL: one URL means one stored credential, so a user who belongs to more than one organization could only ever be connected to whichever one the token happened to be pinned to. The tools, the registry, and the handler are unchanged — only the addressing and the org pinning are new.
+
+`/mcp/o/<orgId>` routes into the same handler, and `AuthGuard` requires the credential's org to equal the org in the path. An admin API key already carries its org, so it works immediately; a mismatch answers 401 with `WWW-Authenticate` pointing at that org's protected-resource document, which is what makes an OAuth client re-run authorization and land on the right organization instead of failing permanently. The shared `/mcp` endpoint keeps accepting any org, so existing connections are untouched.
+
+For OAuth the organization arrives in the resource indicator. `/.well-known/oauth-protected-resource/mcp/o/<orgId>` advertises the org-scoped URL as its own resource identifier, which the MCP SDK echoes back as `resource` on the authorization request; `consentReferenceId` then pins the token to that organization and fails when the signed-in user is not a member, rather than silently falling back to their default org. The document validates only the shape of the org id and names no organization, so it is not an org-existence oracle.
+
+Three constraints from `@better-auth/oauth-provider` shaped the implementation, and each one is load-bearing:
+
+`validAudiences` is a static `string[]` and the options object is spread at construction, so a per-request audience cannot be injected there and an unbounded set of per-org resources cannot be enumerated ahead of time. The resource is therefore narrowed to the base MCP resource on token requests — the only place the provider validates it. Tokens keep `aud` = the base resource with the organization in `org_id`, and the path guard is what enforces the boundary.
+
+`resource` does not survive the redirect to the consent page: the provider signs the *validated* authorize query, and `resource` is not part of that schema (it reads it from the token request body instead). The organization is therefore carried across the round-trip in a short-lived `verifications` row, keyed on an HMAC of the session cookie and `code_challenge` under the server's auth secret — `code_challenge` survives the redirect and PKCE is mandatory for MCP clients, so the key is always available on both legs. The row is written only once membership has been verified, from inside `consentReferenceId`, and read back on the consent request, where the `referenceId` that actually reaches the token is computed. Without this the token pinned to the user's default organization for every non-default one, which the endpoint then rejected permanently.
+
+The session is part of the key on purpose. `code_challenge` is not a secret — it travels in the authorization URL, so it reaches browser history, referrers and access logs — and keying on it alone let any authenticated caller who learned a victim's challenge repoint that victim's pending association, or write rows for organizations they had no part in. Binding the key to the session cookie puts every caller in their own keyspace, and keying the MAC with the server secret means database read access alone cannot confirm a guessed session token, and deferring the write until after the membership check means a refused authorization stores nothing. A missing association or an unavailable store falls back to the default organization, where the path guard still refuses the mismatch.
+
+A path under `/mcp/o/` that does not parse as a valid organization id is refused with 404 rather than falling through to shared-endpoint behaviour. Failing open there was not a tenancy hole — the handler resolves the organization from the credential and never reads the path, so the path can only ever constrain a request, never select it — but it did mean a wrong-case or percent-encoded id produced a *working* connection that silently acted in the caller's default organization, which is exactly the confusion the org-scoped URL exists to remove.
+
+`consentReferenceId` receives no request context, so the requested organization reaches it through an `AsyncLocalStorage` scope established at the auth request boundary.

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -224,6 +224,107 @@
         ]
       }
     },
+    "/mcp/o/{orgId}": {
+      "post": {
+        "description": "Serves the same tools as /mcp, but only for the organization named in the path. A credential belonging to any other organization is refused, so the URL is a guarantee rather than a hint — which is what lets one person hold connections to several organizations at once, since MCP clients key a connection by its URL. An admin API key already carries its organization; an OAuth connection is bound to the organization in the URL at consent time.",
+        "operationId": "McpController_postOrgScoped",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "Organization id: org_ followed by 22 lowercase alphanumerics. Case-sensitive; anything else is rejected rather than falling back to the shared endpoint.",
+            "schema": {
+              "type": "string",
+              "pattern": "^org_[0-9a-z]{22}$"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "MCP endpoint addressed at one organization",
+        "tags": [
+          "Mcp"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      },
+      "get": {
+        "description": "Serves the same tools as /mcp, but only for the organization named in the path. A credential belonging to any other organization is refused, so the URL is a guarantee rather than a hint — which is what lets one person hold connections to several organizations at once, since MCP clients key a connection by its URL. An admin API key already carries its organization; an OAuth connection is bound to the organization in the URL at consent time.",
+        "operationId": "McpController_getOrgScoped",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "Organization id: org_ followed by 22 lowercase alphanumerics. Case-sensitive; anything else is rejected rather than falling back to the shared endpoint.",
+            "schema": {
+              "type": "string",
+              "pattern": "^org_[0-9a-z]{22}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "MCP endpoint addressed at one organization",
+        "tags": [
+          "Mcp"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      },
+      "delete": {
+        "description": "Serves the same tools as /mcp, but only for the organization named in the path. A credential belonging to any other organization is refused, so the URL is a guarantee rather than a hint — which is what lets one person hold connections to several organizations at once, since MCP clients key a connection by its URL. An admin API key already carries its organization; an OAuth connection is bound to the organization in the URL at consent time.",
+        "operationId": "McpController_delOrgScoped",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "Organization id: org_ followed by 22 lowercase alphanumerics. Case-sensitive; anything else is rejected rather than falling back to the shared endpoint.",
+            "schema": {
+              "type": "string",
+              "pattern": "^org_[0-9a-z]{22}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "MCP endpoint addressed at one organization",
+        "tags": [
+          "Mcp"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/api-keys": {
       "post": {
         "operationId": "ApiKeysController_create",

--- a/packages/backend-core/src/auth-controller-factory.test.ts
+++ b/packages/backend-core/src/auth-controller-factory.test.ts
@@ -1,5 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { assertProductionAuthSecret, requireAuthSecret } from './auth-controller-factory.ts';
+import type { Request as ExpressRequestLike } from 'express';
+import {
+  assertProductionAuthSecret,
+  narrowOrgScopedResourceBody,
+  readCodeChallenge,
+  readRequestedResource,
+  requireAuthSecret,
+  resolveMcpOrgScope,
+} from './auth-controller-factory.ts';
+import {
+  buildOrgScopeAssociationKey,
+  registerOrgScopeStore,
+  type OrgScopeStore,
+} from './auth/org-scope-store.ts';
 
 describe('assertProductionAuthSecret', () => {
   const originalNodeEnv = process.env.NODE_ENV;
@@ -60,5 +73,270 @@ describe('assertProductionAuthSecret', () => {
     process.env.NODE_ENV = 'production';
     process.env.MUNIN_AUTH_SECRET = 'replace-me-with-strong-random-secret';
     expect(() => requireAuthSecret()).toThrow(/placeholder\/dev value/);
+  });
+});
+
+describe('org-scoped resource on auth requests', () => {
+  const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+  const originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+  });
+  afterEach(() => {
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+  });
+
+  function requestWith(parts: {
+    query?: Record<string, unknown>;
+    body?: unknown;
+    contentType?: string;
+    rawBody?: string;
+  }) {
+    return {
+      query: parts.query ?? {},
+      body: parts.body,
+      headers: parts.contentType ? { 'content-type': parts.contentType } : {},
+      ...(parts.rawBody === undefined ? {} : { rawBody: Buffer.from(parts.rawBody, 'utf8') }),
+    } as unknown as Parameters<typeof readRequestedResource>[0];
+  }
+
+  it('reads the resource from the authorize query', () => {
+    const resource = `https://mcp.example.test/mcp/o/${ORG_A}`;
+    expect(readRequestedResource(requestWith({ query: { resource } }))).toBe(resource);
+  });
+
+  it('reads the resource from a token request body', () => {
+    const resource = `https://mcp.example.test/mcp/o/${ORG_A}`;
+    expect(readRequestedResource(requestWith({ body: { resource } }))).toBe(resource);
+  });
+
+  it('recovers the resource from the signed query the consent page replays', () => {
+    const resource = `https://mcp.example.test/mcp/o/${ORG_A}`;
+    const oauthQuery = new URLSearchParams({ client_id: 'abc', resource }).toString();
+    expect(readRequestedResource(requestWith({ body: { accept: true, oauth_query: oauthQuery } }))).toBe(
+      resource,
+    );
+  });
+
+  it('returns null when no resource is requested', () => {
+    expect(readRequestedResource(requestWith({ body: { grant_type: 'refresh_token' } }))).toBeNull();
+  });
+
+  it('narrows an org-scoped resource to the base resource on urlencoded token bodies', () => {
+    const resource = `https://mcp.example.test/mcp/o/${ORG_A}`;
+    const rawBody = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: 'xyz',
+      code_verifier: 'a-b_c~d',
+      resource,
+    }).toString();
+    const override = narrowOrgScopedResourceBody(
+      requestWith({
+        body: { grant_type: 'authorization_code', code: 'xyz', code_verifier: 'a-b_c~d', resource },
+        contentType: 'application/x-www-form-urlencoded',
+        rawBody,
+      }),
+    );
+    expect(override).not.toBeNull();
+    expect(override!.contentType).toBe('application/x-www-form-urlencoded');
+    const params = new URLSearchParams(override!.body);
+    expect(params.get('resource')).toBe('https://mcp.example.test');
+    expect(params.get('code')).toBe('xyz');
+    expect(params.get('code_verifier')).toBe('a-b_c~d');
+    expect(params.get('grant_type')).toBe('authorization_code');
+  });
+
+  it('falls back to a JSON body when no raw urlencoded body was captured', () => {
+    const override = narrowOrgScopedResourceBody(
+      requestWith({
+        body: { code: 'xyz', resource: `https://mcp.example.test/mcp/o/${ORG_A}` },
+        contentType: 'application/x-www-form-urlencoded',
+      }),
+    );
+    expect(override!.contentType).toBe('application/json');
+    expect(JSON.parse(override!.body)).toEqual({
+      code: 'xyz',
+      resource: 'https://mcp.example.test',
+    });
+  });
+
+  it('narrows an org-scoped resource on JSON token bodies', () => {
+    const override = narrowOrgScopedResourceBody(
+      requestWith({
+        body: { resource: `https://mcp.example.test/mcp/o/${ORG_A}`, code: 'xyz' },
+        contentType: 'application/json',
+      }),
+    );
+    expect(JSON.parse(override!.body)).toEqual({
+      resource: 'https://mcp.example.test',
+      code: 'xyz',
+    });
+  });
+
+  it('leaves the base resource and foreign-origin resources untouched', () => {
+    expect(
+      narrowOrgScopedResourceBody(requestWith({ body: { resource: 'https://mcp.example.test' } })),
+    ).toBeNull();
+    expect(
+      narrowOrgScopedResourceBody(
+        requestWith({ body: { resource: `https://evil.example.test/mcp/o/${ORG_A}` } }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('carrying the org across the consent round-trip', () => {
+  const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+  const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+  const COOKIE = 'better-auth.session_token=victim-session-token.signature';
+  const OTHER_COOKIE = 'better-auth.session_token=attacker-session-token.signature';
+  const originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+  let recalls: string[];
+
+  const SECRET = 'test-secret-for-the-association-key-000000';
+  const keyOf = (cookie: string, challenge: string) =>
+    buildOrgScopeAssociationKey(SECRET, cookie, challenge);
+
+  function fakeStore(recallValue: string | null = null, failing = false): OrgScopeStore {
+    return {
+      keyFor: (cookieHeader, codeChallenge) =>
+        buildOrgScopeAssociationKey(SECRET, cookieHeader, codeChallenge),
+      remember: () => (failing ? Promise.reject(new Error('store down')) : Promise.resolve()),
+      recall: (key) => {
+        if (failing) return Promise.reject(new Error('store down'));
+        recalls.push(key);
+        return Promise.resolve(recallValue);
+      },
+    };
+  }
+
+  function request(parts: {
+    url?: string;
+    query?: Record<string, unknown>;
+    body?: unknown;
+    cookie?: string;
+  }): ExpressRequestLike {
+    return {
+      originalUrl: parts.url ?? '/auth/oauth2/authorize',
+      url: parts.url ?? '/auth/oauth2/authorize',
+      query: parts.query ?? {},
+      body: parts.body,
+      headers: parts.cookie === undefined ? {} : { cookie: parts.cookie },
+    } as unknown as ExpressRequestLike;
+  }
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+    recalls = [];
+  });
+  afterEach(() => {
+    registerOrgScopeStore(null);
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+  });
+
+  it('reads the code challenge from the authorize query, a body, and the replayed signed query', () => {
+    expect(readCodeChallenge(request({ query: { code_challenge: CHALLENGE } }))).toBe(CHALLENGE);
+    expect(readCodeChallenge(request({ body: { code_challenge: CHALLENGE } }))).toBe(CHALLENGE);
+    const oauthQuery = new URLSearchParams({ client_id: 'abc', code_challenge: CHALLENGE }).toString();
+    expect(readCodeChallenge(request({ body: { accept: true, oauth_query: oauthQuery } }))).toBe(
+      CHALLENGE,
+    );
+    expect(readCodeChallenge(request({ body: { grant_type: 'refresh_token' } }))).toBeNull();
+  });
+
+  it('derives an association key that differs per session for the same challenge', () => {
+    const victim = keyOf(COOKIE, CHALLENGE);
+    const attacker = keyOf(OTHER_COOKIE, CHALLENGE);
+    const otherSecret = buildOrgScopeAssociationKey('a-different-server-secret', COOKIE, CHALLENGE);
+    expect(otherSecret).not.toBe(victim);
+    expect(victim).toBeTruthy();
+    expect(attacker).toBeTruthy();
+    expect(victim).not.toBe(attacker);
+    expect(victim).toBe(keyOf(COOKIE, CHALLENGE));
+    expect(victim).not.toContain('victim-session-token');
+  });
+
+  it('derives no association key without a session or a challenge', () => {
+    expect(buildOrgScopeAssociationKey(SECRET, undefined, CHALLENGE)).toBeNull();
+    expect(buildOrgScopeAssociationKey(SECRET, COOKIE, null)).toBeNull();
+    expect(buildOrgScopeAssociationKey(SECRET, 'unrelated=1', CHALLENGE)).toBeNull();
+    expect(buildOrgScopeAssociationKey('', COOKIE, CHALLENGE)).toBeNull();
+  });
+
+  it('passes the resource and the association key through on authorize', async () => {
+    registerOrgScopeStore(fakeStore());
+    const resource = `https://mcp.example.test/mcp/o/${ORG_A}`;
+    const scope = await resolveMcpOrgScope(
+      request({ query: { resource, code_challenge: CHALLENGE }, cookie: COOKIE }),
+    );
+    expect(scope.resource).toBe(resource);
+    expect(scope.associationKey).toBe(keyOf(COOKIE, CHALLENGE));
+  });
+
+  it('recovers the org on the consent post, where better-auth has dropped the resource', async () => {
+    registerOrgScopeStore(fakeStore(ORG_A));
+    const oauthQuery = new URLSearchParams({ client_id: 'abc', code_challenge: CHALLENGE }).toString();
+    const scope = await resolveMcpOrgScope(
+      request({
+        url: '/auth/oauth2/consent',
+        body: { accept: true, oauth_query: oauthQuery },
+        cookie: COOKIE,
+      }),
+    );
+    expect(scope.resource).toBe(`https://mcp.example.test/mcp/o/${ORG_A}`);
+    expect(recalls).toEqual([keyOf(COOKIE, CHALLENGE)]);
+  });
+
+  it('looks under a different key for a different session, so one session cannot claim another\'s association', async () => {
+    registerOrgScopeStore(fakeStore(ORG_A));
+    const oauthQuery = new URLSearchParams({ code_challenge: CHALLENGE }).toString();
+    await resolveMcpOrgScope(
+      request({ url: '/auth/oauth2/consent', body: { oauth_query: oauthQuery }, cookie: OTHER_COOKIE }),
+    );
+    expect(recalls).toEqual([keyOf(OTHER_COOKIE, CHALLENGE)]);
+    expect(recalls[0]).not.toBe(keyOf(COOKIE, CHALLENGE));
+  });
+
+  it('resolves no org when the association is missing', async () => {
+    registerOrgScopeStore(fakeStore(null));
+    const oauthQuery = new URLSearchParams({ code_challenge: CHALLENGE }).toString();
+    const scope = await resolveMcpOrgScope(
+      request({ url: '/auth/oauth2/consent', body: { oauth_query: oauthQuery }, cookie: COOKIE }),
+    );
+    expect(scope.resource).toBeNull();
+  });
+
+  it('resolves no org without a session, so an unauthenticated caller cannot probe associations', async () => {
+    registerOrgScopeStore(fakeStore(ORG_A));
+    const oauthQuery = new URLSearchParams({ code_challenge: CHALLENGE }).toString();
+    const scope = await resolveMcpOrgScope(
+      request({ url: '/auth/oauth2/consent', body: { oauth_query: oauthQuery } }),
+    );
+    expect(scope.resource).toBeNull();
+    expect(recalls).toEqual([]);
+  });
+
+  it('falls back to the default org instead of failing when the store is unavailable', async () => {
+    registerOrgScopeStore(fakeStore(null, true));
+    const oauthQuery = new URLSearchParams({ code_challenge: CHALLENGE }).toString();
+    await expect(
+      resolveMcpOrgScope(
+        request({ url: '/auth/oauth2/consent', body: { oauth_query: oauthQuery }, cookie: COOKIE }),
+      ),
+    ).resolves.toEqual({ resource: null, associationKey: keyOf(COOKIE, CHALLENGE) });
+  });
+
+  it('ignores a non-org-scoped resource', async () => {
+    registerOrgScopeStore(fakeStore());
+    const scope = await resolveMcpOrgScope(
+      request({
+        query: { resource: 'https://mcp.example.test/mcp', code_challenge: CHALLENGE },
+        cookie: COOKIE,
+      }),
+    );
+    expect(scope.resource).toBeNull();
   });
 });

--- a/packages/backend-core/src/auth-controller-factory.ts
+++ b/packages/backend-core/src/auth-controller-factory.ts
@@ -1,7 +1,20 @@
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
+import {
+  type McpOrgScopeInput,
+  orgScopedMcpResourceUrl,
+  parseOrgScopedMcpResource,
+  withOrgScopedMcpResource,
+} from '@getmunin/core';
+import { mcpResourceUrl } from './oauth/oauth.constants.ts';
+import { orgScopeStore } from './auth/org-scope-store.ts';
 
 interface BetterAuthLike {
   handler: (req: globalThis.Request) => Promise<globalThis.Response>;
+}
+
+interface BodyOverride {
+  contentType: string;
+  body: string;
 }
 
 export async function handleAuthRequest(
@@ -9,9 +22,91 @@ export async function handleAuthRequest(
   req: ExpressRequest,
   res: ExpressResponse,
 ): Promise<void> {
-  const fetchRequest = expressRequestToFetch(req);
-  const fetchResponse = await auth.handler(fetchRequest);
-  await pipeFetchResponseToExpress(fetchResponse, res);
+  await withOrgScopedMcpResource(await resolveMcpOrgScope(req), async () => {
+    const fetchRequest = expressRequestToFetch(req, narrowOrgScopedResourceBody(req));
+    const fetchResponse = await auth.handler(fetchRequest);
+    await pipeFetchResponseToExpress(fetchResponse, res);
+  });
+}
+
+export async function resolveMcpOrgScope(req: ExpressRequest): Promise<McpOrgScopeInput> {
+  const requested = readRequestedResource(req);
+  const orgFromResource = requested ? parseOrgScopedMcpResource(requested) : null;
+  const store = orgScopeStore();
+  const associationKey = store?.keyFor(req.headers?.['cookie'], readCodeChallenge(req)) ?? null;
+
+  if (orgFromResource) return { resource: requested, associationKey };
+
+  if (store && associationKey) {
+    try {
+      const orgId = await store.recall(associationKey);
+      if (orgId) return { resource: orgScopedMcpResourceUrl(orgId), associationKey };
+    } catch (err) {
+      console.warn('[auth] could not recall the org this authorization was started for', { err });
+    }
+  }
+  return { resource: null, associationKey };
+}
+
+export function readCodeChallenge(req: ExpressRequest): string | null {
+  const fromQuery = firstString(req.query?.['code_challenge']);
+  if (fromQuery) return fromQuery;
+  const body = readObjectBody(req);
+  const fromBody = firstString(body?.['code_challenge']);
+  if (fromBody) return fromBody;
+  const oauthQuery = firstString(body?.['oauth_query']);
+  if (oauthQuery) return new URLSearchParams(oauthQuery).get('code_challenge');
+  return null;
+}
+
+
+export function readRequestedResource(req: ExpressRequest): string | null {
+  const fromQuery = firstString(req.query?.['resource']);
+  if (fromQuery) return fromQuery;
+  const body = readObjectBody(req);
+  const fromBody = firstString(body?.['resource']);
+  if (fromBody) return fromBody;
+  const oauthQuery = firstString(body?.['oauth_query']);
+  if (oauthQuery) {
+    const fromOauthQuery = new URLSearchParams(oauthQuery).get('resource');
+    if (fromOauthQuery) return fromOauthQuery;
+  }
+  return null;
+}
+
+export function narrowOrgScopedResourceBody(req: ExpressRequest): BodyOverride | null {
+  const body = readObjectBody(req);
+  const resource = firstString(body?.['resource']);
+  if (!body || !resource || !parseOrgScopedMcpResource(resource)) return null;
+
+  const contentType = req.headers['content-type']?.toString() ?? '';
+  const rawBody = (req as ExpressRequest & { rawBody?: Buffer }).rawBody;
+  if (contentType.includes('application/x-www-form-urlencoded') && rawBody?.length) {
+    const params = new URLSearchParams(rawBody.toString('utf8'));
+    params.set('resource', mcpResourceUrl());
+    return { contentType: 'application/x-www-form-urlencoded', body: params.toString() };
+  }
+  return {
+    contentType: 'application/json',
+    body: JSON.stringify({ ...body, resource: mcpResourceUrl() }),
+  };
+}
+
+function readObjectBody(req: ExpressRequest): Record<string, unknown> | null {
+  const body: unknown = req.body;
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null;
+  return body as Record<string, unknown>;
+}
+
+function firstString(value: unknown): string | null {
+  if (typeof value === 'string') return value.trim() ? value : null;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = firstString(entry);
+      if (found) return found;
+    }
+  }
+  return null;
 }
 
 export function requireAuthSecret(): string {
@@ -48,7 +143,10 @@ function isPlaceholderSecret(secret: string): boolean {
   return PLACEHOLDER_PATTERNS.some((p) => p.test(secret));
 }
 
-function expressRequestToFetch(req: ExpressRequest): globalThis.Request {
+function expressRequestToFetch(
+  req: ExpressRequest,
+  bodyOverride: BodyOverride | null = null,
+): globalThis.Request {
   const protocol = req.headers['x-forwarded-proto']?.toString() ?? req.protocol;
   const host = req.headers['x-forwarded-host']?.toString() ?? req.get('host');
   const url = `${protocol}://${host}${req.originalUrl}`;
@@ -59,6 +157,12 @@ function expressRequestToFetch(req: ExpressRequest): globalThis.Request {
   }
   const init: RequestInit = { method: req.method, headers };
   if (req.method !== 'GET' && req.method !== 'HEAD') {
+    if (bodyOverride) {
+      headers.set('content-type', bodyOverride.contentType);
+      headers.delete('content-length');
+      init.body = bodyOverride.body;
+      return new globalThis.Request(url, init);
+    }
     const rawBody = (req as ExpressRequest & { rawBody?: Buffer }).rawBody;
     if (rawBody && rawBody.length > 0) {
       init.body = new Uint8Array(rawBody);

--- a/packages/backend-core/src/auth/auth-cookies.ts
+++ b/packages/backend-core/src/auth/auth-cookies.ts
@@ -8,3 +8,18 @@ export function sessionCookieNames(): string[] {
   const prefix = authCookiePrefix();
   return [`${prefix}.session_token`, `__Secure-${prefix}.session_token`];
 }
+
+export function readSessionCookie(cookieHeader: string | undefined): string | null {
+  if (!cookieHeader) return null;
+  const names = sessionCookieNames();
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const name = part.slice(0, eq).trim();
+    if (!names.includes(name)) continue;
+    const raw = decodeURIComponent(part.slice(eq + 1).trim());
+    const dot = raw.indexOf('.');
+    return dot >= 0 ? raw.slice(0, dot) : raw;
+  }
+  return null;
+}

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -2,8 +2,9 @@ import { betterAuth, type BetterAuthOptions } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { jwt, captcha } from 'better-auth/plugins';
 import { oauthProvider } from '@better-auth/oauth-provider';
+import { APIError } from 'better-auth/api';
 import { schema, type Db } from '@getmunin/db';
-import { readMembershipsForUser } from '@getmunin/core';
+import { currentOrgScopedMcpResource, readMembershipsForUser } from '@getmunin/core';
 import {
   STANDARD_OIDC_SCOPES,
   SUPPORTED_AUTH_SCOPES,
@@ -16,6 +17,7 @@ import {
   type McpSurface,
 } from '../oauth/mcp-surface.ts';
 import { authCookiePrefix } from './auth-cookies.ts';
+import { createDbOrgScopeStore, orgScopeStore, registerOrgScopeStore } from './org-scope-store.ts';
 import { stripTrailingSlashes } from '@getmunin/types';
 
 type BetterAuthInstance = ReturnType<typeof betterAuth>;
@@ -101,10 +103,34 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
 
   const socialProviders = buildSocialProviders(opts.socialProviders);
 
+  registerOrgScopeStore(createDbOrgScopeStore(opts.db, opts.authSecret));
+
   const resolveDefaultOrgId = async (userId: string): Promise<string | undefined> => {
     const memberships = await readMembershipsForUser(opts.db, userId);
     const active = memberships.find((m) => m.isDefault) ?? memberships[0];
     return active?.orgId;
+  };
+
+  const resolveConsentOrgId = async (userId: string): Promise<string | undefined> => {
+    const orgScoped = currentOrgScopedMcpResource();
+    if (!orgScoped) return await resolveDefaultOrgId(userId);
+    const memberships = await readMembershipsForUser(opts.db, userId);
+    const membership = memberships.find((m) => m.orgId === orgScoped.orgId);
+    if (!membership) {
+      throw new APIError('FORBIDDEN', {
+        error: 'access_denied',
+        error_description: 'signed-in user is not a member of the requested organization',
+      });
+    }
+    const store = orgScopeStore();
+    if (store && orgScoped.associationKey) {
+      try {
+        await store.remember(orgScoped.associationKey, membership.orgId);
+      } catch (err) {
+        console.warn('[auth] could not carry the requested org across the consent step', { err });
+      }
+    }
+    return membership.orgId;
   };
 
   return asMuninAuth(
@@ -143,7 +169,7 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
             page: `${dashboardUrl}/dashboard/oauth/consent`,
             shouldRedirect: () => false,
             consentReferenceId: async ({ user }) =>
-              user?.id ? await resolveDefaultOrgId(user.id) : undefined,
+              user?.id ? await resolveConsentOrgId(user.id) : undefined,
           },
           customAccessTokenClaims: ({ referenceId }) =>
             referenceId ? { org_id: referenceId } : {},

--- a/packages/backend-core/src/auth/org-scope-store.integration.test.ts
+++ b/packages/backend-core/src/auth/org-scope-store.integration.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { and, like, eq } from 'drizzle-orm';
+import { createDbOrgScopeStore, type OrgScopeStore } from './org-scope-store.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run org-scope store integration tests.';
+
+(skipReason ? describe.skip : describe)('org-scope store', () => {
+  const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+  const ORG_B = 'org_bbbbbbbbbbbbbbbbbbbbbb';
+  let db: ReturnType<typeof createDb>;
+  let store: OrgScopeStore;
+
+  beforeAll(async () => {
+    await runMigrations(TEST_URL!);
+    db = createDb(TEST_URL!);
+    store = createDbOrgScopeStore(db, 'integration-test-secret-00000000000000');
+  });
+
+  afterAll(async () => {
+    await db.delete(schema.verifications).where(like(schema.verifications.identifier, 'mcp-org-scope:%'));
+  });
+
+  it('recalls the org it remembered for a code challenge', async () => {
+    await store.remember('challenge-one', ORG_A);
+    await expect(store.recall('challenge-one')).resolves.toBe(ORG_A);
+  });
+
+  it('keeps separate challenges on separate orgs', async () => {
+    await store.remember('challenge-a', ORG_A);
+    await store.remember('challenge-b', ORG_B);
+    await expect(store.recall('challenge-a')).resolves.toBe(ORG_A);
+    await expect(store.recall('challenge-b')).resolves.toBe(ORG_B);
+  });
+
+  it('replaces the org when the same challenge is reused', async () => {
+    await store.remember('challenge-reused', ORG_A);
+    await store.remember('challenge-reused', ORG_B);
+    await expect(store.recall('challenge-reused')).resolves.toBe(ORG_B);
+    const rows = await db
+      .select({ id: schema.verifications.id })
+      .from(schema.verifications)
+      .where(eq(schema.verifications.identifier, 'mcp-org-scope:challenge-reused'));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('recalls nothing for an unknown challenge', async () => {
+    await expect(store.recall('never-seen')).resolves.toBeNull();
+  });
+
+  it('recalls nothing once the association has expired', async () => {
+    await db.insert(schema.verifications).values({
+      identifier: 'mcp-org-scope:challenge-expired',
+      value: ORG_A,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    await expect(store.recall('challenge-expired')).resolves.toBeNull();
+  });
+
+  it('sweeps expired associations when remembering a new one', async () => {
+    await db.insert(schema.verifications).values({
+      identifier: 'mcp-org-scope:challenge-stale',
+      value: ORG_A,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    await store.remember('challenge-fresh', ORG_B);
+    const stale = await db
+      .select({ id: schema.verifications.id })
+      .from(schema.verifications)
+      .where(eq(schema.verifications.identifier, 'mcp-org-scope:challenge-stale'));
+    expect(stale).toHaveLength(0);
+  });
+
+  it('refuses to store a value that is not an org id', async () => {
+    await store.remember('challenge-bogus', 'not-an-org');
+    await expect(store.recall('challenge-bogus')).resolves.toBeNull();
+    const rows = await db
+      .select({ id: schema.verifications.id })
+      .from(schema.verifications)
+      .where(
+        and(
+          like(schema.verifications.identifier, 'mcp-org-scope:%'),
+          eq(schema.verifications.identifier, 'mcp-org-scope:challenge-bogus'),
+        ),
+      );
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/backend-core/src/auth/org-scope-store.ts
+++ b/packages/backend-core/src/auth/org-scope-store.ts
@@ -1,0 +1,83 @@
+import { createHmac } from 'node:crypto';
+import { and, eq, like, lt } from 'drizzle-orm';
+import { schema, type Db } from '@getmunin/db';
+import { isOrgId } from '@getmunin/core';
+import { readSessionCookie } from './auth-cookies.ts';
+
+const IDENTIFIER_PREFIX = 'mcp-org-scope:';
+const TTL_MS = 600_000;
+
+export interface OrgScopeStore {
+  keyFor(cookieHeader: string | undefined, codeChallenge: string | null | undefined): string | null;
+  remember(associationKey: string, orgId: string): Promise<void>;
+  recall(associationKey: string): Promise<string | null>;
+}
+
+export function buildOrgScopeAssociationKey(
+  secret: string,
+  cookieHeader: string | undefined,
+  codeChallenge: string | null | undefined,
+): string | null {
+  if (!secret || !codeChallenge?.trim()) return null;
+  const sessionToken = readSessionCookie(cookieHeader);
+  if (!sessionToken) return null;
+  return createHmac('sha256', secret)
+    .update(`${sessionToken}:${codeChallenge.trim()}`)
+    .digest('base64url');
+}
+
+let registered: OrgScopeStore | null = null;
+
+export function registerOrgScopeStore(store: OrgScopeStore | null): void {
+  registered = store;
+}
+
+export function orgScopeStore(): OrgScopeStore | null {
+  return registered;
+}
+
+export function createDbOrgScopeStore(db: Db, secret: string): OrgScopeStore {
+  return {
+    keyFor(cookieHeader, codeChallenge) {
+      return buildOrgScopeAssociationKey(secret, cookieHeader, codeChallenge);
+    },
+
+    async remember(associationKey: string, orgId: string): Promise<void> {
+      const identifier = identifierFor(associationKey);
+      if (!identifier || !isOrgId(orgId)) return;
+      await db
+        .delete(schema.verifications)
+        .where(
+          and(
+            like(schema.verifications.identifier, `${IDENTIFIER_PREFIX}%`),
+            lt(schema.verifications.expiresAt, new Date()),
+          ),
+        );
+      await db.delete(schema.verifications).where(eq(schema.verifications.identifier, identifier));
+      await db.insert(schema.verifications).values({
+        identifier,
+        value: orgId,
+        expiresAt: new Date(Date.now() + TTL_MS),
+      });
+    },
+
+    async recall(associationKey: string): Promise<string | null> {
+      const identifier = identifierFor(associationKey);
+      if (!identifier) return null;
+      const rows = await db
+        .select({ value: schema.verifications.value, expiresAt: schema.verifications.expiresAt })
+        .from(schema.verifications)
+        .where(eq(schema.verifications.identifier, identifier))
+        .limit(1);
+      const row = rows[0];
+      if (!row || row.expiresAt < new Date()) return null;
+      return isOrgId(row.value) ? row.value : null;
+    },
+  };
+}
+
+function identifierFor(associationKey: string): string | null {
+  const trimmed = associationKey.trim();
+  if (!trimmed || trimmed.length > 128) return null;
+  return `${IDENTIFIER_PREFIX}${trimmed}`;
+}

--- a/packages/backend-core/src/common/auth/auth.guard.test.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.test.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResolvedCredential } from '@getmunin/core';
@@ -279,5 +279,169 @@ describe('AuthGuard audience binding for registered MCP surfaces', () => {
       'WWW-Authenticate',
       'Bearer resource_metadata="https://auth.example.com/.well-known/oauth-protected-resource/mcp/addon"',
     );
+  });
+});
+
+describe('AuthGuard org-scoped MCP endpoints', () => {
+  const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+  const ORG_B = 'org_bbbbbbbbbbbbbbbbbbbbbb';
+  let originalMcp: string | undefined;
+  let originalAuth: string | undefined;
+
+  beforeEach(() => {
+    originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+    originalAuth = process.env.NEXT_PUBLIC_AUTH_URL;
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.com';
+  });
+
+  afterEach(() => {
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+    if (originalAuth === undefined) delete process.env.NEXT_PUBLIC_AUTH_URL;
+    else process.env.NEXT_PUBLIC_AUTH_URL = originalAuth;
+  });
+
+  function credFor(orgId: string, audience?: string): ResolvedCredential {
+    return {
+      actor: { type: 'user', orgId, scopes: ['mcp:admin'], audiences: ['admin'] } as never,
+      ...(audience ? { audience } : {}),
+    };
+  }
+
+  function contextFor(path: string) {
+    return makeContext({
+      headers: { authorization: 'Bearer some-token' },
+      url: path,
+      path,
+    });
+  }
+
+  it('accepts an api key whose org matches the path', async () => {
+    const resolveApiKey = vi.fn().mockResolvedValue(credFor(ORG_A));
+    const guard = makeGuard({ resolveApiKey });
+    const ctx = makeContext({
+      headers: { authorization: 'Bearer mn_admin_abc123' },
+      url: `/mcp/o/${ORG_A}`,
+      path: `/mcp/o/${ORG_A}`,
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('rejects a credential addressed at another org', async () => {
+    const resolveBearerToken = vi.fn().mockResolvedValue(credFor(ORG_B));
+    const guard = makeGuard({ resolveBearerToken });
+    await expect(guard.canActivate(contextFor(`/mcp/o/${ORG_A}`))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('leaves the shared endpoint open to any org', async () => {
+    const resolveBearerToken = vi.fn().mockResolvedValue(credFor(ORG_B));
+    const guard = makeGuard({ resolveBearerToken });
+    await expect(guard.canActivate(contextFor('/mcp'))).resolves.toBe(true);
+  });
+
+  it('accepts the org-scoped resource as an audience on its own path', async () => {
+    const resolveBearerToken = vi
+      .fn()
+      .mockResolvedValue(credFor(ORG_A, `https://mcp.example.com/mcp/o/${ORG_A}`));
+    const guard = makeGuard({ resolveBearerToken });
+    await expect(guard.canActivate(contextFor(`/mcp/o/${ORG_A}`))).resolves.toBe(true);
+  });
+
+  it('rejects one org-scoped resource presented to another org path', async () => {
+    const resolveBearerToken = vi
+      .fn()
+      .mockResolvedValue(credFor(ORG_A, `https://mcp.example.com/mcp/o/${ORG_B}`));
+    const guard = makeGuard({ resolveBearerToken });
+    await expect(guard.canActivate(contextFor(`/mcp/o/${ORG_A}`))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('still accepts the base resource on an org-scoped path', async () => {
+    const resolveBearerToken = vi
+      .fn()
+      .mockResolvedValue(credFor(ORG_A, 'https://mcp.example.com'));
+    const guard = makeGuard({ resolveBearerToken });
+    await expect(guard.canActivate(contextFor(`/mcp/o/${ORG_A}`))).resolves.toBe(true);
+  });
+
+  it('challenges with the org-scoped metadata document so the client re-authorizes into that org', async () => {
+    process.env.NEXT_PUBLIC_AUTH_URL = 'https://auth.example.com';
+    const resolveBearerToken = vi.fn().mockResolvedValue(credFor(ORG_B));
+    const guard = makeGuard({ resolveBearerToken });
+    const res = { setHeader: vi.fn() };
+    const ctx = {
+      getHandler: () => () => undefined,
+      getClass: () => class {},
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: { authorization: 'Bearer some-token' },
+          url: `/mcp/o/${ORG_A}`,
+          path: `/mcp/o/${ORG_A}`,
+        }),
+        getResponse: () => res,
+      }),
+    } as unknown as Parameters<AuthGuard['canActivate']>[0];
+
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'WWW-Authenticate',
+      `Bearer resource_metadata="https://auth.example.com/.well-known/oauth-protected-resource/mcp/o/${ORG_A}"`,
+    );
+  });
+});
+
+describe('AuthGuard malformed org selectors', () => {
+  const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+  let originalMcp: string | undefined;
+
+  beforeEach(() => {
+    originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.com';
+  });
+
+  afterEach(() => {
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+  });
+
+  function guardFor(orgId: string): AuthGuard {
+    return makeGuard({
+      resolveApiKey: vi.fn().mockResolvedValue({
+        actor: { type: 'user', orgId, scopes: ['*'], audiences: ['admin'] } as never,
+      }),
+    });
+  }
+
+  function contextFor(path: string) {
+    return makeContext({
+      headers: { authorization: 'Bearer mn_admin_abc123' },
+      url: path,
+      path,
+    });
+  }
+
+  it.each([
+    ['percent-encoded first character', '/mcp/o/%6frg_aaaaaaaaaaaaaaaaaaaaaa'],
+    ['uppercased org id', '/mcp/o/ORG_AAAAAAAAAAAAAAAAAAAAAA'],
+    ['null byte suffix', '/mcp/o/org_aaaaaaaaaaaaaaaaaaaaaa%00'],
+    ['no org id at all', '/mcp/o/'],
+    ['a sub-path below the org', '/mcp/o/org_aaaaaaaaaaaaaaaaaaaaaa/media'],
+  ])('rejects %s rather than serving the credential its own org', async (_label, path) => {
+    const guard = guardFor(ORG_A);
+    await expect(guard.canActivate(contextFor(path))).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('still serves the exact org-scoped path', async () => {
+    const guard = guardFor(ORG_A);
+    await expect(guard.canActivate(contextFor(`/mcp/o/${ORG_A}`))).resolves.toBe(true);
+  });
+
+  it('leaves the shared endpoint and other MCP paths alone', async () => {
+    const guard = guardFor(ORG_A);
+    await expect(guard.canActivate(contextFor('/mcp'))).resolves.toBe(true);
+    await expect(guard.canActivate(contextFor('/mcp/media'))).resolves.toBe(true);
   });
 });

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -4,6 +4,7 @@ import {
   ExecutionContext,
   Inject,
   Injectable,
+  NotFoundException,
   Optional,
   SetMetadata,
   UnauthorizedException,
@@ -13,6 +14,10 @@ import {
 import { ThrottlerGuard } from '@nestjs/throttler';
 import {
   CredentialResolver,
+  ORG_SCOPED_MCP_PREFIX,
+  orgScopedMcpPath,
+  orgScopedMcpResourceUrl,
+  parseOrgScopedMcpPath,
   registerMcpResourcePaths,
   type ResolvedCredential,
 } from '@getmunin/core';
@@ -29,7 +34,7 @@ import {
   resolveMcpSurfaces,
   type McpSurface,
 } from '../../oauth/mcp-surface.ts';
-import { sessionCookieNames } from '../../auth/auth-cookies.ts';
+import { readSessionCookie } from '../../auth/auth-cookies.ts';
 
 export const ALLOW_ANONYMOUS = 'munin:allow-anonymous';
 export const AllowAnonymous = () => SetMetadata(ALLOW_ANONYMOUS, true);
@@ -86,6 +91,11 @@ export class AuthGuard implements CanActivate {
     ]);
 
     const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const path = requestPath(request);
+    if (path.startsWith(ORG_SCOPED_MCP_PREFIX) && !parseOrgScopedMcpPath(path)) {
+      throw new NotFoundException('not_found');
+    }
+
     const header = request.headers['authorization'];
     const value = Array.isArray(header) ? header[0] : header;
     let credential: ResolvedCredential | null = null;
@@ -132,6 +142,14 @@ export class AuthGuard implements CanActivate {
       }
     }
 
+    const orgScopedOrgId = parseOrgScopedMcpPath(path);
+    if (orgScopedOrgId && credential.actor.orgId !== orgScopedOrgId) {
+      this.maybeSetMcpResourceMetadataHeader(context, request);
+      throw new UnauthorizedException(
+        'credential is not valid for the organization addressed by this endpoint',
+      );
+    }
+
     request.credential = credential;
     return true;
   }
@@ -140,6 +158,11 @@ export class AuthGuard implements CanActivate {
     const accepted = [mcpResourceUrl()];
     const surface = findMcpSurfaceForPath(this.surfaces, requestPath(request));
     if (surface) accepted.push(mcpSurfaceResourceUrl(surface));
+    const orgId = parseOrgScopedMcpPath(requestPath(request));
+    if (orgId) {
+      const orgResource = orgScopedMcpResourceUrl(orgId);
+      if (orgResource) accepted.push(orgResource);
+    }
     return accepted.some((resource) => isSameResourceIdentifier(resource, audience));
   }
 
@@ -149,7 +172,12 @@ export class AuthGuard implements CanActivate {
   ): void {
     if (!isMcpRequest(request)) return;
     const surface = findMcpSurfaceForPath(this.surfaces, requestPath(request));
-    const metadata = surface ? mcpSurfaceMetadataUrl(surface) : resourceMetadataUrl();
+    const orgId = parseOrgScopedMcpPath(requestPath(request));
+    const metadata = surface
+      ? mcpSurfaceMetadataUrl(surface)
+      : orgId
+        ? `${resourceMetadataUrl()}${orgScopedMcpPath(orgId)}`
+        : resourceMetadataUrl();
     const res = context
       .switchToHttp()
       .getResponse<{ setHeader?: (n: string, v: string) => void }>();
@@ -165,21 +193,6 @@ function requestPath(request: AuthenticatedRequest): string {
   const raw = (request.url ?? request.path ?? '').toString();
   const i = raw.indexOf('?');
   return i < 0 ? raw : raw.slice(0, i);
-}
-
-function readSessionCookie(cookieHeader: string | undefined): string | null {
-  if (!cookieHeader) return null;
-  const names = sessionCookieNames();
-  for (const part of cookieHeader.split(';')) {
-    const eq = part.indexOf('=');
-    if (eq < 0) continue;
-    const name = part.slice(0, eq).trim();
-    if (!names.includes(name)) continue;
-    const raw = decodeURIComponent(part.slice(eq + 1).trim());
-    const dot = raw.indexOf('.');
-    return dot >= 0 ? raw.slice(0, dot) : raw;
-  }
-  return null;
 }
 
 function looksLikeApiKey(raw: string): boolean {

--- a/packages/backend-core/src/mcp/mcp.controller.ts
+++ b/packages/backend-core/src/mcp/mcp.controller.ts
@@ -27,6 +27,7 @@ import {
   type ErrorReporter,
 } from '../common/error-reporter/error-reporter.ts';
 import { deriveMcpAudience } from './mcp.audience.ts';
+import { OrgScopedMcpDocs } from './mcp.org-scoped.docs.ts';
 
 @Controller('mcp')
 @UseGuards(AuthGuard, McpBurstGuard)
@@ -54,6 +55,24 @@ export class McpController {
 
   @Delete()
   async del(@Req() req: Request, @Res() res: Response) {
+    return this.handle(req, res, false);
+  }
+
+  @Post('o/:orgId')
+  @OrgScopedMcpDocs()
+  async postOrgScoped(@Req() req: Request, @Res() res: Response) {
+    return this.handle(req, res, true);
+  }
+
+  @Get('o/:orgId')
+  @OrgScopedMcpDocs()
+  async getOrgScoped(@Req() req: Request, @Res() res: Response) {
+    return this.handle(req, res, false);
+  }
+
+  @Delete('o/:orgId')
+  @OrgScopedMcpDocs()
+  async delOrgScoped(@Req() req: Request, @Res() res: Response) {
     return this.handle(req, res, false);
   }
 

--- a/packages/backend-core/src/mcp/mcp.org-scoped.docs.ts
+++ b/packages/backend-core/src/mcp/mcp.org-scoped.docs.ts
@@ -1,0 +1,25 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+export function OrgScopedMcpDocs(): MethodDecorator {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'MCP endpoint addressed at one organization',
+      description:
+        'Serves the same tools as /mcp, but only for the organization named in the path. A ' +
+        'credential belonging to any other organization is refused, so the URL is a guarantee ' +
+        'rather than a hint — which is what lets one person hold connections to several ' +
+        'organizations at once, since MCP clients key a connection by its URL. An admin API key ' +
+        'already carries its organization; an OAuth connection is bound to the organization in ' +
+        'the URL at consent time.',
+    }),
+    ApiParam({
+      name: 'orgId',
+      required: true,
+      description:
+        'Organization id: org_ followed by 22 lowercase alphanumerics. Case-sensitive; anything ' +
+        'else is rejected rather than falling back to the shared endpoint.',
+      schema: { type: 'string', pattern: '^org_[0-9a-z]{22}$' },
+    }),
+  );
+}

--- a/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
@@ -144,3 +144,64 @@ describe('OAuthResourceController with registered MCP surfaces', () => {
     ).toThrow(/below \/mcp/);
   });
 });
+
+describe('OAuthResourceController org-scoped metadata', () => {
+  const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+  let originalUrl: string | undefined;
+  let originalAuthUrl: string | undefined;
+
+  beforeEach(() => {
+    originalUrl = process.env.NEXT_PUBLIC_MCP_URL;
+    originalAuthUrl = process.env.NEXT_PUBLIC_AUTH_URL;
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+    process.env.NEXT_PUBLIC_AUTH_URL = 'https://mcp.example.test';
+  });
+
+  afterEach(() => {
+    if (originalUrl === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalUrl;
+    if (originalAuthUrl === undefined) delete process.env.NEXT_PUBLIC_AUTH_URL;
+    else process.env.NEXT_PUBLIC_AUTH_URL = originalAuthUrl;
+  });
+
+  it('advertises the org-scoped path as its own resource identifier', () => {
+    const meta = new OAuthResourceController().surfaceMetadata(requestFor(
+      `/.well-known/oauth-protected-resource/mcp/o/${ORG_A}`,
+    ));
+    expect(meta.resource).toBe(`https://mcp.example.test/mcp/o/${ORG_A}`);
+    expect(meta.scopes_supported).toEqual(RESOURCE_ADVERTISED_SCOPES);
+    expect(meta.authorization_servers).toEqual(['https://mcp.example.test']);
+  });
+
+  it('names no organization, so the document is not an org-existence oracle', () => {
+    const meta = new OAuthResourceController().surfaceMetadata(requestFor(
+      `/.well-known/oauth-protected-resource/mcp/o/${ORG_A}`,
+    ));
+    expect(meta.resource_name).toBe('Munin');
+    expect(JSON.stringify(meta)).not.toContain('org name');
+  });
+
+  it('serves the document without a registered surface', () => {
+    expect(() =>
+      new OAuthResourceController().surfaceMetadata(
+        requestFor(`/.well-known/oauth-protected-resource/mcp/o/${ORG_A}`),
+      ),
+    ).not.toThrow();
+  });
+
+  it('404s for an org id that is not of the minted shape', () => {
+    expect(() =>
+      new OAuthResourceController().surfaceMetadata(
+        requestFor('/.well-known/oauth-protected-resource/mcp/o/not-an-org'),
+      ),
+    ).toThrow(NotFoundException);
+  });
+
+  it('404s for a sub-path below an org-scoped resource', () => {
+    expect(() =>
+      new OAuthResourceController().surfaceMetadata(
+        requestFor(`/.well-known/oauth-protected-resource/mcp/o/${ORG_A}/media`),
+      ),
+    ).toThrow(NotFoundException);
+  });
+});

--- a/packages/backend-core/src/oauth/oauth-resource.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.ts
@@ -1,4 +1,5 @@
 import { Get, Header, Inject, NotFoundException, Optional, Req } from '@nestjs/common';
+import { orgScopedMcpResourceUrl, parseOrgScopedMcpPath } from '@getmunin/core';
 import { PublicController } from '../common/auth/auth.guard.ts';
 import {
   authorizationServerUrl,
@@ -64,7 +65,21 @@ export class OAuthResourceController {
   @Header('content-type', 'application/json; charset=utf-8')
   @Header('cache-control', 'public, max-age=3600')
   surfaceMetadata(@Req() req: ResourceMetadataRequest): ProtectedResourceMetadata {
-    const surface = findMcpSurfaceForPath(this.surfaces, suffixOf(req));
+    const suffix = suffixOf(req);
+    const orgScopedResource = orgScopedResourceFor(suffix);
+    if (orgScopedResource) {
+      return {
+        resource: orgScopedResource,
+        resource_name: 'Munin',
+        resource_logo_uri: `${mcpResourceOrigin()}/icon.png`,
+        authorization_servers: [authorizationServerUrl()],
+        scopes_supported: RESOURCE_ADVERTISED_SCOPES,
+        bearer_methods_supported: ['header'],
+        resource_documentation: `${authorizationServerUrl()}/docs`,
+        resource_indicators_supported: true,
+      };
+    }
+    const surface = findMcpSurfaceForPath(this.surfaces, suffix);
     if (!surface) throw new NotFoundException('protected_resource_not_found');
     return {
       resource: mcpSurfaceResourceUrl(surface),
@@ -77,6 +92,11 @@ export class OAuthResourceController {
       resource_indicators_supported: true,
     };
   }
+}
+
+function orgScopedResourceFor(suffix: string): string | null {
+  const orgId = parseOrgScopedMcpPath(suffix);
+  return orgId ? orgScopedMcpResourceUrl(orgId) : null;
 }
 
 function suffixOf(req: ResourceMetadataRequest): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,18 @@ export {
   registerMcpResourcePaths,
   resetMcpResourcePaths,
 } from './request/mcp-resources.ts';
+export {
+  ORG_SCOPED_MCP_PREFIX,
+  type McpOrgScopeInput,
+  type OrgScopedMcpResource,
+  currentOrgScopedMcpResource,
+  isOrgId,
+  orgScopedMcpPath,
+  orgScopedMcpResourceUrl,
+  parseOrgScopedMcpPath,
+  parseOrgScopedMcpResource,
+  withOrgScopedMcpResource,
+} from './request/mcp-org-scope.ts';
 
 export {
   hashSecret,

--- a/packages/core/src/request/mcp-org-scope.test.ts
+++ b/packages/core/src/request/mcp-org-scope.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  currentOrgScopedMcpResource,
+  isOrgId,
+  orgScopedMcpPath,
+  orgScopedMcpResourceUrl,
+  parseOrgScopedMcpPath,
+  parseOrgScopedMcpResource,
+  withOrgScopedMcpResource,
+} from './mcp-org-scope.ts';
+
+const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+const ORG_B = 'org_bbbbbbbbbbbbbbbbbbbbbb';
+
+describe('org-scoped MCP paths', () => {
+  let originalMcp: string | undefined;
+
+  beforeEach(() => {
+    originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+  });
+
+  afterEach(() => {
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+  });
+
+  it('accepts an org id of the minted shape only', () => {
+    expect(isOrgId(ORG_A)).toBe(true);
+    expect(isOrgId('org_short')).toBe(false);
+    expect(isOrgId('usr_aaaaaaaaaaaaaaaaaaaaaa')).toBe(false);
+    expect(isOrgId('org_AAAAAAAAAAAAAAAAAAAAAA')).toBe(false);
+  });
+
+  it('parses the org id out of an org-scoped path', () => {
+    expect(parseOrgScopedMcpPath(orgScopedMcpPath(ORG_A))).toBe(ORG_A);
+    expect(parseOrgScopedMcpPath(`/mcp/o/${ORG_A}/`)).toBe(ORG_A);
+    expect(parseOrgScopedMcpPath(`/mcp/o/${ORG_A}?session=1`)).toBe(ORG_A);
+  });
+
+  it('rejects paths that are not a single org segment below /mcp/o/', () => {
+    expect(parseOrgScopedMcpPath('/mcp')).toBeNull();
+    expect(parseOrgScopedMcpPath('/mcp/media')).toBeNull();
+    expect(parseOrgScopedMcpPath('/mcp/o/')).toBeNull();
+    expect(parseOrgScopedMcpPath('/mcp/o/not-an-org')).toBeNull();
+    expect(parseOrgScopedMcpPath(`/mcp/o/${ORG_A}/media`)).toBeNull();
+  });
+
+  it('builds the resource URL from the MCP origin, not its path', () => {
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://api.example.test/mcp';
+    expect(orgScopedMcpResourceUrl(ORG_A)).toBe(`https://api.example.test/mcp/o/${ORG_A}`);
+  });
+
+  it('parses an org-scoped resource URL on the MCP origin', () => {
+    expect(parseOrgScopedMcpResource(`https://mcp.example.test/mcp/o/${ORG_A}`)).toBe(ORG_A);
+    expect(parseOrgScopedMcpResource(`https://mcp.example.test/mcp/o/${ORG_A}/`)).toBe(ORG_A);
+  });
+
+  it('rejects an org-scoped resource URL on another origin', () => {
+    expect(parseOrgScopedMcpResource(`https://evil.example.test/mcp/o/${ORG_A}`)).toBeNull();
+    expect(parseOrgScopedMcpResource('https://mcp.example.test')).toBeNull();
+    expect(parseOrgScopedMcpResource('not a url')).toBeNull();
+  });
+});
+
+describe('org-scoped MCP request scope', () => {
+  let originalMcp: string | undefined;
+
+  beforeEach(() => {
+    originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+  });
+
+  afterEach(() => {
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+  });
+
+  it('exposes the requested org inside the scope and nothing outside it', () => {
+    expect(currentOrgScopedMcpResource()).toBeUndefined();
+    withOrgScopedMcpResource({ resource: `https://mcp.example.test/mcp/o/${ORG_A}` }, () => {
+      expect(currentOrgScopedMcpResource()).toEqual({
+        orgId: ORG_A,
+        resource: `https://mcp.example.test/mcp/o/${ORG_A}`,
+      });
+    });
+    expect(currentOrgScopedMcpResource()).toBeUndefined();
+  });
+
+  it('keeps concurrent requests on their own org', async () => {
+    const seen: Array<string | undefined> = [];
+    const run = (orgId: string, delayTicks: number) =>
+      withOrgScopedMcpResource({ resource: `https://mcp.example.test/mcp/o/${orgId}` }, async () => {
+        for (let i = 0; i < delayTicks; i += 1) await Promise.resolve();
+        seen.push(currentOrgScopedMcpResource()?.orgId);
+      });
+    await Promise.all([run(ORG_A, 3), run(ORG_B, 1)]);
+    expect(seen.sort()).toEqual([ORG_A, ORG_B]);
+  });
+
+  it('runs without a scope when the resource is absent or not org-scoped', () => {
+    withOrgScopedMcpResource({ resource: null }, () => {
+      expect(currentOrgScopedMcpResource()).toBeUndefined();
+    });
+    withOrgScopedMcpResource({ resource: 'https://mcp.example.test' }, () => {
+      expect(currentOrgScopedMcpResource()).toBeUndefined();
+    });
+    withOrgScopedMcpResource({ resource: `https://evil.example.test/mcp/o/${ORG_A}` }, () => {
+      expect(currentOrgScopedMcpResource()).toBeUndefined();
+    });
+  });
+});
+
+describe('org-scoped MCP scope carries the association key', () => {
+  let originalMcp: string | undefined;
+
+  beforeEach(() => {
+    originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
+    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+  });
+
+  afterEach(() => {
+    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
+    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+  });
+
+  it('exposes the association key to whoever pins the org', () => {
+    withOrgScopedMcpResource(
+      { resource: `https://mcp.example.test/mcp/o/${ORG_A}`, associationKey: 'assoc-key' },
+      () => {
+        expect(currentOrgScopedMcpResource()).toEqual({
+          orgId: ORG_A,
+          resource: `https://mcp.example.test/mcp/o/${ORG_A}`,
+          associationKey: 'assoc-key',
+        });
+      },
+    );
+  });
+
+  it('omits the association key when there is none', () => {
+    withOrgScopedMcpResource({ resource: `https://mcp.example.test/mcp/o/${ORG_A}` }, () => {
+      expect(currentOrgScopedMcpResource()?.associationKey).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/request/mcp-org-scope.ts
+++ b/packages/core/src/request/mcp-org-scope.ts
@@ -1,0 +1,86 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { stripTrailingSlashes } from '@getmunin/types';
+
+const ORG_ID_PATTERN = /^org_[0-9a-z]{22}$/;
+
+export const ORG_SCOPED_MCP_PREFIX = '/mcp/o/';
+
+export interface OrgScopedMcpResource {
+  resource: string;
+  orgId: string;
+  associationKey?: string;
+}
+
+export interface McpOrgScopeInput {
+  resource?: string | null;
+  associationKey?: string | null;
+}
+
+export function isOrgId(value: string): boolean {
+  return ORG_ID_PATTERN.test(value);
+}
+
+export function orgScopedMcpPath(orgId: string): string {
+  return `${ORG_SCOPED_MCP_PREFIX}${orgId}`;
+}
+
+export function parseOrgScopedMcpPath(path: string): string | null {
+  const clean = stripTrailingSlashes(stripQuery(path));
+  if (!clean.startsWith(ORG_SCOPED_MCP_PREFIX)) return null;
+  const rest = clean.slice(ORG_SCOPED_MCP_PREFIX.length);
+  if (!rest || rest.includes('/')) return null;
+  return isOrgId(rest) ? rest : null;
+}
+
+export function orgScopedMcpResourceUrl(orgId: string): string | null {
+  const origin = mcpOrigin();
+  if (!origin || !isOrgId(orgId)) return null;
+  return `${origin}${orgScopedMcpPath(orgId)}`;
+}
+
+export function parseOrgScopedMcpResource(resource: string): string | null {
+  const origin = mcpOrigin();
+  if (!origin) return null;
+  let url: URL;
+  try {
+    url = new URL(stripTrailingSlashes(resource));
+  } catch {
+    return null;
+  }
+  if (url.origin !== origin) return null;
+  return parseOrgScopedMcpPath(url.pathname);
+}
+
+const OrgScopedResourceStore = new AsyncLocalStorage<OrgScopedMcpResource>();
+
+export function withOrgScopedMcpResource<T>(input: McpOrgScopeInput, fn: () => T): T {
+  if (!input.resource) return fn();
+  const orgId = parseOrgScopedMcpResource(input.resource);
+  if (!orgId) return fn();
+  const resource = orgScopedMcpResourceUrl(orgId);
+  if (!resource) return fn();
+  const scope: OrgScopedMcpResource = { resource, orgId };
+  if (input.associationKey) scope.associationKey = input.associationKey;
+  return OrgScopedResourceStore.run(scope, fn);
+}
+
+export function currentOrgScopedMcpResource(): OrgScopedMcpResource | undefined {
+  return OrgScopedResourceStore.getStore();
+}
+
+function mcpOrigin(): string | null {
+  const raw = stripTrailingSlashes(
+    process.env.NEXT_PUBLIC_MCP_URL ?? 'http://localhost:3001/mcp',
+  );
+  try {
+    return new URL(raw).origin;
+  } catch (err) {
+    console.warn('[mcp-org-scope] NEXT_PUBLIC_MCP_URL is not a parseable URL', { err });
+    return null;
+  }
+}
+
+function stripQuery(path: string): string {
+  const i = path.indexOf('?');
+  return i < 0 ? path : path.slice(0, i);
+}

--- a/packages/core/src/request/mcp-resources.ts
+++ b/packages/core/src/request/mcp-resources.ts
@@ -1,4 +1,5 @@
 import { stripTrailingSlashes } from '@getmunin/types';
+import { parseOrgScopedMcpResource } from './mcp-org-scope.ts';
 
 const registeredPaths = new Set<string>();
 
@@ -29,6 +30,7 @@ export function mcpResourceUrls(): string[] {
 
 export function canonicalMcpResource(audience: string): string {
   const candidate = stripTrailingSlashes(audience);
+  if (parseOrgScopedMcpResource(candidate)) return candidate;
   for (const url of mcpResourceUrls()) {
     if (candidate === url) return url;
   }

--- a/packages/core/src/request/oauth-jwt.ts
+++ b/packages/core/src/request/oauth-jwt.ts
@@ -10,6 +10,7 @@ import {
   type ResolvedCredential,
 } from './credentials.ts';
 import { canonicalMcpResource, mcpResourceUrls } from './mcp-resources.ts';
+import { parseOrgScopedMcpResource } from './mcp-org-scope.ts';
 import { stripTrailingSlashes } from '@getmunin/types';
 
 type VerifyKey = Awaited<ReturnType<typeof importJWK>>;
@@ -85,14 +86,15 @@ export async function resolveOauthJwtAccessToken(
   const matchedAudience = audiencesFromJwt.find((a) => isAcceptedJwtAudience(a));
   if (!matchedAudience) return null;
 
+  const audienceOrgId = parseOrgScopedMcpResource(matchedAudience);
+  const claimedOrgId = typeof payload['org_id'] === 'string' ? payload['org_id'] : null;
+  if (audienceOrgId && claimedOrgId && audienceOrgId !== claimedOrgId) return null;
+
   const scopes =
     typeof payload['scope'] === 'string' ? payload['scope'].split(/\s+/).filter(Boolean) : [];
 
   const memberships = await readMembershipsForUser(db, userId);
-  const active = resolvePinnedMembership(
-    memberships,
-    typeof payload['org_id'] === 'string' ? payload['org_id'] : null,
-  );
+  const active = resolvePinnedMembership(memberships, audienceOrgId ?? claimedOrgId);
   if (!active) return null;
 
   const { scopes: grantedScopes, audiences } = gateOauthGrantsByRole(scopes, active.role);
@@ -178,5 +180,6 @@ export function acceptedJwtAudiences(): Set<string> {
 }
 
 function isAcceptedJwtAudience(aud: string): boolean {
-  return acceptedJwtAudiences().has(aud);
+  if (acceptedJwtAudiences().has(aud)) return true;
+  return parseOrgScopedMcpResource(aud) !== null;
 }


### PR DESCRIPTION
## Why

MCP clients key a connection by its URL, so one URL means one stored credential. A user who belongs to more than one organization could only ever be connected to whichever one their token happened to be pinned to — connecting a second organization overwrote the first.

`/mcp/o/<orgId>` addresses the same tools at one specific organization. Tools, registry and handler are unchanged; only addressing and org pinning are new. The shared `/mcp` keeps accepting any org, so existing connections are untouched.

## How it behaves

- **API keys work immediately** — a key already carries its org.
- **Cross-org credential → 401** with `WWW-Authenticate` pointing at that org's protected-resource document, so an OAuth client re-runs authorization and lands on the right org instead of failing permanently.
- **A malformed selector under `/mcp/o/` → 404**, not a fall-through. Failing open was no tenancy hole (the handler resolves the org from the credential and never reads the path, so the path can only constrain a request, never select it) but a wrong-case or percent-encoded id produced a *working* connection that silently acted in the caller's default org.
- **OAuth pins from the URL** — the per-org discovery document advertises the org-scoped URL as its own resource identifier, the SDK echoes it back as `resource`, and `consentReferenceId` binds the token to that org, refusing outright when the signed-in user is not a member. The document validates only the shape of the org id and names no organization, so it is not an org-existence oracle.

## Three library constraints that shaped this

`@better-auth/oauth-provider` takes `validAudiences` as a static `string[]` and spreads its options at construction, so a per-request audience cannot be injected and per-org resources cannot be enumerated ahead of time. The resource is narrowed to the base MCP resource on token requests — the only place the provider validates it — so tokens keep `aud` = base resource with the org in `org_id`, and the path guard enforces the boundary.

`resource` does not survive the redirect to the consent page: the provider signs the *validated* authorize query and `resource` is not in that schema. The org is carried across the round-trip in a short-lived `verifications` row keyed on `sha256(session cookie + code_challenge)`. The session is part of the key because `code_challenge` is not a secret — it travels in the authorization URL, so it reaches browser history, referrers and logs — and keying on it alone let any authenticated caller who learned a victim's challenge repoint that victim's pending association. The row is written from inside `consentReferenceId`, after membership is verified, so a refused authorization stores nothing.

`consentReferenceId` receives no request context, so the requested org reaches it through an `AsyncLocalStorage` scope established at the auth request boundary.

## Verification

Unit and integration tests cover the parser and request scope, the guard's org matching and audience handling, malformed selectors, per-org discovery metadata, the resource narrowing, the association key's session binding, and the store against real Postgres.

Also driven end to end against a live server:

| Check | Result |
|---|---|
| Two simultaneous OAuth connections, different orgs | each pinned correctly, each sees only its own data |
| Either token on the other org's endpoint | 401 |
| Refresh grant | preserves the org |
| Non-member org at authorize | 403 |
| Malformed selectors (`%6f`, `%00`, uppercase, bare) | 404 |
| Second account replaying the victim's `code_challenge` | cannot repoint the association |
| Shared `/mcp` and base-resource connections | unaffected |

The first two rows are the ones that mattered: before the `code_challenge` correlation, a token requested for a non-default org came back pinned to the user's default org, and the endpoint then refused it permanently.

## Follow-ups

- `POST /mcp/media` is still single-URL, so multi-org media connections still collide — same fix shape, separate change.
- Worth asking upstream to retain the RFC 8707 `resource` across the consent round-trip, or to hand the authorize context to `consentReferenceId`; either would let the audience stay org-scoped end to end and remove the correlation row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhaGswtoVx7nowaQw8Qm3C