### PR TITLE
feat(oauth): report which org a pending authorization will bind to

### DIFF
--- a/.changeset/oauth-pending-org.md
+++ b/.changeset/oauth-pending-org.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Expose which organization a pending authorization will bind to, so a consent screen can tell an org-scoped connection from a plain one.
+
+`GET /v1/oauth/pending-org?code_challenge=…` answers `{ pinned, orgId? }` for the caller's own session. A dashboard cannot work this out from the URL: `resource` never reaches the consent page, because the provider signs the *validated* authorize query and `resource` is not part of that schema. Without this signal a consent screen has to pick one behaviour for both cases — either offer an organization switcher that cannot change what an org-scoped connection binds to, or hide it and remove the only way to choose the organization for a connection to the shared endpoint, since that one binds to whichever membership is `isDefault`.
+
+The lookup is keyed the same way the association is written — an HMAC of the session cookie and `code_challenge` — so it only ever answers for the session that started the authorization, and a caller cannot probe another user's pending organization. Absent association, absent cookie, absent challenge and unregistered store all answer `{ pinned: false }`, which is the safe default: the caller then treats the organization as still up for grabs.

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -6666,6 +6666,37 @@
         "security": []
       }
     },
+    "/v1/oauth/pending-org": {
+      "get": {
+        "operationId": "OAuthPendingOrgController_pending",
+        "parameters": [
+          {
+            "name": "code_challenge",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "OAuthPendingOrg"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/system/alerts": {
       "get": {
         "operationId": "SystemAlertsController_list",

--- a/packages/backend-core/src/oauth/oauth-pending-org.controller.test.ts
+++ b/packages/backend-core/src/oauth/oauth-pending-org.controller.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
+import { ActorIdentity, withContext } from '@getmunin/core';
+import { OAuthPendingOrgController } from './oauth-pending-org.controller.ts';
+import {
+  buildOrgScopeAssociationKey,
+  registerOrgScopeStore,
+  type OrgScopeStore,
+} from '../auth/org-scope-store.ts';
+
+const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+const SECRET = 'pending-org-controller-secret-0000000000';
+const COOKIE = 'better-auth.session_token=owner-session.signature';
+const OTHER_COOKIE = 'better-auth.session_token=other-session.signature';
+
+function storeHolding(associations: Record<string, string>): OrgScopeStore {
+  return {
+    keyFor: (cookieHeader, codeChallenge) =>
+      buildOrgScopeAssociationKey(SECRET, cookieHeader, codeChallenge),
+    remember: () => Promise.resolve(),
+    recall: (key) => Promise.resolve(associations[key] ?? null),
+  };
+}
+
+function requestWith(cookie?: string) {
+  return { headers: cookie === undefined ? {} : { cookie } };
+}
+
+function asUser<T>(fn: () => Promise<T>): Promise<T> {
+  const actor = new ActorIdentity('user', 'usr_1', ORG_A, ['*'], ['admin'], undefined, undefined, undefined, 'usr_1');
+  return withContext({ db: {} as never, actor, correlationId: 'test' }, fn);
+}
+
+describe('OAuthPendingOrgController', () => {
+  beforeEach(() => {
+    registerOrgScopeStore(
+      storeHolding({ [buildOrgScopeAssociationKey(SECRET, COOKIE, CHALLENGE)!]: ORG_A }),
+    );
+  });
+  afterEach(() => registerOrgScopeStore(null));
+
+  it('reports the org a pending authorization will bind to', async () => {
+    const result = await asUser(() =>
+      new OAuthPendingOrgController().pending(requestWith(COOKIE), CHALLENGE),
+    );
+    expect(result).toEqual({ pinned: true, orgId: ORG_A });
+  });
+
+  it('reports nothing pinned for an authorization that named no org', async () => {
+    const result = await asUser(() =>
+      new OAuthPendingOrgController().pending(requestWith(COOKIE), 'a-different-challenge'),
+    );
+    expect(result).toEqual({ pinned: false });
+  });
+
+  it('does not reveal another session\'s pending org', async () => {
+    const result = await asUser(() =>
+      new OAuthPendingOrgController().pending(requestWith(OTHER_COOKIE), CHALLENGE),
+    );
+    expect(result).toEqual({ pinned: false });
+  });
+
+  it('reports nothing pinned without a session cookie or a challenge', async () => {
+    await expect(
+      asUser(() => new OAuthPendingOrgController().pending(requestWith(), CHALLENGE)),
+    ).resolves.toEqual({ pinned: false });
+    await expect(
+      asUser(() => new OAuthPendingOrgController().pending(requestWith(COOKIE), undefined)),
+    ).resolves.toEqual({ pinned: false });
+  });
+
+  it('refuses a non-user credential', async () => {
+    const actor = new ActorIdentity('admin_agent', 'akey_1', ORG_A, ['*'], ['admin']);
+    await expect(
+      withContext({ db: {} as never, actor, correlationId: 'test' }, () =>
+        new OAuthPendingOrgController().pending(requestWith(COOKIE), CHALLENGE),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('reports nothing pinned when no store is registered', async () => {
+    registerOrgScopeStore(null);
+    await expect(
+      asUser(() => new OAuthPendingOrgController().pending(requestWith(COOKIE), CHALLENGE)),
+    ).resolves.toEqual({ pinned: false });
+  });
+});

--- a/packages/backend-core/src/oauth/oauth-pending-org.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-pending-org.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  ForbiddenException,
+  Get,
+  Header,
+  Query,
+  Req,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { getCurrentContext } from '@getmunin/core';
+import { AuthGuard } from '../common/auth/auth.guard.ts';
+import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
+import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
+import { orgScopeStore } from '../auth/org-scope-store.ts';
+
+export interface PendingAuthorizationOrgDto {
+  pinned: boolean;
+  orgId?: string;
+}
+
+interface CookieCarryingRequest {
+  headers: Record<string, string | string[] | undefined>;
+}
+
+@Controller('v1/oauth/pending-org')
+@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseInterceptors(TenancyInterceptor)
+export class OAuthPendingOrgController {
+  @Get()
+  @Header('cache-control', 'no-store')
+  async pending(
+    @Req() req: CookieCarryingRequest,
+    @Query('code_challenge') codeChallenge?: string,
+  ): Promise<PendingAuthorizationOrgDto> {
+    const actor = getCurrentContext().actor!;
+    if (actor.type !== 'user' || !actor.userId) {
+      throw new ForbiddenException('user session required');
+    }
+
+    const store = orgScopeStore();
+    if (!store || !codeChallenge) return { pinned: false };
+
+    const cookieHeader = req.headers['cookie'];
+    const key = store.keyFor(
+      Array.isArray(cookieHeader) ? cookieHeader[0] : cookieHeader,
+      codeChallenge,
+    );
+    if (!key) return { pinned: false };
+
+    const orgId = await store.recall(key);
+    return orgId ? { pinned: true, orgId } : { pinned: false };
+  }
+}

--- a/packages/backend-core/src/oauth/oauth.module.ts
+++ b/packages/backend-core/src/oauth/oauth.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { OAuthAsAliasController } from './oauth-as-alias.controller.ts';
 import { OAuthClientInfoController } from './oauth-client-info.controller.ts';
+import { OAuthPendingOrgController } from './oauth-pending-org.controller.ts';
 import { OAuthResourceController } from './oauth-resource.controller.ts';
 
 @Module({
@@ -8,6 +9,7 @@ import { OAuthResourceController } from './oauth-resource.controller.ts';
     OAuthResourceController,
     OAuthAsAliasController,
     OAuthClientInfoController,
+    OAuthPendingOrgController,
   ],
 })
 export class OAuthModule {}


### PR DESCRIPTION
Unblocks a consent screen from telling an org-scoped MCP connection apart from a plain one.

## Why a backend signal is needed at all

`resource` never reaches the consent page. better-auth signs the *validated* authorize query and `resource` is not part of that schema — the same thing getmunin/munin-cloud#363 documented for the media gate. So a dashboard has exactly two options today, and both are wrong:

- **Show the org switcher always** — for an org-scoped URL it offers something it cannot deliver: the URL and the stored association decide the binding, and the path guard refuses a mismatch.
- **Hide it always** — removes the only way to choose the organization for a connection to the shared endpoint, which binds to whichever membership is `isDefault` (`consentReferenceId` → `resolveDefaultOrgId`, and `PATCH /v1/me/memberships/active` is what sets it).

The second shipped in munin-cloud#364 and had to be reverted in munin-cloud#365. This gives the page the missing fact instead.

## The endpoint

`GET /v1/oauth/pending-org?code_challenge=…` → `{ pinned: boolean, orgId?: string }`

A caller renders a switcher when `pinned` is false, and names the target organization when it is true.

## Why it cannot leak

It is keyed exactly as the association is written: an HMAC of the session cookie and `code_challenge` under the auth secret. So it only ever answers for the session that started that authorization — another user hitting it with the same challenge computes a different key and gets `{ pinned: false }`, which is asserted in the tests. The association itself is only ever written after membership was verified, so a `pinned` answer is always an organization the caller belongs to.

Missing association, missing cookie, missing challenge, and unregistered store all answer `{ pinned: false }` — the safe default, since the caller then treats the organization as still open rather than naming one it cannot confirm. Session required (`AuthGuard` + `ControlPlaneGuard`), `cache-control: no-store`.

## Tests

Six cases: the happy path, an unknown challenge, **another session cannot read the pinned org**, missing cookie/challenge, a non-user credential refused, and no store registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhaGswtoVx7nowaQw8Qm3C