### PR TITLE
fix(oauth): carry the requested org across the consent redirect

### DIFF
--- a/.changeset/pin-the-org-through-the-consent-round-trip.md
+++ b/.changeset/pin-the-org-through-the-consent-round-trip.md
@@ -1,0 +1,16 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/core': minor
+---
+
+Carry the organization an org-scoped MCP connection asked for all the way to the token, for clients that send `prompt=consent` or no resource indicator on the authorize request.
+
+An authorization started at `/mcp/o/<orgId>` was landing on the user's default organization instead of the one in the URL. The association that carries the org across the consent redirect was written from inside `consentReferenceId`, and `@better-auth/oauth-provider` returns to the consent page **before** it calls that hook whenever the request carries `prompt=consent` — so on the one leg that names an organization, nothing was ever written, and the consent leg then had nothing to recall. Verified against a live authorization server: not one association row had ever been written, and every consent bound to the default org. Downstream, `AuthGuard` refused the resulting token on the org-scoped path, so the connection came back with no tools at all.
+
+Three changes make the org survive the round-trip:
+
+- The association is written at the auth-request boundary, on any request that names an org, rather than from a provider hook that a prompt can skip.
+- It is keyed on both an HMAC of the session cookie and `code_challenge` **and** an HMAC of `code_challenge` alone, so an authorization that starts before the browser has a session — the ordinary case for a first connection — is still recoverable after sign-in. Recall prefers the session-bound key. The challenge-only key is first-write-wins, so a later request cannot repoint an association an earlier one already claimed; a caller who learns another user's `code_challenge` can read which organization it named, which is an opaque id for an authorization they must already hold the URL of.
+- The org-scoped protected-resource document advertises a marker scope, `mcp:org:<orgId>`, alongside the usual list. A client requests exactly the scopes that document advertises, so the organization now reaches the authorization server even from a client that only sends `resource` at token exchange, which is where RFC 8707 permits it and where the provider reads it. The marker is stripped from the query and body before the provider validates scopes, so it never reaches a consent screen, a stored grant, or a token, and the shared endpoint's document does not carry one.
+
+The resource indicator remains the primary channel and takes precedence when both are present. A missing association still falls back to the default organization, where the path guard refuses the mismatch, and a signed-in user who is not a member of the requested organization is still refused at consent rather than quietly redirected elsewhere.

--- a/packages/backend-core/src/auth-controller-factory.test.ts
+++ b/packages/backend-core/src/auth-controller-factory.test.ts
@@ -2,15 +2,18 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Request as ExpressRequestLike } from 'express';
 import {
   assertProductionAuthSecret,
-  narrowOrgScopedResourceBody,
+  narrowAuthRequestBody,
+  narrowOrgMarkerQuery,
   readCodeChallenge,
+  readRequestedOrgId,
   readRequestedResource,
   requireAuthSecret,
   resolveMcpOrgScope,
 } from './auth-controller-factory.ts';
 import {
-  buildOrgScopeAssociationKey,
+  buildOrgScopeAssociationKeys,
   registerOrgScopeStore,
+  type OrgScopeAssociationKeys,
   type OrgScopeStore,
 } from './auth/org-scope-store.ts';
 
@@ -48,9 +51,9 @@ describe('assertProductionAuthSecret', () => {
   it('rejects known placeholder shapes even at full length', () => {
     process.env.NODE_ENV = 'production';
     const padded = (s: string) => s + 'x'.repeat(Math.max(0, 33 - s.length));
-    expect(() => assertProductionAuthSecret(padded('replace-me-with-strong-random-secret'))).toThrow(
-      /placeholder\/dev value/,
-    );
+    expect(() =>
+      assertProductionAuthSecret(padded('replace-me-with-strong-random-secret')),
+    ).toThrow(/placeholder\/dev value/);
     expect(() => assertProductionAuthSecret(padded('dev-secret-do-not-use-in-prod'))).toThrow(
       /placeholder\/dev value/,
     );
@@ -78,6 +81,7 @@ describe('assertProductionAuthSecret', () => {
 
 describe('org-scoped resource on auth requests', () => {
   const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+  const ORG_B = 'org_bbbbbbbbbbbbbbbbbbbbbb';
   const originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
 
   beforeEach(() => {
@@ -89,12 +93,15 @@ describe('org-scoped resource on auth requests', () => {
   });
 
   function requestWith(parts: {
+    url?: string;
     query?: Record<string, unknown>;
     body?: unknown;
     contentType?: string;
     rawBody?: string;
   }) {
     return {
+      originalUrl: parts.url ?? '/auth/oauth2/authorize',
+      url: parts.url ?? '/auth/oauth2/authorize',
       query: parts.query ?? {},
       body: parts.body,
       headers: parts.contentType ? { 'content-type': parts.contentType } : {},
@@ -115,13 +122,91 @@ describe('org-scoped resource on auth requests', () => {
   it('recovers the resource from the signed query the consent page replays', () => {
     const resource = `https://mcp.example.test/mcp/o/${ORG_A}`;
     const oauthQuery = new URLSearchParams({ client_id: 'abc', resource }).toString();
-    expect(readRequestedResource(requestWith({ body: { accept: true, oauth_query: oauthQuery } }))).toBe(
-      resource,
-    );
+    expect(
+      readRequestedResource(requestWith({ body: { accept: true, oauth_query: oauthQuery } })),
+    ).toBe(resource);
   });
 
   it('returns null when no resource is requested', () => {
-    expect(readRequestedResource(requestWith({ body: { grant_type: 'refresh_token' } }))).toBeNull();
+    expect(
+      readRequestedResource(requestWith({ body: { grant_type: 'refresh_token' } })),
+    ).toBeNull();
+  });
+
+  it('reads the org from the marker scope when the client sends no resource', () => {
+    expect(
+      readRequestedOrgId(requestWith({ query: { scope: `offline_access mcp:org:${ORG_A}` } })),
+    ).toBe(ORG_A);
+    expect(readRequestedOrgId(requestWith({ body: { scope: `mcp:org:${ORG_A} kb:read` } }))).toBe(
+      ORG_A,
+    );
+    expect(
+      readRequestedOrgId(requestWith({ query: { scope: 'offline_access kb:read' } })),
+    ).toBeNull();
+  });
+
+  it('prefers the resource over the marker scope when a client sends both', () => {
+    expect(
+      readRequestedOrgId(
+        requestWith({
+          query: {
+            resource: `https://mcp.example.test/mcp/o/${ORG_A}`,
+            scope: `mcp:org:${ORG_B}`,
+          },
+        }),
+      ),
+    ).toBe(ORG_A);
+  });
+
+  it('ignores a marker in the replayed signed query, which the provider never signed one into', () => {
+    const oauthQuery = new URLSearchParams({ scope: `mcp:org:${ORG_A}` }).toString();
+    expect(
+      readRequestedOrgId(requestWith({ body: { accept: true, oauth_query: oauthQuery } })),
+    ).toBeNull();
+  });
+
+  it('strips the marker scope out of the authorize query the provider will validate', () => {
+    const query = narrowOrgMarkerQuery(
+      requestWith({
+        url: `/auth/oauth2/authorize?client_id=abc&scope=offline_access+mcp%3Aorg%3A${ORG_A}+kb%3Aread`,
+        query: { client_id: 'abc', scope: `offline_access mcp:org:${ORG_A} kb:read` },
+      }),
+    );
+    expect(query).not.toBeNull();
+    const params = new URLSearchParams(query!);
+    expect(params.get('scope')).toBe('offline_access kb:read');
+    expect(params.get('client_id')).toBe('abc');
+  });
+
+  it('drops the scope parameter entirely when the marker was all of it', () => {
+    const query = narrowOrgMarkerQuery(
+      requestWith({
+        url: `/auth/oauth2/register?scope=mcp%3Aorg%3A${ORG_A}`,
+        query: { scope: `mcp:org:${ORG_A}` },
+      }),
+    );
+    expect(new URLSearchParams(query!).has('scope')).toBe(false);
+  });
+
+  it('leaves a query without a marker untouched', () => {
+    expect(
+      narrowOrgMarkerQuery(
+        requestWith({
+          url: '/auth/oauth2/authorize?scope=kb%3Aread',
+          query: { scope: 'kb:read' },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('strips the marker scope out of a request body', () => {
+    const override = narrowAuthRequestBody(
+      requestWith({
+        body: { client_name: 'app', scope: `offline_access mcp:org:${ORG_A}` },
+        contentType: 'application/json',
+      }),
+    );
+    expect(JSON.parse(override!.body)).toEqual({ client_name: 'app', scope: 'offline_access' });
   });
 
   it('narrows an org-scoped resource to the base resource on urlencoded token bodies', () => {
@@ -132,7 +217,7 @@ describe('org-scoped resource on auth requests', () => {
       code_verifier: 'a-b_c~d',
       resource,
     }).toString();
-    const override = narrowOrgScopedResourceBody(
+    const override = narrowAuthRequestBody(
       requestWith({
         body: { grant_type: 'authorization_code', code: 'xyz', code_verifier: 'a-b_c~d', resource },
         contentType: 'application/x-www-form-urlencoded',
@@ -149,7 +234,7 @@ describe('org-scoped resource on auth requests', () => {
   });
 
   it('falls back to a JSON body when no raw urlencoded body was captured', () => {
-    const override = narrowOrgScopedResourceBody(
+    const override = narrowAuthRequestBody(
       requestWith({
         body: { code: 'xyz', resource: `https://mcp.example.test/mcp/o/${ORG_A}` },
         contentType: 'application/x-www-form-urlencoded',
@@ -163,7 +248,7 @@ describe('org-scoped resource on auth requests', () => {
   });
 
   it('narrows an org-scoped resource on JSON token bodies', () => {
-    const override = narrowOrgScopedResourceBody(
+    const override = narrowAuthRequestBody(
       requestWith({
         body: { resource: `https://mcp.example.test/mcp/o/${ORG_A}`, code: 'xyz' },
         contentType: 'application/json',
@@ -177,10 +262,10 @@ describe('org-scoped resource on auth requests', () => {
 
   it('leaves the base resource and foreign-origin resources untouched', () => {
     expect(
-      narrowOrgScopedResourceBody(requestWith({ body: { resource: 'https://mcp.example.test' } })),
+      narrowAuthRequestBody(requestWith({ body: { resource: 'https://mcp.example.test' } })),
     ).toBeNull();
     expect(
-      narrowOrgScopedResourceBody(
+      narrowAuthRequestBody(
         requestWith({ body: { resource: `https://evil.example.test/mcp/o/${ORG_A}` } }),
       ),
     ).toBeNull();
@@ -193,20 +278,25 @@ describe('carrying the org across the consent round-trip', () => {
   const COOKIE = 'better-auth.session_token=victim-session-token.signature';
   const OTHER_COOKIE = 'better-auth.session_token=attacker-session-token.signature';
   const originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
-  let recalls: string[];
+  let recalls: OrgScopeAssociationKeys[];
+  let remembered: Array<{ keys: OrgScopeAssociationKeys; orgId: string }>;
 
   const SECRET = 'test-secret-for-the-association-key-000000';
-  const keyOf = (cookie: string, challenge: string) =>
-    buildOrgScopeAssociationKey(SECRET, cookie, challenge);
+  const keysOf = (cookie: string | undefined, challenge: string | undefined) =>
+    buildOrgScopeAssociationKeys(SECRET, cookie, challenge);
 
   function fakeStore(recallValue: string | null = null, failing = false): OrgScopeStore {
     return {
-      keyFor: (cookieHeader, codeChallenge) =>
-        buildOrgScopeAssociationKey(SECRET, cookieHeader, codeChallenge),
-      remember: () => (failing ? Promise.reject(new Error('store down')) : Promise.resolve()),
-      recall: (key) => {
+      keysFor: (cookieHeader, codeChallenge) =>
+        buildOrgScopeAssociationKeys(SECRET, cookieHeader, codeChallenge),
+      remember: (keys, orgId) => {
         if (failing) return Promise.reject(new Error('store down'));
-        recalls.push(key);
+        remembered.push({ keys, orgId });
+        return Promise.resolve();
+      },
+      recall: (keys) => {
+        if (failing) return Promise.reject(new Error('store down'));
+        recalls.push(keys);
         return Promise.resolve(recallValue);
       },
     };
@@ -230,6 +320,7 @@ describe('carrying the org across the consent round-trip', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
     recalls = [];
+    remembered = [];
   });
   afterEach(() => {
     registerOrgScopeStore(null);
@@ -240,45 +331,81 @@ describe('carrying the org across the consent round-trip', () => {
   it('reads the code challenge from the authorize query, a body, and the replayed signed query', () => {
     expect(readCodeChallenge(request({ query: { code_challenge: CHALLENGE } }))).toBe(CHALLENGE);
     expect(readCodeChallenge(request({ body: { code_challenge: CHALLENGE } }))).toBe(CHALLENGE);
-    const oauthQuery = new URLSearchParams({ client_id: 'abc', code_challenge: CHALLENGE }).toString();
+    const oauthQuery = new URLSearchParams({
+      client_id: 'abc',
+      code_challenge: CHALLENGE,
+    }).toString();
     expect(readCodeChallenge(request({ body: { accept: true, oauth_query: oauthQuery } }))).toBe(
       CHALLENGE,
     );
     expect(readCodeChallenge(request({ body: { grant_type: 'refresh_token' } }))).toBeNull();
   });
 
-  it('derives an association key that differs per session for the same challenge', () => {
-    const victim = keyOf(COOKIE, CHALLENGE);
-    const attacker = keyOf(OTHER_COOKIE, CHALLENGE);
-    const otherSecret = buildOrgScopeAssociationKey('a-different-server-secret', COOKIE, CHALLENGE);
+  it('derives a session key that differs per session for the same challenge', () => {
+    const victim = keysOf(COOKIE, CHALLENGE).session;
+    const attacker = keysOf(OTHER_COOKIE, CHALLENGE).session;
+    const otherSecret = buildOrgScopeAssociationKeys(
+      'a-different-server-secret',
+      COOKIE,
+      CHALLENGE,
+    ).session;
     expect(otherSecret).not.toBe(victim);
     expect(victim).toBeTruthy();
     expect(attacker).toBeTruthy();
     expect(victim).not.toBe(attacker);
-    expect(victim).toBe(keyOf(COOKIE, CHALLENGE));
+    expect(victim).toBe(keysOf(COOKIE, CHALLENGE).session);
     expect(victim).not.toContain('victim-session-token');
   });
 
-  it('derives no association key without a session or a challenge', () => {
-    expect(buildOrgScopeAssociationKey(SECRET, undefined, CHALLENGE)).toBeNull();
-    expect(buildOrgScopeAssociationKey(SECRET, COOKIE, null)).toBeNull();
-    expect(buildOrgScopeAssociationKey(SECRET, 'unrelated=1', CHALLENGE)).toBeNull();
-    expect(buildOrgScopeAssociationKey('', COOKIE, CHALLENGE)).toBeNull();
+  it('derives a challenge key with no session, and no key at all without a challenge', () => {
+    const anonymous = keysOf(undefined, CHALLENGE);
+    expect(anonymous.session).toBeNull();
+    expect(anonymous.challenge).toBeTruthy();
+    expect(anonymous.challenge).toBe(keysOf(COOKIE, CHALLENGE).challenge);
+    expect(anonymous.challenge).not.toContain(CHALLENGE);
+    expect(keysOf(COOKIE, undefined)).toEqual({ session: null, challenge: null });
+    expect(buildOrgScopeAssociationKeys('', COOKIE, CHALLENGE)).toEqual({
+      session: null,
+      challenge: null,
+    });
   });
 
-  it('passes the resource and the association key through on authorize', async () => {
+  it('writes the association on the authorize leg, which is the only one carrying the org', async () => {
     registerOrgScopeStore(fakeStore());
     const resource = `https://mcp.example.test/mcp/o/${ORG_A}`;
     const scope = await resolveMcpOrgScope(
       request({ query: { resource, code_challenge: CHALLENGE }, cookie: COOKIE }),
     );
     expect(scope.resource).toBe(resource);
-    expect(scope.associationKey).toBe(keyOf(COOKIE, CHALLENGE));
+    expect(remembered).toEqual([{ keys: keysOf(COOKIE, CHALLENGE), orgId: ORG_A }]);
+  });
+
+  it('writes the association for an authorize that only carries the marker scope', async () => {
+    registerOrgScopeStore(fakeStore());
+    const scope = await resolveMcpOrgScope(
+      request({
+        query: { scope: `offline_access mcp:org:${ORG_A}`, code_challenge: CHALLENGE },
+        cookie: COOKIE,
+      }),
+    );
+    expect(scope.resource).toBe(`https://mcp.example.test/mcp/o/${ORG_A}`);
+    expect(remembered).toEqual([{ keys: keysOf(COOKIE, CHALLENGE), orgId: ORG_A }]);
+  });
+
+  it('writes the association before the caller has signed in', async () => {
+    registerOrgScopeStore(fakeStore());
+    await resolveMcpOrgScope(
+      request({ query: { scope: `mcp:org:${ORG_A}`, code_challenge: CHALLENGE } }),
+    );
+    expect(remembered).toEqual([{ keys: keysOf(undefined, CHALLENGE), orgId: ORG_A }]);
   });
 
   it('recovers the org on the consent post, where better-auth has dropped the resource', async () => {
     registerOrgScopeStore(fakeStore(ORG_A));
-    const oauthQuery = new URLSearchParams({ client_id: 'abc', code_challenge: CHALLENGE }).toString();
+    const oauthQuery = new URLSearchParams({
+      client_id: 'abc',
+      code_challenge: CHALLENGE,
+    }).toString();
     const scope = await resolveMcpOrgScope(
       request({
         url: '/auth/oauth2/consent',
@@ -287,17 +414,21 @@ describe('carrying the org across the consent round-trip', () => {
       }),
     );
     expect(scope.resource).toBe(`https://mcp.example.test/mcp/o/${ORG_A}`);
-    expect(recalls).toEqual([keyOf(COOKIE, CHALLENGE)]);
+    expect(recalls).toEqual([keysOf(COOKIE, CHALLENGE)]);
   });
 
-  it('looks under a different key for a different session, so one session cannot claim another\'s association', async () => {
+  it("looks under this session's key first, so one session cannot claim another's association", async () => {
     registerOrgScopeStore(fakeStore(ORG_A));
     const oauthQuery = new URLSearchParams({ code_challenge: CHALLENGE }).toString();
     await resolveMcpOrgScope(
-      request({ url: '/auth/oauth2/consent', body: { oauth_query: oauthQuery }, cookie: OTHER_COOKIE }),
+      request({
+        url: '/auth/oauth2/consent',
+        body: { oauth_query: oauthQuery },
+        cookie: OTHER_COOKIE,
+      }),
     );
-    expect(recalls).toEqual([keyOf(OTHER_COOKIE, CHALLENGE)]);
-    expect(recalls[0]).not.toBe(keyOf(COOKIE, CHALLENGE));
+    expect(recalls).toEqual([keysOf(OTHER_COOKIE, CHALLENGE)]);
+    expect(recalls[0]!.session).not.toBe(keysOf(COOKIE, CHALLENGE).session);
   });
 
   it('resolves no org when the association is missing', async () => {
@@ -309,11 +440,10 @@ describe('carrying the org across the consent round-trip', () => {
     expect(scope.resource).toBeNull();
   });
 
-  it('resolves no org without a session, so an unauthenticated caller cannot probe associations', async () => {
+  it('resolves no org for a request that carries no challenge to look one up by', async () => {
     registerOrgScopeStore(fakeStore(ORG_A));
-    const oauthQuery = new URLSearchParams({ code_challenge: CHALLENGE }).toString();
     const scope = await resolveMcpOrgScope(
-      request({ url: '/auth/oauth2/consent', body: { oauth_query: oauthQuery } }),
+      request({ url: '/auth/oauth2/token', body: { grant_type: 'refresh_token' }, cookie: COOKIE }),
     );
     expect(scope.resource).toBeNull();
     expect(recalls).toEqual([]);
@@ -326,7 +456,17 @@ describe('carrying the org across the consent round-trip', () => {
       resolveMcpOrgScope(
         request({ url: '/auth/oauth2/consent', body: { oauth_query: oauthQuery }, cookie: COOKIE }),
       ),
-    ).resolves.toEqual({ resource: null, associationKey: keyOf(COOKIE, CHALLENGE) });
+    ).resolves.toEqual({ resource: null });
+  });
+
+  it('still resolves the requested org when the association cannot be written', async () => {
+    registerOrgScopeStore(fakeStore(null, true));
+    const resource = `https://mcp.example.test/mcp/o/${ORG_A}`;
+    await expect(
+      resolveMcpOrgScope(
+        request({ query: { resource, code_challenge: CHALLENGE }, cookie: COOKIE }),
+      ),
+    ).resolves.toEqual({ resource });
   });
 
   it('ignores a non-org-scoped resource', async () => {

--- a/packages/backend-core/src/auth-controller-factory.ts
+++ b/packages/backend-core/src/auth-controller-factory.ts
@@ -3,10 +3,11 @@ import {
   type McpOrgScopeInput,
   orgScopedMcpResourceUrl,
   parseOrgScopedMcpResource,
+  splitOrgScopeMarker,
   withOrgScopedMcpResource,
 } from '@getmunin/core';
 import { mcpResourceUrl } from './oauth/oauth.constants.ts';
-import { orgScopeStore } from './auth/org-scope-store.ts';
+import { hasOrgScopeAssociationKey, orgScopeStore } from './auth/org-scope-store.ts';
 
 interface BetterAuthLike {
   handler: (req: globalThis.Request) => Promise<globalThis.Response>;
@@ -23,29 +24,55 @@ export async function handleAuthRequest(
   res: ExpressResponse,
 ): Promise<void> {
   await withOrgScopedMcpResource(await resolveMcpOrgScope(req), async () => {
-    const fetchRequest = expressRequestToFetch(req, narrowOrgScopedResourceBody(req));
+    const fetchRequest = expressRequestToFetch(
+      req,
+      narrowAuthRequestBody(req),
+      narrowOrgMarkerQuery(req),
+    );
     const fetchResponse = await auth.handler(fetchRequest);
     await pipeFetchResponseToExpress(fetchResponse, res);
   });
 }
 
 export async function resolveMcpOrgScope(req: ExpressRequest): Promise<McpOrgScopeInput> {
-  const requested = readRequestedResource(req);
-  const orgFromResource = requested ? parseOrgScopedMcpResource(requested) : null;
   const store = orgScopeStore();
-  const associationKey = store?.keyFor(req.headers?.['cookie'], readCodeChallenge(req)) ?? null;
+  const keys = store?.keysFor(req.headers?.['cookie'], readCodeChallenge(req)) ?? null;
+  const requestedOrgId = readRequestedOrgId(req);
 
-  if (orgFromResource) return { resource: requested, associationKey };
+  if (requestedOrgId) {
+    if (store && hasOrgScopeAssociationKey(keys)) {
+      try {
+        await store.remember(keys!, requestedOrgId);
+      } catch (err) {
+        console.warn('[auth] could not carry the requested org across the consent step', { err });
+      }
+    }
+    return { resource: orgScopedMcpResourceUrl(requestedOrgId) };
+  }
 
-  if (store && associationKey) {
+  if (store && hasOrgScopeAssociationKey(keys)) {
     try {
-      const orgId = await store.recall(associationKey);
-      if (orgId) return { resource: orgScopedMcpResourceUrl(orgId), associationKey };
+      const orgId = await store.recall(keys!);
+      if (orgId) return { resource: orgScopedMcpResourceUrl(orgId) };
     } catch (err) {
       console.warn('[auth] could not recall the org this authorization was started for', { err });
     }
   }
-  return { resource: null, associationKey };
+  return { resource: null };
+}
+
+export function readRequestedOrgId(req: ExpressRequest): string | null {
+  const requested = readRequestedResource(req);
+  const fromResource = requested ? parseOrgScopedMcpResource(requested) : null;
+  if (fromResource) return fromResource;
+  const scope = readRequestedScope(req);
+  return scope ? splitOrgScopeMarker(scope).orgId : null;
+}
+
+export function readRequestedScope(req: ExpressRequest): string | null {
+  const fromQuery = firstString(req.query?.['scope']);
+  if (fromQuery) return fromQuery;
+  return firstString(readObjectBody(req)?.['scope']);
 }
 
 export function readCodeChallenge(req: ExpressRequest): string | null {
@@ -58,7 +85,6 @@ export function readCodeChallenge(req: ExpressRequest): string | null {
   if (oauthQuery) return new URLSearchParams(oauthQuery).get('code_challenge');
   return null;
 }
-
 
 export function readRequestedResource(req: ExpressRequest): string | null {
   const fromQuery = firstString(req.query?.['resource']);
@@ -74,22 +100,59 @@ export function readRequestedResource(req: ExpressRequest): string | null {
   return null;
 }
 
-export function narrowOrgScopedResourceBody(req: ExpressRequest): BodyOverride | null {
+export function narrowAuthRequestBody(req: ExpressRequest): BodyOverride | null {
   const body = readObjectBody(req);
-  const resource = firstString(body?.['resource']);
-  if (!body || !resource || !parseOrgScopedMcpResource(resource)) return null;
+  if (!body) return null;
+
+  const resource = firstString(body['resource']);
+  const narrowedResource =
+    resource && parseOrgScopedMcpResource(resource) ? mcpResourceUrl() : null;
+  const scope = firstString(body['scope']);
+  const split = scope ? splitOrgScopeMarker(scope) : null;
+  const narrowedScope = split?.orgId ? split.scopes : null;
+  if (!narrowedResource && narrowedScope === null) return null;
 
   const contentType = req.headers['content-type']?.toString() ?? '';
   const rawBody = (req as ExpressRequest & { rawBody?: Buffer }).rawBody;
   if (contentType.includes('application/x-www-form-urlencoded') && rawBody?.length) {
     const params = new URLSearchParams(rawBody.toString('utf8'));
-    params.set('resource', mcpResourceUrl());
+    if (narrowedResource) params.set('resource', narrowedResource);
+    if (narrowedScope !== null) {
+      if (narrowedScope) params.set('scope', narrowedScope);
+      else params.delete('scope');
+    }
     return { contentType: 'application/x-www-form-urlencoded', body: params.toString() };
   }
-  return {
-    contentType: 'application/json',
-    body: JSON.stringify({ ...body, resource: mcpResourceUrl() }),
-  };
+
+  const narrowed: Record<string, unknown> = { ...body };
+  if (narrowedResource) narrowed['resource'] = narrowedResource;
+  if (narrowedScope !== null) {
+    if (narrowedScope) narrowed['scope'] = narrowedScope;
+    else delete narrowed['scope'];
+  }
+  return { contentType: 'application/json', body: JSON.stringify(narrowed) };
+}
+
+export function narrowOrgMarkerQuery(req: ExpressRequest): string | null {
+  const scope = firstString(req.query?.['scope']);
+  if (!scope) return null;
+  const { orgId, scopes } = splitOrgScopeMarker(scope);
+  if (!orgId) return null;
+  const params = new URLSearchParams(queryStringOf(req));
+  if (scopes) params.set('scope', scopes);
+  else params.delete('scope');
+  return params.toString();
+}
+
+function queryStringOf(req: ExpressRequest): string {
+  const raw = req.originalUrl ?? req.url ?? '';
+  const at = raw.indexOf('?');
+  return at < 0 ? '' : raw.slice(at + 1);
+}
+
+function pathOf(url: string): string {
+  const at = url.indexOf('?');
+  return at < 0 ? url : url.slice(0, at);
 }
 
 function readObjectBody(req: ExpressRequest): Record<string, unknown> | null {
@@ -146,10 +209,15 @@ function isPlaceholderSecret(secret: string): boolean {
 function expressRequestToFetch(
   req: ExpressRequest,
   bodyOverride: BodyOverride | null = null,
+  queryOverride: string | null = null,
 ): globalThis.Request {
   const protocol = req.headers['x-forwarded-proto']?.toString() ?? req.protocol;
   const host = req.headers['x-forwarded-host']?.toString() ?? req.get('host');
-  const url = `${protocol}://${host}${req.originalUrl}`;
+  const path =
+    queryOverride === null
+      ? req.originalUrl
+      : `${pathOf(req.originalUrl)}${queryOverride ? `?${queryOverride}` : ''}`;
+  const url = `${protocol}://${host}${path}`;
   const headers = new Headers();
   for (const [name, value] of Object.entries(req.headers)) {
     if (Array.isArray(value)) value.forEach((v) => headers.append(name, v));

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -17,7 +17,7 @@ import {
   type McpSurface,
 } from '../oauth/mcp-surface.ts';
 import { authCookiePrefix } from './auth-cookies.ts';
-import { createDbOrgScopeStore, orgScopeStore, registerOrgScopeStore } from './org-scope-store.ts';
+import { createDbOrgScopeStore, registerOrgScopeStore } from './org-scope-store.ts';
 import { stripTrailingSlashes } from '@getmunin/types';
 
 type BetterAuthInstance = ReturnType<typeof betterAuth>;
@@ -121,14 +121,6 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
         error: 'access_denied',
         error_description: 'signed-in user is not a member of the requested organization',
       });
-    }
-    const store = orgScopeStore();
-    if (store && orgScoped.associationKey) {
-      try {
-        await store.remember(orgScoped.associationKey, membership.orgId);
-      } catch (err) {
-        console.warn('[auth] could not carry the requested org across the consent step', { err });
-      }
     }
     return membership.orgId;
   };

--- a/packages/backend-core/src/auth/org-scope-store.integration.test.ts
+++ b/packages/backend-core/src/auth/org-scope-store.integration.test.ts
@@ -1,7 +1,11 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { and, like, eq } from 'drizzle-orm';
-import { createDbOrgScopeStore, type OrgScopeStore } from './org-scope-store.ts';
+import {
+  createDbOrgScopeStore,
+  type OrgScopeAssociationKeys,
+  type OrgScopeStore,
+} from './org-scope-store.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
@@ -14,6 +18,11 @@ const skipReason = TEST_URL
   let db: ReturnType<typeof createDb>;
   let store: OrgScopeStore;
 
+  const keys = (session: string | null, challenge: string | null): OrgScopeAssociationKeys => ({
+    session,
+    challenge,
+  });
+
   beforeAll(async () => {
     await runMigrations(TEST_URL!);
     db = createDb(TEST_URL!);
@@ -21,34 +30,54 @@ const skipReason = TEST_URL
   });
 
   afterAll(async () => {
-    await db.delete(schema.verifications).where(like(schema.verifications.identifier, 'mcp-org-scope:%'));
+    await db
+      .delete(schema.verifications)
+      .where(like(schema.verifications.identifier, 'mcp-org-scope:%'));
   });
 
-  it('recalls the org it remembered for a code challenge', async () => {
-    await store.remember('challenge-one', ORG_A);
-    await expect(store.recall('challenge-one')).resolves.toBe(ORG_A);
+  it('recalls the org it remembered for a session', async () => {
+    await store.remember(keys('session-one', 'challenge-one'), ORG_A);
+    await expect(store.recall(keys('session-one', 'challenge-one'))).resolves.toBe(ORG_A);
+  });
+
+  it('recalls an association written before the browser had a session', async () => {
+    await store.remember(keys(null, 'challenge-anonymous'), ORG_A);
+    await expect(store.recall(keys('session-new', 'challenge-anonymous'))).resolves.toBe(ORG_A);
   });
 
   it('keeps separate challenges on separate orgs', async () => {
-    await store.remember('challenge-a', ORG_A);
-    await store.remember('challenge-b', ORG_B);
-    await expect(store.recall('challenge-a')).resolves.toBe(ORG_A);
-    await expect(store.recall('challenge-b')).resolves.toBe(ORG_B);
+    await store.remember(keys('session-a', 'challenge-a'), ORG_A);
+    await store.remember(keys('session-b', 'challenge-b'), ORG_B);
+    await expect(store.recall(keys('session-a', 'challenge-a'))).resolves.toBe(ORG_A);
+    await expect(store.recall(keys('session-b', 'challenge-b'))).resolves.toBe(ORG_B);
   });
 
-  it('replaces the org when the same challenge is reused', async () => {
-    await store.remember('challenge-reused', ORG_A);
-    await store.remember('challenge-reused', ORG_B);
-    await expect(store.recall('challenge-reused')).resolves.toBe(ORG_B);
+  it('replaces the org when the same session reuses a challenge', async () => {
+    await store.remember(keys('session-reused', 'challenge-reused'), ORG_A);
+    await store.remember(keys('session-reused', 'challenge-reused'), ORG_B);
+    await expect(store.recall(keys('session-reused', null))).resolves.toBe(ORG_B);
     const rows = await db
       .select({ id: schema.verifications.id })
       .from(schema.verifications)
-      .where(eq(schema.verifications.identifier, 'mcp-org-scope:challenge-reused'));
+      .where(eq(schema.verifications.identifier, 'mcp-org-scope:session-reused'));
     expect(rows).toHaveLength(1);
   });
 
+  it('will not let a later request repoint a challenge another request already claimed', async () => {
+    await store.remember(keys('session-first', 'challenge-contested'), ORG_A);
+    await store.remember(keys('session-second', 'challenge-contested'), ORG_B);
+    await expect(store.recall(keys(null, 'challenge-contested'))).resolves.toBe(ORG_A);
+  });
+
+  it('prefers the association the recalling session started', async () => {
+    await store.remember(keys(null, 'challenge-both'), ORG_B);
+    await store.remember(keys('session-both', 'challenge-both'), ORG_A);
+    await expect(store.recall(keys('session-both', 'challenge-both'))).resolves.toBe(ORG_A);
+    await expect(store.recall(keys('session-unrelated', 'challenge-both'))).resolves.toBe(ORG_B);
+  });
+
   it('recalls nothing for an unknown challenge', async () => {
-    await expect(store.recall('never-seen')).resolves.toBeNull();
+    await expect(store.recall(keys('never-seen', 'never-seen-either'))).resolves.toBeNull();
   });
 
   it('recalls nothing once the association has expired', async () => {
@@ -57,7 +86,7 @@ const skipReason = TEST_URL
       value: ORG_A,
       expiresAt: new Date(Date.now() - 1000),
     });
-    await expect(store.recall('challenge-expired')).resolves.toBeNull();
+    await expect(store.recall(keys(null, 'challenge-expired'))).resolves.toBeNull();
   });
 
   it('sweeps expired associations when remembering a new one', async () => {
@@ -66,7 +95,7 @@ const skipReason = TEST_URL
       value: ORG_A,
       expiresAt: new Date(Date.now() - 1000),
     });
-    await store.remember('challenge-fresh', ORG_B);
+    await store.remember(keys('session-fresh', 'challenge-fresh'), ORG_B);
     const stale = await db
       .select({ id: schema.verifications.id })
       .from(schema.verifications)
@@ -75,17 +104,27 @@ const skipReason = TEST_URL
   });
 
   it('refuses to store a value that is not an org id', async () => {
-    await store.remember('challenge-bogus', 'not-an-org');
-    await expect(store.recall('challenge-bogus')).resolves.toBeNull();
+    await store.remember(keys('session-bogus', 'challenge-bogus'), 'not-an-org');
+    await expect(store.recall(keys('session-bogus', 'challenge-bogus'))).resolves.toBeNull();
     const rows = await db
       .select({ id: schema.verifications.id })
       .from(schema.verifications)
       .where(
         and(
           like(schema.verifications.identifier, 'mcp-org-scope:%'),
-          eq(schema.verifications.identifier, 'mcp-org-scope:challenge-bogus'),
+          eq(schema.verifications.identifier, 'mcp-org-scope:session-bogus'),
         ),
       );
     expect(rows).toHaveLength(0);
+  });
+
+  it('derives no keys without a challenge, and a session key only with a session cookie', () => {
+    const secret = 'integration-test-secret-00000000000000';
+    const cookie = 'better-auth.session_token=abc.signature';
+    const derived = createDbOrgScopeStore(db, secret);
+    expect(derived.keysFor(cookie, undefined)).toEqual({ session: null, challenge: null });
+    expect(derived.keysFor(undefined, 'a-challenge').session).toBeNull();
+    expect(derived.keysFor(undefined, 'a-challenge').challenge).toBeTruthy();
+    expect(derived.keysFor(cookie, 'a-challenge').session).toBeTruthy();
   });
 });

--- a/packages/backend-core/src/auth/org-scope-store.ts
+++ b/packages/backend-core/src/auth/org-scope-store.ts
@@ -7,23 +7,36 @@ import { readSessionCookie } from './auth-cookies.ts';
 const IDENTIFIER_PREFIX = 'mcp-org-scope:';
 const TTL_MS = 600_000;
 
-export interface OrgScopeStore {
-  keyFor(cookieHeader: string | undefined, codeChallenge: string | null | undefined): string | null;
-  remember(associationKey: string, orgId: string): Promise<void>;
-  recall(associationKey: string): Promise<string | null>;
+export interface OrgScopeAssociationKeys {
+  session: string | null;
+  challenge: string | null;
 }
 
-export function buildOrgScopeAssociationKey(
+export interface OrgScopeStore {
+  keysFor(
+    cookieHeader: string | undefined,
+    codeChallenge: string | null | undefined,
+  ): OrgScopeAssociationKeys;
+  remember(keys: OrgScopeAssociationKeys, orgId: string): Promise<void>;
+  recall(keys: OrgScopeAssociationKeys): Promise<string | null>;
+}
+
+export function buildOrgScopeAssociationKeys(
   secret: string,
   cookieHeader: string | undefined,
   codeChallenge: string | null | undefined,
-): string | null {
-  if (!secret || !codeChallenge?.trim()) return null;
+): OrgScopeAssociationKeys {
+  const challenge = codeChallenge?.trim();
+  if (!secret || !challenge) return { session: null, challenge: null };
   const sessionToken = readSessionCookie(cookieHeader);
-  if (!sessionToken) return null;
-  return createHmac('sha256', secret)
-    .update(`${sessionToken}:${codeChallenge.trim()}`)
-    .digest('base64url');
+  return {
+    session: sessionToken ? digest(secret, `session:${sessionToken}:${challenge}`) : null,
+    challenge: digest(secret, `challenge:${challenge}`),
+  };
+}
+
+export function hasOrgScopeAssociationKey(keys: OrgScopeAssociationKeys | null): boolean {
+  return Boolean(keys && (keys.session || keys.challenge));
 }
 
 let registered: OrgScopeStore | null = null;
@@ -37,14 +50,26 @@ export function orgScopeStore(): OrgScopeStore | null {
 }
 
 export function createDbOrgScopeStore(db: Db, secret: string): OrgScopeStore {
+  async function readOne(associationKey: string): Promise<string | null> {
+    const identifier = identifierFor(associationKey);
+    if (!identifier) return null;
+    const rows = await db
+      .select({ value: schema.verifications.value, expiresAt: schema.verifications.expiresAt })
+      .from(schema.verifications)
+      .where(eq(schema.verifications.identifier, identifier))
+      .limit(1);
+    const row = rows[0];
+    if (!row || row.expiresAt < new Date()) return null;
+    return isOrgId(row.value) ? row.value : null;
+  }
+
   return {
-    keyFor(cookieHeader, codeChallenge) {
-      return buildOrgScopeAssociationKey(secret, cookieHeader, codeChallenge);
+    keysFor(cookieHeader, codeChallenge) {
+      return buildOrgScopeAssociationKeys(secret, cookieHeader, codeChallenge);
     },
 
-    async remember(associationKey: string, orgId: string): Promise<void> {
-      const identifier = identifierFor(associationKey);
-      if (!identifier || !isOrgId(orgId)) return;
+    async remember(keys: OrgScopeAssociationKeys, orgId: string): Promise<void> {
+      if (!isOrgId(orgId) || !hasOrgScopeAssociationKey(keys)) return;
       await db
         .delete(schema.verifications)
         .where(
@@ -53,27 +78,44 @@ export function createDbOrgScopeStore(db: Db, secret: string): OrgScopeStore {
             lt(schema.verifications.expiresAt, new Date()),
           ),
         );
-      await db.delete(schema.verifications).where(eq(schema.verifications.identifier, identifier));
-      await db.insert(schema.verifications).values({
-        identifier,
-        value: orgId,
-        expiresAt: new Date(Date.now() + TTL_MS),
-      });
+
+      const sessionIdentifier = keys.session ? identifierFor(keys.session) : null;
+      if (sessionIdentifier) {
+        await db
+          .delete(schema.verifications)
+          .where(eq(schema.verifications.identifier, sessionIdentifier));
+        await db.insert(schema.verifications).values({
+          identifier: sessionIdentifier,
+          value: orgId,
+          expiresAt: new Date(Date.now() + TTL_MS),
+        });
+      }
+
+      const challengeIdentifier = keys.challenge ? identifierFor(keys.challenge) : null;
+      if (challengeIdentifier && !(await readOne(keys.challenge!))) {
+        await db
+          .delete(schema.verifications)
+          .where(eq(schema.verifications.identifier, challengeIdentifier));
+        await db.insert(schema.verifications).values({
+          identifier: challengeIdentifier,
+          value: orgId,
+          expiresAt: new Date(Date.now() + TTL_MS),
+        });
+      }
     },
 
-    async recall(associationKey: string): Promise<string | null> {
-      const identifier = identifierFor(associationKey);
-      if (!identifier) return null;
-      const rows = await db
-        .select({ value: schema.verifications.value, expiresAt: schema.verifications.expiresAt })
-        .from(schema.verifications)
-        .where(eq(schema.verifications.identifier, identifier))
-        .limit(1);
-      const row = rows[0];
-      if (!row || row.expiresAt < new Date()) return null;
-      return isOrgId(row.value) ? row.value : null;
+    async recall(keys: OrgScopeAssociationKeys): Promise<string | null> {
+      if (keys.session) {
+        const fromSession = await readOne(keys.session);
+        if (fromSession) return fromSession;
+      }
+      return keys.challenge ? await readOne(keys.challenge) : null;
     },
   };
+}
+
+function digest(secret: string, material: string): string {
+  return createHmac('sha256', secret).update(material).digest('base64url');
 }
 
 function identifierFor(associationKey: string): string | null {

--- a/packages/backend-core/src/oauth/oauth-pending-org.controller.test.ts
+++ b/packages/backend-core/src/oauth/oauth-pending-org.controller.test.ts
@@ -3,23 +3,33 @@ import { ForbiddenException } from '@nestjs/common';
 import { ActorIdentity, withContext } from '@getmunin/core';
 import { OAuthPendingOrgController } from './oauth-pending-org.controller.ts';
 import {
-  buildOrgScopeAssociationKey,
+  buildOrgScopeAssociationKeys,
   registerOrgScopeStore,
+  type OrgScopeAssociationKeys,
   type OrgScopeStore,
 } from '../auth/org-scope-store.ts';
 
 const ORG_A = 'org_aaaaaaaaaaaaaaaaaaaaaa';
+const ORG_B = 'org_bbbbbbbbbbbbbbbbbbbbbb';
 const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 const SECRET = 'pending-org-controller-secret-0000000000';
 const COOKIE = 'better-auth.session_token=owner-session.signature';
 const OTHER_COOKIE = 'better-auth.session_token=other-session.signature';
 
+const keysOf = (cookie: string | undefined, challenge: string | undefined) =>
+  buildOrgScopeAssociationKeys(SECRET, cookie, challenge);
+
 function storeHolding(associations: Record<string, string>): OrgScopeStore {
   return {
-    keyFor: (cookieHeader, codeChallenge) =>
-      buildOrgScopeAssociationKey(SECRET, cookieHeader, codeChallenge),
+    keysFor: (cookieHeader, codeChallenge) =>
+      buildOrgScopeAssociationKeys(SECRET, cookieHeader, codeChallenge),
     remember: () => Promise.resolve(),
-    recall: (key) => Promise.resolve(associations[key] ?? null),
+    recall: (keys: OrgScopeAssociationKeys) =>
+      Promise.resolve(
+        (keys.session ? associations[keys.session] : undefined) ??
+          (keys.challenge ? associations[keys.challenge] : undefined) ??
+          null,
+      ),
   };
 }
 
@@ -28,15 +38,23 @@ function requestWith(cookie?: string) {
 }
 
 function asUser<T>(fn: () => Promise<T>): Promise<T> {
-  const actor = new ActorIdentity('user', 'usr_1', ORG_A, ['*'], ['admin'], undefined, undefined, undefined, 'usr_1');
+  const actor = new ActorIdentity(
+    'user',
+    'usr_1',
+    ORG_A,
+    ['*'],
+    ['admin'],
+    undefined,
+    undefined,
+    undefined,
+    'usr_1',
+  );
   return withContext({ db: {} as never, actor, correlationId: 'test' }, fn);
 }
 
 describe('OAuthPendingOrgController', () => {
   beforeEach(() => {
-    registerOrgScopeStore(
-      storeHolding({ [buildOrgScopeAssociationKey(SECRET, COOKIE, CHALLENGE)!]: ORG_A }),
-    );
+    registerOrgScopeStore(storeHolding({ [keysOf(COOKIE, CHALLENGE).session!]: ORG_A }));
   });
   afterEach(() => registerOrgScopeStore(null));
 
@@ -47,6 +65,14 @@ describe('OAuthPendingOrgController', () => {
     expect(result).toEqual({ pinned: true, orgId: ORG_A });
   });
 
+  it('reports an association written before the caller signed in', async () => {
+    registerOrgScopeStore(storeHolding({ [keysOf(undefined, CHALLENGE).challenge!]: ORG_B }));
+    const result = await asUser(() =>
+      new OAuthPendingOrgController().pending(requestWith(COOKIE), CHALLENGE),
+    );
+    expect(result).toEqual({ pinned: true, orgId: ORG_B });
+  });
+
   it('reports nothing pinned for an authorization that named no org', async () => {
     const result = await asUser(() =>
       new OAuthPendingOrgController().pending(requestWith(COOKIE), 'a-different-challenge'),
@@ -54,17 +80,22 @@ describe('OAuthPendingOrgController', () => {
     expect(result).toEqual({ pinned: false });
   });
 
-  it('does not reveal another session\'s pending org', async () => {
-    const result = await asUser(() =>
-      new OAuthPendingOrgController().pending(requestWith(OTHER_COOKIE), CHALLENGE),
+  it('prefers the association this session started over one keyed on the challenge alone', async () => {
+    registerOrgScopeStore(
+      storeHolding({
+        [keysOf(COOKIE, CHALLENGE).session!]: ORG_A,
+        [keysOf(undefined, CHALLENGE).challenge!]: ORG_B,
+      }),
     );
-    expect(result).toEqual({ pinned: false });
+    await expect(
+      asUser(() => new OAuthPendingOrgController().pending(requestWith(COOKIE), CHALLENGE)),
+    ).resolves.toEqual({ pinned: true, orgId: ORG_A });
+    await expect(
+      asUser(() => new OAuthPendingOrgController().pending(requestWith(OTHER_COOKIE), CHALLENGE)),
+    ).resolves.toEqual({ pinned: true, orgId: ORG_B });
   });
 
-  it('reports nothing pinned without a session cookie or a challenge', async () => {
-    await expect(
-      asUser(() => new OAuthPendingOrgController().pending(requestWith(), CHALLENGE)),
-    ).resolves.toEqual({ pinned: false });
+  it('reports nothing pinned without a challenge', async () => {
     await expect(
       asUser(() => new OAuthPendingOrgController().pending(requestWith(COOKIE), undefined)),
     ).resolves.toEqual({ pinned: false });

--- a/packages/backend-core/src/oauth/oauth-pending-org.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-pending-org.controller.ts
@@ -12,7 +12,7 @@ import { getCurrentContext } from '@getmunin/core';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
 import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
-import { orgScopeStore } from '../auth/org-scope-store.ts';
+import { hasOrgScopeAssociationKey, orgScopeStore } from '../auth/org-scope-store.ts';
 
 export interface PendingAuthorizationOrgDto {
   pinned: boolean;
@@ -42,13 +42,13 @@ export class OAuthPendingOrgController {
     if (!store || !codeChallenge) return { pinned: false };
 
     const cookieHeader = req.headers['cookie'];
-    const key = store.keyFor(
+    const keys = store.keysFor(
       Array.isArray(cookieHeader) ? cookieHeader[0] : cookieHeader,
       codeChallenge,
     );
-    if (!key) return { pinned: false };
+    if (!hasOrgScopeAssociationKey(keys)) return { pinned: false };
 
-    const orgId = await store.recall(key);
+    const orgId = await store.recall(keys);
     return orgId ? { pinned: true, orgId } : { pinned: false };
   }
 }

--- a/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.test.ts
@@ -98,9 +98,9 @@ describe('OAuthResourceController with registered MCP surfaces', () => {
   });
 
   it('serves a metadata document for the surface path', () => {
-    const meta = new OAuthResourceController(surfaces).surfaceMetadata(requestFor(
-      '/.well-known/oauth-protected-resource/mcp/addon',
-    ));
+    const meta = new OAuthResourceController(surfaces).surfaceMetadata(
+      requestFor('/.well-known/oauth-protected-resource/mcp/addon'),
+    );
     expect(meta.resource).toBe('https://mcp.example.test/mcp/addon');
     expect(meta.resource_name).toBe('Addon');
     expect(meta.scopes_supported).toEqual(['offline_access', 'addon:write']);
@@ -108,9 +108,9 @@ describe('OAuthResourceController with registered MCP surfaces', () => {
   });
 
   it('serves the same document for paths below the surface', () => {
-    const meta = new OAuthResourceController(surfaces).surfaceMetadata(requestFor(
-      '/.well-known/oauth-protected-resource/mcp/addon/session/1',
-    ));
+    const meta = new OAuthResourceController(surfaces).surfaceMetadata(
+      requestFor('/.well-known/oauth-protected-resource/mcp/addon/session/1'),
+    );
     expect(meta.resource).toBe('https://mcp.example.test/mcp/addon');
   });
 
@@ -165,18 +165,27 @@ describe('OAuthResourceController org-scoped metadata', () => {
   });
 
   it('advertises the org-scoped path as its own resource identifier', () => {
-    const meta = new OAuthResourceController().surfaceMetadata(requestFor(
-      `/.well-known/oauth-protected-resource/mcp/o/${ORG_A}`,
-    ));
+    const meta = new OAuthResourceController().surfaceMetadata(
+      requestFor(`/.well-known/oauth-protected-resource/mcp/o/${ORG_A}`),
+    );
     expect(meta.resource).toBe(`https://mcp.example.test/mcp/o/${ORG_A}`);
-    expect(meta.scopes_supported).toEqual(RESOURCE_ADVERTISED_SCOPES);
+    expect(meta.scopes_supported).toEqual([...RESOURCE_ADVERTISED_SCOPES, `mcp:org:${ORG_A}`]);
     expect(meta.authorization_servers).toEqual(['https://mcp.example.test']);
   });
 
+  it('advertises a marker scope so a client that ignores resource still names the org', () => {
+    const meta = new OAuthResourceController().surfaceMetadata(
+      requestFor(`/.well-known/oauth-protected-resource/mcp/o/${ORG_A}`),
+    );
+    expect(meta.scopes_supported).toContain(`mcp:org:${ORG_A}`);
+    const shared = new OAuthResourceController().metadata();
+    expect(shared.scopes_supported.some((s) => s.startsWith('mcp:org:'))).toBe(false);
+  });
+
   it('names no organization, so the document is not an org-existence oracle', () => {
-    const meta = new OAuthResourceController().surfaceMetadata(requestFor(
-      `/.well-known/oauth-protected-resource/mcp/o/${ORG_A}`,
-    ));
+    const meta = new OAuthResourceController().surfaceMetadata(
+      requestFor(`/.well-known/oauth-protected-resource/mcp/o/${ORG_A}`),
+    );
     expect(meta.resource_name).toBe('Munin');
     expect(JSON.stringify(meta)).not.toContain('org name');
   });

--- a/packages/backend-core/src/oauth/oauth-resource.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-resource.controller.ts
@@ -1,5 +1,9 @@
 import { Get, Header, Inject, NotFoundException, Optional, Req } from '@nestjs/common';
-import { orgScopedMcpResourceUrl, parseOrgScopedMcpPath } from '@getmunin/core';
+import {
+  orgScopeMarkerScope,
+  orgScopedMcpResourceUrl,
+  parseOrgScopedMcpPath,
+} from '@getmunin/core';
 import { PublicController } from '../common/auth/auth.guard.ts';
 import {
   authorizationServerUrl,
@@ -66,14 +70,15 @@ export class OAuthResourceController {
   @Header('cache-control', 'public, max-age=3600')
   surfaceMetadata(@Req() req: ResourceMetadataRequest): ProtectedResourceMetadata {
     const suffix = suffixOf(req);
-    const orgScopedResource = orgScopedResourceFor(suffix);
-    if (orgScopedResource) {
+    const orgId = parseOrgScopedMcpPath(suffix);
+    const orgScopedResource = orgId ? orgScopedMcpResourceUrl(orgId) : null;
+    if (orgId && orgScopedResource) {
       return {
         resource: orgScopedResource,
         resource_name: 'Munin',
         resource_logo_uri: `${mcpResourceOrigin()}/icon.png`,
         authorization_servers: [authorizationServerUrl()],
-        scopes_supported: RESOURCE_ADVERTISED_SCOPES,
+        scopes_supported: [...RESOURCE_ADVERTISED_SCOPES, orgScopeMarkerScope(orgId)!],
         bearer_methods_supported: ['header'],
         resource_documentation: `${authorizationServerUrl()}/docs`,
         resource_indicators_supported: true,
@@ -92,11 +97,6 @@ export class OAuthResourceController {
       resource_indicators_supported: true,
     };
   }
-}
-
-function orgScopedResourceFor(suffix: string): string | null {
-  const orgId = parseOrgScopedMcpPath(suffix);
-  return orgId ? orgScopedMcpResourceUrl(orgId) : null;
 }
 
 function suffixOf(req: ResourceMetadataRequest): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,14 +28,18 @@ export {
 } from './request/mcp-resources.ts';
 export {
   ORG_SCOPED_MCP_PREFIX,
+  ORG_SCOPE_MARKER_PREFIX,
   type McpOrgScopeInput,
   type OrgScopedMcpResource,
   currentOrgScopedMcpResource,
   isOrgId,
+  orgScopeMarkerScope,
   orgScopedMcpPath,
   orgScopedMcpResourceUrl,
+  parseOrgScopeMarkerScope,
   parseOrgScopedMcpPath,
   parseOrgScopedMcpResource,
+  splitOrgScopeMarker,
   withOrgScopedMcpResource,
 } from './request/mcp-org-scope.ts';
 

--- a/packages/core/src/request/mcp-org-scope.test.ts
+++ b/packages/core/src/request/mcp-org-scope.test.ts
@@ -2,10 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   currentOrgScopedMcpResource,
   isOrgId,
+  orgScopeMarkerScope,
   orgScopedMcpPath,
   orgScopedMcpResourceUrl,
+  parseOrgScopeMarkerScope,
   parseOrgScopedMcpPath,
   parseOrgScopedMcpResource,
+  splitOrgScopeMarker,
   withOrgScopedMcpResource,
 } from './mcp-org-scope.ts';
 
@@ -90,10 +93,13 @@ describe('org-scoped MCP request scope', () => {
   it('keeps concurrent requests on their own org', async () => {
     const seen: Array<string | undefined> = [];
     const run = (orgId: string, delayTicks: number) =>
-      withOrgScopedMcpResource({ resource: `https://mcp.example.test/mcp/o/${orgId}` }, async () => {
-        for (let i = 0; i < delayTicks; i += 1) await Promise.resolve();
-        seen.push(currentOrgScopedMcpResource()?.orgId);
-      });
+      withOrgScopedMcpResource(
+        { resource: `https://mcp.example.test/mcp/o/${orgId}` },
+        async () => {
+          for (let i = 0; i < delayTicks; i += 1) await Promise.resolve();
+          seen.push(currentOrgScopedMcpResource()?.orgId);
+        },
+      );
     await Promise.all([run(ORG_A, 3), run(ORG_B, 1)]);
     expect(seen.sort()).toEqual([ORG_A, ORG_B]);
   });
@@ -111,35 +117,36 @@ describe('org-scoped MCP request scope', () => {
   });
 });
 
-describe('org-scoped MCP scope carries the association key', () => {
-  let originalMcp: string | undefined;
-
-  beforeEach(() => {
-    originalMcp = process.env.NEXT_PUBLIC_MCP_URL;
-    process.env.NEXT_PUBLIC_MCP_URL = 'https://mcp.example.test';
+describe('org marker scope', () => {
+  it('names the org in a scope a client will echo back', () => {
+    expect(orgScopeMarkerScope(ORG_A)).toBe(`mcp:org:${ORG_A}`);
+    expect(parseOrgScopeMarkerScope(`mcp:org:${ORG_A}`)).toBe(ORG_A);
+    expect(parseOrgScopeMarkerScope(` mcp:org:${ORG_A} `)).toBe(ORG_A);
   });
 
-  afterEach(() => {
-    if (originalMcp === undefined) delete process.env.NEXT_PUBLIC_MCP_URL;
-    else process.env.NEXT_PUBLIC_MCP_URL = originalMcp;
+  it('refuses to mint or read a marker for anything but an org id', () => {
+    expect(orgScopeMarkerScope('not-an-org')).toBeNull();
+    expect(parseOrgScopeMarkerScope('mcp:org:not-an-org')).toBeNull();
+    expect(parseOrgScopeMarkerScope('kb:read')).toBeNull();
+    expect(parseOrgScopeMarkerScope('mcp:organization')).toBeNull();
   });
 
-  it('exposes the association key to whoever pins the org', () => {
-    withOrgScopedMcpResource(
-      { resource: `https://mcp.example.test/mcp/o/${ORG_A}`, associationKey: 'assoc-key' },
-      () => {
-        expect(currentOrgScopedMcpResource()).toEqual({
-          orgId: ORG_A,
-          resource: `https://mcp.example.test/mcp/o/${ORG_A}`,
-          associationKey: 'assoc-key',
-        });
-      },
-    );
+  it('splits the marker out of a requested scope list', () => {
+    expect(splitOrgScopeMarker(`offline_access mcp:org:${ORG_A} kb:read`)).toEqual({
+      orgId: ORG_A,
+      scopes: 'offline_access kb:read',
+    });
+    expect(splitOrgScopeMarker(`mcp:org:${ORG_A}`)).toEqual({ orgId: ORG_A, scopes: '' });
+    expect(splitOrgScopeMarker('offline_access  kb:read')).toEqual({
+      orgId: null,
+      scopes: 'offline_access kb:read',
+    });
   });
 
-  it('omits the association key when there is none', () => {
-    withOrgScopedMcpResource({ resource: `https://mcp.example.test/mcp/o/${ORG_A}` }, () => {
-      expect(currentOrgScopedMcpResource()?.associationKey).toBeUndefined();
+  it('takes the first marker and drops every malformed one, so none reaches the provider', () => {
+    expect(splitOrgScopeMarker(`mcp:org:${ORG_A} mcp:org:${ORG_B} mcp:org:bogus kb:read`)).toEqual({
+      orgId: ORG_A,
+      scopes: 'kb:read',
     });
   });
 });

--- a/packages/core/src/request/mcp-org-scope.ts
+++ b/packages/core/src/request/mcp-org-scope.ts
@@ -5,15 +5,15 @@ const ORG_ID_PATTERN = /^org_[0-9a-z]{22}$/;
 
 export const ORG_SCOPED_MCP_PREFIX = '/mcp/o/';
 
+export const ORG_SCOPE_MARKER_PREFIX = 'mcp:org:';
+
 export interface OrgScopedMcpResource {
   resource: string;
   orgId: string;
-  associationKey?: string;
 }
 
 export interface McpOrgScopeInput {
   resource?: string | null;
-  associationKey?: string | null;
 }
 
 export function isOrgId(value: string): boolean {
@@ -38,6 +38,29 @@ export function orgScopedMcpResourceUrl(orgId: string): string | null {
   return `${origin}${orgScopedMcpPath(orgId)}`;
 }
 
+export function orgScopeMarkerScope(orgId: string): string | null {
+  return isOrgId(orgId) ? `${ORG_SCOPE_MARKER_PREFIX}${orgId}` : null;
+}
+
+export function parseOrgScopeMarkerScope(scope: string): string | null {
+  const trimmed = scope.trim();
+  if (!trimmed.startsWith(ORG_SCOPE_MARKER_PREFIX)) return null;
+  const orgId = trimmed.slice(ORG_SCOPE_MARKER_PREFIX.length);
+  return isOrgId(orgId) ? orgId : null;
+}
+
+export function splitOrgScopeMarker(scopeValue: string): { orgId: string | null; scopes: string } {
+  const entries = scopeValue.split(/\s+/).filter(Boolean);
+  let orgId: string | null = null;
+  const kept: string[] = [];
+  for (const entry of entries) {
+    const marked = parseOrgScopeMarkerScope(entry);
+    if (marked) orgId ??= marked;
+    else if (!entry.startsWith(ORG_SCOPE_MARKER_PREFIX)) kept.push(entry);
+  }
+  return { orgId, scopes: kept.join(' ') };
+}
+
 export function parseOrgScopedMcpResource(resource: string): string | null {
   const origin = mcpOrigin();
   if (!origin) return null;
@@ -59,9 +82,7 @@ export function withOrgScopedMcpResource<T>(input: McpOrgScopeInput, fn: () => T
   if (!orgId) return fn();
   const resource = orgScopedMcpResourceUrl(orgId);
   if (!resource) return fn();
-  const scope: OrgScopedMcpResource = { resource, orgId };
-  if (input.associationKey) scope.associationKey = input.associationKey;
-  return OrgScopedResourceStore.run(scope, fn);
+  return OrgScopedResourceStore.run({ resource, orgId }, fn);
 }
 
 export function currentOrgScopedMcpResource(): OrgScopedMcpResource | undefined {
@@ -69,9 +90,7 @@ export function currentOrgScopedMcpResource(): OrgScopedMcpResource | undefined 
 }
 
 function mcpOrigin(): string | null {
-  const raw = stripTrailingSlashes(
-    process.env.NEXT_PUBLIC_MCP_URL ?? 'http://localhost:3001/mcp',
-  );
+  const raw = stripTrailingSlashes(process.env.NEXT_PUBLIC_MCP_URL ?? 'http://localhost:3001/mcp');
   try {
     return new URL(raw).origin;
   } catch (err) {


### PR DESCRIPTION
An authorization started at `/mcp/o/<orgId>` bound to the user's **default** organization instead of the one in the URL, and the resulting token was then refused by `AuthGuard` on the org-scoped path — so the connection came back with no tools at all.

## Root cause

The association that carries the org across the consent redirect was written from inside `consentReferenceId`. In `@better-auth/oauth-provider` the authorize handler returns `redirectWithPromptCode(ctx, opts, 'consent')` **before** it calls that hook whenever the request carries `prompt=consent`:

```js
if (promptSet?.has("consent")) return redirectWithPromptCode(ctx, opts, "consent", ...)
const referenceId = await opts.postLogin?.consentReferenceId?.({ ... })   // never reached
```

claude.ai sends `prompt=consent` on every authorize request. So on the one leg that names an organization nothing was written, and the consent leg — whose body is the *signed* query, which carries no `resource` — had nothing to recall and fell through to the default org.

Verified against a live authorization server: not one `mcp-org-scope:%` row had ever been written, and every `oauth_consent.reference_id` was the caller's default membership.

## Changes

- **The write moves to the auth-request boundary**, where every leg passes and no prompt can skip it.
- **Two association keys.** The existing HMAC of the session cookie and `code_challenge`, plus an HMAC of `code_challenge` alone, so an authorization that starts before the browser has a session — the ordinary first connection — survives the login redirect. Recall prefers the session-bound key. The challenge-only key is first-write-wins, so a later request cannot repoint an association an earlier one already claimed; the residual exposure is that a caller who learns another user's `code_challenge` can read which organization it named, an opaque id for an authorization they must already hold the URL of.
- **The org-scoped protected-resource document advertises a marker scope, `mcp:org:<orgId>`.** A client requests exactly the scopes that document advertises — the same property #795 leaned on for the media surface — so the org reaches the server even from a client that sends `resource` only at token exchange, which is where RFC 8707 permits it and where the provider reads it. The marker is stripped from the query and body before the provider validates scopes, so it reaches no consent screen, stored grant or token, and the shared endpoint's document carries none.

`resource` stays the primary channel and wins when both are present. A missing association still falls back to the default org, where the path guard refuses the mismatch, and a signed-in user who is not a member of the requested organization is still refused at consent.

## Risk

A client now sees one scope in the org-scoped resource document that the authorization-server metadata does not list — it cannot, since the value is per-org — and the granted scope list comes back without it. A client strict about granted-vs-requested scopes would error rather than mis-pin. Only org-scoped connections are exposed; the shared endpoint and the media surface are untouched. Worth exercising a pinned URL against a real client first.

## Tests

`@getmunin/core` fully green. New coverage for the marker scope helpers, for reading the org from either channel, for the stripping on query and body, for the eager write on the authorize leg (including with no session), and for first-write-wins and session precedence in the store. backend-core's failing set is identical to a clean-`main` baseline (pre-existing local env-pollution failures in `oauth-jwt-resolver` / `oauth-as-alias` / `oauth-resource`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhaGswtoVx7nowaQw8Qm3C