### PR TITLE
ci: bound and retry the playwright system-dep install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,11 +267,25 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         run: pnpm --filter @getmunin/web exec playwright install --with-deps chromium
 
+      # install-deps shells out to apt-get, which stalls on a bad mirror often
+      # enough to matter. Without a per-attempt bound a stall burns the job's
+      # whole 15-minute budget, so each try is capped and retried.
       - name: Install browser deps (cache hit path)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter @getmunin/web exec playwright install-deps chromium
+        timeout-minutes: 8
+        run: |
+          for attempt in 1 2 3; do
+            if timeout -k 10s 120s pnpm --filter @getmunin/web exec playwright install-deps chromium; then
+              exit 0
+            fi
+            echo "::warning::playwright install-deps failed or stalled (attempt ${attempt}/3)"
+            sleep 10
+          done
+          echo "::error::playwright install-deps failed after 3 attempts"
+          exit 1
 
       - name: Run Playwright tests
         run: pnpm --filter @getmunin/web e2e


### PR DESCRIPTION
## What happened

On #803 the `e2e (playwright)` job hung with every other check already green. The browser cache **hit** — `Install Playwright browsers` was skipped — and the job sat in `Install browser deps (cache hit path)` for 11 minutes until the run was cancelled. That step is `playwright install-deps chromium`, which shells out to `apt-get`; it stalled on package installation.

The step normally finishes in seconds, so `apt-get` sits on the critical path of every e2e run, and a mirror stall costs the job's entire 15-minute budget.

## The change

Each `install-deps` attempt is capped at 120s and retried up to three times. A stall now costs a couple of minutes instead of the whole job, and a transient failure recovers without a manual re-run. The cache-miss step gets a 10-minute bound for the same reason — it runs apt too (`--with-deps`), on top of the browser download.

**A step-level `timeout-minutes` alone would not fix this.** It kills the step outright, so a first-attempt stall would never reach a retry. The bound has to be per attempt, hence `timeout -k 10s 120s` inside the loop, with `timeout-minutes` retained only as an outer backstop.

## Why not just drop the step

`ubuntu-latest` already ships most of Chromium's shared libraries, so deleting `install-deps` on the cache-hit path is tempting and would take apt off the critical path entirely. Keeping it costs ~30–60s on a healthy run but preserves the safety net if GitHub ever slims the runner image — the failure mode there is a missing `.so` at test time, which is far more confusing than a slow install. Retry now, revisit if it recurs.

## Testing

The loop was exercised against stubs for all four paths (with a `timeout` shim, since GNU `timeout` is Linux-only and this was validated on macOS):

| Stub behaviour | Result |
|---|---|
| succeeds immediately | `SUCCESS on attempt 1`, exit 0 |
| always fails | 3 attempts, `::error::`, exit 1 |
| **hangs** | each attempt killed at the bound, 3 attempts, exit 1 — never runs past the cap |
| **fails once then succeeds** | `SUCCESS on attempt 2`, exit 0 |

The last two are the ones that matter: a stall is bounded rather than open-ended, and the observed flake self-heals. Also confirmed `set -e` does not abort on the failing `if` condition, and the workflow YAML parses with the expected `timeout-minutes` on both steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)