### PR TITLE
feat(mcp): return the org name from ping

### DIFF
--- a/.changeset/ping-returns-org-name.md
+++ b/.changeset/ping-returns-org-name.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/backend-core': minor
+---
+
+The `ping` MCP tool now returns the organization's name alongside its id, so an agent can confirm which tenant it is connected to without a second call.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -2,7 +2,7 @@
   {
     "name": "ping",
     "title": "Ping the MCP server",
-    "description": "Verify the MCP pipe; echoes a message and returns the resolved org and actor type.",
+    "description": "Verify the MCP pipe; echoes a message and returns the resolved org id, org name and actor type.",
     "audiences": [
       "admin",
       "self_service"

--- a/packages/backend-core/src/mcp/mcp.integration.test.ts
+++ b/packages/backend-core/src/mcp/mcp.integration.test.ts
@@ -126,8 +126,12 @@ const skipReason = TEST_URL
       expect(kbSearch.annotations!.readOnlyHint).toBe(true);
       expect(kbSearch.annotations!.destructiveHint).toBe(false);
 
-      const ping = await c.callTool({ name: 'ping', arguments: { message: 'hi' } });
-      expect(JSON.stringify(ping)).toContain('hi');
+      const ping = parseToolResult<{ message: string; orgId: string; orgName: string }>(
+        await c.callTool({ name: 'ping', arguments: { message: 'hi' } }),
+      );
+      expect(ping.message).toBe('hi');
+      expect(ping.orgId).toBe(orgId);
+      expect(ping.orgName).toBe('MCP IT Org');
 
       const space = parseToolResult<{ id: string }>(
         await c.callTool({

--- a/packages/backend-core/src/mcp/ping.tool.ts
+++ b/packages/backend-core/src/mcp/ping.tool.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { McpTool } from '@getmunin/mcp-toolkit';
 import { getCurrentContext } from '@getmunin/core';
+import { schema } from '@getmunin/db';
 
 const PingInput = z.object({
   message: z.string().optional(),
@@ -12,18 +14,30 @@ export class PingMcpTool {
   @McpTool({
     name: 'ping',
     title: 'Ping the MCP server',
-    description: 'Verify the MCP pipe; echoes a message and returns the resolved org and actor type.',
+    description:
+      'Verify the MCP pipe; echoes a message and returns the resolved org id, org name and actor type.',
     audiences: ['admin', 'self_service'],
     scopes: [],
     input: PingInput,
     readOnlyHint: true,
     destructiveHint: false,
   })
-  ping(args: z.infer<typeof PingInput>) {
+  async ping(args: z.infer<typeof PingInput>) {
     const ctx = getCurrentContext();
+    const orgId = ctx.actor?.orgId;
+    let orgName: string | null = null;
+    if (orgId) {
+      const [org] = await ctx.db
+        .select({ name: schema.orgs.name })
+        .from(schema.orgs)
+        .where(eq(schema.orgs.id, orgId))
+        .limit(1);
+      orgName = org?.name?.trim() || null;
+    }
     return {
       message: args.message ?? 'pong',
-      orgId: ctx.actor?.orgId,
+      orgId,
+      orgName,
       actorType: ctx.actor?.type,
       correlationId: ctx.correlationId,
       now: new Date().toISOString(),


### PR DESCRIPTION
`ping` already resolved the org id; confirming *which* tenant a connector is actually bound to meant a second call to find the name. It now reads the org row and returns `orgName` alongside `orgId`.

- The handler is async and queries `orgs` through the request-scoped `ctx.db`. RLS on `orgs` already scopes the row to `app.org_id`, and the policy admits both `admin` and `self_service` actors, so no extra gating is needed.
- `orgName` is `null` when the name is blank or there is no actor.
- Tool description updated to match, `docs-fixtures/mcp-tools.json` regenerated.
- The admin ping assertion in `mcp.integration.test.ts` now parses the result and checks `orgId`/`orgName` instead of substring-matching the JSON.

Verified with `pnpm -F @getmunin/backend-core typecheck` and the full backend-core suite against a local Postgres (129 files / 1622 tests, all passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)