### PR TITLE
fix(oauth): keep the org association alive as long as the request

### DIFF
--- a/.changeset/org-scope-association-lifetime.md
+++ b/.changeset/org-scope-association-lifetime.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Keep the org association for an org-scoped authorization alive for as long as the request can still be submitted.
+
+The association carrying the organization across the consent redirect expired after ten minutes, the same window the provider gives its signed authorize query. Leaving a consent screen open past that and reloading it swapped the organization label for the organization switcher: the association was gone, so `GET /v1/oauth/pending-org` correctly answered `pinned: false`. In the simple case the request had expired too, so this was misleading rather than harmful — approving it fails the provider's own signature check.
+
+The two clocks come apart when an authorization takes more than one leg, because `redirectWithPromptCode` re-signs the query on each one while the association keeps the expiry from the first. Start signed out, take a few minutes over the login, and there is a window where the re-signed request is still valid but the association has expired — the screen offers a switcher, and approving binds the token to the default organization instead of the one in the URL.
+
+The lifetime is now an hour and every recall pushes the expiry out again, so the association outlives the request it belongs to no matter how many legs it takes. An expired row is still never resurrected. Nothing about the keying changes: one organization per `code_challenge`, first-write-wins on the challenge-only key, the session-bound key preferred on recall, and membership still verified at consent. The cost is that a row keyed on an HMAC of a `code_challenge` can now linger up to an hour after a flow ends, readable only by a caller who presents that same challenge.

--- a/packages/backend-core/src/auth/org-scope-store.integration.test.ts
+++ b/packages/backend-core/src/auth/org-scope-store.integration.test.ts
@@ -80,6 +80,68 @@ const skipReason = TEST_URL
     await expect(store.recall(keys('never-seen', 'never-seen-either'))).resolves.toBeNull();
   });
 
+  it('outlives the authorization request it belongs to', async () => {
+    await store.remember(keys('session-window', 'challenge-window'), ORG_A);
+    const rows = await db
+      .select({ expiresAt: schema.verifications.expiresAt })
+      .from(schema.verifications)
+      .where(eq(schema.verifications.identifier, 'mcp-org-scope:session-window'));
+    const remainingMs = rows[0]!.expiresAt.getTime() - Date.now();
+    expect(remainingMs).toBeGreaterThan(600_000);
+  });
+
+  it('pushes the expiry out on every recall, so a re-signed request cannot outlast it', async () => {
+    await store.remember(keys('session-sliding', 'challenge-sliding'), ORG_A);
+    const expiryOf = async (identifier: string) => {
+      const rows = await db
+        .select({ expiresAt: schema.verifications.expiresAt })
+        .from(schema.verifications)
+        .where(eq(schema.verifications.identifier, identifier));
+      return rows[0]!.expiresAt.getTime();
+    };
+    await db
+      .update(schema.verifications)
+      .set({ expiresAt: new Date(Date.now() + 30_000) })
+      .where(eq(schema.verifications.identifier, 'mcp-org-scope:session-sliding'));
+    const before = await expiryOf('mcp-org-scope:session-sliding');
+    await expect(store.recall(keys('session-sliding', 'challenge-sliding'))).resolves.toBe(ORG_A);
+    expect(await expiryOf('mcp-org-scope:session-sliding')).toBeGreaterThan(before);
+  });
+
+  it('pushes out the challenge-keyed expiry when that is the one that answered', async () => {
+    await store.remember(keys(null, 'challenge-sliding-anon'), ORG_A);
+    await db
+      .update(schema.verifications)
+      .set({ expiresAt: new Date(Date.now() + 30_000) })
+      .where(eq(schema.verifications.identifier, 'mcp-org-scope:challenge-sliding-anon'));
+    const rowsBefore = await db
+      .select({ expiresAt: schema.verifications.expiresAt })
+      .from(schema.verifications)
+      .where(eq(schema.verifications.identifier, 'mcp-org-scope:challenge-sliding-anon'));
+    await expect(store.recall(keys('session-absent', 'challenge-sliding-anon'))).resolves.toBe(
+      ORG_A,
+    );
+    const rowsAfter = await db
+      .select({ expiresAt: schema.verifications.expiresAt })
+      .from(schema.verifications)
+      .where(eq(schema.verifications.identifier, 'mcp-org-scope:challenge-sliding-anon'));
+    expect(rowsAfter[0]!.expiresAt.getTime()).toBeGreaterThan(rowsBefore[0]!.expiresAt.getTime());
+  });
+
+  it('does not resurrect an association that already expired', async () => {
+    await db.insert(schema.verifications).values({
+      identifier: 'mcp-org-scope:challenge-gone',
+      value: ORG_A,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    await expect(store.recall(keys(null, 'challenge-gone'))).resolves.toBeNull();
+    const rows = await db
+      .select({ expiresAt: schema.verifications.expiresAt })
+      .from(schema.verifications)
+      .where(eq(schema.verifications.identifier, 'mcp-org-scope:challenge-gone'));
+    expect(rows[0]!.expiresAt.getTime()).toBeLessThan(Date.now());
+  });
+
   it('recalls nothing once the association has expired', async () => {
     await db.insert(schema.verifications).values({
       identifier: 'mcp-org-scope:challenge-expired',

--- a/packages/backend-core/src/auth/org-scope-store.ts
+++ b/packages/backend-core/src/auth/org-scope-store.ts
@@ -5,7 +5,7 @@ import { isOrgId } from '@getmunin/core';
 import { readSessionCookie } from './auth-cookies.ts';
 
 const IDENTIFIER_PREFIX = 'mcp-org-scope:';
-const TTL_MS = 600_000;
+const TTL_MS = 3_600_000;
 
 export interface OrgScopeAssociationKeys {
   session: string | null;
@@ -63,6 +63,15 @@ export function createDbOrgScopeStore(db: Db, secret: string): OrgScopeStore {
     return isOrgId(row.value) ? row.value : null;
   }
 
+  async function extend(associationKey: string): Promise<void> {
+    const identifier = identifierFor(associationKey);
+    if (!identifier) return;
+    await db
+      .update(schema.verifications)
+      .set({ expiresAt: new Date(Date.now() + TTL_MS) })
+      .where(eq(schema.verifications.identifier, identifier));
+  }
+
   return {
     keysFor(cookieHeader, codeChallenge) {
       return buildOrgScopeAssociationKeys(secret, cookieHeader, codeChallenge);
@@ -107,9 +116,15 @@ export function createDbOrgScopeStore(db: Db, secret: string): OrgScopeStore {
     async recall(keys: OrgScopeAssociationKeys): Promise<string | null> {
       if (keys.session) {
         const fromSession = await readOne(keys.session);
-        if (fromSession) return fromSession;
+        if (fromSession) {
+          await extend(keys.session);
+          return fromSession;
+        }
       }
-      return keys.challenge ? await readOne(keys.challenge) : null;
+      if (!keys.challenge) return null;
+      const fromChallenge = await readOne(keys.challenge);
+      if (fromChallenge) await extend(keys.challenge);
+      return fromChallenge;
     },
   };
 }

--- a/packages/dashboard-pages/src/auth/authorization-expiry.test.ts
+++ b/packages/dashboard-pages/src/auth/authorization-expiry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUTHORIZATION_CLOCK_GRACE_MS,
+  authorizationExpiresAt,
+  authorizationHasExpired,
+} from './authorization-expiry';
+
+const NOW = 1_770_000_000_000;
+const seconds = (ms: number) => String(Math.floor(ms / 1000));
+
+describe('authorization expiry', () => {
+  it('treats a request with no exp as one that cannot be judged', () => {
+    expect(authorizationExpiresAt(null)).toBeNull();
+    expect(authorizationExpiresAt(undefined)).toBeNull();
+    expect(authorizationExpiresAt('')).toBeNull();
+    expect(authorizationHasExpired(null, NOW)).toBe(false);
+  });
+
+  it('ignores an exp that is not a positive number', () => {
+    expect(authorizationExpiresAt('not-a-number')).toBeNull();
+    expect(authorizationExpiresAt('-1')).toBeNull();
+    expect(authorizationExpiresAt('0')).toBeNull();
+    expect(authorizationHasExpired('not-a-number', NOW)).toBe(false);
+  });
+
+  it('reads exp as seconds and adds the clock grace', () => {
+    expect(authorizationExpiresAt(seconds(NOW))).toBe(NOW + AUTHORIZATION_CLOCK_GRACE_MS);
+  });
+
+  it('holds a request that is still live', () => {
+    expect(authorizationHasExpired(seconds(NOW + 60_000), NOW)).toBe(false);
+  });
+
+  it('keeps trusting a just-lapsed request, so a fast client clock cannot hide a live one', () => {
+    expect(authorizationHasExpired(seconds(NOW - 30_000), NOW)).toBe(false);
+  });
+
+  it('calls it expired once it is past the grace', () => {
+    expect(authorizationHasExpired(seconds(NOW - AUTHORIZATION_CLOCK_GRACE_MS - 1000), NOW)).toBe(
+      true,
+    );
+  });
+});

--- a/packages/dashboard-pages/src/auth/authorization-expiry.ts
+++ b/packages/dashboard-pages/src/auth/authorization-expiry.ts
@@ -1,0 +1,15 @@
+export const AUTHORIZATION_CLOCK_GRACE_MS = 60_000;
+
+export function authorizationExpiresAt(raw: string | null | undefined): number | null {
+  const seconds = Number(raw ?? '');
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return seconds * 1000 + AUTHORIZATION_CLOCK_GRACE_MS;
+}
+
+export function authorizationHasExpired(
+  raw: string | null | undefined,
+  now: number = Date.now(),
+): boolean {
+  const expiresAt = authorizationExpiresAt(raw);
+  return expiresAt !== null && expiresAt <= now;
+}

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1005,6 +1005,14 @@
         "cancelling": "Cancelling…",
         "dashboard": "Open dashboard"
       },
+      "expired": {
+        "eyebrow": "OAuth 2.1 · request expired",
+        "title": "This request has <em>expired</em>.",
+        "sub": "<client></client> started this authorization too long ago for it to be completed. Nothing was shared, and nothing was authorized.",
+        "panelTitle": "Start the connection again from the application",
+        "body": "Authorization requests are short-lived on purpose. Go back to the application that opened this page and connect again — it will send a fresh request, and this page will ask you to approve that one instead.",
+        "dashboard": "Open dashboard"
+      },
       "missingParams": "Missing OAuth request. Return to the application that started the authorization flow.",
       "errors": {
         "generic": "Something went wrong. Please try again."

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1005,6 +1005,14 @@
         "cancelling": "Avbryter …",
         "dashboard": "Åpne dashbordet"
       },
+      "expired": {
+        "eyebrow": "OAuth 2.1 · forespørselen er utløpt",
+        "title": "Denne forespørselen er <em>utløpt</em>.",
+        "sub": "<client></client> startet denne autoriseringen for lenge siden til at den kan fullføres. Ingenting ble delt, og ingenting ble autorisert.",
+        "panelTitle": "Start tilkoblingen på nytt fra applikasjonen",
+        "body": "Autorisasjonsforespørsler er kortvarige med hensikt. Gå tilbake til applikasjonen som åpnet denne siden og koble til på nytt — den sender en ny forespørsel, og da er det den du blir bedt om å godkjenne her.",
+        "dashboard": "Åpne dashbordet"
+      },
       "missingParams": "Mangler OAuth-forespørsel. Gå tilbake til applikasjonen som startet autoriseringen.",
       "errors": {
         "generic": "Noe gikk galt. Prøv igjen."

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { PageSpinner } from '@getmunin/ui';
 import { authClient } from '../auth-client';
+import { authorizationExpiresAt } from '../auth/authorization-expiry';
 import { api, ApiError } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 
@@ -95,7 +96,7 @@ function groupScopes(scopes: string[]): ModuleScopes[] {
 }
 
 type FlowState = 'new' | 'granted' | 'denied';
-type HeaderState = FlowState | 'blocked';
+type HeaderState = FlowState | 'blocked' | 'expired';
 
 const REDIRECT_DELAY_MS = 1200;
 
@@ -129,6 +130,15 @@ export function OAuthConsentPage({
   const [flow, setFlow] = useState<FlowState>('new');
   const [busy, setBusy] = useState<'allow' | 'deny' | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const expiresAtMs = authorizationExpiresAt(search?.get('exp'));
+  const [expired, setExpired] = useState(() => expiresAtMs !== null && expiresAtMs <= Date.now());
+
+  useEffect(() => {
+    if (expiresAtMs === null || expired) return;
+    const id = window.setTimeout(() => setExpired(true), Math.max(expiresAtMs - Date.now(), 0));
+    return () => window.clearTimeout(id);
+  }, [expiresAtMs, expired]);
 
   useEffect(() => {
     if (!isPending && !session) {
@@ -174,20 +184,23 @@ export function OAuthConsentPage({
     }
   }
 
-  const blocked = flow === 'new' && denial !== null;
+  const stale = flow === 'new' && expired;
+  const blocked = flow === 'new' && !stale && denial !== null;
   const resourceName = denial?.resourceName ?? resourceInfo?.name ?? '';
 
   return (
     <div className="min-h-screen bg-background">
       <main className="mx-auto flex w-full max-w-[720px] flex-col px-6 py-12 sm:py-16">
         <EditorialHeader
-          flow={blocked ? 'blocked' : flow}
+          flow={stale ? 'expired' : blocked ? 'blocked' : flow}
           clientName={displayName}
           resourceName={resourceName}
         />
 
         <section className="mt-8 border-[1px] border-ink bg-paper dark:border-rule-on-dark dark:bg-card">
-          {blocked ? (
+          {stale ? (
+            <ExpiredPane clientInfo={clientInfo} clientId={clientId} displayName={displayName} />
+          ) : blocked ? (
             <BlockedPane
               clientInfo={clientInfo}
               clientId={clientId}
@@ -237,6 +250,23 @@ interface EditorialHeaderProps {
 
 function EditorialHeader({ flow, clientName, resourceName }: EditorialHeaderProps) {
   const t = useTranslations('dashboard.oauthConsent');
+  if (flow === 'expired') {
+    return (
+      <header className="mb-6">
+        <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-mute">
+          {t('expired.eyebrow')}
+        </div>
+        <h1 className="font-serif text-[clamp(46px,6.6vw,72px)] font-normal leading-[0.98] tracking-[-0.02em] min-w-0 [overflow-wrap:anywhere] [word-break:break-word]">
+          {t.rich('expired.title', { em: (chunks) => <em className="not-italic text-ink italic">{chunks}</em> })}
+        </h1>
+        <p className="mt-4 max-w-[54ch] text-base leading-relaxed text-ink-soft [overflow-wrap:anywhere]">
+          {t.rich('expired.sub', {
+            client: () => <em className="not-italic font-medium text-ink italic">{clientName}</em>,
+          })}
+        </p>
+      </header>
+    );
+  }
   if (flow === 'blocked') {
     return (
       <header className="mb-6">
@@ -503,6 +533,39 @@ function ResourcePermissionRow({ permission }: { permission: OAuthResourcePermis
         <ScopePill kind={permission.level} label={t(`actions.${permission.level}`)} />
       </div>
     </li>
+  );
+}
+
+interface ExpiredPaneProps {
+  clientInfo: OAuthClientInfo | null;
+  clientId: string;
+  displayName: string;
+}
+
+function ExpiredPane({ clientInfo, clientId, displayName }: ExpiredPaneProps) {
+  const t = useTranslations('dashboard.oauthConsent');
+  return (
+    <>
+      <IdentityCard clientInfo={clientInfo} clientId={clientId} displayName={displayName} />
+
+      <div className="flex flex-col gap-4 px-7 py-8">
+        <div className="font-serif text-[24px] tracking-[-0.01em] [overflow-wrap:anywhere]">
+          {t('expired.panelTitle')}
+        </div>
+        <div className="max-w-[52ch] text-sm leading-relaxed text-ink-soft [overflow-wrap:anywhere]">
+          {t('expired.body')}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 border-t-[1px] border-rule-soft px-7 py-5 dark:border-rule-on-dark">
+        <a
+          href="/dashboard"
+          className="inline-flex h-11 items-center justify-center border-[1px] border-ink bg-transparent px-6 font-sans text-[15px] font-medium text-ink no-underline transition hover:bg-ink hover:text-paper"
+        >
+          {t('expired.dashboard')}
+        </a>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Reported from a real flow: add a pinned MCP URL in Claude Desktop, reach the Munin consent page, and the correct organization label appears and survives a reload. Leave the page open 5–10 minutes, reload again, and the **organization switcher** appears in its place.

## Cause

`TTL_MS` on the association row was 600_000 — ten minutes. Past that, `recall` finds nothing and `GET /v1/oauth/pending-org` truthfully answers `pinned: false`, so the consent screen falls back to the switcher.

That is the same window the provider gives its signed authorize query (`verifyOAuthQueryParams` enforces `exp >= now`, and `codeExpiresIn` defaults to 600s and is not overridden). In a single-leg flow both clocks start together, so a screen older than ten minutes is already dead and approving it fails the signature check — misleading UI, not a mis-binding.

The clocks come apart when an authorization takes more than one leg. `redirectWithPromptCode` re-signs the query on each leg, while the association keeps the expiry from the first:

```
t0    authorize (signed out) → association written, expires t0+10m
t0-t3 user signs in
t3    authorize resumed      → query re-signed, exp = t3+10m
t10   association expires    ← request still valid for 3 more minutes
```

In that window the screen offers a switcher and approving binds the token to the **default** organization rather than the one in the URL — exactly the failure #801 exists to prevent, reintroduced by a timeout.

## Change

The lifetime becomes an hour, and every `recall` pushes the expiry out again, so the association outlives the request no matter how many legs it takes. An expired row is still never resurrected.

Keying is untouched: one organization per `code_challenge`, first-write-wins on the challenge-only key, session-bound key preferred on recall, membership verified at consent. The trade is that a row keyed on an HMAC of a `code_challenge` can linger up to an hour past the flow, readable only by a caller presenting that same challenge.

## Tests

Four new cases in the store's integration suite: the granted window exceeds the provider's own, recall extends a nearly-expired session-keyed row, recall extends a challenge-keyed row when that is the one that answered, and an already-expired row is neither returned nor revived.

Run against Postgres rather than left to CI — all 15 cases in the suite pass, and `@getmunin/backend-core` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhaGswtoVx7nowaQw8Qm3C

---

## Second commit: say the request expired, rather than offering it

Raising the association's lifetime removes the wrong org binding, but leaves a screen that lies in the other direction: an authorization the provider will no longer accept still rendered the full approve/deny UI, so the only way to discover it was dead was to approve it and get `invalid_signature` back.

The consent page now reads `exp` out of the signed query it was handed and renders an expired state — which client asked, that nothing was shared or authorized, and to start again from the application. No approve, no deny, because neither can succeed. A timer flips the page into that state at the moment `exp` passes, so a screen left open stops offering a request it can no longer complete without needing a reload.

`exp` is trusted only once it is a minute past, because the comparison runs against the visitor's clock: a browser running fast must not hide a live request. Erring the other way costs nothing — the screen behaves as it does today, and the provider refuses at submit.

The decision is a pure function in `src/auth/authorization-expiry.ts`, tested over the grace boundary, an `exp` in the future, and absent/negative/non-numeric values, so those cases are asserted rather than reasoned about. `@getmunin/dashboard-pages` typechecks and its suite passes at 76 tests.

Prettier wanted to reformat all of `oauth-consent.tsx` and both message files, which would have buried this in ~260 lines of churn; the edits are applied by hand instead, so the diff is additive.

**Known gap, deliberately not fixed here:** the topbar organization control is cloud-side, so on an expired request this page says "expired" while that switcher still renders beside it. It needs the same `authorizationHasExpired` check, which belongs in the cloud repo alongside its next dependency bump.
