### PR TITLE
fix(conv): make credential links reachable and stop creating broken email channels

### DIFF
--- a/.changeset/credential-handoff-anonymous-route.md
+++ b/.changeset/credential-handoff-anonymous-route.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+Fix credential-handoff links, which answered `401 invalid or expired credential` on every click in cloud.
+
+`CredentialHandoffController` was a plain `@Controller('v1/credentials')` with no `@AllowAnonymous()`. OSS applies `AuthGuard` per controller, so the endpoint was reachable there and every integration test passed; cloud registers `AuthGuard` as a global `APP_GUARD`, so both the describe (GET) and complete (POST) requests were rejected before the handoff service ran. The entry page fetches with `anonymous: true` — correct, since the link exists for people who hold no Munin credential — which made the failure total: every link minted by `conv_request_channel_credentials`, `conv_configure_email_channel` or `connectors_request_credentials` was dead on arrival, and the auth guard's message read as if the *link* had expired. It is now a `PublicController` with public throttling, guarded by a test that fails if any controller declares neither `AuthGuard` nor an anonymous opt-out.
+
+A channel whose stored config is missing its credential slots now answers the link with a `conv_channel_config_invalid` 400 carrying `fieldErrors`, instead of an unmapped error that surfaced as a bare 500 — the interceptor that maps it only covers the dashboard's channel controller. The entry page names those fields, and no longer keeps showing a stale load error after a later attempt succeeds.

--- a/.changeset/drop-conv-create-channel.md
+++ b/.changeset/drop-conv-create-channel.md
@@ -1,0 +1,10 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/db': minor
+---
+
+Remove `conv_create_channel`. It took `config` as a free-form object and persisted it verbatim, with no per-type validation, no encryption and no credential slots — so an email channel created through it read as complete in `conv_list_channels` and was unusable: the stored config failed the schema every later read applied, the credential link could not describe its password fields, and the dashboard had nowhere to save them. A plaintext `password` passed in that config was stored unencrypted and echoed back, since config masking only covers `encrypted*` keys.
+
+Both remaining types already have a tool that provisions them properly, and the type this tool made easiest to reach was the one it broke: `conv_configure_email_channel` validates the transport config, encrypts secrets and returns a credential link; `conv_create_widget_channel` mints the widget key a chat channel cannot work without. Voice and SMS were removed from this tool for the same reason in 4.76.0; nothing remained that it could create correctly. Use those tools instead, or `conv_import` when moving historical channel rows between servers.
+
+Migration `0073_conv_email_channel_credential_slots` repairs email channels already written that way: it adds the missing `encryptedPassword` slots, deactivates the channel so an existing credential link can complete it, and drops any plaintext `password` key.

--- a/packages/backend-core/docs-fixtures/mcp-tools.json
+++ b/packages/backend-core/docs-fixtures/mcp-tools.json
@@ -3139,55 +3139,6 @@
     }
   },
   {
-    "name": "conv_create_channel",
-    "title": "Conv: Create conversation channel",
-    "description": "Add an `email` or `chat` (widget) conversation channel whose configuration is self-contained. Channel-specific configuration goes in `config`. Voice and SMS channels are vendor-backed and rejected here — they need the credential handoff that conv_configure_voice_sms_channel performs.",
-    "audiences": [
-      "admin"
-    ],
-    "scopes": [
-      "conv:write"
-    ],
-    "danger": "destructive",
-    "readOnly": false,
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "email",
-            "chat"
-          ]
-        },
-        "vendor": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 32
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        },
-        "config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
-          "additionalProperties": {}
-        }
-      },
-      "required": [
-        "type",
-        "vendor",
-        "name"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
     "name": "conv_list_topics",
     "title": "Conv: List conversation topics",
     "description": "List conversation topics (Billing, Support, Refunds, …) for your org.",

--- a/packages/backend-core/src/common/auth/controller-auth-declared.test.ts
+++ b/packages/backend-core/src/common/auth/controller-auth-declared.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+function controllerFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...controllerFiles(full));
+      continue;
+    }
+    if (entry.endsWith('.controller.ts')) out.push(full);
+  }
+  return out;
+}
+
+const MARKERS = ['@PublicController(', 'AllowAnonymous()', 'UseGuards(AuthGuard'];
+
+describe('controllers declare their auth stance, because cloud registers AuthGuard as a global APP_GUARD', () => {
+  it('every controller either applies AuthGuard itself or opts out via PublicController/AllowAnonymous — a controller that does neither is open in OSS and 401 in cloud', () => {
+    const undeclared = controllerFiles(SRC_ROOT)
+      .filter((file) => {
+        const source = readFileSync(file, 'utf8');
+        return !MARKERS.some((marker) => source.includes(marker));
+      })
+      .map((file) => relative(SRC_ROOT, file));
+    expect(undeclared).toEqual([]);
+  });
+});

--- a/packages/backend-core/src/modules/conv/channels/channel-credential.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-credential.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
 import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
@@ -451,6 +452,47 @@ const skipReason = TEST_URL
       ),
     );
     expect(mailer.active).toBe(true);
+  });
+
+  it('answers a link for a channel whose stored config lost its credential slots with a coded, field-listing error instead of an unmapped crash', async () => {
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    const [broken] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'email',
+        vendor: 'smtp',
+        name: 'Slotless inbox',
+        config: {
+          addressing: { fromAddress: 'slotless@acme.test' },
+          outbound: {
+            provider: 'smtp',
+            host: 'smtp.acme.test',
+            port: 587,
+            secure: true,
+            username: 'slotless@acme.test',
+          },
+        },
+      })
+      .returning();
+    const link = await asAdmin(() => channels.requestLink(broken!.id));
+    const token = tokenFromUrl(link.url);
+
+    const failure = await handoff.describe(token).then(
+      () => null,
+      (err: unknown) => err,
+    );
+    expect(failure).toBeInstanceOf(BadRequestException);
+    const body = (failure as BadRequestException).getResponse() as {
+      code: string;
+      fieldErrors: Array<{ field: string }>;
+    };
+    expect(body.code).toBe('conv_channel_config_invalid');
+    expect(body.fieldErrors.map((fe) => fe.field)).toContain('outbound.encryptedPassword');
+
+    const applied = await asAdmin(() => channels.apply(broken!.id, { smtpPassword: 'pw' }));
+    expect(applied.ok).toBe(false);
+    expect(applied.error).toContain('outbound.encryptedPassword');
   });
 
   it('refuses a credential link for a vendor without deferred-setup support', async () => {

--- a/packages/backend-core/src/modules/conv/channels/channel-credential.service.ts
+++ b/packages/backend-core/src/modules/conv/channels/channel-credential.service.ts
@@ -14,6 +14,7 @@ import { EmailService, jsonbToStored } from '../email/email.service.ts';
 import { EmailChannelProbe, type EmailProbeResult } from '../email/email-probe.service.ts';
 import type { StoredEmailChannelConfig } from '../email/email.service.ts';
 import { ChannelAdminService } from './channel-admin.service.ts';
+import { ChannelConfigInvalidError } from './stored-config.ts';
 import {
   CredentialHandoffService,
   type CredentialLink,
@@ -26,6 +27,17 @@ import type {
 
 export interface EmailChannelTester {
   test(config: StoredEmailChannelConfig): Promise<EmailProbeResult>;
+}
+
+function asHttpConfigError(err: unknown): Error {
+  if (err instanceof ChannelConfigInvalidError) {
+    return new BadRequestException({
+      message: err.message,
+      code: err.code,
+      fieldErrors: err.fieldErrors,
+    });
+  }
+  return err instanceof Error ? err : new Error(String(err));
 }
 
 @Injectable()
@@ -58,6 +70,23 @@ export class ChannelCredentialService implements CredentialTargetHandler {
   }
 
   async describe(targetId: string): Promise<CredentialTargetDescription | null> {
+    try {
+      return await this.describeTarget(targetId);
+    } catch (err) {
+      throw asHttpConfigError(err);
+    }
+  }
+
+  async apply(targetId: string, secrets: Record<string, string>): Promise<CredentialApplyResult> {
+    try {
+      return await this.applyToTarget(targetId, secrets);
+    } catch (err) {
+      if (err instanceof ChannelConfigInvalidError) return { ok: false, error: err.message };
+      throw err;
+    }
+  }
+
+  private async describeTarget(targetId: string): Promise<CredentialTargetDescription | null> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
       .select({ name: schema.convChannels.name, type: schema.convChannels.type, vendor: schema.convChannels.vendor })
@@ -82,7 +111,10 @@ export class ChannelCredentialService implements CredentialTargetHandler {
     };
   }
 
-  async apply(targetId: string, secrets: Record<string, string>): Promise<CredentialApplyResult> {
+  private async applyToTarget(
+    targetId: string,
+    secrets: Record<string, string>,
+  ): Promise<CredentialApplyResult> {
     const ctx = getCurrentContext();
     const rows = await ctx.db
       .select({ type: schema.convChannels.type })

--- a/packages/backend-core/src/modules/conv/conv.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.integration.test.ts
@@ -133,8 +133,8 @@ const skipReason = TEST_URL
     const channel = await withClient(adminKey, async (c) => {
       return parseToolResult<{ id: string }>(
         await c.callTool({
-          name: 'conv_create_channel',
-          arguments: { type: 'chat', vendor: 'munin', name: 'Web chat' },
+          name: 'conv_create_widget_channel',
+          arguments: { name: 'Web chat', originAllowlist: ['https://acme.test'] },
         }),
       );
     });
@@ -147,7 +147,7 @@ const skipReason = TEST_URL
       expect(names).not.toContain('conv_list_my_conversations');
       expect(names).not.toContain('conv_get_my_conversation');
       expect(names).not.toContain('conv_send_message_in_my_conversation');
-      expect(names).not.toContain('conv_create_channel');
+      expect(names).not.toContain('conv_create_widget_channel');
       expect(names).not.toContain('conv_change_status');
     });
 
@@ -638,19 +638,14 @@ const skipReason = TEST_URL
     });
   }, 30_000);
 
-  it('createChannel rejects vendor-backed voice and sms types, which need the credential handoff', async () => {
+  it('offers no free-form channel create tool: every channel family provisions through the tool that validates its config and hands over credentials', async () => {
     await withClient(adminKey, async (c) => {
-      for (const type of ['voice', 'sms']) {
-        const rejected = (await c.callTool({
-          name: 'conv_create_channel',
-          arguments: { type, vendor: 'twilioSms', name: `Rejected ${type}` },
-        })) as { isError?: boolean; content?: Array<{ text?: string }> };
-        expect(rejected.isError).toBe(true);
-      }
-      const channels = parseToolResult<{ name: string }[]>(
-        await c.callTool({ name: 'conv_list_channels', arguments: {} }),
-      );
-      expect(channels.map((ch) => ch.name).filter((n) => n.startsWith('Rejected'))).toEqual([]);
+      const { tools } = await c.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).not.toContain('conv_create_channel');
+      expect(names).toContain('conv_configure_email_channel');
+      expect(names).toContain('conv_create_widget_channel');
+      expect(names).toContain('conv_configure_voice_sms_channel');
     });
   }, 30_000);
 

--- a/packages/backend-core/src/modules/conv/conv.service.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.test.ts
@@ -92,6 +92,28 @@ const skipReason = TEST_URL
     });
   }
 
+  async function insertChannel(input: {
+    type: 'email' | 'chat' | 'sms' | 'voice';
+    vendor: string;
+    name: string;
+    config?: Record<string, unknown>;
+    defaultAgentMode?: 'auto' | 'draft_only';
+  }) {
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    const [row] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: input.type,
+        vendor: input.vendor,
+        name: input.name,
+        config: input.config ?? {},
+        ...(input.defaultAgentMode ? { defaultAgentMode: input.defaultAgentMode } : {}),
+      })
+      .returning();
+    return row!;
+  }
+
   async function eventTypes(): Promise<string[]> {
     const rows = await db.execute<{ type: string }>(
       sql`SELECT type FROM events WHERE org_id = ${orgId} ORDER BY created_at`,
@@ -100,57 +122,39 @@ const skipReason = TEST_URL
   }
 
   describe('channels', () => {
-    it('createChannel persists with type, name, config', async () => {
-      const ch = await run(() =>
-        svc.createChannel({ type: 'email', vendor: 'smtp', name: 'Support', config: { foo: 'bar' } }),
-      );
-      expect(ch.type).toBe('email');
-      expect(ch.name).toBe('Support');
-      expect(ch.config).toEqual({ foo: 'bar' });
-      expect(ch.active).toBe(true);
-    });
-
     it('listChannels returns rows in name order', async () => {
-      await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'B' }));
-      await run(() => svc.createChannel({ type: 'chat', vendor: 'munin', name: 'A' }));
+      await insertChannel({ type: 'email', vendor: 'smtp', name: 'B' });
+      await insertChannel({ type: 'chat', vendor: 'munin', name: 'A' });
       const list = await run(() => svc.listChannels());
       expect(list.map((c) => c.name)).toEqual(['A', 'B']);
     });
 
-    it('createChannel defaults agentMode to auto and persists an explicit draft_only', async () => {
-      const auto = await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'Auto' }));
-      expect(auto.defaultAgentMode).toBe('auto');
-      const draft = await run(() =>
-        svc.createChannel({
-          type: 'email',
-          vendor: 'smtp',
-          name: 'Draft',
-          defaultAgentMode: 'draft_only',
-        }),
-      );
-      expect(draft.defaultAgentMode).toBe('draft_only');
+    it('listChannels reports the stored defaultAgentMode, defaulting to auto', async () => {
+      await insertChannel({ type: 'email', vendor: 'smtp', name: 'Auto' });
+      await insertChannel({ type: 'email', vendor: 'smtp', name: 'Draft', defaultAgentMode: 'draft_only' });
       const list = await run(() => svc.listChannels());
+      expect(list.find((c) => c.name === 'Auto')!.defaultAgentMode).toBe('auto');
       expect(list.find((c) => c.name === 'Draft')!.defaultAgentMode).toBe('draft_only');
     });
 
     it('firstActiveChannel returns first by createdAt; null when none', async () => {
       const empty = await run(() => svc.firstActiveChannel());
       expect(empty).toBeNull();
-      const ch1 = await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'First' }));
-      await run(() => svc.createChannel({ type: 'chat', vendor: 'munin', name: 'Second' }));
+      const ch1 = await insertChannel({ type: 'email', vendor: 'smtp', name: 'First' });
+      await insertChannel({ type: 'chat', vendor: 'munin', name: 'Second' });
       const found = await run(() => svc.firstActiveChannel());
       expect(found!.id).toBe(ch1.id);
     });
 
     it('firstActiveChannel filters by typeHint', async () => {
-      await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'E' }));
-      const chatCh = await run(() => svc.createChannel({ type: 'chat', vendor: 'munin', name: 'C' }));
+      await insertChannel({ type: 'email', vendor: 'smtp', name: 'E' });
+      const chatCh = await insertChannel({ type: 'chat', vendor: 'munin', name: 'C' });
       const found = await run(() => svc.firstActiveChannel('chat'));
       expect(found!.id).toBe(chatCh.id);
     });
 
     it('firstActiveChannel ignores inactive channels', async () => {
-      const ch = await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'E' }));
+      const ch = await insertChannel({ type: 'email', vendor: 'smtp', name: 'E' });
       await db
         .update(schema.convChannels)
         .set({ active: false })
@@ -306,7 +310,7 @@ const skipReason = TEST_URL
 
   describe('conversations', () => {
     async function seedChannel() {
-      return run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'Support' }));
+      return insertChannel({ type: 'email', vendor: 'smtp', name: 'Support' });
     }
 
     it('createConversation rejects unknown channel and inactive channel', async () => {
@@ -357,14 +361,7 @@ const skipReason = TEST_URL
     });
 
     it('createConversation inherits the channel defaultAgentMode; explicit mode still wins', async () => {
-      const ch = await run(() =>
-        svc.createChannel({
-          type: 'email',
-          vendor: 'smtp',
-          name: 'Outreach',
-          defaultAgentMode: 'draft_only',
-        }),
-      );
+      const ch = await insertChannel({ type: 'email', vendor: 'smtp', name: 'Outreach', defaultAgentMode: 'draft_only' });
       const inherited = await run(() =>
         svc.createConversation({
           channelId: ch.id,
@@ -492,9 +489,7 @@ const skipReason = TEST_URL
   describe('messaging', () => {
     async function seedConversation(channelType: 'email' | 'chat' = 'email') {
       const vendor = channelType === 'email' ? 'smtp' : 'munin';
-      const ch = await run(() =>
-        svc.createChannel({ type: channelType, vendor, name: 'X' }),
-      );
+      const ch = await insertChannel({ type: channelType, vendor, name: 'X' });
       const conv = await run(() =>
         svc.createConversation({
           channelId: ch.id,
@@ -591,7 +586,7 @@ const skipReason = TEST_URL
 
   describe('assignment and status', () => {
     async function seedConv() {
-      const ch = await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'X' }));
+      const ch = await insertChannel({ type: 'email', vendor: 'smtp', name: 'X' });
       return run(() =>
         svc.createConversation({
           channelId: ch.id,
@@ -643,7 +638,7 @@ const skipReason = TEST_URL
     });
 
     it('inbound end_user message on outreach conv (draft_only) enqueues outreach reply-draft', async () => {
-      const ch = await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'outreach-ch' }));
+      const ch = await insertChannel({ type: 'email', vendor: 'smtp', name: 'outreach-ch' });
       const [seg] = await db
         .insert(schema.crmSegments)
         .values({
@@ -693,7 +688,7 @@ const skipReason = TEST_URL
     });
 
     it('inbound on an outreach conv with autoDraftReplies=false does NOT enqueue reply-draft', async () => {
-      const ch = await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'outreach-ch-noreply' }));
+      const ch = await insertChannel({ type: 'email', vendor: 'smtp', name: 'outreach-ch-noreply' });
       const [seg] = await db
         .insert(schema.crmSegments)
         .values({
@@ -797,7 +792,7 @@ const skipReason = TEST_URL
 
   describe('search', () => {
     it('searchMessages matches case-insensitively on body', async () => {
-      const ch = await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'X' }));
+      const ch = await insertChannel({ type: 'email', vendor: 'smtp', name: 'X' });
       const conv = await run(() =>
         svc.createConversation({
           channelId: ch.id,
@@ -819,7 +814,7 @@ const skipReason = TEST_URL
 
   describe('RLS', () => {
     it('cross-org isolation: another org cannot see this org\'s channels', async () => {
-      const mine = await run(() => svc.createChannel({ type: 'email', vendor: 'smtp', name: 'mine' }));
+      const mine = await insertChannel({ type: 'email', vendor: 'smtp', name: 'mine' });
       const [otherOrg] = await db
         .insert(schema.orgs)
         .values({ name: 'Other' })

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -251,29 +251,6 @@ export class ConvService {
     return toChannelDto(row);
   }
 
-  async createChannel(input: {
-    type: ChannelType;
-    vendor: string;
-    name: string;
-    config?: Record<string, unknown>;
-    defaultAgentMode?: AgentMode;
-  }): Promise<ChannelDto> {
-    const ctx = getCurrentContext();
-    const actor = ctx.actor!;
-    const [row] = await ctx.db
-      .insert(schema.convChannels)
-      .values({
-        orgId: actor.orgId,
-        type: input.type,
-        vendor: input.vendor,
-        name: input.name,
-        config: input.config ?? {},
-        ...(input.defaultAgentMode ? { defaultAgentMode: input.defaultAgentMode } : {}),
-      })
-      .returning();
-    return toChannelDto(row!);
-  }
-
   async firstActiveChannel(typeHint?: ChannelType): Promise<ChannelDto | null> {
     const ctx = getCurrentContext();
     const filters: SQL[] = [eq(schema.convChannels.active, true)];

--- a/packages/backend-core/src/modules/conv/conv.tools.ts
+++ b/packages/backend-core/src/modules/conv/conv.tools.ts
@@ -6,7 +6,6 @@ import { AGENT_MODES, CHANNEL_TYPES, ConvService, HANDOVER_FILTERS, STATUSES } f
 import { IdMapSchema } from '../../common/transfer/transfer.types.ts';
 
 const ChannelTypeSchema = z.enum(CHANNEL_TYPES);
-const SelfContainedChannelTypeSchema = z.enum(['email', 'chat']);
 const StatusSchema = z.enum(STATUSES);
 const AgentModeSchema = z.enum(AGENT_MODES);
 const HandoverSchema = z.enum(HANDOVER_FILTERS);
@@ -71,13 +70,6 @@ const EmailOpenStatsInput = z.object({
     .max(365)
     .optional()
     .describe('Window size in days, counted back from now. Defaults to 30.'),
-});
-
-const CreateChannelInput = z.object({
-  type: SelfContainedChannelTypeSchema,
-  vendor: z.string().min(1).max(32),
-  name: z.string().min(1).max(120),
-  config: z.record(z.string(), z.unknown()).optional(),
 });
 
 const CreateTopicInput = z.object({
@@ -281,21 +273,6 @@ export class ConvAdminTools {
   })
   listChannels() {
     return this.conv.listChannels();
-  }
-
-  @McpTool({
-    name: 'conv_create_channel',
-    title: 'Conv: Create conversation channel',
-    description:
-      'Add an `email` or `chat` (widget) conversation channel whose configuration is self-contained. Channel-specific configuration goes in `config`. Voice and SMS channels are vendor-backed and rejected here — they need the credential handoff that conv_configure_voice_sms_channel performs.',
-    audiences: ['admin'],
-    scopes: ['conv:write'],
-    input: CreateChannelInput,
-    readOnlyHint: false,
-    destructiveHint: true,
-  })
-  createChannel(args: z.infer<typeof CreateChannelInput>) {
-    return this.conv.createChannel(args);
   }
 
   @McpTool({

--- a/packages/backend-core/src/modules/conv/conv.transfer.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.transfer.integration.test.ts
@@ -176,8 +176,8 @@ const skipReason = TEST_URL
   it('moves channels + conversations + messages to a different org, remaps ids, redacts credentials', async () => {
     const channel = await withClient(adminKeyA, async (c) => {
       const res = await c.callTool({
-        name: 'conv_create_channel',
-        arguments: { type: 'chat', vendor: 'widget', name: 'Website widget' },
+        name: 'conv_create_widget_channel',
+        arguments: { name: 'Website widget', originAllowlist: ['https://acme.test'] },
       });
       return firstJson(res) as { id: string };
     });

--- a/packages/backend-core/src/modules/credential-handoff/credential-handoff.controller.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-handoff.controller.ts
@@ -1,6 +1,7 @@
-import { BadRequestException, Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { BadRequestException, Body, Get, Post, Query } from '@nestjs/common';
 import { createZodDto } from 'nestjs-zod';
 import { z } from 'zod';
+import { PublicController } from '../../common/auth/auth.guard.ts';
 import {
   CredentialHandoffService,
   type CredentialLink,
@@ -17,7 +18,7 @@ class CompleteCredentialHandoffBody extends createZodDto(
   }),
 ) {}
 
-@Controller('v1/credentials')
+@PublicController('v1/credentials', { throttle: true })
 export class CredentialHandoffController {
   constructor(private readonly handoff: CredentialHandoffService) {}
 

--- a/packages/backend-core/src/modules/credential-handoff/credential-handoff.module.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-handoff.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
+import { PublicThrottleModule } from '../../common/rate-limit/public-throttle.module.ts';
 import { CredentialTargetRegistry } from './credential-target.ts';
 import { CredentialHandoffService } from './credential-handoff.service.ts';
 import { CredentialHandoffController } from './credential-handoff.controller.ts';
 
 @Module({
+  imports: [PublicThrottleModule],
   controllers: [CredentialHandoffController],
   providers: [
     { provide: CredentialTargetRegistry, useFactory: () => new CredentialTargetRegistry() },

--- a/packages/backend-core/src/modules/credential-handoff/credential-handoff.public-route.test.ts
+++ b/packages/backend-core/src/modules/credential-handoff/credential-handoff.public-route.test.ts
@@ -1,0 +1,78 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Module, NotFoundException, type INestApplication } from '@nestjs/common';
+import { APP_GUARD, NestFactory } from '@nestjs/core';
+import { ThrottlerModule } from '@nestjs/throttler';
+import type { AddressInfo } from 'node:net';
+import type { Db } from '@getmunin/db';
+import { AuthGuard } from '../../common/auth/auth.guard.ts';
+import { DB } from '../../common/db/db.module.ts';
+import { CredentialHandoffController } from './credential-handoff.controller.ts';
+import { CredentialHandoffService } from './credential-handoff.service.ts';
+
+const reached: string[] = [];
+
+const handoffStub = {
+  describe: (token: string) => {
+    reached.push(`describe:${token}`);
+    return Promise.reject(
+      new NotFoundException('credential_handoff_not_found: invalid or expired link'),
+    );
+  },
+  complete: (token: string) => {
+    reached.push(`complete:${token}`);
+    return Promise.reject(
+      new NotFoundException('credential_handoff_not_found: invalid or expired link'),
+    );
+  },
+};
+
+@Module({
+  imports: [ThrottlerModule.forRoot([{ ttl: 60_000, limit: 1000 }])],
+  controllers: [CredentialHandoffController],
+  providers: [
+    { provide: DB, useValue: {} as Db },
+    { provide: CredentialHandoffService, useValue: handoffStub },
+    AuthGuard,
+    { provide: APP_GUARD, useExisting: AuthGuard },
+  ],
+})
+class CloudShapedModule {}
+
+describe('credential-handoff routes with AuthGuard registered as a global APP_GUARD, as cloud registers it', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    app = await NestFactory.create(CloudShapedModule, { logger: false, abortOnError: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('expected an AddressInfo from app.getHttpServer()');
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  it('lets an unauthenticated describe reach the handoff service, which is the only caller a one-time link ever has', async () => {
+    const res = await fetch(`${baseUrl}/v1/credentials?token=mncl_probe_describe`);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { message?: string };
+    expect(body.message).toContain('invalid or expired link');
+    expect(reached).toContain('describe:mncl_probe_describe');
+  });
+
+  it('lets an unauthenticated complete reach the handoff service', async () => {
+    const res = await fetch(`${baseUrl}/v1/credentials`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'mncl_probe_complete', secrets: { smtpPassword: 'pw' } }),
+    });
+    expect(res.status).toBe(404);
+    expect(reached).toContain('complete:mncl_probe_complete');
+  });
+});

--- a/packages/backend-core/src/modules/crm/crm.integration.test.ts
+++ b/packages/backend-core/src/modules/crm/crm.integration.test.ts
@@ -280,8 +280,14 @@ const skipReason = TEST_URL
       );
       const channel = parseToolResult<{ id: string }>(
         await c.callTool({
-          name: 'conv_create_channel',
-          arguments: { type: 'email', vendor: 'smtp', name: 'Outreach Channel' },
+          name: 'conv_configure_email_channel',
+          arguments: {
+            name: 'Outreach Channel',
+            config: {
+              addressing: { fromAddress: 'outreach@example.com' },
+              outbound: { provider: 'mailer' },
+            },
+          },
         }),
       );
       await c.callTool({

--- a/packages/backend-core/src/modules/outreach/outreach.transfer.integration.test.ts
+++ b/packages/backend-core/src/modules/outreach/outreach.transfer.integration.test.ts
@@ -116,8 +116,14 @@ const skipReason = TEST_URL
     const seeded = await withClient(adminKeyA, async (c) => {
       const channel = firstJson(
         (await c.callTool({
-          name: 'conv_create_channel',
-          arguments: { type: 'email', vendor: 'smtp', name: 'Newsletter', config: {} },
+          name: 'conv_configure_email_channel',
+          arguments: {
+            name: 'Newsletter',
+            config: {
+              addressing: { fromAddress: 'newsletter@example.com' },
+              outbound: { provider: 'mailer' },
+            },
+          },
         })),
       ) as { id: string };
       const segment = firstJson(

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -545,7 +545,8 @@
         "submit": "Save",
         "saved": "Credentials saved",
         "savedUntested": "Saved — couldn't verify yet: {error}",
-        "error": "Couldn't save credentials."
+        "error": "Couldn't save credentials.",
+        "missingFields": "Missing: {fields}"
       },
       "emptyTitle": "No channels yet",
       "emptyBody": "Add a chat widget or email channel to start collecting messages.",
@@ -1485,6 +1486,7 @@
     "lede": "This one-time link lets you enter an integration's secret credentials directly, without sharing them in a chat.",
     "loading": "Loading…",
     "invalid": "This link is invalid or has expired.",
+    "missingFields": "Missing from the saved settings: {fields}",
     "for": "Credentials for {vendor}",
     "submit": "Save credentials",
     "reassurance": "Credentials are encrypted at rest and never shown again. This link works once.",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -574,7 +574,8 @@
         "submit": "Lagre",
         "saved": "Tilgang lagret",
         "savedUntested": "Lagret — kunne ikke verifisere ennå: {error}",
-        "error": "Kunne ikke lagre tilgang."
+        "error": "Kunne ikke lagre tilgang.",
+        "missingFields": "Mangler: {fields}"
       },
       "emptyTitle": "Ingen kanaler ennå",
       "emptyBody": "Legg til en chat-widget- eller e-post-kanal for å begynne å motta meldinger.",
@@ -1485,6 +1486,7 @@
     "lede": "Denne engangslenken lar deg legge inn en integrasjons hemmelige tilgangsnøkler direkte, uten å dele dem i en chat.",
     "loading": "Laster …",
     "invalid": "Denne lenken er ugyldig eller utløpt.",
+    "missingFields": "Mangler i de lagrede innstillingene: {fields}",
     "for": "Tilgang for {vendor}",
     "submit": "Lagre",
     "reassurance": "Tilgangsnøklene krypteres i hvile og vises aldri igjen. Denne lenken virker én gang.",

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -1644,7 +1644,13 @@ function EnterChannelCredentialsDialog({
       else notify.info(t('enterCredentials.savedUntested', { error: res.error ?? '' }));
       onDone();
     } catch (err) {
-      setError(translate(err) || t('enterCredentials.error'));
+      const message = translate(err) || t('enterCredentials.error');
+      const fields = err instanceof ApiError ? err.fieldErrors.map((fe) => fe.field) : [];
+      setError(
+        fields.length > 0
+          ? `${message} ${t('enterCredentials.missingFields', { fields: fields.join(', ') })}`
+          : message,
+      );
     } finally {
       setSaving(false);
     }
@@ -1761,7 +1767,13 @@ function EnterVendorCredentialsDialog({
       else notify.info(t('enterCredentials.savedUntested', { error: res.error ?? '' }));
       onDone();
     } catch (err) {
-      setError(translate(err) || t('enterCredentials.error'));
+      const message = translate(err) || t('enterCredentials.error');
+      const fields = err instanceof ApiError ? err.fieldErrors.map((fe) => fe.field) : [];
+      setError(
+        fields.length > 0
+          ? `${message} ${t('enterCredentials.missingFields', { fields: fields.join(', ') })}`
+          : message,
+      );
     } finally {
       setSaving(false);
     }

--- a/packages/dashboard-pages/src/pages/credential-entry.tsx
+++ b/packages/dashboard-pages/src/pages/credential-entry.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { Button, Card, CardContent, CardHeader, CardTitle, Hero, Input, Label } from '@getmunin/ui';
-import { api } from '../api';
+import { ApiError, api } from '../api';
 import { useTranslateError } from '../i18n/translate-error';
 
 interface Field {
@@ -25,7 +25,7 @@ export function CredentialEntryPage() {
   const translate = useTranslateError();
   const token = useSearchParams().get('token') ?? '';
   const [pending, setPending] = useState<Pending | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<{ message: string; fields: string[] } | null>(null);
   const [values, setValues] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
   const [done, setDone] = useState<{ ok: boolean; detail?: string; retryable?: boolean } | null>(
@@ -34,7 +34,7 @@ export function CredentialEntryPage() {
 
   const load = useCallback(async () => {
     if (!token) {
-      setLoadError(t('invalid'));
+      setLoadError({ message: t('invalid'), fields: [] });
       return;
     }
     try {
@@ -42,8 +42,12 @@ export function CredentialEntryPage() {
         anonymous: true,
       });
       setPending(p);
+      setLoadError(null);
     } catch (err) {
-      setLoadError(translate(err));
+      setLoadError({
+        message: translate(err),
+        fields: err instanceof ApiError ? err.fieldErrors.map((fe) => fe.field) : [],
+      });
     }
   }, [token, t, translate]);
 
@@ -80,8 +84,13 @@ export function CredentialEntryPage() {
       <Hero eyebrow={t('eyebrow')} title={t('title')} lede={t('lede')} />
       <Card className="mt-8">
         {loadError ? (
-          <CardContent>
-            <p className="text-sm text-destructive">{loadError}</p>
+          <CardContent className="space-y-2">
+            <p className="text-sm text-destructive">{loadError.message}</p>
+            {loadError.fields.length > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {t('missingFields', { fields: loadError.fields.join(', ') })}
+              </p>
+            )}
           </CardContent>
         ) : done ? (
           <CardContent className="space-y-4">

--- a/packages/db/drizzle/0073_conv_email_channel_credential_slots.sql
+++ b/packages/db/drizzle/0073_conv_email_channel_credential_slots.sql
@@ -1,0 +1,43 @@
+-- Repair email channels written by the removed free-form `conv_create_channel`
+-- tool. That path persisted the caller's `config` verbatim, so an SMTP/IMAP block
+-- could land without the `encryptedPassword` slot the stored-config schema
+-- requires. Every read of such a channel then failed validation: the
+-- credential-handoff link could not describe its fields and the dashboard could
+-- not save into it, while the row still reported active. The configure path
+-- writes the slot as an empty string and leaves the channel inactive until a
+-- password arrives — this brings the stragglers to that state so the existing
+-- credential link repairs them.
+--
+-- The same path could persist a plaintext `password` (secrets are meant to be
+-- pgcrypto-encrypted into `encryptedPassword`); those keys are dropped rather
+-- than migrated, since nothing ever read them and the operator re-enters the
+-- password through the link.
+--
+-- conv_channels is FORCE RLS, so the migration role sees zero rows without the
+-- bypass. Idempotent: each statement only matches blocks still in the bad shape.
+DO $$
+BEGIN
+  PERFORM set_config('app.bypass_rls', 'on', true);
+
+  UPDATE conv_channels
+  SET config = jsonb_set(config, '{outbound,encryptedPassword}', '""'::jsonb),
+      active = false,
+      updated_at = now()
+  WHERE type = 'email'
+    AND config -> 'outbound' ->> 'provider' = 'smtp'
+    AND NOT (config -> 'outbound' ? 'encryptedPassword');
+
+  UPDATE conv_channels
+  SET config = jsonb_set(config, '{inbound,encryptedPassword}', '""'::jsonb),
+      active = false,
+      updated_at = now()
+  WHERE type = 'email'
+    AND jsonb_typeof(config -> 'inbound') = 'object'
+    AND NOT (config -> 'inbound' ? 'encryptedPassword');
+
+  UPDATE conv_channels
+  SET config = (config #- '{outbound,password}') #- '{inbound,password}',
+      updated_at = now()
+  WHERE type = 'email'
+    AND ((config -> 'outbound' ? 'password') OR (config -> 'inbound' ? 'password'));
+END $$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1787211085927,
       "tag": "0072_audit_log_origin",
       "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1787221606047,
+      "tag": "0073_conv_email_channel_credential_slots",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Two bugs found while cloning an email channel between orgs over MCP. The second one creates a channel that reads as complete and is unusable; the first removed the diagnostic that would have caught it.

## 1. Credential links answered 401 on every click in cloud

`CredentialHandoffController` was a plain `@Controller('v1/credentials')` with no `@AllowAnonymous()`. OSS applies `AuthGuard` per controller, so the route was reachable there and every integration test passed. Cloud registers `AuthGuard` as a global `APP_GUARD` (`apps/backend-cloud/src/app.module.ts`), so both the describe (GET) and complete (POST) requests were rejected before the handoff service ran:

```
$ curl -i 'https://api.getmunin.com/v1/credentials?token=mncl_bogus_probe_token'
401 {"message":"invalid or expired credential","error":"Unauthorized","statusCode":401}
```

That message comes from `auth.guard.ts` and is about the *bearer credential*, which is why it read as an expired link. The entry page fetches with `anonymous: true` — correct, since the link exists for people who hold no Munin credential — so the failure was total: every link from `conv_request_channel_credentials`, `conv_configure_email_channel` and `connectors_request_credentials` was dead on arrival, in every org.

Now a `PublicController` with public throttling. Two tests guard it:

- `credential-handoff.public-route.test.ts` boots a module shaped like cloud (real `AuthGuard` as `APP_GUARD`) and asserts an unauthenticated describe and complete both reach the service. Against the old decorator it fails with `expected 401 to be 404`.
- `controller-auth-declared.test.ts` sweeps every `*.controller.ts` in `backend-core` and fails if one declares neither `AuthGuard` nor an anonymous opt-out. Credential-handoff was the only offender.

## 2. `conv_create_channel` accepted a structurally invalid email channel

It took `config` as a free-form object and persisted it verbatim — no per-type validation, no encryption, no credential slots. An email channel created through it looked correct in `conv_list_channels` and was unusable: the stored config failed the schema every later read applied, so the credential link could not describe its password fields and the dashboard had nowhere to save them. A plaintext `password` passed in that config was stored unencrypted and echoed back, since config masking only covers `encrypted*` keys.

The tool is removed rather than narrowed. Rejecting `email` would have left `chat`, which it breaks the same way — a widget channel with no widget key — and both types already have a tool that provisions them properly: `conv_configure_email_channel` validates the transport config, encrypts secrets and returns a credential link; `conv_create_widget_channel` mints the key. Voice and SMS were removed from this tool for the same reason in 4.76.0, so nothing remained that it could create correctly. `conv_import` still moves historical channel rows between servers.

## Error surfacing

A channel whose stored config lost its credential slots now answers the link with a `conv_channel_config_invalid` 400 carrying `fieldErrors`, instead of an unmapped `ChannelConfigInvalidError` that surfaced as a bare 500 — the interceptor that maps it only covers the dashboard's channel controller. The entry page names those fields and no longer keeps showing a stale load error after a later attempt succeeds; both channel credential dialogs name them too.

## Migration

`0073_conv_email_channel_credential_slots` repairs channels already written by the removed tool: adds the missing `encryptedPassword` slots, deactivates the channel so an existing link can complete it, and drops any plaintext `password`.

Smoke-tested against a scratch DB already at 0072, seeded with five rows — broken create-path, plaintext-password, healthy SMTP, mailer-only, widget. The first two were repaired and deactivated, the other three untouched and still active; verified as the non-superuser `munin_app` role (the `bypass_rls` in the `DO` block is doing real work), and re-running the body is a no-op.

## Verification

- `pnpm -F @getmunin/backend-core test` — 1643 passed
- `pnpm -F @getmunin/dashboard-pages test` — 81 passed
- `pnpm lint`, `pnpm typecheck` — clean
- docs fixtures regenerated (204 tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
