### PR TITLE
fix(conv): stop the agent answering one inbound message twice

### DIFF
--- a/.changeset/fix-double-agent-reply.md
+++ b/.changeset/fix-double-agent-reply.md
@@ -1,0 +1,23 @@
+---
+'@getmunin/agent-runtime': patch
+'@getmunin/backend-core': patch
+---
+
+Stop the agent sending two replies to one inbound message.
+
+A visitor email could get answered twice. The recovery sweeper that picks up unanswered
+conversations runs every 30s and had no minimum age or in-flight exclusion, so a
+conversation whose first reply was still being generated (25s is normal for a tool-using
+turn) was a valid candidate. Three guards should have stopped the duplicate and each had
+a gap: the in-process abort is cooperative and `runAgent` never re-checks it after the
+final provider response, so a superseded run still returned an answer and posted it; the
+cross-runner lease is released immediately after posting; and the backend
+`agent_reply_race` check only rejects a post when an agent message is newer than *the
+caller's own snapshot*, so a run that read the conversation after the first reply landed
+carried that reply as its own `sinceMessageId` and passed. Nothing checked that the last
+public message was still the visitor's — `resolveDelivery` only required that some
+inbound message existed somewhere in the thread.
+
+Three fixes: a reply run now bails when the last non-internal message is not from the
+visitor; `run()` checks the abort signal after generation completes and before posting;
+and the awaiting-reply query excludes conversations holding a live runner lease.

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -505,6 +505,128 @@ describe('createConversationHandler', () => {
     expect(postSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('skips when the last public message is already an agent reply (no double answer)', async () => {
+    const rest = buildRest({
+      getConversation: vi.fn(() =>
+        Promise.resolve(
+          buildConversation({
+            messages: [
+              {
+                id: 'msg_1',
+                authorType: 'end_user',
+                body: 'can I refinance with a payment default?',
+                createdAt: new Date(Date.now() - 30_000).toISOString(),
+                internal: false,
+              },
+              {
+                id: 'msg_2',
+                authorType: 'agent',
+                body: 'yes, here is how it works',
+                createdAt: new Date().toISOString(),
+                internal: false,
+              },
+            ],
+          }),
+        ),
+      ),
+    });
+    const postSpy = vi.fn(() => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+    const stubProvider: Provider = () => Promise.resolve(assistantStop('a second answer'));
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      prompts: buildPrompts(),
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+      provider: stubProvider,
+    });
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('still replies when only an internal agent note follows the visitor message', async () => {
+    const rest = buildRest({
+      getConversation: vi.fn(() =>
+        Promise.resolve(
+          buildConversation({
+            messages: [
+              {
+                id: 'msg_1',
+                authorType: 'end_user',
+                body: 'can I refinance with a payment default?',
+                createdAt: new Date(Date.now() - 30_000).toISOString(),
+                internal: false,
+              },
+              {
+                id: 'msg_2',
+                authorType: 'agent',
+                body: 'routing note for staff',
+                createdAt: new Date().toISOString(),
+                internal: true,
+              },
+            ],
+          }),
+        ),
+      ),
+    });
+    const postSpy = vi.fn(() => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+    const stubProvider: Provider = () => Promise.resolve(assistantStop('yes, here is how'));
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      prompts: buildPrompts(),
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+      provider: stubProvider,
+    });
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+    expect(postSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not post a reply from a run superseded after the provider had already answered', async () => {
+    let releaseFirst: (() => void) | null = null;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let providerCalls = 0;
+    const stubProvider: Provider = () => {
+      providerCalls += 1;
+      if (providerCalls === 1) return firstGate.then(() => assistantStop('stale answer'));
+      return Promise.resolve(assistantStop('fresh answer'));
+    };
+    const rest = buildRest();
+    const postSpy = vi.fn((_conversationId: string, _body: string) => Promise.resolve());
+    rest.postAgentMessage = postSpy;
+    const handler = createConversationHandler({
+      config: { ...baseConfig, auditEnabled: false },
+      rest,
+      prompts: buildPrompts(),
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+      provider: stubProvider,
+    });
+
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(providerCalls).toBe(1);
+
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await new Promise((r) => setTimeout(r, 0));
+    releaseFirst!();
+    await handler.flush();
+    for (let i = 0; i < 5; i += 1) await new Promise((r) => setTimeout(r, 5));
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(postSpy.mock.calls[0]![1]).toBe('fresh answer');
+  });
+
   it('skips when another runner already owns the conversation', async () => {
     const rest = buildRest();
     const postSpy = vi.fn(() => Promise.resolve());

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -174,9 +174,13 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
       return null;
     }
     if (mode === 'greet') return delivery;
-    const last = lastInbound(detail);
+    const last = lastPublicMessage(detail);
     if (!last) {
       log.info(`skip ${detail.id}: no inbound message yet`);
+      return null;
+    }
+    if (last.authorType !== 'user' && last.authorType !== 'end_user') {
+      log.info(`skip ${detail.id}: already answered (last public message is ${last.authorType})`);
       return null;
     }
     return delivery;
@@ -307,6 +311,8 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
           abortSignal: signal,
           provider: deps.provider,
         });
+
+        if (signal.aborted) return;
 
         if (reply.body.trim().length > 0) {
           deps.onProviderSuccess?.();
@@ -609,13 +615,13 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
   };
 }
 
-function lastInbound(detail: ConversationDetail): ConversationMessage | null {
+function lastPublicMessage(
+  detail: ConversationDetail,
+): ConversationDetail['messages'][number] | null {
   for (let i = detail.messages.length - 1; i >= 0; i -= 1) {
     const m = detail.messages[i];
-    if (!m) continue;
-    if (m.authorType === 'user' || m.authorType === 'end_user') {
-      return { authorType: m.authorType, body: m.body, createdAt: m.createdAt };
-    }
+    if (!m || m.internal) continue;
+    return m;
   }
   return null;
 }

--- a/packages/backend-core/src/modules/conv/conv.awaiting-reply.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.awaiting-reply.integration.test.ts
@@ -118,6 +118,8 @@ const skipReason = TEST_URL
     assigneeUserId?: string | null;
     endUserId?: string | null;
     lastMessageAt?: Date;
+    runnerHolder?: string;
+    runnerLeaseExpiresAt?: Date;
     messages: Array<{
       authorType: 'user' | 'agent' | 'end_user' | 'system';
       internal?: boolean;
@@ -138,6 +140,8 @@ const skipReason = TEST_URL
         agentMode: opts.agentMode ?? 'auto',
         assigneeUserId: opts.assigneeUserId ?? null,
         lastMessageAt: opts.lastMessageAt ?? new Date(),
+        runnerHolder: opts.runnerHolder ?? null,
+        runnerLeaseExpiresAt: opts.runnerLeaseExpiresAt ?? null,
       })
       .returning();
     for (const m of opts.messages) {
@@ -184,6 +188,24 @@ const skipReason = TEST_URL
         { authorType: 'end_user', offsetMs: 0 },
         { authorType: 'agent', internal: true, offsetMs: 1000 },
       ],
+    });
+    expect(await awaitingIds()).toContain(id);
+  });
+
+  it('excludes a conversation a runner is answering right now', async () => {
+    const id = await mkConv({
+      runnerHolder: 'runner-a',
+      runnerLeaseExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      messages: [{ authorType: 'end_user', offsetMs: 0 }],
+    });
+    expect(await awaitingIds()).not.toContain(id);
+  });
+
+  it('includes a conversation whose runner lease has expired', async () => {
+    const id = await mkConv({
+      runnerHolder: 'runner-a',
+      runnerLeaseExpiresAt: new Date(Date.now() - 60 * 1000),
+      messages: [{ authorType: 'end_user', offsetMs: 0 }],
     });
     expect(await awaitingIds()).toContain(id);
   });

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -493,6 +493,10 @@ export class ConvService {
           sql`${schema.convChannels.type} <> 'voice'`,
           sql`${schema.convConversations.lastMessageAt} > now() - make_interval(mins => ${lookbackMinutes})`,
           sql`(
+            ${schema.convConversations.runnerLeaseExpiresAt} IS NULL
+            OR ${schema.convConversations.runnerLeaseExpiresAt} < now()
+          )`,
+          sql`(
             SELECT author_type FROM conv_messages
             WHERE conversation_id = ${schema.convConversations.id}
               AND internal = false


### PR DESCRIPTION
## What happened

A visitor emailed the demo org's email channel and got **two** replies. In `ccv_3zu5do0pl75i2s1bucz5il` there is one inbound message and two public agent replies, at `11:18:09.980` and `11:18:21.062` — independent generations of the same answer (the second even leaks raw `(source-url:…)` markers from KB results). The inbound arrived at `11:17:44.638`.

Not a duplicate ingest (one inbound message row, one `Message-ID`), not a duplicate channel (the org has one email channel), and not a curator job going rogue — every skill job is tool-locked via `TOOL_PREFIXES_BY_URI` and none can call `conv_send_message`. Two other conversations in the same session got exactly one reply each, so it's a race.

## Root cause

The first reply took **25 seconds**. The sweeper that recovers unanswered conversations runs every **30 s** (`RECONCILE_INTERVAL_MS`) and on every bus reconnect, and `listConversationsAwaitingAgentReply` had a 60-minute lookback but **no minimum age and no in-flight exclusion** — a conversation whose reply is being generated right now was a valid candidate.

Three guards should have stopped the second run. Each had a gap:

1. **In-process abort** — `spawn()` aborts the previous run, but the abort is cooperative and `runAgent` only re-checks `abortSignal` at the top of each tool iteration. An abort arriving during the *final* provider call is ignored, so the superseded run returns an answer and posts it.
2. **Cross-runner lease** — `tryAcquireConversation` is a correct atomic conditional UPDATE, but `releaseClaim` runs in the `finally` right after posting, so the lease frees the instant reply 1 lands.
3. **Backend race guard** — `AgentReplyRaceError` only rejects a post when an agent message is newer than *the caller's own snapshot*. A run that read the conversation **after** reply 1 landed carries reply 1 as its own `sinceMessageId` and sails through.

And the guard that didn't exist: `resolveDelivery` only required that *some* inbound message existed (`lastInbound` scanned backwards for any), never that the **last** public message was the visitor's. Since `run()` waits `debounceMs` *before* re-reading the conversation, the sweeper's candidate list is stale by design:

> sweep SELECT lands just before reply 1 is inserted → `handle()` → debounce → `getConversation` now includes reply 1 → `resolveDelivery` says go → lease is free → second full answer, invisible to the race guard.

## The fix

- `resolveDelivery` bails when the last non-internal message is not from the visitor (`lastInbound` → `lastPublicMessage`). This closes every trigger path at once — 30 s tick, bus reconnect, runner respawn.
- `run()` checks the abort signal after generation completes and before posting, so a superseded run stops instead of posting a stale answer.
- `listConversationsAwaitingAgentReply` excludes conversations holding a live runner lease, so the sweeper stops nominating conversations that are already being answered.

## Tests

Each new test was checked against the unfixed code rather than trusted on a green run — worth it, because the first version of the superseded-run test passed vacuously: `flush()` only awaits runs still in the in-flight map, and a superseded run has already been evicted, so the assertion fired before the duplicate post landed.

Confirmed failing before / passing after:

- `skips when the last public message is already an agent reply (no double answer)`
- `does not post a reply from a run superseded after the provider had already answered`
- `excludes a conversation a runner is answering right now`

Guards against over-correction: `still replies when only an internal agent note follows the visitor message`, `includes a conversation whose runner lease has expired`.

Suites: agent-runtime 390 passed, agent-host 142 passed, all 387 backend-core `conv` tests passed, workspace typecheck clean, eslint clean.

## Note

The two replies remain in the demo org's conversation #3 — no prod data was touched, and the fix only takes effect on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)