### PR TITLE
fix(widget): nofollow the powered-by links and keep their referrer

### DIFF
--- a/.changeset/widget-credit-link-rel-utm.md
+++ b/.changeset/widget-credit-link-rel-utm.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/chat-widget': patch
+---
+
+Mark the widget's "Powered by Munin" links `rel="nofollow noopener"` and tag the href with UTM params.
+
+The credit link is rendered into every embedding site's template, which is exactly the pattern Google's link spam guidance calls out as a link scheme ("links embedded in widgets that get distributed across various sites", "links in the footers or templates of various sites"). Googlebot renders JS and flattens open shadow roots, so the link was discoverable and followable — carrying the manipulation risk without any realistic ranking benefit, since widget links are devalued by policy either way. `nofollow` takes that risk off the table at no cost.
+
+Dropping `noreferrer` is the part that gains something: it was stripping the `Referer` header, so every real click landed in analytics as direct traffic with no way to tell which embedding site sent it. With only `noopener` (which is what actually covers the `target="_blank"` security concern), clicks now carry a referrer host and show up in `analytics_list_referrer_hosts`. The href gains `utm_source=widget&utm_medium=referral&utm_campaign=powered_by` — the three params `tracker.js` reads; `utm_content` is deliberately omitted because the tracker ignores it and the referrer host already provides the per-install dimension.
+
+The href also points at the canonical `www.getmunin.com` rather than the apex, which 301s to it — one less redirect hop per click.
+
+Both call sites (welcome eyebrow and panel footer) now build the anchor from one helper, so the href and rel can't drift apart.

--- a/apps/chat-widget/src/ui.test.ts
+++ b/apps/chat-widget/src/ui.test.ts
@@ -904,3 +904,36 @@ describe('ui: open/close/isOpen', () => {
     expect(($('.launcher')).hidden).toBe(true);
   });
 });
+
+describe('ui: powered-by credit links', () => {
+  function creditAnchors(): HTMLAnchorElement[] {
+    controller = mount(baseConfig, strings, { onSend: () => {}, onTypingIntent: () => {} });
+    const anchors = $$('.footer-credit a, .welcome-eyebrow a') as HTMLAnchorElement[];
+    expect(anchors.length).toBe(2);
+    return anchors;
+  }
+
+  it('marks the credit links nofollow so a site-wide widget link is never a link scheme', () => {
+    for (const a of creditAnchors()) {
+      const rel = (a.getAttribute('rel') ?? '').split(/\s+/);
+      expect(rel).toContain('nofollow');
+      expect(rel).toContain('noopener');
+    }
+  });
+
+  it('omits noreferrer so widget clicks arrive with a referrer host instead of as direct traffic', () => {
+    for (const a of creditAnchors()) {
+      expect(a.getAttribute('rel')).not.toContain('noreferrer');
+    }
+  });
+
+  it('tags the credit href with UTM params the tracker reads', () => {
+    for (const a of creditAnchors()) {
+      const url = new URL(a.getAttribute('href')!);
+      expect(url.origin).toBe('https://www.getmunin.com');
+      expect(url.searchParams.get('utm_source')).toBe('widget');
+      expect(url.searchParams.get('utm_medium')).toBe('referral');
+      expect(url.searchParams.get('utm_campaign')).toBe('powered_by');
+    }
+  });
+});

--- a/apps/chat-widget/src/ui.ts
+++ b/apps/chat-widget/src/ui.ts
@@ -57,6 +57,12 @@ export interface UiController {
 
 const TYPING_IDLE_MS = 800;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const CREDIT_URL =
+  'https://www.getmunin.com/?utm_source=widget&utm_medium=referral&utm_campaign=powered_by';
+
+function creditLinkHtml(strings: Strings): string {
+  return `<a href="${escapeAttr(CREDIT_URL)}" target="_blank" rel="nofollow noopener">${escapeHtml(strings.poweredBy)} <strong>Munin</strong></a>`;
+}
 
 export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): UiController {
   const locale = pickLocale(config.locale).locale;
@@ -594,7 +600,7 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
   }
 
   if (config.eyebrow === null) {
-    panel.welcomeEyebrowEl.innerHTML = `<a href="https://getmunin.com" target="_blank" rel="noopener noreferrer">${escapeHtml(strings.poweredBy)} <strong>Munin</strong></a>`;
+    panel.welcomeEyebrowEl.innerHTML = creditLinkHtml(strings);
   } else {
     panel.welcomeEyebrowEl.textContent = config.eyebrow;
   }
@@ -1005,7 +1011,7 @@ function renderPanel(config: WidgetConfig, strings: Strings): PanelHandles {
         <span class="counter"></span>
       </div>
     </form>
-    <div class="footer-credit"><a href="https://getmunin.com" target="_blank" rel="noopener noreferrer">${escapeHtml(strings.poweredBy)} <strong>Munin</strong></a></div>
+    <div class="footer-credit">${creditLinkHtml(strings)}</div>
     <div class="voice-call" hidden>
       <button type="button" class="voice-call-min" aria-label="${escapeAttr(strings.voiceMinimizeAriaLabel)}">↙ ${escapeHtml(strings.voiceBackToChat)}</button>
       <div class="voice-call-stage">


### PR DESCRIPTION
## Why

The widget's two "Powered by Munin" credit links (welcome eyebrow + panel footer) pointed at `https://getmunin.com` with `rel="noopener noreferrer"`. That combination gets the tradeoff backwards.

**The link was followable.** `noreferrer` is not `nofollow`. The credit link renders into every embedding site's page template, and Googlebot renders JS and flattens open shadow roots — so it was discoverable and followable. Google's link spam guidance names this pattern directly: "links embedded in widgets that get distributed across various sites" and "links in the footers or templates of various sites." Widget links get devalued by policy regardless, so we were carrying the manipulation risk with no realistic ranking upside. `nofollow` removes that exposure at zero cost.

**`noreferrer` was costing real attribution.** It stripped the `Referer` header, so every genuine human click from the widget arrived at getmunin.com as *direct* traffic — no way to tell which embedding site sent it, or that the widget sent it at all. `noopener` alone is what actually covers the `target="_blank"` security concern; `noreferrer` was redundant for security and expensive for measurement.

## What changed

```html
<a href="https://www.getmunin.com/?utm_source=widget&utm_medium=referral&utm_campaign=powered_by"
   target="_blank" rel="nofollow noopener">
```

- `rel="nofollow noopener"` — risk off the table, security preserved, referrer restored. Clicks now show up in `analytics_list_referrer_hosts`.
- UTM params limited to `utm_source` / `utm_medium` / `utm_campaign` — the three `readUtm()` in `tracker-bundle.ts` actually parses. `utm_content` is deliberately omitted: the tracker ignores it, and the restored referrer host already provides the per-install dimension it would have carried.
- Canonical `www.getmunin.com` instead of the apex, which 301s to it — one less redirect hop per click.
- Both call sites now build the anchor from a single `creditLinkHtml()` helper, so href and rel can't drift apart.

## Scope note

`markdown.ts` renders links inside conversation message bodies with `rel="noopener noreferrer"` and is intentionally untouched — those are outbound third-party URLs from KB/message content, a different concern where `noreferrer` is arguably correct.

## Testing

Three tests in `ui.test.ts` encode the invariants (nofollow present, noreferrer absent, UTM params and canonical origin intact), with the reasoning in the test names per the repo's no-comments rule. Full `@getmunin/chat-widget` suite: 174 passed. Typecheck and lint clean.

Verified the redirect claim directly: `https://getmunin.com/` → `301` → `https://www.getmunin.com/`, which serves `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)