### PR TITLE
fix(dashboard): fit drawers, the MCP snippet footer and the topbar to a phone viewport

### DIFF
--- a/.changeset/mobile-drawer-and-topbar-fit.md
+++ b/.changeset/mobile-drawer-and-topbar-fit.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/dashboard-pages': patch
+'@getmunin/ui': patch
+---
+
+Fix three mobile-viewport regressions in the dashboard shell.
+
+Side sheets were sized with `h-full` on a `position: fixed` element, which resolves against the initial containing block — on iOS Safari that is the *large* viewport, so the bottom of every drawer sat behind the browser toolbar and the footer actions (approve, dismiss, cancel scheduled) were half-covered. They now use `100dvh` anchored to the top, which tracks the toolbar as it collapses and expands.
+
+The docs-link row under the Connect MCP snippet on Get started could not shrink: the docs URL is one long unbreakable token, so the flex row overflowed its card and pushed the copy button past the right edge of the viewport. The link may now wrap and the button no longer shrinks.
+
+The dashboard topbar used an 8px gap on mobile, which left the org selector nearly touching the logo once a `leftSlot` was supplied. Mobile now gets 16px; the desktop gap (which also has a rule between the two) is unchanged.

--- a/packages/dashboard-pages/src/components/dashboard/get-started.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/get-started.tsx
@@ -111,19 +111,19 @@ export function GetStarted() {
             <pre className="m-0 px-4 py-4 overflow-x-auto font-mono text-xs leading-[1.6] text-ink dark:text-foreground">
               <code>{setup.snippet}</code>
             </pre>
-            <div className="flex justify-between items-center px-3.5 py-2 border-t-[1px] border-rule-soft bg-paper dark:bg-secondary dark:border-rule-on-dark">
+            <div className="flex justify-between items-center gap-3 px-3.5 py-2 border-t-[1px] border-rule-soft bg-paper dark:bg-secondary dark:border-rule-on-dark">
               <a
                 href={setup.docsHref}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute hover:text-cobalt transition-colors duration-fast"
+                className="min-w-0 break-words font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute hover:text-cobalt transition-colors duration-fast"
               >
                 {setup.docsLabel} ↗
               </a>
               <button
                 type="button"
                 onClick={copySnippet}
-                className="font-mono text-[10px] uppercase tracking-eyebrow bg-ink text-paper border-0 px-3 py-1.5 cursor-pointer hover:bg-black dark:bg-foreground dark:text-background"
+                className="shrink-0 font-mono text-[10px] uppercase tracking-eyebrow bg-ink text-paper border-0 px-3 py-1.5 cursor-pointer hover:bg-black dark:bg-foreground dark:text-background"
               >
                 {copied ? t('copied') : t('copy')}
               </button>

--- a/packages/dashboard-pages/src/components/munin-topbar.tsx
+++ b/packages/dashboard-pages/src/components/munin-topbar.tsx
@@ -29,7 +29,7 @@ export function DashboardTopbar({
   settingsLabel,
 }: DashboardTopbarProps) {
   return (
-    <header className={`${topbarChromeBase} flex h-14 items-stretch gap-2 px-4 md:gap-6 md:px-10`}>
+    <header className={`${topbarChromeBase} flex h-14 items-stretch gap-4 px-4 md:gap-6 md:px-10`}>
       <Link
         href={brandHref}
         className="flex items-center gap-1 self-center text-ink dark:text-foreground"

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -12,9 +12,9 @@ const sheetVariants = cva(
         top: "inset-x-0 top-0 border-b-[1px] border-ink data-[starting-style]:-translate-y-full data-[ending-style]:-translate-y-full dark:border-rule-on-dark",
         bottom:
           "inset-x-0 bottom-0 border-t-[1px] border-ink data-[starting-style]:translate-y-full data-[ending-style]:translate-y-full dark:border-rule-on-dark",
-        left: "inset-y-0 left-0 h-full w-full max-w-[560px] border-r-[1px] border-ink data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full dark:border-rule-on-dark",
+        left: "top-0 left-0 h-[100dvh] w-full max-w-[560px] border-r-[1px] border-ink data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full dark:border-rule-on-dark",
         right:
-          "inset-y-0 right-0 h-full w-full max-w-[560px] border-l-[1px] border-ink data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full dark:border-rule-on-dark",
+          "top-0 right-0 h-[100dvh] w-full max-w-[560px] border-l-[1px] border-ink data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full dark:border-rule-on-dark",
       },
     },
     defaultVariants: { side: "right" },


### PR DESCRIPTION
Three mobile-viewport fixes, all reported from an iPhone.

**Drawer footers sat behind the browser toolbar.** Side sheets were sized with `h-full` on a `position: fixed` element, which resolves against the initial containing block — on iOS Safari that is the *large* viewport (toolbars hidden), so the bottom ~50px of every drawer was covered and the footer actions (approve, dismiss, cancel scheduled) were half-visible. They now use `100dvh` anchored to the top, which tracks the toolbar as it collapses and expands. Covers all three inbox drawers plus the settings mobile menu (`side="left"`).

**The copy button on Get started was pushed off-screen.** The docs URL under the Connect MCP snippet is one long unbreakable token, so the footer flex row's min-content width exceeded its card and shoved the button past the right edge of the viewport. The link is now `min-w-0 break-words` — it wraps to a second line on a narrow screen rather than truncating away the guide name — and the button no longer shrinks.

**The org selector nearly touched the logo.** The dashboard topbar used an 8px gap on mobile, which is too tight once a `leftSlot` supplies the switcher (munin-cloud). Mobile now gets 16px; the desktop gap is unchanged, since it also has a vertical rule between the two.

## Testing

Typecheck passes on both packages. The `100dvh` change is only observable on iOS Safari — desktop responsive mode cannot reproduce the original clipping — so that one wants a look on a real phone before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiRhcZUpZ3u538xCioS8dv