### PR TITLE
fix(analytics): validate import source and readDepth at the boundary

### DIFF
--- a/.changeset/analytics-import-source-enum.md
+++ b/.changeset/analytics-import-source-enum.md
@@ -1,0 +1,18 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Validate `source` and `readDepth` on analytics import instead of letting Postgres reject them.
+
+`analytics_import` (and `POST /v1/analytics/import`) accepted `source` as any string up to 8
+characters, but `analytics_view_events` has a check constraint allowing only `pixel`, `beacon` or
+`tracker`. Importing a plausible-looking value such as `web` passed schema validation and then
+failed inside the database, surfacing as `500 Internal server error` with no indication of which
+field was wrong — during a bulk import of hundreds of events, with nothing written.
+
+The enum already existed in `analytics.tools.ts` as `ViewSourceSchema` and was applied to all six
+read filters, but never to the import path — the one place the value comes from the caller. It now
+lives in `ingest-fields.ts` alongside the other shared ingest boundary helpers, so the MCP tool and
+the HTTP controller validate against one definition. `readDepth` had the same gap and is now bounded
+to 0–100 to match its own check constraint. Both boundaries now return a validation error naming the
+field.

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -10110,7 +10110,11 @@
                     },
                     "source": {
                       "type": "string",
-                      "maxLength": 8
+                      "enum": [
+                        "pixel",
+                        "beacon",
+                        "tracker"
+                      ]
                     },
                     "path": {
                       "anyOf": [
@@ -10218,8 +10222,8 @@
                       "anyOf": [
                         {
                           "type": "integer",
-                          "minimum": -9007199254740991,
-                          "maximum": 9007199254740991
+                          "minimum": 0,
+                          "maximum": 100
                         },
                         {
                           "type": "null"

--- a/packages/backend-core/src/control/analytics-transfer.controller.ts
+++ b/packages/backend-core/src/control/analytics-transfer.controller.ts
@@ -26,6 +26,10 @@ import {
   type ExportPage,
   type ImportResult,
 } from '../common/transfer/transfer.types.ts';
+import {
+  analyticsReadDepth,
+  analyticsViewSource,
+} from '../modules/analytics/ingest-fields.ts';
 
 class ImportAnalyticsBody extends createZodDto(
   z.object({
@@ -56,7 +60,7 @@ class ImportAnalyticsBody extends createZodDto(
             id: z.string(),
             subjectType: z.string().max(32),
             subjectId: z.string(),
-            source: z.string().max(8),
+            source: analyticsViewSource,
             path: z.string().nullable().optional(),
             locale: z.string().nullable().optional(),
             referrer: z.string().nullable().optional(),
@@ -67,7 +71,7 @@ class ImportAnalyticsBody extends createZodDto(
             endUserId: z.string().nullable().optional(),
             userAgentClass: z.string().nullable().optional(),
             dwellMs: z.number().int().nullable().optional(),
-            readDepth: z.number().int().nullable().optional(),
+            readDepth: analyticsReadDepth.nullable().optional(),
             country: z.string().nullable().optional(),
             metadata: z.record(z.string(), z.unknown()).nullable().optional(),
             createdAt: z.string(),

--- a/packages/backend-core/src/modules/analytics/analytics.tools.ts
+++ b/packages/backend-core/src/modules/analytics/analytics.tools.ts
@@ -4,6 +4,7 @@ import { McpTool } from '@getmunin/mcp-toolkit';
 import { AnalyticsService } from './analytics.service.ts';
 import { CursorInputSchema, IdMapSchema } from '../../common/transfer/transfer.types.ts';
 import { INSPECTOR_APP_URI } from '../../mcp/inspector.resource.ts';
+import { analyticsReadDepth, analyticsViewSource } from './ingest-fields.ts';
 
 const AnalyticsImportInput = z.object({
   config: z
@@ -34,7 +35,7 @@ const AnalyticsImportInput = z.object({
           id: z.string(),
           subjectType: z.string().max(32),
           subjectId: z.string(),
-          source: z.string().max(8),
+          source: analyticsViewSource,
           trackerId: z.string().nullable().optional(),
           path: z.string().nullable().optional(),
           locale: z.string().nullable().optional(),
@@ -46,7 +47,7 @@ const AnalyticsImportInput = z.object({
           endUserId: z.string().nullable().optional(),
           userAgentClass: z.string().nullable().optional(),
           dwellMs: z.number().int().nullable().optional(),
-          readDepth: z.number().int().nullable().optional(),
+          readDepth: analyticsReadDepth.nullable().optional(),
           country: z.string().nullable().optional(),
           metadata: z.record(z.string(), z.unknown()).nullable().optional(),
           createdAt: z.string(),
@@ -71,8 +72,6 @@ const AnalyticsImportInput = z.object({
 });
 
 const EmptyInput = z.object({});
-
-const ViewSourceSchema = z.enum(['pixel', 'beacon', 'tracker']);
 
 const CanonicalLocales = z.array(z.string().min(1).max(16)).max(32);
 
@@ -113,7 +112,7 @@ const TopSubjectsInput = z.object({
   subjectType: z.string().max(32).optional(),
   sinceDays: z.number().int().min(1).max(365).default(30),
   limit: z.number().int().min(1).max(200).default(20),
-  source: ViewSourceSchema.optional(),
+  source: analyticsViewSource.optional(),
   trackerId: TrackerIdFilter,
   endUserId: z.string().optional(),
   contactId: z.string().optional(),
@@ -123,7 +122,7 @@ const TopCountriesInput = z.object({
   subjectType: z.string().max(32).optional(),
   sinceDays: z.number().int().min(1).max(365).default(30),
   limit: z.number().int().min(1).max(200).default(50),
-  source: ViewSourceSchema.optional(),
+  source: analyticsViewSource.optional(),
   trackerId: TrackerIdFilter,
 });
 
@@ -131,7 +130,7 @@ const TrafficBySourceInput = z.object({
   subjectType: z.string().max(32).optional(),
   sinceDays: z.number().int().min(1).max(365).default(30),
   limit: z.number().int().min(1).max(200).default(50),
-  source: ViewSourceSchema.optional(),
+  source: analyticsViewSource.optional(),
   trackerId: TrackerIdFilter,
 });
 
@@ -140,7 +139,7 @@ const ReferrerHostsInput = z.object({
   excludeHost: z.string().max(255).optional(),
   sinceDays: z.number().int().min(1).max(365).default(30),
   limit: z.number().int().min(1).max(200).default(50),
-  source: ViewSourceSchema.optional(),
+  source: analyticsViewSource.optional(),
   trackerId: TrackerIdFilter,
 });
 
@@ -148,7 +147,7 @@ const ViewsOverTimeInput = z.object({
   subjectType: z.string().max(32).optional(),
   subjectId: z.string().optional(),
   sinceDays: z.number().int().min(1).max(365).default(30),
-  source: ViewSourceSchema.optional(),
+  source: analyticsViewSource.optional(),
   trackerId: TrackerIdFilter,
   endUserId: z.string().optional(),
   contactId: z.string().optional(),
@@ -193,7 +192,7 @@ const FunnelInput = z.object({
   steps: z.array(FunnelStepSchema).min(2).max(8),
   sinceDays: z.number().int().min(1).max(365).default(30),
   stepWindowHours: z.number().int().min(1).max(24 * 365).optional(),
-  source: ViewSourceSchema.optional(),
+  source: analyticsViewSource.optional(),
   trackerId: TrackerIdFilter,
 });
 

--- a/packages/backend-core/src/modules/analytics/ingest-fields.test.ts
+++ b/packages/backend-core/src/modules/analytics/ingest-fields.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { MAX_INGEST_FIELD_LENGTH, truncatedString } from './ingest-fields.ts';
+import {
+  ANALYTICS_VIEW_SOURCES,
+  MAX_INGEST_FIELD_LENGTH,
+  analyticsReadDepth,
+  analyticsViewSource,
+  truncatedString,
+} from './ingest-fields.ts';
 
 describe('truncatedString', () => {
   it('leaves a value inside the limit untouched', () => {
@@ -27,5 +33,30 @@ describe('truncatedString', () => {
     expect(truncatedString(512).safeParse('x'.repeat(MAX_INGEST_FIELD_LENGTH + 1)).success).toBe(
       false,
     );
+  });
+});
+
+describe('analyticsViewSource', () => {
+  it('accepts every source analytics_view_events_source_chk allows', () => {
+    for (const source of ANALYTICS_VIEW_SOURCES) {
+      expect(analyticsViewSource.safeParse(source).success).toBe(true);
+    }
+  });
+
+  it('rejects an unknown source at the boundary rather than letting Postgres raise a 500', () => {
+    expect(analyticsViewSource.safeParse('web').success).toBe(false);
+    expect(analyticsViewSource.safeParse('').success).toBe(false);
+  });
+});
+
+describe('analyticsReadDepth', () => {
+  it('accepts the whole percentage range analytics_view_events_read_depth_chk allows', () => {
+    expect(analyticsReadDepth.safeParse(0).success).toBe(true);
+    expect(analyticsReadDepth.safeParse(100).success).toBe(true);
+  });
+
+  it('rejects a depth outside 0-100 rather than letting Postgres raise a 500', () => {
+    expect(analyticsReadDepth.safeParse(-1).success).toBe(false);
+    expect(analyticsReadDepth.safeParse(101).success).toBe(false);
   });
 });

--- a/packages/backend-core/src/modules/analytics/ingest-fields.ts
+++ b/packages/backend-core/src/modules/analytics/ingest-fields.ts
@@ -8,3 +8,9 @@ export function truncatedString(max: number) {
     .max(MAX_INGEST_FIELD_LENGTH)
     .transform((value) => value.slice(0, max));
 }
+
+export const ANALYTICS_VIEW_SOURCES = ['pixel', 'beacon', 'tracker'] as const;
+
+export const analyticsViewSource = z.enum(ANALYTICS_VIEW_SOURCES);
+
+export const analyticsReadDepth = z.number().int().min(0).max(100);


### PR DESCRIPTION
## The bug

`analytics_import` (and `POST /v1/analytics/import`) declared `source` as `z.string().max(8)`, but
`analytics_view_events` has a check constraint allowing only `pixel`, `beacon` or `tracker`.

Importing a plausible-looking value — `web` — passed schema validation and then failed inside
Postgres:

```
PostgresError: new row for relation "analytics_view_events"
violates check constraint "analytics_view_events_source_chk"
```

which surfaced to the caller as a bare `500 Internal server error` naming no field, mid-way through
a bulk import of several hundred events, with nothing written. Found while scripting a demo import;
it took a look at `pg_constraint` to work out which field was even at fault.

The enum **already existed** in `analytics.tools.ts` as `ViewSourceSchema` and was applied to all six
read/filter schemas — but never to the import schema, which is the one place the value is
caller-supplied.

`readDepth` had the same gap: `analytics_view_events_read_depth_chk` bounds it to 0–100, the schema
accepted any integer.

## The change

- `ingest-fields.ts` — the module that already holds the shared analytics ingest-boundary helpers —
  now exports `ANALYTICS_VIEW_SOURCES`, `analyticsViewSource` and `analyticsReadDepth`.
- The MCP tool and the HTTP controller both import them, so the two boundaries validate against one
  definition and can't drift. The duplicate local enum is gone.
- Both now return a validation error naming the offending field instead of a 500.
- `openapi.json` regenerates to advertise `enum: [pixel, beacon, tracker]` and `minimum: 0,
  maximum: 100`, so API clients get the domain without reading the migration.

No behaviour change for valid input, and no migration — this only tightens validation to match
constraints the database already enforced.

## Tests

Four unit tests in `ingest-fields.test.ts`, invariants encoded in the test names per the
no-comments rule. `'web'` is the regression anchor since it's the value that actually broke.

- `pnpm -F @getmunin/backend-core typecheck` — clean
- analytics suite — 43/43 passing

The full `backend-core` run has 10 failures, all in `src/oauth/*`. I confirmed they reproduce on a
clean tree (they depend on `NEXT_PUBLIC_MCP_URL` being set) — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhaGswtoVx7nowaQw8Qm3C