### PR TITLE
fix(slack): render mirrored message bodies as Slack mrkdwn, not raw markdown

### DIFF
--- a/.changeset/slack-mrkdwn-conversion.md
+++ b/.changeset/slack-mrkdwn-conversion.md
@@ -1,0 +1,22 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Render message bodies mirrored into Slack as Slack mrkdwn instead of raw markdown.
+
+Agent replies are written in markdown, but Slack's mrkdwn is a different dialect: it
+reads `*bold*`, not `**bold**`, and has no link, heading or list syntax at all. The
+bridge previously only HTML-escaped the body, so a mirrored reply showed literal `**`
+around every bold span, `[label](url)` link pairs and `###` heading markers.
+
+`markdownToMrkdwn` now converts before posting: `**bold**`/`__bold__` → `*bold*`,
+`*italic*` → `_italic_`, `~~strike~~` → `~strike~`, headings → a bold line,
+`[label](url)`/`![alt](url)` → `<url|label>`, bullets → `•`/`◦`/`▪` by nesting depth,
+task items → `☐`/`☑`, and horizontal rules are dropped. Code spans and fenced blocks
+are held aside so emphasis inside them survives untouched, and fence language hints
+are stripped because Slack renders them as body text. Conversion covers mirrored
+conversation messages (both the unfurled and author-labeled variants) and outreach
+draft bodies in approval cards.
+
+Body truncation is now link- and fence-aware: it backs off a cut that would land inside
+a `<url|label>` span or a trailing HTML entity, and closes a fence left open by the cut.

--- a/packages/backend-core/src/modules/slack/slack-mrkdwn.test.ts
+++ b/packages/backend-core/src/modules/slack/slack-mrkdwn.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { escapeSlackText, markdownToMrkdwn } from './slack-mrkdwn.ts';
+
+describe('escapeSlackText', () => {
+  it('escapes mrkdwn control characters', () => {
+    expect(escapeSlackText('a <b> & c')).toBe('a &lt;b&gt; &amp; c');
+  });
+});
+
+describe('markdownToMrkdwn', () => {
+  it('turns double-asterisk bold into single-asterisk bold', () => {
+    expect(markdownToMrkdwn('**Slik fungerer det:**')).toBe('*Slik fungerer det:*');
+    expect(markdownToMrkdwn('a **bold** b **also bold** c')).toBe(
+      'a *bold* b *also bold* c',
+    );
+  });
+
+  it('reads underscore bold as bold and single asterisks as italic', () => {
+    expect(markdownToMrkdwn('__strong__ and *emphasis*')).toBe('*strong* and _emphasis_');
+  });
+
+  it('keeps bold inside a bulleted line', () => {
+    expect(markdownToMrkdwn('- **Svare på spørsmål** basert på info')).toBe(
+      '• *Svare på spørsmål* basert på info',
+    );
+  });
+
+  it('renders headings as bold lines without stacking emphasis markers', () => {
+    expect(markdownToMrkdwn('## Teknisk setup')).toBe('*Teknisk setup*');
+    expect(markdownToMrkdwn('### **Teknisk setup**')).toBe('*Teknisk setup*');
+  });
+
+  it('rewrites bullets by nesting depth and preserves ordered lists', () => {
+    expect(markdownToMrkdwn('- one\n  - two\n    - three\n1. first')).toBe(
+      '• one\n  ◦ two\n    ▪ three\n1. first',
+    );
+  });
+
+  it('renders task list markers as checkboxes', () => {
+    expect(markdownToMrkdwn('- [ ] todo\n- [x] done')).toBe('• ☐ todo\n• ☑ done');
+  });
+
+  it('converts inline links, images and bare autolinks to Slack link syntax', () => {
+    expect(markdownToMrkdwn('see [Threll.ai](https://threll.ai) now')).toBe(
+      'see <https://threll.ai|Threll.ai> now',
+    );
+    expect(markdownToMrkdwn('[docs](https://x.dev/a "Title")')).toBe('<https://x.dev/a|docs>');
+    expect(markdownToMrkdwn('![logo](https://x.dev/l.png)')).toBe('<https://x.dev/l.png|logo>');
+    expect(markdownToMrkdwn('<https://x.dev/a>')).toBe('<https://x.dev/a>');
+    expect(markdownToMrkdwn('[mail](hello@x.dev)')).toBe('<mailto:hello@x.dev|mail>');
+  });
+
+  it('drops the link wrapper when the target is not addressable', () => {
+    expect(markdownToMrkdwn('[section](#anchor)')).toBe('section');
+  });
+
+  it('escapes ampersands inside link targets', () => {
+    expect(markdownToMrkdwn('[q](https://x.dev/s?a=1&b=2)')).toBe(
+      '<https://x.dev/s?a=1&amp;b=2|q>',
+    );
+  });
+
+  it('collapses double tildes to Slack strikethrough', () => {
+    expect(markdownToMrkdwn('~~gone~~')).toBe('~gone~');
+  });
+
+  it('leaves code spans and fences untouched, dropping the fence language', () => {
+    expect(markdownToMrkdwn('use `a **b** c` here')).toBe('use `a **b** c` here');
+    expect(markdownToMrkdwn('```ts\nconst a = b ** 2;\n```')).toBe(
+      '```\nconst a = b ** 2;\n```',
+    );
+  });
+
+  it('escapes mrkdwn control characters inside code as well as prose', () => {
+    expect(markdownToMrkdwn('`a < b`')).toBe('`a &lt; b`');
+    expect(markdownToMrkdwn('a & <b>')).toBe('a &amp; &lt;b&gt;');
+  });
+
+  it('drops horizontal rules and normalizes blockquotes', () => {
+    expect(markdownToMrkdwn('a\n---\nb')).toBe('a\nb');
+    expect(markdownToMrkdwn('>quoted')).toBe('> quoted');
+  });
+
+  it('does not leave a gaping hole where a horizontal rule was', () => {
+    expect(markdownToMrkdwn('a\n\n---\n\nb')).toBe('a\n\nb');
+  });
+
+  it('unescapes backslash-escaped markdown punctuation', () => {
+    expect(markdownToMrkdwn('a \\* b \\_c\\_')).toBe('a * b _c_');
+  });
+
+  it('leaves plain prose and stray asterisks alone', () => {
+    expect(markdownToMrkdwn('2 * 3 = 6')).toBe('2 * 3 = 6');
+    expect(markdownToMrkdwn('Hei! Hvordan går det?')).toBe('Hei! Hvordan går det?');
+  });
+
+  it('leaves an email signature dash separator intact', () => {
+    expect(markdownToMrkdwn('Vennlig hilsen\n--\nEspen')).toBe('Vennlig hilsen\n--\nEspen');
+  });
+});

--- a/packages/backend-core/src/modules/slack/slack-mrkdwn.ts
+++ b/packages/backend-core/src/modules/slack/slack-mrkdwn.ts
@@ -1,0 +1,97 @@
+const BOLD = '\u0001';
+const ITALIC = '\u0002';
+const CODE_OPEN = '\u0003';
+const CODE_CLOSE = '\u0004';
+
+export function escapeSlackText(text: string): string {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+const BULLETS = ['•', '◦', '▪'];
+
+function stash(store: string[], value: string): string {
+  store.push(value);
+  return `${CODE_OPEN}${store.length - 1}${CODE_CLOSE}`;
+}
+
+function slackLink(url: string, label: string): string {
+  const target = /^(https?:|mailto:|tel:)/i.test(url)
+    ? url
+    : /^www\./i.test(url)
+      ? `https://${url}`
+      : /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(url)
+        ? `mailto:${url}`
+        : null;
+  if (!target) return label;
+  return `<${target}|${label}>`;
+}
+
+function indentWidth(indent: string): number {
+  return indent.replaceAll('\t', '  ').length;
+}
+
+function convertBlockLine(line: string): string[] {
+  if (/^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/.test(line)) return [];
+
+  const heading = /^ {0,3}#{1,6}[ \t]+(.*?)[ \t]*#*$/.exec(line);
+  if (heading) {
+    const text = (heading[1] ?? '').replaceAll('**', '').replaceAll('__', '');
+    return text.length > 0 ? [`${BOLD}${text}${BOLD}`] : [];
+  }
+
+  const quote = /^ {0,3}&gt;[ \t]?(.*)$/.exec(line);
+  if (quote) return [`> ${quote[1] ?? ''}`];
+
+  const bullet = /^([ \t]*)[-*+][ \t]+(.*)$/.exec(line);
+  if (bullet) {
+    const indent = bullet[1] ?? '';
+    const depth = Math.min(Math.floor(indentWidth(indent) / 2), BULLETS.length - 1);
+    const marker = BULLETS[depth] ?? BULLETS[0];
+    const rest = bullet[2] ?? '';
+    const task = /^\[([ xX])\][ \t]+(.*)$/.exec(rest);
+    const content = task ? `${task[1] === ' ' ? '☐' : '☑'} ${task[2] ?? ''}` : rest;
+    return [`${indent}${marker} ${content}`];
+  }
+
+  return [line];
+}
+
+export function markdownToMrkdwn(markdown: string): string {
+  const code: string[] = [];
+  const stashed = markdown
+    .replaceAll('\r\n', '\n')
+    .replace(/```[^\n`]*\n?([\s\S]*?)```/g, (_match, body: string) =>
+      stash(code, `\`\`\`\n${escapeSlackText(body.replace(/^\n+|\n+$/g, ''))}\n\`\`\``),
+    )
+    .replace(/`([^`\n]+)`/g, (_match, body: string) =>
+      stash(code, `\`${escapeSlackText(body)}\``),
+    );
+
+  const blocks = escapeSlackText(stashed)
+    .split('\n')
+    .flatMap(convertBlockLine)
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n');
+
+  return blocks
+    .replace(/&lt;(https?:\/\/[^\s|&]+)&gt;/g, '<$1>')
+    .replace(
+      /!\[([^\]\n]*)\]\(\s*([^)\s]+?)(?:\s+"[^"\n]*")?\s*\)/g,
+      (_match, alt: string, url: string) => slackLink(url, alt || url),
+    )
+    .replace(
+      /\[([^\]\n]*)\]\(\s*([^)\s]+?)(?:\s+"[^"\n]*")?\s*\)/g,
+      (_match, label: string, url: string) => slackLink(url, label || url),
+    )
+    .replace(/\*\*(?=\S)([\s\S]*?\S)\*\*/g, `${BOLD}$1${BOLD}`)
+    .replace(/(?<![\w\\])__(?=\S)([\s\S]*?\S)__(?!\w)/g, `${BOLD}$1${BOLD}`)
+    .replace(/~~(?=\S)([\s\S]*?\S)~~/g, '~$1~')
+    .replace(/(?<![\w*\\])\*(?=[^\s*])([^*\n]*[^\s*]|)\*(?!\w)/g, `${ITALIC}$1${ITALIC}`)
+    .replace(/\\([\\`*_~[\]()#+\-.!>])/g, '$1')
+    .replace(
+      new RegExp(`${CODE_OPEN}(\\d+)${CODE_CLOSE}`, 'g'),
+      (_match, index: string) => code[Number(index)] ?? '',
+    )
+    .replaceAll(BOLD, '*')
+    .replaceAll(ITALIC, '_');
+}

--- a/packages/backend-core/src/modules/slack/slack-projection.test.ts
+++ b/packages/backend-core/src/modules/slack/slack-projection.test.ts
@@ -152,6 +152,38 @@ describe('messageBodyText', () => {
       .toBe('Hi there');
   });
 
+  it('renders an agent reply written in markdown as Slack mrkdwn', () => {
+    const text = messageBodyText({
+      authorKind: 'agent',
+      authorName: 'Thea',
+      internal: false,
+      body: '**Slik fungerer det:**\n- **Svare** på spørsmål\n\nSe [Threll.ai](https://threll.ai).',
+    });
+    expect(text).toBe(
+      '*Slik fungerer det:*\n• *Svare* på spørsmål\n\nSe <https://threll.ai|Threll.ai>.',
+    );
+  });
+
+  it('closes an unterminated code fence and keeps a link whole when truncating', () => {
+    const fenced = messageBodyText({
+      authorKind: 'agent',
+      authorName: 'Thea',
+      internal: false,
+      body: `\`\`\`\n${'x'.repeat(5000)}\n\`\`\``,
+    });
+    expect(fenced.split('```')).toHaveLength(3);
+    expect(fenced).toContain('_(truncated)_');
+
+    const linked = messageBodyText({
+      authorKind: 'agent',
+      authorName: 'Thea',
+      internal: false,
+      body: `${'x'.repeat(2890)}[docs](https://threll.ai/docs)`,
+    });
+    expect(linked).not.toContain('<https://threll.ai/docs|do');
+    expect(linked).toContain('… _(truncated)_');
+  });
+
   it('composes the gear+bold wrap with the internal-note prefix', () => {
     const text = messageBodyText({
       authorKind: 'system',

--- a/packages/backend-core/src/modules/slack/slack-projection.ts
+++ b/packages/backend-core/src/modules/slack/slack-projection.ts
@@ -1,3 +1,7 @@
+import { escapeSlackText, markdownToMrkdwn } from './slack-mrkdwn.ts';
+
+export { escapeSlackText, markdownToMrkdwn };
+
 export type AuthorKind = 'user' | 'agent' | 'end_user' | 'system';
 
 export interface ConversationSnapshot {
@@ -41,13 +45,15 @@ export function parseMessageAttachments(raw: unknown[]): MessageAttachment[] {
 
 const MAX_BODY_CHARS = 2900;
 
-export function escapeSlackText(text: string): string {
-  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-}
-
 function truncate(text: string, max = MAX_BODY_CHARS): string {
   if (text.length <= max) return text;
-  return `${text.slice(0, max)}… _(truncated)_`;
+  let cut = text.slice(0, max);
+  const openLink = cut.lastIndexOf('<');
+  if (openLink > cut.lastIndexOf('>')) cut = cut.slice(0, openLink);
+  cut = cut.replace(/&[a-z]*$/, '').replace(/[*_~]+$/, '');
+  const fences = cut.split('```').length - 1;
+  if (fences % 2 === 1) cut = `${cut}\n\`\`\``;
+  return `${cut}… _(truncated)_`;
 }
 
 export function authorLabel(kind: AuthorKind, name: string | null): string {
@@ -88,7 +94,7 @@ export function threadParentText(conv: ConversationSnapshot): string {
 }
 
 export function messageText(msg: MessageSnapshot): string {
-  const quoted = truncate(escapeSlackText(msg.body))
+  const quoted = truncate(markdownToMrkdwn(msg.body))
     .split('\n')
     .map((line) => `> ${line}`)
     .join('\n');
@@ -126,7 +132,7 @@ export function speakerIdentity(kind: AuthorKind, name: string | null): SpeakerI
 }
 
 export function messageBodyText(msg: MessageSnapshot): string {
-  const rawBody = truncate(escapeSlackText(msg.body));
+  const rawBody = truncate(markdownToMrkdwn(msg.body));
   const body = msg.authorKind === 'system' ? `:gear: *${rawBody}*` : rawBody;
   const attachmentLines = (msg.attachments ?? []).map((a) => {
     const name = escapeSlackText(a.name ?? 'attachment');
@@ -383,7 +389,7 @@ export function outreachProposalApprovalText(snap: OutreachProposalApprovalSnaps
   const footer = `<${snap.dashboardUrl}|Review in Munin>`;
   const overhead = [...header, footer].reduce((total, line) => total + line.length + 1, 0);
   const body = quotedBodyLines(
-    escapeSlackText(snap.draftBody),
+    markdownToMrkdwn(snap.draftBody),
     Math.max(TRUNCATION_MARKER.length, MAX_BODY_CHARS - overhead),
   );
   return [...header, ...body, footer].join('\n');


### PR DESCRIPTION
Agent replies are written in markdown, but Slack's mrkdwn is a different dialect: it reads `*bold*`, not `**bold**`, and has no link, heading or list syntax at all. The bridge only HTML-escaped the body before posting, so a mirrored reply showed literal `**` around every bold span, `[label](url)` pairs, and `###` heading markers.

## What changed

New `slack-mrkdwn.ts` with `markdownToMrkdwn()`, applied at the three body sites in `slack-projection.ts` — `messageText` and `messageBodyText` (both mirror variants, unfurled and author-labeled) and the outreach approval card's draft body.

| markdown | Slack mrkdwn |
|---|---|
| `**bold**`, `__bold__` | `*bold*` |
| `*italic*` | `_italic_` |
| `~~strike~~` | `~strike~` |
| `## Heading` | `*Heading*` (bold line) |
| `[label](url)`, `![alt](url)`, `<url>` | `<url\|label>` |
| `- item` (by nesting depth) | `• ` / `◦ ` / `▪ ` |
| `- [ ]` / `- [x]` | `• ☐` / `• ☑` |
| `---` | dropped, without leaving a blank-line hole |
| ` ```ts ` fence | fence kept, language hint stripped (Slack renders it as body text) |

Code spans and fenced blocks are stashed before any inline pass, so `b ** 2` inside code survives untouched. Non-addressable link targets (`[x](#anchor)`) degrade to the plain label; a bare email target becomes `mailto:`. `escapeSlackText` moved into the new module and now also covers code content.

Body truncation is link- and fence-aware: it backs off a cut that would land inside a `<url|label>` span or a trailing HTML entity, and closes a fence the cut left open.

## The screenshot case, after

```
Ja, det er mulig. <https://threll.ai|Threll.ai> tilbyr innkommende samtaleløsninger.

*Slik fungerer det i hovedtrekk:*

• *Svare på spørsmål* basert på informasjonen du gir den
  ◦ inkl. _avlysning_ og ~utsettelse~

*Teknisk setup*
Se `docs/sip.md` og <https://threll.ai/docs>.
```

## Judgment calls

- **Conversion applies to inbound customer bodies too**, not only agent replies — the projection functions are shared. A plain-text email using `- ` as a dash bullet becomes `• `; a `--` signature separator is untouched (the bullet rule needs a single marker plus whitespace).
- **Markdown tables pass through unchanged.** Slack has no table syntax, and wrapping them in a code fence seemed worse than leaving the pipes as-is.
- No skill doc changes: this is a transparent rendering fix behind the existing bridge, no new agent-facing surface, and no `slack/*` skill documents body formatting.

## Testing

- 17 new converter tests (`slack-mrkdwn.test.ts`) + 3 projection tests covering the markdown path, fence-safe truncation, and link-safe truncation.
- `pnpm -F @getmunin/backend-core test` — 1814 tests / 142 files green, integration suites included against a migrated local `munin_test`.
- `pnpm typecheck` clean; eslint applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
