### PR TITLE
feat(connectors): show who can reach each data connection

### DIFF
--- a/.changeset/connector-audience-badge.md
+++ b/.changeset/connector-audience-badge.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+'@getmunin/ui': minor
+---
+
+Show on each data-connection card who can actually reach it.
+
+The Integrations page listed every connector in one undifferentiated section, so nothing told an operator that connecting Bing Webmaster Tools exposes no surface at all to the customer-facing chatbot, while connecting Gastroplanner lets customers cancel their own bookings. That is a material fact when you are about to hand a vendor credential over.
+
+Audience is a property of the domain's tool surface, not of the vendor, so it is derived from `ConnectorDomain` in the backend (`audienceForDomain`) and carried on both the vendor and connection DTOs rather than recomputed in the dashboard. `commerce` and `bookings` ship admin tools and a self-service half, so they read "Customers + team". `seo` is admin-only — its five `seo_*` tools are `audiences: ['admin']`, `seo:read` is absent from both `CONNECTOR_DOMAIN_SCOPES` and `SELF_SERVICE_SCOPES` — so it reads "Team only". Custom MCP servers are proxied only into end-user agent sessions, so they read "Customers only".
+
+No enforcement changes: the audience gate, the connector scope map and the delegated-token scope allow-list already decided this. The badge only makes the existing decision visible.

--- a/packages/backend-core/src/modules/connectors/connector-audience.test.ts
+++ b/packages/backend-core/src/modules/connectors/connector-audience.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { audienceForDomain, type ConnectorDomain } from './connector.ts';
+
+describe('audienceForDomain', () => {
+  it('marks commerce and bookings as reachable by customers and the team', () => {
+    expect(audienceForDomain('commerce')).toBe('both');
+    expect(audienceForDomain('bookings')).toBe('both');
+  });
+
+  it('marks seo as team-only because it ships no self-service tools', () => {
+    expect(audienceForDomain('seo')).toBe('team');
+  });
+
+  it('marks custom mcp as customer-only because its tools are proxied into end-user sessions', () => {
+    expect(audienceForDomain('mcp')).toBe('customer');
+  });
+
+  it('covers every connector domain', () => {
+    const domains: ConnectorDomain[] = ['commerce', 'bookings', 'mcp', 'seo'];
+    for (const domain of domains) {
+      expect(['customer', 'team', 'both']).toContain(audienceForDomain(domain));
+    }
+  });
+});

--- a/packages/backend-core/src/modules/connectors/connector.ts
+++ b/packages/backend-core/src/modules/connectors/connector.ts
@@ -21,6 +21,19 @@ export interface ConnectorAdapter {
 
 export type ConnectorDomain = 'commerce' | 'bookings' | 'mcp' | 'seo';
 
+export type ConnectorAudience = 'customer' | 'team' | 'both';
+
+const AUDIENCE_BY_DOMAIN: Record<ConnectorDomain, ConnectorAudience> = {
+  commerce: 'both',
+  bookings: 'both',
+  mcp: 'customer',
+  seo: 'team',
+};
+
+export function audienceForDomain(domain: ConnectorDomain): ConnectorAudience {
+  return AUDIENCE_BY_DOMAIN[domain];
+}
+
 export interface ConnectorConnectionContext {
   config: Record<string, unknown>;
   decryptSecret(ciphertext: string): Promise<string>;

--- a/packages/backend-core/src/modules/connectors/connectors.service.ts
+++ b/packages/backend-core/src/modules/connectors/connectors.service.ts
@@ -17,9 +17,11 @@ import {
 } from '@getmunin/core';
 import {
   ConnectorRegistry,
+  audienceForDomain,
   supportsToolCatalog,
   type ConnectorAdapter,
   type ConnectorConnectionContext,
+  type ConnectorAudience,
   type ConnectorDomain,
   type SelectableTool,
   type ToolCatalogAdapter,
@@ -45,6 +47,7 @@ export interface ConnectorConnectionDto {
   name: string;
   active: boolean;
   credentialState: CredentialState;
+  audience: ConnectorAudience;
   settings: Record<string, unknown>;
   needsAuthorization: boolean;
   lastTestedAt: string | null;
@@ -56,6 +59,7 @@ export interface ConnectorVendorDto {
   vendor: string;
   domain: ConnectorDomain;
   displayName: string;
+  audience: ConnectorAudience;
   oauth: boolean;
   configFields: Array<{
     key: string;
@@ -116,6 +120,7 @@ export class ConnectorsService {
       vendor: adapter.vendor,
       domain: adapter.domain,
       displayName: adapter.displayName,
+      audience: audienceForDomain(adapter.domain),
       configFields: adapter.configFields,
       oauth: !!adapter.oauth,
     }));
@@ -688,6 +693,7 @@ export class ConnectorsService {
       name: row.name,
       active: row.active,
       credentialState: state,
+      audience: audienceForDomain(row.domain as ConnectorDomain),
       settings: state === 'pending' ? withoutGrant(row.config) : adapter.publicConfig(row.config),
       needsAuthorization: !!adapter.oauth && state !== 'active',
       lastTestedAt: row.lastTestedAt?.toISOString() ?? null,

--- a/packages/dashboard-pages/src/components/integrations/connect-connector-dialog.tsx
+++ b/packages/dashboard-pages/src/components/integrations/connect-connector-dialog.tsx
@@ -32,10 +32,13 @@ function initialValues(
   return out;
 }
 
+export type ConnectorAudience = 'customer' | 'team' | 'both';
+
 export interface ConnectVendor {
   vendor: string;
   domain: string;
   displayName: string;
+  audience?: ConnectorAudience;
   oauth?: boolean;
   configFields: VendorField[];
 }

--- a/packages/dashboard-pages/src/components/integrations/connectors-grid.tsx
+++ b/packages/dashboard-pages/src/components/integrations/connectors-grid.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DropdownMenuItem, SectionHead } from '@getmunin/ui';
+import { Badge, Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DropdownMenuItem, SectionHead } from '@getmunin/ui';
 import { api } from '../../api';
 import { notify } from '../../lib/notify';
 import { useTranslateError } from '../../i18n/translate-error';
@@ -12,6 +12,7 @@ import { CardGrid, CardMenu, StatusLine } from '../card-kit';
 import { IntegrationCard } from './integration-card';
 import {
   ConnectConnectorDialog,
+  type ConnectorAudience,
   type ConnectVendor,
   type CreatedConnection,
   type EditableConnection,
@@ -30,12 +31,28 @@ interface Connection {
   active: boolean;
   credentialState: 'active' | 'pending' | 'expired' | 'revoked';
   needsAuthorization: boolean;
+  audience?: ConnectorAudience;
   lastTestError: string | null;
   settings?: { allowedTools?: string[] };
 }
 
 function supportsToolPicker(conn: Pick<Connection, 'domain' | 'credentialState'>): boolean {
   return conn.domain === 'mcp' && conn.credentialState === 'active';
+}
+
+function AudienceBadge({
+  audience,
+  label,
+}: {
+  audience: ConnectorAudience | undefined;
+  label: (key: string) => string;
+}) {
+  if (!audience) return null;
+  return (
+    <Badge variant="secondary" className="before:hidden">
+      {label(`audience.${audience}`)}
+    </Badge>
+  );
 }
 
 function shortDetail(detail: string | undefined): string {
@@ -188,6 +205,7 @@ export function DataConnectionsSection() {
               name={displayName}
               instance={conn.name}
               meta={<StatusLine tone={s.tone} label={s.label} />}
+              badge={<AudienceBadge audience={conn.audience} label={t} />}
               description={tc(`description.${present.descriptionKey}`)}
               menu={
                 <CardMenu label={t('moreMenu')} disabled={busyId === conn.id}>
@@ -245,6 +263,7 @@ export function DataConnectionsSection() {
               key={v.vendor}
               vendor={v.vendor}
               name={v.displayName}
+              badge={<AudienceBadge audience={v.audience} label={t} />}
               description={tc(`description.${present.descriptionKey}`)}
               footer={
                 <Button type="button" variant="outline" size="sm" className="whitespace-nowrap" onClick={() => setConnectVendor(v)}>

--- a/packages/dashboard-pages/src/components/integrations/integration-card.tsx
+++ b/packages/dashboard-pages/src/components/integrations/integration-card.tsx
@@ -8,6 +8,7 @@ export function IntegrationCard({
   name,
   instance,
   meta,
+  badge,
   description,
   footer,
   menu,
@@ -16,6 +17,7 @@ export function IntegrationCard({
   name: string;
   instance?: string;
   meta?: ReactNode;
+  badge?: ReactNode;
   description: string;
   footer: ReactNode;
   menu?: ReactNode;
@@ -34,6 +36,7 @@ export function IntegrationCard({
         </div>
         {menu ? <div className="ml-auto flex-none self-start">{menu}</div> : null}
       </div>
+      {badge ? <div className="flex flex-wrap items-center gap-2">{badge}</div> : null}
       <p className="flex-1 text-[13px] leading-snug text-ink-mute">{description}</p>
       <div className="flex flex-wrap items-center gap-2">{footer}</div>
     </div>

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1379,6 +1379,11 @@
       "subtitle": "Live against the vendor — nothing is stored in Munin"
     },
     "connectors": {
+      "audience": {
+        "both": "Customers + team",
+        "team": "Team only",
+        "customer": "Customers only"
+      },
       "title": "Connections",
       "lede": "Connected commerce and booking systems agents can use on a customer's behalf.",
       "name": "Name",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1379,6 +1379,11 @@
       "subtitle": "Direkte mot leverandøren — ingenting lagres i Munin"
     },
     "connectors": {
+      "audience": {
+        "both": "Kunder og medarbeidere",
+        "team": "Bare medarbeidere",
+        "customer": "Bare kunder"
+      },
       "title": "Koblinger",
       "lede": "Tilkoblede handels- og bookingsystemer agenter kan bruke på vegne av en kunde.",
       "name": "Navn",


### PR DESCRIPTION
Stacked on #825 (4/4). Merge after it.

The Integrations page lists every connector in one undifferentiated section. Nothing on it tells an operator that connecting **Bing Webmaster Tools** exposes no surface at all to the customer-facing chatbot, while connecting **Gastroplanner** lets customers cancel their own bookings. That's a material fact at exactly the moment you're handing a vendor credential over.

Each card now carries a badge:

| Domain | Badge | Why |
|---|---|---|
| `commerce`, `bookings` | Customers + team | Admin tools plus a `*.self-service.tools.ts` half |
| `seo` | Team only | All five `seo_*` tools are `audiences: ['admin']` |
| `mcp` | Customers only | `ext_*` tools are proxied only into end-user agent sessions |

## Where the truth lives

Audience is a property of the domain's tool surface, not of the vendor — Bing and Google Search Console are both `seo`, so both are team-only for the same reason. So it's derived once via `audienceForDomain()` in `connector.ts` and carried on both `ConnectorVendorDto` and `ConnectorConnectionDto`.

Deliberately **not** a lookup table in `dashboard-pages`: the backend already states this fact in three places (the per-tool `audiences` gate, `CONNECTOR_DOMAIN_SCOPES` in `agent-host`, and `SELF_SERVICE_SCOPES` on the delegated-token boundary). A fourth copy in React would drift the first time a domain grows a self-service half.

New vendors in an existing domain get the badge for free.

## No enforcement change

This is presentation only. The three locks above already decided who reaches what; a chatbot cannot reach `seo_*` today for three independent reasons, and this PR changes none of them. `connector-audience.test.ts` pins the mapping with the rationale in each test name so the `seo` → team-only and `mcp` → customer-only calls can't be quietly flipped.

## Known coarseness

"Customers + team" flattens a real distinction: for commerce, customers reach the catalog and *their own* orders (`commerce_get_my_order`, which has no `email` in its schema and re-derives it from the delegated token), while the team reaches *any* customer's (`commerce_lookup_order`, which takes `email`). The badge doesn't express that. Shipping the coarse version deliberately — a tooltip fights the card's density, and it's easy to add if anyone asks.

## Test

`pnpm typecheck` and `pnpm lint` clean across 31 tasks; 31 connector tests pass. Verified on the local dashboard against the running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
