### PR TITLE
fix(docs): restore spaces swallowed after inline code and emphasis in the guides

### DIFF
--- a/.changeset/docs-guide-jsx-space-loss.md
+++ b/.changeset/docs-guide-jsx-space-loss.md
@@ -1,0 +1,28 @@
+---
+'@getmunin/docs-pages': patch
+---
+
+Restore the spaces that vanished after inline `<code>`/`<em>`/`<strong>` in the guide prose.
+
+Seven guides rendered joined-up words — "Open _Choose tools_on the connection's menu", "must not
+take an `email` or `customerId`argument", "**All spoofable.**Anyone can send mail". The space was in
+the source; Next's bundled SWC dropped it. A multi-line JSX text run whose text contains an HTML
+entity (`&rsquo;`, `&quot;`, `&lt;`, …) loses its *leading* space during the entity decode — the
+trailing space survives, a single-line run survives, and the same source compiled with upstream
+`@swc/core` keeps it, so this only shows up in a Next build. It reproduces on both 16.2.12 (OSS
+`apps/web`) and 16.2.6 (cloud marketing), and there is nothing in the source to hint at it: the
+paragraph looks correct.
+
+Each of the 18 affected boundaries now carries an explicit `{' '}`, which compiles to its own string
+child and is immune to the bug. Verified by compiling every `.tsx` in the repo with Next's SWC and
+asserting no element child is followed by a text child that starts mid-word, and by diffing the
+rendered text of the touched files against the same files compiled with an unaffected SWC. Only
+`packages/docs-pages/src/guides/` was affected; nothing under `apps/web` hit the pattern.
+
+One neighbouring defect fixed along the way, this one genuinely in the source: in the chat-widget
+guide, `<code>"dark"</code>` ended a line and `pins the panel` began the next, so ordinary JSX
+line-joining left no space at all.
+
+Also gives a `docs-attrs` definition list breathing room before a following paragraph. On the
+custom-MCP-server guide the "Provenance describes the turn happening right now" paragraph butted
+straight against the `self_reported` row, reading as a fourth definition rather than prose.

--- a/packages/docs-pages/src/docs.css
+++ b/packages/docs-pages/src/docs.css
@@ -1566,6 +1566,9 @@
   row-gap: 14px;
   align-items: baseline;
 }
+.docs-attrs + .tag-blurb {
+  margin-top: 24px;
+}
 .docs-attrs dt {
   font-family: var(--munin-mono);
   font-size: 12px;

--- a/packages/docs-pages/src/guides/audiences-and-tokens/page.tsx
+++ b/packages/docs-pages/src/guides/audiences-and-tokens/page.tsx
@@ -154,8 +154,9 @@ export default function AudiencesAndTokens() {
         </dd>
         <dt>Don&rsquo;t paper over audience with scopes</dt>
         <dd>
-          Scopes refine permissions <em>within</em> an audience. They don&rsquo;t upgrade a
-          self-service token into an admin one. If a tool isn&rsquo;t visible to{' '}
+          Scopes refine permissions <em>within</em>{' '}
+          an audience. They don&rsquo;t upgrade a self-service token into an admin one. If a tool
+          isn&rsquo;t visible to{' '}
           <code>self_service</code>, no scope value will reveal it.
         </dd>
       </dl>

--- a/packages/docs-pages/src/guides/chat-widget/page.tsx
+++ b/packages/docs-pages/src/guides/chat-widget/page.tsx
@@ -25,9 +25,10 @@ export default function WidgetGuide() {
           Drop-in <em>chat widget</em>.
         </h1>
         <p className="lede">
-          One <code style={{ fontFamily: 'var(--munin-mono)' }}>&lt;script&gt;</code> tag on your site
-          gives visitors a chat launcher that opens a Munin conversation. The widget runs inside a Shadow
-          DOM, so your host page&rsquo;s CSS can&rsquo;t bleed in and ours can&rsquo;t bleed out.
+          One <code style={{ fontFamily: 'var(--munin-mono)' }}>&lt;script&gt;</code>{' '}
+          tag on your site gives visitors a chat launcher that opens a Munin conversation. The
+          widget runs inside a Shadow DOM, so your host page&rsquo;s CSS can&rsquo;t bleed in and
+          ours can&rsquo;t bleed out.
         </p>
       </header>
 
@@ -113,8 +114,9 @@ export default function WidgetGuide() {
         </dd>
         <dt>data-munin-color-scheme</dt>
         <dd>
-          <code>&quot;auto&quot;</code> (default) follows the visitor&rsquo;s OS/browser preference and
-          updates live if they flip it; <code>&quot;light&quot;</code> or <code>&quot;dark&quot;</code>
+          <code>&quot;auto&quot;</code>{' '}
+          (default) follows the visitor&rsquo;s OS/browser preference and updates live if they flip
+          it; <code>&quot;light&quot;</code> or <code>&quot;dark&quot;</code>{' '}
           pins the panel regardless of their OS setting. The launcher bubble, header bar and voice-call
           screen keep their fixed near-black chrome in every mode unless you set the color attributes
           above &mdash; only the panel body (welcome/chat/composer/cards) inverts.
@@ -184,10 +186,11 @@ const userHash = crypto
         Both <code>localStorage</code> and the fallback cookie are scoped to the exact host by default, so a
         conversation started on <code>www.example.com</code> does <em>not</em> carry over to{' '}
         <code>app.example.com</code>. To share one thread across sibling subdomains, set{' '}
-        <code>data-munin-cookie-domain=&quot;.example.com&quot;</code> on every page&rsquo;s embed — the
-        session and visitor cookies are then written with that <code>Domain</code> and the anonymous thread
-        is claimed when the visitor signs in on the app. The value must be a suffix of the page&rsquo;s host,
-        or it&rsquo;s ignored.
+        <code>data-munin-cookie-domain=&quot;.example.com&quot;</code>{' '}
+        on every page&rsquo;s embed — the session and visitor cookies are then written with that{' '}
+        <code>Domain</code>{' '}
+        and the anonymous thread is claimed when the visitor signs in on the app. The value must be
+        a suffix of the page&rsquo;s host, or it&rsquo;s ignored.
       </p>
 
       <h3 className="tag-h" id="identify-after-load" style={{ marginTop: 32 }}>
@@ -221,8 +224,9 @@ window.mn?.widget?.ready
         <code>window.mn.analytics.identify()</code> with a different hash and a different secret — the
         two never share a call. Idempotent — calling it twice with the
         same <code>externalId</code> is a no-op. Calling it with a
-        different <code>externalId</code> on a session that&rsquo;s already verified returns 403; mint a
-        fresh session if you genuinely need to swap identities mid-flight.
+        different <code>externalId</code>{' '}
+        on a session that&rsquo;s already verified returns 403; mint a fresh session if you genuinely
+        need to swap identities mid-flight.
       </p>
 
       <h2 className="tag-h" id="programmatic" style={{ marginTop: 56 }}>
@@ -231,9 +235,9 @@ window.mn?.widget?.ready
       <p className="tag-blurb">
         Once the deferred script has executed, <code>window.mn.widget</code> exposes{' '}
         <code>open()</code>, <code>close()</code>, <code>toggle()</code>, and{' '}
-        <code>isOpen()</code> so you can drive the panel from your own nav, a &ldquo;Chat with
-        us&rdquo; link, or a proactive prompt on a timer — instead of relying on the launcher bubble
-        alone.
+        <code>isOpen()</code>{' '}
+        so you can drive the panel from your own nav, a &ldquo;Chat with us&rdquo; link, or a
+        proactive prompt on a timer — instead of relying on the launcher bubble alone.
       </p>
       <div className="curl">
         <div className="curl-h">
@@ -245,11 +249,12 @@ window.mn?.widget?.ready
 });`}</pre>
       </div>
       <p className="tag-blurb" style={{ marginTop: 16 }}>
-        The script tag has <code>defer</code>, so <code>window.mn.widget</code> isn&rsquo;t installed
-        until the page has parsed — safe to call from a click handler, not safe to call synchronously
-        from an inline <code>&lt;script&gt;</code> placed above the widget tag. It&rsquo;s a single
-        global: on a page with two widget embeds it stays bound to whichever mounted first, and the
-        second logs a console warning rather than silently stealing it.
+        The script tag has <code>defer</code>, so <code>window.mn.widget</code>{' '}
+        isn&rsquo;t installed until the page has parsed — safe to call from a click handler, not safe
+        to call synchronously from an inline <code>&lt;script&gt;</code>{' '}
+        placed above the widget tag. It&rsquo;s a single global: on a page with two widget embeds it
+        stays bound to whichever mounted first, and the second logs a console warning rather than
+        silently stealing it.
       </p>
 
       <h2 className="tag-h" id="visitor" style={{ marginTop: 56 }}>
@@ -303,9 +308,10 @@ window.mn?.widget?.ready
         </dd>
         <dt>Typing indicator</dt>
         <dd>
-          The runner emits realtime <code>typing</code> events while it&rsquo;s generating, with a 3-second
-          keepalive so the indicator stays alive through long replies. Server auto-clears after 5 seconds
-          of silence; widget auto-clears locally after 5 seconds as a fallback.
+          The runner emits realtime <code>typing</code>{' '}
+          events while it&rsquo;s generating, with a 3-second keepalive so the indicator stays alive
+          through long replies. Server auto-clears after 5 seconds of silence; widget auto-clears
+          locally after 5 seconds as a fallback.
         </dd>
         <dt>Handover to a human</dt>
         <dd>
@@ -327,9 +333,10 @@ window.mn?.widget?.ready
         </dd>
         <dt>Identity verification</dt>
         <dd>
-          The HMAC pairs an <code>externalId</code> to a digest signed with the channel&rsquo;s identity
-          secret. Without this, a visitor can&rsquo;t claim someone else&rsquo;s identity — they get an
-          anonymous session bound to their local sessionId.
+          The HMAC pairs an <code>externalId</code>{' '}
+          to a digest signed with the channel&rsquo;s identity secret. Without this, a visitor
+          can&rsquo;t claim someone else&rsquo;s identity — they get an anonymous session bound to
+          their local sessionId.
         </dd>
         <dt>Require verified identity</dt>
         <dd>

--- a/packages/docs-pages/src/guides/connect-chatgpt/page.tsx
+++ b/packages/docs-pages/src/guides/connect-chatgpt/page.tsx
@@ -101,8 +101,9 @@ export default function ConnectChatGPT() {
         </h2>
         <p className="tag-blurb">
           Adding the app doesn&rsquo;t auto-attach it to every chat. In the composer, open the
-          tools menu and toggle <em>Munin</em> on. ChatGPT will then call Munin tools when it
-          decides they&rsquo;re relevant — or you can name a tool directly in the prompt.
+          tools menu and toggle <em>Munin</em>{' '}
+          on. ChatGPT will then call Munin tools when it decides they&rsquo;re relevant — or you can
+          name a tool directly in the prompt.
         </p>
 
         <h2 className="tag-h" id="scope" style={{ marginTop: 56 }}>

--- a/packages/docs-pages/src/guides/connect-gemini/page.tsx
+++ b/packages/docs-pages/src/guides/connect-gemini/page.tsx
@@ -88,9 +88,10 @@ export default function ConnectGemini() {
           3 · Verify
         </h2>
         <p className="tag-blurb">
-          Run <code>gemini mcp list</code> — it prints every connected server and the tools it
-          discovered. If Munin doesn&rsquo;t show, re-run with <code>--verbose</code> to see the
-          handshake error. Then prompt Gemini in a session with{' '}
+          Run <code>gemini mcp list</code>{' '}
+          — it prints every connected server and the tools it discovered. If Munin doesn&rsquo;t
+          show, re-run with <code>--verbose</code> to see the handshake error. Then prompt Gemini in
+          a session with{' '}
           <em>&ldquo;List the Munin tools you can call&rdquo;</em> as a smoke test.
         </p>
         <p className="tag-blurb">

--- a/packages/docs-pages/src/guides/connect-openclaw/page.tsx
+++ b/packages/docs-pages/src/guides/connect-openclaw/page.tsx
@@ -48,8 +48,9 @@ export default function ConnectOpenClaw() {
         <p className="tag-blurb">
           The one-shot command writes the entry into{' '}
           <code>~/.openclaw/openclaw.json</code> for you. Prefer{' '}
-          <code>streamable-http</code> — it&rsquo;s the modern Munin transport and handles
-          long-running tool calls without an open SSE stream.
+          <code>streamable-http</code>{' '}
+          — it&rsquo;s the modern Munin transport and handles long-running tool calls without an
+          open SSE stream.
         </p>
         <div className="curl">
           <div className="curl-h">

--- a/packages/docs-pages/src/guides/connect-your-own-system/page.tsx
+++ b/packages/docs-pages/src/guides/connect-your-own-system/page.tsx
@@ -105,10 +105,11 @@ export default function ConnectYourOwnSystem() {
             3 · Choose what customers may reach
           </h2>
           <p className="tag-blurb">
-            Open <em>Choose tools</em> on the connection&rsquo;s menu. Munin asks your server what it
-            offers and lists every tool with a checkbox; tick the ones customers may call. This is
-            the safety mechanism: a server you misconfigured, or pointed at the wrong system, stays
-            silent until a human deliberately ticks something. Agents do the same thing with{' '}
+            Open <em>Choose tools</em>{' '}
+            on the connection&rsquo;s menu. Munin asks your server what it offers and lists every
+            tool with a checkbox; tick the ones customers may call. This is the safety mechanism: a
+            server you misconfigured, or pointed at the wrong system, stays silent until a human
+            deliberately ticks something. Agents do the same thing with{' '}
             <code>connectors_list_server_tools</code> and <code>connectors_set_allowed_tools</code>.
           </p>
           <dl className="docs-attrs">
@@ -125,9 +126,10 @@ export default function ConnectYourOwnSystem() {
             Who is asking <span className="ct">and how much to trust it</span>
           </h2>
           <p className="tag-blurb">
-            Your tools must not take an <code>email</code> or <code>customerId</code> argument. An
-            argument is something a confused or manipulated model can fill in with somebody
-            else&rsquo;s identity. Instead every call carries an <code>X-Munin-Identity</code>{' '}
+            Your tools must not take an <code>email</code> or <code>customerId</code>{' '}
+            argument. An argument is something a confused or manipulated model can fill in with
+            somebody else&rsquo;s identity. Instead every call carries an{' '}
+            <code>X-Munin-Identity</code>{' '}
             header — a short-lived ES256 JWT you verify against a public per-org JWKS document —
             naming the person the agent is serving and, crucially, <em>how well that name is
             known</em>.
@@ -145,9 +147,9 @@ export default function ConnectYourOwnSystem() {
             </dt>
             <dd>
               Taken from the channel envelope — an email <code>From:</code> header, an SMS sender, a
-              caller ID. <strong>All spoofable.</strong> Anyone can send mail claiming to be
-              someone. Fine for order status; not sufficient on its own for anything you
-              wouldn&rsquo;t put on a postcard.
+              caller ID. <strong>All spoofable.</strong>{' '}
+              Anyone can send mail claiming to be someone. Fine for order status; not sufficient on
+              its own for anything you wouldn&rsquo;t put on a postcard.
             </dd>
             <dt>
               <code>self_reported</code>

--- a/packages/docs-pages/src/guides/skills-vs-tools-vs-rest/page.tsx
+++ b/packages/docs-pages/src/guides/skills-vs-tools-vs-rest/page.tsx
@@ -98,9 +98,10 @@ export default function SkillsVsToolsVsRest() {
       <dl className="docs-attrs">
         <dt>Shape</dt>
         <dd>
-          A <code>.md</code> file with YAML frontmatter (title, description, audiences) and a body
-          written like a runbook — short, imperative, ordered. Indexed at startup and loaded into
-          the agent&rsquo;s context only when its description matches the situation.
+          A <code>.md</code>{' '}
+          file with YAML frontmatter (title, description, audiences) and a body written like a
+          runbook — short, imperative, ordered. Indexed at startup and loaded into the
+          agent&rsquo;s context only when its description matches the situation.
         </dd>
         <dt>Audience</dt>
         <dd>


### PR DESCRIPTION
Spotted on `/docs/guides/connect-your-own-system` — "Open *Choose tools*on the connection's menu", "must not take an `email` or `customerId`argument", "**All spoofable.**Anyone can send mail". The space is in the source; **Next's bundled SWC drops it.**

## Root cause

A multi-line JSX text run whose text contains an HTML entity (`&rsquo;`, `&quot;`, `&lt;`, …) loses its **leading** space during entity decoding:

```jsx
Open <em>Choose tools</em> on the connection&rsquo;s menu. Munin asks your server what it
offers and lists every tool with a checkbox; …
```

compiles to `…_jsx("em", { children: "Choose tools" }), "on the connection’s menu…"`.

Narrowed down by transforming the same snippet four ways:

| shape | leading space |
|---|---|
| multi-line run, entity anywhere in it | **dropped** |
| single-line run, entity | kept |
| multi-line run, no entity | kept |
| same source via upstream `@swc/core` 1.15.32 | kept |

Trailing spaces survive. So it only manifests in a Next build — reproduced on 16.2.12 (OSS `apps/web`) and 16.2.6 (cloud marketing), which is why it shipped: nothing in the source looks wrong.

## The fix

Each of the 18 affected boundaries now carries an explicit `{' '}`, which compiles to its own string child and is immune to the bug. Affected guides: `connect-your-own-system` (3), `chat-widget` (10), `audiences-and-tokens`, `connect-chatgpt`, `connect-gemini`, `connect-openclaw`, `skills-vs-tools-vs-rest`.

One neighbouring defect fixed on the way, this one genuinely in the source: in the chat-widget guide `<code>"dark"</code>` ended a line and `pins the panel` began the next, so ordinary JSX line-joining left no space at all.

## Also

`.docs-attrs + .tag-blurb { margin-top: 24px }`. `.docs-attrs` has no bottom margin and `.tag-blurb` no top margin, so on this guide the "Provenance describes the turn happening right now" paragraph butted straight against the `self_reported` row and read as a fourth definition rather than prose. Three call sites benefit; none override it inline.

## Verification

- Compiled **every** `.tsx` in the repo with Next's SWC and asserted no element child is followed by a text child that starts mid-word → 0 remaining (was 19).
- Diffed the rendered text of each touched file against the same file compiled with an unaffected SWC → identical, so the re-wrapping changed no wording. The one intended difference is the `"dark"` → `pins` space.
- Scanned `apps/web` (0 spots) and munin-cloud's own components (10 detector hits, all false positives: icon-then-label and `<br />`).
- `pnpm -F @getmunin/docs-pages lint` and `typecheck` pass.

## Known gap

The bug returns silently whenever someone writes new guide prose with an apostrophe after an inline `<code>`. `docs-pages` has no test setup today, so there's no guard — happy to add one (compile the guides, assert no mid-word text child) in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)