### PR TITLE
fix(dashboard): one card-grid layout across Trackers, Channels and Integrations

### DIFF
--- a/.changeset/tracker-cards-match-card-grid.md
+++ b/.changeset/tracker-cards-match-card-grid.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Card grids on Trackers, Channels and Integrations now share one layout. The settings content column has no max-width, so the Trackers page's two-column grid stretched each card to roughly 600px on a wide viewport — twice the width of a channel or connector card, with a 160px sparkline floating in it. `CardGrid` and `CardGridSkeleton` lost the `columns` prop entirely: every call site rendered three columns except that one, so hardcoding the layout is what keeps the pages from drifting apart again.
+
+The two Integrations sections also loaded behind a single full-width `CardSkeleton` while Trackers and Channels loaded behind a `CardGridSkeleton`, so the placeholder was a wide bar where the real content is a grid of cards. Both sections now use `CardGridSkeleton` at the card count they actually render — three for connectors, one for the Slack bridge.

--- a/packages/dashboard-pages/src/components/card-kit.tsx
+++ b/packages/dashboard-pages/src/components/card-kit.tsx
@@ -10,22 +10,9 @@ import {
   cn,
 } from '@getmunin/ui';
 
-export function CardGrid({
-  children,
-  columns = 3,
-}: {
-  children: ReactNode;
-  columns?: 2 | 3;
-}) {
+export function CardGrid({ children }: { children: ReactNode }) {
   return (
-    <div
-      className={cn(
-        'grid grid-cols-1 gap-3.5',
-        columns === 2 ? 'sm:grid-cols-2' : 'sm:grid-cols-2 lg:grid-cols-3',
-      )}
-    >
-      {children}
-    </div>
+    <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
   );
 }
 

--- a/packages/dashboard-pages/src/components/integrations/connectors-grid.tsx
+++ b/packages/dashboard-pages/src/components/integrations/connectors-grid.tsx
@@ -7,7 +7,7 @@ import { api } from '../../api';
 import { notify } from '../../lib/notify';
 import { useTranslateError } from '../../i18n/translate-error';
 import { useConfirm } from '../confirm-dialog';
-import { CardSkeleton } from '../skeleton';
+import { CardGridSkeleton } from '../skeleton';
 import { CardGrid, CardMenu, StatusLine } from '../card-kit';
 import { IntegrationCard } from './integration-card';
 import {
@@ -167,7 +167,7 @@ export function DataConnectionsSection() {
     return (
       <section className="space-y-4">
         <SectionHead title={td('title')} subtitle={td('subtitle')} />
-        <CardSkeleton />
+        <CardGridSkeleton count={3} />
       </section>
     );
   }

--- a/packages/dashboard-pages/src/components/integrations/operator-bridges-grid.tsx
+++ b/packages/dashboard-pages/src/components/integrations/operator-bridges-grid.tsx
@@ -7,7 +7,7 @@ import { api } from '../../api';
 import { notify } from '../../lib/notify';
 import { useTranslateError } from '../../i18n/translate-error';
 import { useConfirm } from '../confirm-dialog';
-import { CardSkeleton } from '../skeleton';
+import { CardGridSkeleton } from '../skeleton';
 import { CardGrid, CardMenu, StatusLine } from '../card-kit';
 import { IntegrationCard } from './integration-card';
 import { NativeSelect } from '../native-select';
@@ -120,7 +120,7 @@ export function OperatorBridgesSection() {
     return (
       <section className="space-y-4">
         {heading}
-        <CardSkeleton />
+        <CardGridSkeleton count={1} />
       </section>
     );
   }

--- a/packages/dashboard-pages/src/components/skeleton.tsx
+++ b/packages/dashboard-pages/src/components/skeleton.tsx
@@ -86,21 +86,12 @@ function SettingsCardSkeleton() {
   );
 }
 
-export function CardGridSkeleton({
-  count = 3,
-  columns = 3,
-}: {
-  count?: number;
-  columns?: 2 | 3;
-}) {
+export function CardGridSkeleton({ count = 3 }: { count?: number }) {
   return (
     <div
       role="status"
       aria-busy="true"
-      className={cn(
-        'grid grid-cols-1 gap-3.5',
-        columns === 2 ? 'sm:grid-cols-2' : 'sm:grid-cols-2 lg:grid-cols-3',
-      )}
+      className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3"
     >
       <span className="sr-only">Loading…</span>
       {Array.from({ length: count }).map((_, i) => (

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -578,11 +578,11 @@ export function ChannelsPage() {
         />
 
         {channels === null ? (
-          <CardGridSkeleton count={3} columns={3} />
+          <CardGridSkeleton count={3} />
         ) : channels.length === 0 ? (
           <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
         ) : (
-          <CardGrid columns={3}>
+          <CardGrid>
             {channels.map((c) => (
               <ChannelRow
                 key={c.id}

--- a/packages/dashboard-pages/src/pages/trackers.tsx
+++ b/packages/dashboard-pages/src/pages/trackers.tsx
@@ -229,11 +229,11 @@ export function TrackersPage() {
         />
 
         {trackers === null ? (
-          <CardGridSkeleton count={2} columns={2} />
+          <CardGridSkeleton count={3} />
         ) : trackers.length === 0 ? (
           <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
         ) : (
-          <CardGrid columns={2}>
+          <CardGrid>
             {trackers.map((tr) => (
               <TrackerRow
                 key={tr.id}


### PR DESCRIPTION
## What

Trackers cards were visibly wider than channel and connector cards. `CardGrid`/`CardGridSkeleton` took a `columns?: 2 | 3` prop and the Trackers page was the only caller passing `2` — channels, connectors and operator bridges all rendered three.

The settings shell puts page content in a `flex-1` column with no max-width (`shells/settings-shell.tsx`), so on a ~1600px viewport a two-column grid gives each tracker card ~600px against ~400px for the others, with the fixed 160×36 sparkline adrift in the extra space.

Rather than flipping Trackers to `columns={3}`, this drops the prop: all four call sites already wanted three columns, so hardcoding the grid classes in one place is what stops the pages drifting apart again. The Trackers loading skeleton also goes from 2 to 3 placeholders to match the new row width.

Second half: both Integrations sections loaded behind a single full-width `CardSkeleton` while Trackers and Channels use `CardGridSkeleton`, so mid-load the page showed one wide bar where the real content is a grid of cards. Both now use `CardGridSkeleton` at the count they actually render — three for connectors (the catalog has six vendors, so the grid is never sparse), one for the Slack bridge.

## Left alone deliberately

`SettingsCard` (`p-4`, mono eyebrow, no icon) and `IntegrationCard` (`p-5 gap-3`, `VendorIcon`, no eyebrow) still differ in internal padding and body copy size (`text-[12.5px]` vs `text-[13px]`). Those read as intentional — connector cards are vendor-branded — so flattening them is a separate design call. Vertical behaviour was already consistent: both are `flex flex-col` with a `flex-1` filler, so cards fill their row height and pin the footer to the bottom.

## Test plan

- `pnpm -F @getmunin/dashboard-pages typecheck` — clean
- `pnpm -F @getmunin/dashboard-pages lint` — clean
- Not verified in a browser. The change is Tailwind class strings only, now shared from a single hardcoded literal across all four grids, but a reviewer with the stack up should eyeball Trackers, Channels and Integrations side by side at a wide viewport, plus the three loading states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)