### PR TITLE
fix(conv): strip quoted history from Nordic-locale Gmail replies

### DIFF
--- a/.changeset/quiet-pugs-smile.md
+++ b/.changeset/quiet-pugs-smile.md
@@ -1,0 +1,20 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Strip quoted history from inbound email replies that Gmail formats in a Nordic locale.
+
+`stripQuotedReplyText` missed two things that combined to leave a full quoted thread in the
+stored message body. First, the only Norwegian attribution pattern assumed a leading "den",
+so Gmail's date-first form ("ons. 26. aug. 2026 kl. 14:05 skrev Support <s@x.example>:")
+matched nothing — and Gmail hard-wraps that line at 76 columns, putting the address's closing
+`>:` on its own line, which defeated the end-of-line anchor regardless. Second, the heuristic
+fallback scans up from the end of the message over quoted lines, so it bailed immediately when
+the sender's client placed their signature *below* the quote rather than above it.
+
+Attribution lines are now matched with their quote markers removed (so a nested
+`> On … wrote:` is recognised too), a wrapped address is rejoined before matching, date-first
+Nordic attributions are recognised when the line also carries a time of day, and the trailing
+scan retries above a signature block. A quote cut no longer swallows a signature that sat
+below the quote — it is re-attached so the signature split still records it — and an
+attribution on the very first line no longer reduces the whole message to `(no body)`.

--- a/packages/backend-core/src/modules/conv/email/reply-history.test.ts
+++ b/packages/backend-core/src/modules/conv/email/reply-history.test.ts
@@ -4,8 +4,98 @@ import {
   detectSignatureBlock,
   isTrailingSignatureSplit,
   splitSignatureText,
+  stripQuotedReplyText,
   stripSignatureText,
 } from './reply-history.ts';
+
+const GMAIL_NB_REPLY = [
+  'Så du får ikke gjort noe med dette?',
+  '',
+  'ons. 26. aug. 2026 kl. 14:05 skrev uScore Support <uscore-demo@getmunin.com',
+  '>:',
+  '',
+  '> Hei,',
+  '>',
+  '> Boligverdien som vises i uScore er et *estimat* hentet fra vår partner',
+  '> *Boligmappa* – den beregnes automatisk.',
+  '>',
+  '> Vennlig hilsen',
+  '> uScore-teamet',
+  '>',
+  '> On Wed, 26 Aug 2026 12:04:24 GMT, Kjell Rune Monsø <kjell@apps.no> wrote:',
+  '>',
+  '> Hei! Jeg fikk helt feil pris på boligen min, dette kan ikke stemme. Fiks!',
+  '>',
+  '>',
+  '',
+  '-- ',
+  'Med vennlig hilsen',
+  'Kjell Rune Monsø',
+  '',
+  'Mobil: 414 25 762',
+  'Mail: kjell@apps.no',
+  'Web: www.apps.no',
+].join('\n');
+
+describe('stripQuotedReplyText', () => {
+  it('cuts a Gmail Norwegian attribution whose address wrapped onto the next line', () => {
+    const r = stripQuotedReplyText(GMAIL_NB_REPLY);
+    expect(r).not.toContain('Boligverdien');
+    expect(r).not.toContain('skrev uScore Support');
+    expect(r.startsWith('Så du får ikke gjort noe med dette?')).toBe(true);
+  });
+
+  it('keeps a signature that sits below the quoted block so the signature split still sees it', () => {
+    const r = stripQuotedReplyText(GMAIL_NB_REPLY);
+    expect(splitSignatureText(r).clean).toBe('Så du får ikke gjort noe med dette?');
+    expect(splitSignatureText(r).signature).toContain('Mobil: 414 25 762');
+  });
+
+  it('cuts an English attribution line', () => {
+    const r = stripQuotedReplyText(
+      'Thanks!\n\nOn Wed, 26 Aug 2026 at 14:05, Support <s@x.example> wrote:\n\n> Hello there\n> and more\n',
+    );
+    expect(r).toBe('Thanks!');
+  });
+
+  it('cuts a nested attribution that carries its own quote marker', () => {
+    const r = stripQuotedReplyText(
+      'Takk!\n\n> On Wed, 26 Aug 2026 12:04:24 GMT, Sam <sam@x.example> wrote:\n>\n> Original question\n>\n',
+    );
+    expect(r).toBe('Takk!');
+  });
+
+  it('falls back to the trailing quoted run when no attribution is recognised', () => {
+    const r = stripQuotedReplyText('Kort svar.\n\n> gammel melding\n> linje to\n> linje tre\n');
+    expect(r).toBe('Kort svar.');
+  });
+
+  it('finds a trailing quoted run that sits above a signature', () => {
+    const r = stripQuotedReplyText(
+      'Kort svar.\n\n> gammel melding\n> linje to\n> linje tre\n\n--\nSam\nsam@x.example',
+    );
+    expect(r).toBe('Kort svar.\n\n--\nSam\nsam@x.example');
+  });
+
+  it('leaves a message with no quoted history untouched', () => {
+    const body = 'Hei!\n\nJeg lurer på en ting om prisen.';
+    expect(stripQuotedReplyText(body)).toBe(body);
+  });
+
+  it('keeps the whole body when the attribution is the first line and nothing precedes it', () => {
+    const body = 'On Wed, 26 Aug 2026 at 14:05, Support <s@x.example> wrote:\n\n> Hello\n\nMy answer.';
+    expect(stripQuotedReplyText(body)).toBe(body);
+  });
+
+  it('does not treat an ordinary Norwegian sentence ending in a colon as an attribution', () => {
+    const body = 'Han skrev dette til meg:\n\nog jeg lurer på hva det betyr.';
+    expect(stripQuotedReplyText(body)).toBe(body);
+  });
+
+  it('handles empty input', () => {
+    expect(stripQuotedReplyText('')).toBe('');
+  });
+});
 
 describe('splitSignatureText', () => {
   it('returns null signature when no opener present', () => {

--- a/packages/backend-core/src/modules/conv/email/reply-history.ts
+++ b/packages/backend-core/src/modules/conv/email/reply-history.ts
@@ -33,30 +33,86 @@ const QUOTE_HEADER_PATTERNS: RegExp[] = [
   /^_{5,}\s*$/,
 ];
 
+const QUOTE_MARKER = /^(?:>\s?)+/;
+const WRAPPED_ADDRESS_TAIL = /^>\s*:$/;
+const TIME_OF_DAY = /\d{1,2}[.:]\d{2}/;
+const DATE_FIRST_QUOTE_VERB = /\b(?:skrev|skreiv|skrifaði|kirjoitti)\b/i;
+const MAX_QUOTE_HEADER_LENGTH = 200;
+
 export function stripQuotedReplyText(body: string): string {
   if (!body) return body;
-  const lines = body.split(/\r?\n/);
-  let cut = lines.length;
+  const lines = unwrapAttributionBreaks(body.split(/\r?\n/));
+  const cut =
+    findQuoteHeaderCut(lines) ?? findTrailingQuoteCut(lines) ?? findQuoteCutAboveSignature(lines);
+  if (cut === null) return lines.join('\n').replace(/\s+$/g, '').trim();
+  return joinAroundQuote(lines, cut);
+}
+
+function hasUnclosedAngle(line: string): boolean {
+  const open = line.lastIndexOf('<');
+  return open >= 0 && line.indexOf('>', open) < 0;
+}
+
+function unwrapAttributionBreaks(lines: string[]): string[] {
+  const out: string[] = [];
   for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i]!.trim();
-    if (QUOTE_HEADER_PATTERNS.some((re) => re.test(line))) {
-      cut = i;
-      break;
+    const line = lines[i]!;
+    const next = lines[i + 1];
+    if (next !== undefined && hasUnclosedAngle(line) && WRAPPED_ADDRESS_TAIL.test(next.trim())) {
+      out.push(`${line}${next.trim()}`);
+      i += 1;
+      continue;
     }
+    out.push(line);
   }
-  if (cut === lines.length) {
-    let i = lines.length - 1;
-    while (i >= 0) {
-      const t = lines[i]!.trim();
-      if (t === '' || t.startsWith('>')) {
-        i -= 1;
-        continue;
-      }
-      break;
+  return out;
+}
+
+function isQuoteHeaderLine(line: string): boolean {
+  const text = line.replace(QUOTE_MARKER, '').trim();
+  if (!text || text.length > MAX_QUOTE_HEADER_LENGTH) return false;
+  if (QUOTE_HEADER_PATTERNS.some((re) => re.test(text))) return true;
+  return text.endsWith(':') && TIME_OF_DAY.test(text) && DATE_FIRST_QUOTE_VERB.test(text);
+}
+
+function findQuoteHeaderCut(lines: string[]): number | null {
+  for (let i = 0; i < lines.length; i += 1) {
+    if (!isQuoteHeaderLine(lines[i]!)) continue;
+    if (!lines.slice(0, i).some((l) => l.trim() !== '')) return null;
+    return i;
+  }
+  return null;
+}
+
+function findTrailingQuoteCut(lines: string[]): number | null {
+  let i = lines.length - 1;
+  while (i >= 0) {
+    const t = lines[i]!.trim();
+    if (t === '' || t.startsWith('>')) {
+      i -= 1;
+      continue;
     }
-    if (i < lines.length - 3 && i < lines.length - 1) cut = i + 1;
+    break;
   }
-  return lines.slice(0, cut).join('\n').replace(/\s+$/g, '').trim();
+  if (i < lines.length - 3 && i < lines.length - 1) return i + 1;
+  return null;
+}
+
+function findQuoteCutAboveSignature(lines: string[]): number | null {
+  const opener = findSignatureOpener(lines);
+  if (opener === null) return null;
+  return findTrailingQuoteCut(lines.slice(0, opener));
+}
+
+function joinAroundQuote(lines: string[], cut: number): string {
+  const kept = lines.slice(0, cut).join('\n').replace(/\s+$/g, '').trim();
+  const below = lines.slice(cut);
+  const opener = findSignatureOpener(below);
+  if (opener === null) return kept;
+  const signature = below.slice(opener);
+  if (signature.some((l) => l.trimStart().startsWith('>'))) return kept;
+  const text = signature.join('\n').replace(/\s+$/g, '');
+  return text ? `${kept}\n\n${text}` : kept;
 }
 
 export function stripQuotedReplyHtml(html: string | null): string | null {
@@ -106,18 +162,18 @@ export function stripSignatureText(body: string): string {
   return splitSignatureText(body).clean;
 }
 
+function findSignatureOpener(lines: string[]): number | null {
+  for (let i = 0; i < lines.length; i += 1) {
+    if (SIGNATURE_OPENERS.some((re) => re.test(lines[i]!.trim()))) return i;
+  }
+  return null;
+}
+
 export function splitSignatureText(body: string): { clean: string; signature: string | null } {
   if (!body) return { clean: body, signature: null };
   const lines = body.split(/\r?\n/);
-  let cut = -1;
-  for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i]!.trim();
-    if (SIGNATURE_OPENERS.some((re) => re.test(line))) {
-      cut = i;
-      break;
-    }
-  }
-  if (cut < 0) return { clean: body, signature: null };
+  const cut = findSignatureOpener(lines);
+  if (cut === null) return { clean: body, signature: null };
   const kept = lines.slice(0, cut);
   let nonEmpty = 0;
   for (const l of kept) if (l.trim() !== '') nonEmpty += 1;


### PR DESCRIPTION
An inbound reply in the Globex demo org kept its entire quoted thread in the stored message body ([`cvm_9krpmull9610ytdjuzpddy`](https://github.com/getmunin/munin) — `metadata.preStripBody` shows `stripQuotedReplyText` was a complete no-op on it).

## Why it happened

Two independent gaps compounded; either alone would have been survivable.

**1. The attribution line matched nothing.** The raw text part was:

```
ons. 26. aug. 2026 kl. 14:05 skrev Globex Support <demo@getmunin.com
>:
```

The only Norwegian entry in `QUOTE_HEADER_PATTERNS` is `/^den .+ skrev .+:\s*$/i`, which assumes a leading "den" — Gmail's Norwegian attribution is date-first. And Gmail hard-wrapped at 76 columns, so the address's closing `>:` landed on its own line and the `:\s*$` anchor could not match even in principle. The same body also carries our own `> On Wed, 26 Aug 2026 …, Ola Nordmann <ola.nordmann@example.no> wrote:` from `formatQuotedHistory`, which would have matched `/^on .+ wrote:$/i` except patterns were tested against the line with its `>` prefix intact.

**2. The tail-scan fallback bailed.** It walks up from the bottom over blank/`>`-prefixed lines, but this sender's Gmail puts the signature *below* the quote, so the scan stopped on `Web: www.example.no`, `i < lines.length - 3` was false, and nothing was cut.

## The fix

- Rejoin a wrapped attribution before matching (a line with an unclosed `<` followed by a line that is just `>:`).
- Match attribution patterns with quote markers stripped, so a nested `> On … wrote:` is recognised.
- Recognise date-first Nordic attributions: a line ending in `:` carrying both a time of day and `skrev`/`skreiv`/`skrifaði`/`kirjoitti`. The time requirement is what keeps an ordinary sentence like "Han skrev dette til meg:" from matching.
- Retry the trailing scan above a signature block.

Two guards came along with it: a quote cut re-attaches a signature that sat below the quote, so the adapter's `splitSignatureText` still records `metadata.signatureText`; and an attribution on the very first line is ignored rather than reducing the message to `(no body)`.

`email-adapter.ts` is deliberately untouched. Reordering it to split the signature before stripping quotes would fix this message too, but it regresses Outlook — `_____` is both a signature opener and a quote header, so a signature-first pass would classify an entire Outlook quote as the signature.

## Verification

- Replayed the actual stored body through the adapter's exact two-step sequence: `body` becomes `Så du får ikke gjort noe med dette?`, `signatureText` still captures the full block.
- `reply-history.test.ts`: 32 pass (22 pre-existing, 10 new). The file previously had **zero** coverage for `stripQuotedReplyText` — every test in it was signature-related.
- Full `src/modules/conv` suite: 404 pass across 37 files. `tsc --noEmit` and eslint clean.

Not addressed here: the already-stored polluted message. There is no MCP tool that rewrites a message body (`conv_strip_message_signature` only touches signatures), so re-stripping it would need a direct DB update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

