### PR TITLE
fix(docs-pages): stop docs content widening the viewport on phones

### DIFF
--- a/.changeset/tidy-pandas-shave.md
+++ b/.changeset/tidy-pandas-shave.md
@@ -1,0 +1,25 @@
+---
+'@getmunin/docs-pages': patch
+---
+
+Stop the docs pages from widening the viewport on phones.
+
+Three rules in `docs.css` let content push the document past the viewport, which on iOS
+Safari shrink-to-fits the whole page rather than scrolling the offending element:
+
+- `.field-block` had no scroll container, so a REST parameter table (365px min-content)
+  pushed `/docs/rest` to 410px inside a 390px viewport. It now scrolls on its own axis,
+  matching how `.curl > pre` and `.docs-switcher` already behave.
+- Inline `<code>` had no wrap opportunity, so a single long token — e.g.
+  `window.mn.widget.identify(externalId, userHash)` in the chat-widget guide — measured
+  311px inside a 280px column. `overflow-wrap: anywhere` applies to inline code only
+  (`:not(pre) > code`), so scrollable code blocks are untouched: `white-space: pre`
+  suppresses wrapping there regardless.
+- `.docs-attrs dt` kept `white-space: nowrap` in the ≤720px single-column layout. That is
+  right for short mono keys but not for the prose `dt`s in the
+  skills-vs-tools-vs-rest guide, whose min-content was a whole 399px sentence.
+
+Verified across 13 viewport widths (320–1024) on all 22 docs routes — 286 page-loads,
+`documentElement.scrollWidth == clientWidth` everywhere. Desktop rendering is unchanged:
+every rule either applies only below a breakpoint or only engages when content would
+otherwise overflow.

--- a/packages/docs-pages/src/docs.css
+++ b/packages/docs-pages/src/docs.css
@@ -15,6 +15,9 @@
   --docs-red: #c0392b;
   --docs-green: #2a6f4e;
 }
+.docs :not(pre) > code {
+  overflow-wrap: anywhere;
+}
 @media (prefers-color-scheme: dark) {
   .docs {
     --docs-rule: rgb(255 255 255 / 0.1);
@@ -481,6 +484,7 @@
 
 .field-block {
   margin: 18px 0;
+  overflow-x: auto;
 }
 .field-block-h {
   font-family: var(--munin-mono);
@@ -1596,5 +1600,6 @@
   }
   .docs-attrs dt {
     margin-top: 10px;
+    white-space: normal;
   }
 }


### PR DESCRIPTION
Three rules in `docs.css` let content push the document past the viewport rather than scrolling on its own axis. On iOS Safari the result is not a scrollbar on the offending element — the browser shrink-to-fits the whole page, so the site renders zoomed out with a blank gutter down the right side.

Found while chasing the same class of bug in the marketing footer on `getmunin.com`; the docs half of it lives here.

## What was overflowing

| Route | Element | Measured |
|---|---|---|
| `/docs/rest` | `table.field-table` in `.field-block` | 365px min-content in a 300px column → document 410px at a 390px viewport |
| `/docs/guides/chat-widget` | inline `<code>window.mn.widget.identify(externalId, userHash)</code>` | 311px in a 280px column → document 331px at 320px |
| `/docs/guides/skills-vs-tools-vs-rest` | `.docs-attrs dt` | 399px min-content (a whole sentence) → document 399px at ≤390px |

## The changes

- **`.field-block { overflow-x: auto }`** — makes the parameter table scroll on its own axis, which is how `.curl > pre` and `.docs-switcher` already behave. Those two were flagged by a naive scan and turned out to be correct by design; this one was the genuine gap.
- **`.docs :not(pre) > code { overflow-wrap: anywhere }`** — inline code had no break opportunity. Scoped away from `pre` so code blocks keep horizontal scrolling; `white-space: pre` would suppress wrapping there regardless, so this is belt-and-braces.
- **`.docs-attrs dt { white-space: normal }` inside the existing `≤720px` block** — `nowrap` is correct for short mono keys in the two-column desktop layout, but the `dt`s in the skills guide are prose, and the mobile layout is already single-column, so nothing depends on them staying on one line.

## Verification

Swept all 22 docs routes at 13 widths (320, 360, 375, 390, 430, 600, 700, 719, 721, 760, 800, 880, 1024) — **286 page-loads, all with `documentElement.scrollWidth == clientWidth`**. The 719/721/760/800 widths are in there deliberately to cover both sides of the `.docs-attrs` breakpoint.

Desktop rendering is unchanged: each rule either sits below a breakpoint, or only engages when the content would otherwise overflow.

Verified by building the changed `docs.css` into `munin-cloud`'s marketing app (which mounts these same components at `/docs`) and running the sweep against it, then restoring the published copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
