### PR TITLE
feat(auth): scope a dashboard session's org per request

### DIFF
--- a/.changeset/shiny-hounds-repeat.md
+++ b/.changeset/shiny-hounds-repeat.md
@@ -1,0 +1,16 @@
+---
+'@getmunin/dashboard-pages': minor
+'@getmunin/backend-core': minor
+'@getmunin/types': minor
+'@getmunin/core': minor
+---
+
+Scope a dashboard session's organization per request instead of per account
+
+The active organization was a single account-wide flag (`org_members.is_default`) that every `/v1/*` request re-read, while the dashboard read the organization name once at page load and cached it. Switching organizations in one tab therefore changed what every other open tab was served, without changing what those tabs displayed — a stale label sitting on top of another organization's data. The same applied to a second browser or device, so no tab-local mechanism could have fixed it.
+
+Session credentials now accept a requested organization. `CredentialResolver.resolveSessionToken` takes an optional organization id, checks it against the caller's memberships, and refuses with `OrgAccessDeniedError` when it isn't one — it never quietly serves a different organization instead. The control-plane guard reads that id from an `x-munin-org` request header on the session-cookie path only, so API keys and OAuth tokens stay bound to the organization they were issued for, and it maps the refusal to a `403` carrying `code: org_access_denied`. Every authenticated response now echoes the organization that served it in an `x-munin-org` response header (exposed through CORS), and the realtime websocket takes the same id as an `orgId` connect parameter.
+
+On the client, the dashboard keeps its organization in `sessionStorage`, which is per-tab: a tab pins itself to whichever organization served its first response and stays there, so `is_default` now only decides where a *new* tab starts. `api()` sends the pin, adopts the served organization when it has none, and — if the pin is refused, which is what a user switching accounts in the same tab looks like — drops it and retries once, so recovery is invisible rather than a wall of errors.
+
+This is the transport half of the fix. Until the organization also appears in the dashboard URL, server-rendered layouts still read `is_default`, so a tab pinned elsewhere can briefly render the account-wide organization name before the client corrects it.

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -9,7 +9,7 @@ import { join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { Request, Response, NextFunction } from 'express';
 import { STORAGE } from './common/storage/storage.token.ts';
-import { stripTrailingSlashes } from '@getmunin/types';
+import { ORG_HEADER, stripTrailingSlashes } from '@getmunin/types';
 
 const JSON_BODY_LIMIT = '4mb';
 
@@ -201,7 +201,7 @@ export function corsMiddleware(strictOrigins: string[] | true) {
       if (explicitlyAllowed) {
         res.setHeader('Access-Control-Allow-Credentials', 'true');
       }
-      res.setHeader('Access-Control-Expose-Headers', 'x-request-id');
+      res.setHeader('Access-Control-Expose-Headers', `x-request-id,${ORG_HEADER}`);
     }
 
     if (req.method === 'OPTIONS') {

--- a/packages/backend-core/src/common/auth/auth.guard.test.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.test.ts
@@ -1,7 +1,7 @@
 import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ResolvedCredential } from '@getmunin/core';
+import { OrgAccessDeniedError, type ResolvedCredential } from '@getmunin/core';
 import { AuthGuard, type AuthenticatedRequest } from './auth.guard.ts';
 import type { McpSurface } from '../../oauth/mcp-surface.ts';
 
@@ -46,7 +46,7 @@ describe('AuthGuard cookie fallback', () => {
       path: '/v1/kb/spaces',
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
-    expect(resolveSessionToken).toHaveBeenCalledWith('raw');
+    expect(resolveSessionToken).toHaveBeenCalledWith('raw', null);
   });
 
   it('rejects session cookie on /mcp — bearer required', async () => {
@@ -74,6 +74,78 @@ describe('AuthGuard cookie fallback', () => {
   });
 });
 
+describe('AuthGuard per-request org selection', () => {
+  it('passes the x-munin-org header through to session resolution', async () => {
+    const resolveSessionToken = vi.fn().mockResolvedValue({ actor: { type: 'user' } });
+    const guard = makeGuard({ resolveSessionToken });
+    const ctx = makeContext({
+      headers: { cookie: SESSION_COOKIE, 'x-munin-org': 'org_two' },
+      url: '/v1/kb/spaces',
+      path: '/v1/kb/spaces',
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(resolveSessionToken).toHaveBeenCalledWith('raw', 'org_two');
+  });
+
+  it('treats a blank x-munin-org header as unset', async () => {
+    const resolveSessionToken = vi.fn().mockResolvedValue({ actor: { type: 'user' } });
+    const guard = makeGuard({ resolveSessionToken });
+    const ctx = makeContext({
+      headers: { cookie: SESSION_COOKIE, 'x-munin-org': '   ' },
+      url: '/v1/kb/spaces',
+      path: '/v1/kb/spaces',
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(resolveSessionToken).toHaveBeenCalledWith('raw', null);
+  });
+
+  it('answers a non-membership org with a coded 403, not a 401', async () => {
+    const resolveSessionToken = vi.fn().mockRejectedValue(new OrgAccessDeniedError('org_other'));
+    const guard = makeGuard({ resolveSessionToken });
+    const ctx = makeContext({
+      headers: { cookie: SESSION_COOKIE, 'x-munin-org': 'org_other' },
+      url: '/v1/kb/spaces',
+      path: '/v1/kb/spaces',
+    });
+    await expect(guard.canActivate(ctx)).rejects.toMatchObject({
+      status: 403,
+      response: { code: 'org_access_denied' },
+    });
+  });
+
+  it('ignores x-munin-org when the caller authenticates with an api key', async () => {
+    const resolveApiKey = vi.fn().mockResolvedValue({ actor: { type: 'admin_agent', orgId: 'org_key' } });
+    const guard = makeGuard({ resolveApiKey });
+    const ctx = makeContext({
+      headers: { authorization: 'Bearer mn_admin_abc', 'x-munin-org': 'org_other' },
+      url: '/v1/kb/spaces',
+      path: '/v1/kb/spaces',
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(resolveApiKey).toHaveBeenCalledWith('mn_admin_abc');
+  });
+
+  it('echoes the org that actually served the request', async () => {
+    const resolveSessionToken = vi
+      .fn()
+      .mockResolvedValue({ actor: { type: 'user', orgId: 'org_served' } });
+    const guard = makeGuard({ resolveSessionToken });
+    const req = {
+      headers: { cookie: SESSION_COOKIE },
+      url: '/v1/kb/spaces',
+      path: '/v1/kb/spaces',
+    };
+    const res = { setHeader: vi.fn() };
+    const ctx = {
+      getHandler: () => () => undefined,
+      getClass: () => class {},
+      switchToHttp: () => ({ getRequest: () => req, getResponse: () => res }),
+    } as unknown as Parameters<AuthGuard['canActivate']>[0];
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(res.setHeader).toHaveBeenCalledWith('x-munin-org', 'org_served');
+  });
+});
+
 describe('AuthGuard cookie prefix (MUNIN_AUTH_COOKIE_PREFIX)', () => {
   let originalPrefix: string | undefined;
 
@@ -95,7 +167,7 @@ describe('AuthGuard cookie prefix (MUNIN_AUTH_COOKIE_PREFIX)', () => {
       path: '/v1/kb/spaces',
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
-    expect(resolveSessionToken).toHaveBeenCalledWith('raw');
+    expect(resolveSessionToken).toHaveBeenCalledWith('raw', null);
   });
 
   it('ignores a default-named cookie from another environment', async () => {
@@ -109,7 +181,7 @@ describe('AuthGuard cookie prefix (MUNIN_AUTH_COOKIE_PREFIX)', () => {
       path: '/v1/kb/spaces',
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
-    expect(resolveSessionToken).toHaveBeenCalledWith('devraw');
+    expect(resolveSessionToken).toHaveBeenCalledWith('devraw', null);
   });
 });
 

--- a/packages/backend-core/src/common/auth/auth.guard.ts
+++ b/packages/backend-core/src/common/auth/auth.guard.ts
@@ -2,6 +2,7 @@ import {
   CanActivate,
   Controller,
   ExecutionContext,
+  ForbiddenException,
   Inject,
   Injectable,
   NotFoundException,
@@ -12,8 +13,10 @@ import {
   applyDecorators,
 } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
+import { ORG_ACCESS_DENIED_CODE, ORG_HEADER } from '@getmunin/types';
 import {
   CredentialResolver,
+  OrgAccessDeniedError,
   looksOrgScoped,
   orgScopedPath,
   orgScopedResourceUrl,
@@ -117,7 +120,17 @@ export class AuthGuard implements CanActivate {
       const cookieValue = Array.isArray(cookieHeader) ? cookieHeader[0] : cookieHeader;
       const sessionToken = readSessionCookie(cookieValue);
       if (sessionToken) {
-        credential = await this.resolver.resolveSessionToken(sessionToken);
+        try {
+          credential = await this.resolver.resolveSessionToken(
+            sessionToken,
+            readRequestedOrgId(request),
+          );
+        } catch (err) {
+          if (err instanceof OrgAccessDeniedError) {
+            throw new ForbiddenException({ message: err.message, code: ORG_ACCESS_DENIED_CODE });
+          }
+          throw err;
+        }
       }
     }
 
@@ -148,7 +161,16 @@ export class AuthGuard implements CanActivate {
     }
 
     request.credential = credential;
+    this.echoServingOrg(context, credential);
     return true;
+  }
+
+  private echoServingOrg(context: ExecutionContext, credential: ResolvedCredential): void {
+    if (!credential.actor.orgId) return;
+    const res = context
+      .switchToHttp()
+      .getResponse<{ setHeader?: (n: string, v: string) => void }>();
+    res.setHeader?.(ORG_HEADER, credential.actor.orgId);
   }
 
   private audienceCoversRequest(audience: string, request: AuthenticatedRequest): boolean {
@@ -181,6 +203,13 @@ export class AuthGuard implements CanActivate {
       .getResponse<{ setHeader?: (n: string, v: string) => void }>();
     res.setHeader?.('WWW-Authenticate', `Bearer resource_metadata="${metadata}"`);
   }
+}
+
+function readRequestedOrgId(request: AuthenticatedRequest): string | null {
+  const raw = request.headers[ORG_HEADER];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
 }
 
 function isMcpRequest(request: AuthenticatedRequest): boolean {

--- a/packages/backend-core/src/realtime/realtime.gateway.ts
+++ b/packages/backend-core/src/realtime/realtime.gateway.ts
@@ -15,6 +15,7 @@ import { eq, sql } from 'drizzle-orm';
 import {
   ActorIdentity,
   CredentialResolver,
+  OrgAccessDeniedError,
   WebhookDispatcher,
   parseEnvDisableFlag,
   withContext,
@@ -753,7 +754,12 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     const cookieValue = readHeader(req, 'cookie');
     const sessionToken = readSessionCookie(cookieValue);
     if (sessionToken) {
-      const credential = await this.resolver.resolveSessionToken(sessionToken);
+      const credential = await this.resolver
+        .resolveSessionToken(sessionToken, readRequestedOrgId(req))
+        .catch((err: unknown) => {
+          if (err instanceof OrgAccessDeniedError) return null;
+          throw err;
+        });
       return credential ? { credential, fromCookie: true } : null;
     }
     return null;
@@ -775,6 +781,14 @@ export class RealtimeGateway implements OnApplicationBootstrap, OnModuleDestroy 
     }
     return this.resolver.resolveBearerToken(raw);
   }
+}
+
+function readRequestedOrgId(req: IncomingMessage): string | null {
+  const raw = req.url ?? '';
+  const query = raw.slice(raw.indexOf('?') + 1);
+  if (!raw.includes('?')) return null;
+  const value = new URLSearchParams(query).get('orgId')?.trim();
+  return value ? value : null;
 }
 
 function readHeader(req: IncomingMessage, name: string): string | undefined {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export {
 export { AuditLogger, type AuditEventInput } from './request/audit.ts';
 export {
   CredentialResolver,
+  OrgAccessDeniedError,
   type ResolvedCredential,
   readMembershipsForUser,
 } from './request/credentials.ts';

--- a/packages/core/src/request/credentials.test.ts
+++ b/packages/core/src/request/credentials.test.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import type { Db } from '@getmunin/db';
 import { sql } from 'drizzle-orm';
-import { CredentialResolver } from './credentials.ts';
+import { CredentialResolver, OrgAccessDeniedError } from './credentials.ts';
 import { buildApiKey, keyPrefix } from '../crypto/keys.ts';
 import { hashSecret } from '../crypto/primitives.ts';
 
@@ -210,5 +210,91 @@ const skipReason = TEST_URL
     expect(out!.actor.type).toBe('user');
     expect(out!.actor.id).toBe(userId);
     expect(out!.actor.clientId).toBe('client_attribution_test');
+  });
+});
+
+(skipReason ? describe.skip : describe)('CredentialResolver.resolveSessionToken', () => {
+  let db: Db;
+  let defaultOrgId: string;
+  let otherOrgId: string;
+  let strangerOrgId: string;
+  let userId: string;
+  const token = `session-org-scope-${Date.now()}`;
+
+  beforeAll(async () => {
+    await runMigrations(TEST_URL!);
+    db = createDb(TEST_URL!, { serviceRole: true });
+    const orgs = await db
+      .insert(schema.orgs)
+      .values([
+        { name: 'Session Default Org' },
+        { name: 'Session Other Org' },
+        { name: 'Session Stranger Org' },
+      ])
+      .returning();
+    defaultOrgId = orgs[0]!.id;
+    otherOrgId = orgs[1]!.id;
+    strangerOrgId = orgs[2]!.id;
+
+    const [user] = await db
+      .insert(schema.users)
+      .values({ email: `session-org-scope-${Date.now()}@example.com`, emailVerified: true })
+      .returning();
+    userId = user!.id;
+
+    await db.insert(schema.orgMembers).values([
+      { orgId: defaultOrgId, userId, role: 'owner', isDefault: true },
+      { orgId: otherOrgId, userId, role: 'admin', isDefault: false },
+    ]);
+
+    await db.insert(schema.sessions).values({
+      userId,
+      token,
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.delete(schema.users).where(sql`id = ${userId}`);
+      await db
+        .delete(schema.orgs)
+        .where(sql`id in (${defaultOrgId}, ${otherOrgId}, ${strangerOrgId})`);
+      void db.$client.end();
+    }
+  });
+
+  it('falls back to the account-wide default when no org is requested', async () => {
+    const out = await new CredentialResolver(db).resolveSessionToken(token);
+    expect(out!.actor.orgId).toBe(defaultOrgId);
+  });
+
+  it('serves a requested org the user belongs to, over the default', async () => {
+    const out = await new CredentialResolver(db).resolveSessionToken(token, otherOrgId);
+    expect(out!.actor.orgId).toBe(otherOrgId);
+    expect(out!.actor.id).toBe(userId);
+  });
+
+  it('refuses a requested org the user does not belong to rather than serving another', async () => {
+    await expect(
+      new CredentialResolver(db).resolveSessionToken(token, strangerOrgId),
+    ).rejects.toBeInstanceOf(OrgAccessDeniedError);
+  });
+
+  it('refuses an unknown org id rather than falling back to the default', async () => {
+    await expect(
+      new CredentialResolver(db).resolveSessionToken(token, 'org_does_not_exist'),
+    ).rejects.toBeInstanceOf(OrgAccessDeniedError);
+  });
+
+  it('returns null for an expired session even when an org is requested', async () => {
+    const expired = `session-org-scope-expired-${Date.now()}`;
+    await db.insert(schema.sessions).values({
+      userId,
+      token: expired,
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+    const out = await new CredentialResolver(db).resolveSessionToken(expired, otherOrgId);
+    expect(out).toBeNull();
   });
 });

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -5,7 +5,7 @@ import { and, eq, gt, isNull, sql } from 'drizzle-orm';
 import { ActorIdentity, type ActorType, type Audience } from './context.ts';
 import { hashSecret } from '../crypto/primitives.ts';
 import { looksLikeJwt, resolveOauthJwtAccessToken } from './oauth-jwt.ts';
-import { stripTrailingSlashes } from '@getmunin/types';
+import { ORG_ACCESS_DENIED_CODE, stripTrailingSlashes } from '@getmunin/types';
 
 async function readMembershipsForUser(
   db: Db,
@@ -32,11 +32,38 @@ function resolvePinnedMembership(
 
 export { resolvePinnedMembership };
 
+export class OrgAccessDeniedError extends Error {
+  readonly code = ORG_ACCESS_DENIED_CODE;
+
+  constructor(readonly orgId: string) {
+    super(`${ORG_ACCESS_DENIED_CODE}: you are not a member of the requested organization`);
+    this.name = 'OrgAccessDeniedError';
+  }
+}
+
 function hashOauthOpaqueToken(rawToken: string): string {
   return createHash('sha256').update(rawToken).digest('base64url');
 }
 
 const WIDGET_ALLOWED_SCOPES: ReadonlySet<string> = new Set(['conv:widget:write']);
+
+function sessionCredential(
+  session: typeof schema.sessions.$inferSelect,
+  orgId: string,
+): ResolvedCredential {
+  const actor = new ActorIdentity(
+    'user',
+    session.userId,
+    orgId,
+    ['*'],
+    ['admin'],
+    undefined,
+    session.id,
+    undefined,
+    session.userId,
+  );
+  return { actor, expiresAt: session.expiresAt };
+}
 
 export interface ResolvedCredential {
   actor: ActorIdentity;
@@ -184,7 +211,10 @@ export class CredentialResolver {
     return { actor };
   }
 
-  async resolveSessionToken(rawToken: string): Promise<ResolvedCredential | null> {
+  async resolveSessionToken(
+    rawToken: string,
+    requestedOrgId?: string | null,
+  ): Promise<ResolvedCredential | null> {
     const sessionRows = await this.db
       .select()
       .from(schema.sessions)
@@ -194,23 +224,18 @@ export class CredentialResolver {
     if (!session) return null;
 
     const memberships = await readMembershipsForUser(this.db, session.userId);
+    if (requestedOrgId) {
+      const requested = memberships.find((m) => m.orgId === requestedOrgId);
+      if (!requested) throw new OrgAccessDeniedError(requestedOrgId);
+      return sessionCredential(session, requested.orgId);
+    }
+
     const membership =
       memberships.find((m) => m.isDefault) ??
       [...memberships].sort((a, b) => +a.createdAt - +b.createdAt)[0];
     if (!membership) return null;
 
-    const actor = new ActorIdentity(
-      'user',
-      session.userId,
-      membership.orgId,
-      ['*'],
-      ['admin'],
-      undefined,
-      session.id,
-      undefined,
-      session.userId,
-    );
-    return { actor, expiresAt: session.expiresAt };
+    return sessionCredential(session, membership.orgId);
   }
 
   async resolveSessionUserId(rawToken: string): Promise<string | null> {

--- a/packages/dashboard-pages/src/api.test.ts
+++ b/packages/dashboard-pages/src/api.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ORG_ACCESS_DENIED_CODE, ORG_HEADER } from '@getmunin/types';
+import { api } from './api';
+import { clearActiveOrgId, getActiveOrgId, setActiveOrgId } from './auth/active-org';
+
+function installSessionStorage(): void {
+  const entries = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => void entries.set(key, value),
+    removeItem: (key: string) => void entries.delete(key),
+  };
+  Object.defineProperty(globalThis, 'window', {
+    value: { sessionStorage: storage },
+    configurable: true,
+    writable: true,
+  });
+}
+
+function jsonResponse(
+  body: unknown,
+  init: { status?: number; orgHeader?: string } = {},
+): Response {
+  const headers: Record<string, string> = {};
+  if (init.orgHeader) headers[ORG_HEADER] = init.orgHeader;
+  return new Response(JSON.stringify(body), { status: init.status ?? 200, headers });
+}
+
+function orgOf(call: unknown[]): string | undefined {
+  const init = call[1] as RequestInit;
+  return (init.headers as Record<string, string>)[ORG_HEADER];
+}
+
+describe('api org scoping', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com';
+    installSessionStorage();
+    clearActiveOrgId();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('pins the tab to the org that served the first response', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }, { orgHeader: 'org_a' }));
+    await api('/v1/me/memberships');
+    expect(orgOf(fetchMock.mock.calls[0]!)).toBeUndefined();
+    expect(getActiveOrgId()).toBe('org_a');
+  });
+
+  it('sends the pinned org on every later request', async () => {
+    setActiveOrgId('org_a');
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }, { orgHeader: 'org_a' }));
+    await api('/v1/kb/spaces');
+    expect(orgOf(fetchMock.mock.calls[0]!)).toBe('org_a');
+  });
+
+  it('leaves a pinned tab alone when another tab switches org', async () => {
+    setActiveOrgId('org_a');
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }, { orgHeader: 'org_a' }));
+    await api('/v1/kb/spaces');
+    expect(getActiveOrgId()).toBe('org_a');
+  });
+
+  it('drops the pin and retries once when the server refuses the org', async () => {
+    setActiveOrgId('org_gone');
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ message: 'nope', code: ORG_ACCESS_DENIED_CODE }, { status: 403 }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ ok: true }, { orgHeader: 'org_current' }));
+
+    await expect(api('/v1/kb/spaces')).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(orgOf(fetchMock.mock.calls[0]!)).toBe('org_gone');
+    expect(orgOf(fetchMock.mock.calls[1]!)).toBeUndefined();
+    expect(getActiveOrgId()).toBe('org_current');
+  });
+
+  it('does not retry a 403 that is not about org access', async () => {
+    setActiveOrgId('org_a');
+    fetchMock.mockResolvedValue(
+      jsonResponse({ message: 'forbidden', code: 'FORBIDDEN' }, { status: 403 }),
+    );
+    await expect(api('/v1/kb/spaces')).rejects.toMatchObject({ status: 403 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getActiveOrgId()).toBe('org_a');
+  });
+
+  it('never sends the org header on anonymous requests', async () => {
+    setActiveOrgId('org_a');
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }, { orgHeader: 'org_a' }));
+    await api('/v1/public/mcp-tools', { anonymous: true });
+    expect(orgOf(fetchMock.mock.calls[0]!)).toBeUndefined();
+  });
+});

--- a/packages/dashboard-pages/src/api.ts
+++ b/packages/dashboard-pages/src/api.ts
@@ -1,3 +1,6 @@
+import { ORG_ACCESS_DENIED_CODE, ORG_HEADER } from '@getmunin/types';
+import { clearActiveOrgId, getActiveOrgId, setActiveOrgId } from './auth/active-org';
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
 export interface ApiFieldError {
@@ -42,16 +45,14 @@ export interface ApiOptions extends RequestInit {
 export async function api<T>(path: string, init: ApiOptions = {}): Promise<T> {
   const { anonymous, ...rest } = init;
   const method = (rest.method ?? 'GET').toUpperCase();
+  const requestedOrgId = anonymous ? null : getActiveOrgId();
   let res: Response;
   try {
-    res = await fetch(`${API_URL}${path}`, {
-      ...rest,
-      credentials: anonymous ? 'omit' : 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(rest.headers ?? {}),
-      },
-    });
+    res = await sendRequest(path, rest, anonymous, requestedOrgId);
+    if (requestedOrgId && (await isOrgAccessDenied(res))) {
+      clearActiveOrgId();
+      res = await sendRequest(path, rest, anonymous, null);
+    }
   } catch (err) {
     if (typeof console !== 'undefined') {
       console.debug('[munin/api] network error', { path, method, err });
@@ -66,6 +67,8 @@ export async function api<T>(path: string, init: ApiOptions = {}): Promise<T> {
       code: 'NETWORK_ERROR',
     });
   }
+  if (!anonymous) reconcileServingOrg(res, getActiveOrgId());
+
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     const parsed = parseErrorBody(text);
@@ -82,6 +85,47 @@ export async function api<T>(path: string, init: ApiOptions = {}): Promise<T> {
   }
   if (res.status === 204) return undefined as T;
   return (await res.json()) as T;
+}
+
+function sendRequest(
+  path: string,
+  rest: RequestInit,
+  anonymous: boolean | undefined,
+  orgId: string | null,
+): Promise<Response> {
+  return fetch(`${API_URL}${path}`, {
+    ...rest,
+    credentials: anonymous ? 'omit' : 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(orgId ? { [ORG_HEADER]: orgId } : {}),
+      ...(rest.headers ?? {}),
+    },
+  });
+}
+
+async function isOrgAccessDenied(res: Response): Promise<boolean> {
+  if (res.status !== 403) return false;
+  const text = await res
+    .clone()
+    .text()
+    .catch(() => '');
+  return parseErrorBody(text).code === ORG_ACCESS_DENIED_CODE;
+}
+
+function reconcileServingOrg(res: Response, requestedOrgId: string | null): void {
+  const servingOrgId = res.headers.get(ORG_HEADER)?.trim();
+  if (!servingOrgId) return;
+  if (!requestedOrgId) {
+    setActiveOrgId(servingOrgId);
+    return;
+  }
+  if (servingOrgId === requestedOrgId) return;
+  console.warn('[munin/api] served a different org than requested', {
+    requestedOrgId,
+    servingOrgId,
+  });
+  setActiveOrgId(servingOrgId);
 }
 
 function parseErrorBody(body: string): {

--- a/packages/dashboard-pages/src/auth/active-org.ts
+++ b/packages/dashboard-pages/src/auth/active-org.ts
@@ -1,0 +1,41 @@
+'use client';
+
+const STORAGE_KEY = 'munin.active-org';
+
+function store(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function write(apply: (storage: Storage) => void): void {
+  const storage = store();
+  if (!storage) return;
+  try {
+    apply(storage);
+  } catch {
+    return;
+  }
+}
+
+export function getActiveOrgId(): string | null {
+  const storage = store();
+  if (!storage) return null;
+  try {
+    const value = storage.getItem(STORAGE_KEY)?.trim();
+    return value ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setActiveOrgId(orgId: string): void {
+  write((storage) => storage.setItem(STORAGE_KEY, orgId));
+}
+
+export function clearActiveOrgId(): void {
+  write((storage) => storage.removeItem(STORAGE_KEY));
+}

--- a/packages/dashboard-pages/src/auth/use-active-role.ts
+++ b/packages/dashboard-pages/src/auth/use-active-role.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { api } from '../api';
+import { getActiveOrgId } from './active-org';
 
 export type OrgRole = 'owner' | 'admin' | 'member';
 
@@ -35,7 +36,12 @@ export function invalidateActiveMembershipCache(): void {
 function fetchActiveMembership(): Promise<ActiveMembership | null> {
   if (cache) return cache.promise;
   const promise = api<MembershipDto[]>('/v1/me/memberships').then((rows) => {
-    const active = rows.find((m) => m.isDefault) ?? rows[0] ?? null;
+    const pinnedOrgId = getActiveOrgId();
+    const active =
+      (pinnedOrgId ? rows.find((m) => m.orgId === pinnedOrgId) : undefined) ??
+      rows.find((m) => m.isDefault) ??
+      rows[0] ??
+      null;
     if (!active || !isOrgRole(active.role)) {
       if (cache) cache.value = null;
       return null;

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -84,6 +84,7 @@ export {
   AuthLoading,
 } from './components/auth-shell';
 export { useTranslateError, translateError, getErrorCode } from './i18n/translate-error';
+export { clearActiveOrgId, getActiveOrgId, setActiveOrgId } from './auth/active-org';
 export {
   useActiveRole,
   useActiveMembership,

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1700,7 +1700,8 @@
     "conv_channel_config_invalid": "This channel's saved settings are incomplete, so it can't be used yet. Open its settings, fill in what's missing and save to repair it.",
     "conv_invalid": "This draft is no longer the one waiting on this conversation — it was already sent, or the agent has written a newer one. Reopen the conversation to see where it stands.",
     "kb_version_conflict": "Someone changed this text while you had it open, so nothing was saved. Reopen it to see the current version and decide on that.",
-    "kb_curation_decided": "This one was already decided — published or dismissed — so it won't be proposed again. Refresh the queue."
+    "kb_curation_decided": "This one was already decided — published or dismissed — so it won't be proposed again. Refresh the queue.",
+    "org_access_denied": "This tab was open in an organization you no longer have access to. Reloading with your current organization."
   },
   "footer": {
     "privacy": "Privacy",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1700,7 +1700,8 @@
     "conv_channel_config_invalid": "Kanalen har ufullstendige innstillinger og kan ikke brukes ennå. Åpne innstillingene, fyll ut det som mangler og lagre for å reparere den.",
     "conv_invalid": "Dette utkastet ligger ikke lenger til behandling i samtalen – det er allerede sendt, eller agenten har skrevet et nyere. Åpne samtalen på nytt for å se hvor den står.",
     "kb_version_conflict": "Noen endret teksten mens du hadde den åpen, så ingenting ble lagret. Åpne den på nytt for å se gjeldende versjon og ta stilling til den.",
-    "kb_curation_decided": "Denne er allerede behandlet – publisert eller forkastet – og blir ikke foreslått igjen. Oppdater køen."
+    "kb_curation_decided": "Denne er allerede behandlet – publisert eller forkastet – og blir ikke foreslått igjen. Oppdater køen.",
+    "org_access_denied": "Denne fanen var åpen i en organisasjon du ikke lenger har tilgang til. Laster inn på nytt med organisasjonen du er i nå."
   },
   "footer": {
     "privacy": "Personvern",

--- a/packages/dashboard-pages/src/realtime.ts
+++ b/packages/dashboard-pages/src/realtime.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { getActiveOrgId } from './auth/active-org';
 
 export interface RealtimeEventRow {
   id: string;
@@ -122,7 +123,11 @@ class RealtimeClient {
       this.reconnectTimer = null;
     }
     this.setStatus('connecting');
-    const url = API_URL.replace(/^http/, 'ws') + '/v1/realtime';
+    const orgId = getActiveOrgId();
+    const url =
+      API_URL.replace(/^http/, 'ws') +
+      '/v1/realtime' +
+      (orgId ? `?orgId=${encodeURIComponent(orgId)}` : '');
     const ws = new WebSocket(url);
     this.ws = ws;
 

--- a/packages/dashboard-pages/src/shells/settings-shell.tsx
+++ b/packages/dashboard-pages/src/shells/settings-shell.tsx
@@ -12,6 +12,7 @@ import {
   SheetContent,
 } from '@getmunin/ui';
 import { authClient } from '../auth-client';
+import { clearActiveOrgId } from '../auth/active-org';
 import { isOwnerOrAdmin, useActiveRole } from '../auth/use-active-role';
 import { SettingsTopbar } from '../components/munin-topbar';
 import { Link, usePathname, useRouter } from '../i18n-navigation';
@@ -48,6 +49,7 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
   const signOut = () => {
     void (async () => {
       await authClient.signOut();
+      clearActiveOrgId();
       router.push('/login');
     })();
   };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -103,6 +103,7 @@ export {
   type LlmProviderPreset,
 } from './llm-providers.ts';
 export { stripTrailingSlashes } from './url.ts';
+export { ORG_ACCESS_DENIED_CODE, ORG_HEADER } from './org-scope.ts';
 export {
   actorKindFromId,
   AGENT_HOST_ACTOR,

--- a/packages/types/src/org-scope.ts
+++ b/packages/types/src/org-scope.ts
@@ -1,0 +1,3 @@
+export const ORG_HEADER = 'x-munin-org';
+
+export const ORG_ACCESS_DENIED_CODE = 'org_access_denied';


### PR DESCRIPTION
## The bug

Open the dashboard in two tabs, switch org in one, and after a while the other tab still shows the old org name — but serves the new org's data.

The active org was a single account-wide flag, `org_members.is_default`. Every `/v1/*` request re-read it (`packages/core/src/request/credentials.ts`), while the dashboard read the org name **once** at page load and cached it module-level (`use-active-role.ts`). Switching in one tab flipped the flag for the whole account, so every other open tab kept rendering a stale label on top of another org's data. Same for a second browser or device, so no tab-local mechanism (BroadcastChannel and friends) could have fixed it.

## The fix

Make the org an explicit parameter of each request instead of account-wide state.

**Backend**
- `resolveSessionToken` takes an optional requested org, validates it against the caller's memberships, and throws `OrgAccessDeniedError` when it isn't one. It never quietly serves a different org — silently serving the wrong org is the bug being fixed.
- The guard reads it from `x-munin-org` **on the session-cookie branch only**, so API keys and OAuth tokens stay bound to the org they were issued for, and maps the refusal to a `403` carrying `code: org_access_denied`.
- Authenticated responses echo the serving org in `x-munin-org`; the realtime websocket takes the same id as an `orgId` connect param.
- `Access-Control-Expose-Headers` now includes the header — without it the client can send an org but never read back which one it got.

**Client**
- The org lives in `sessionStorage`, which is per-tab by construction. A tab pins itself to whichever org served its first response and stays there; `is_default` now only decides where a *new* tab starts.
- `api()` sends the pin, adopts the served org when it has none, and on a refused pin drops it and retries once — so signing in as a different user in the same tab recovers invisibly instead of erroring across the page. That one retry is why no sign-in path needed touching.
- `useActiveMembership` resolves the label from the pinned org, so label and data now derive from the same value.

## Testing

Workspace typecheck and lint clean. New tests: 5 in `core` (requested org honoured over the default, refusal for non-membership and unknown org, expired session), 5 guard tests (header passthrough, blank header, coded 403, API-key path ignores the header, response echo), 6 `api()` tests (pinning, retry, no retry on unrelated 403, anonymous requests). Suites pass — core 533, dashboard-pages 87, backend-core auth+realtime 81.

Smoke-tested against a local server with a real session and two orgs:

| Request | Result |
|---|---|
| no header | `is_default` org, echoed back |
| `x-munin-org:` second org | that org's data only |
| `x-munin-org:` non-membership org | `403` + `org_access_denied`, no fallback |

Two tabs pinned to different orgs each keep their own data and label.

## Scope / follow-ups

This is the transport half. Two things deliberately not in here:

- **Nothing sets the pin on a switch yet.** `setActiveOrgId` is exported but unused here — a consumer that offers org switching has to call it before reloading, otherwise a switch only takes effect for newly opened tabs. Until then the behaviour is: each tab pins to whatever it first loaded, which already stops the stale-label bug.
- **Server-rendered layouts still read `is_default`**, since they can't see `sessionStorage`, so a tab pinned elsewhere can briefly render the account-wide org name before the client corrects it. That goes away when the org moves into the dashboard URL (Layer 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
