### PR TITLE
feat(dashboard): console shell with sidebar and mobile nav sheet

### DIFF
--- a/.changeset/oversight-console-shell.md
+++ b/.changeset/oversight-console-shell.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/dashboard-pages': minor
+---
+
+Console shell: the dashboard grows a persistent 280px sidebar on tablet and up, and a
+full-screen navigation sheet behind a single glyph on phones. Nav lives in a
+`console-groups` registry that host apps extend the same way `settings-groups` is
+extended, and every entry is role-gated by omission — a member sees no Admin group at
+all rather than a disabled one.
+
+Two supporting changes: the sidebar takes an injected slot next to the mark, so a host
+app can put its own organization switcher there, and `/dashboard/settings` is now a real
+grouped index page instead of a redirect to Team, which gives phones a settings list to
+navigate from.

--- a/apps/web/app/[locale]/dashboard/settings/page.tsx
+++ b/apps/web/app/[locale]/dashboard/settings/page.tsx
@@ -1,4 +1,1 @@
-import { createSettingsIndexRedirect } from '@getmunin/dashboard-pages';
-import { DEFAULT_LOCALE } from '@/i18n/locales';
-
-export default createSettingsIndexRedirect({ defaultLocale: DEFAULT_LOCALE });
+export { SettingsIndexPage as default } from '@getmunin/dashboard-pages';

--- a/packages/dashboard-pages/src/components/munin-topbar.tsx
+++ b/packages/dashboard-pages/src/components/munin-topbar.tsx
@@ -73,6 +73,57 @@ export function DashboardTopbar({
   );
 }
 
+export interface ConsoleTopbarProps {
+  brand: string;
+  brandHref?: string;
+  logoSrc?: string;
+  viewLabel: string;
+  orgSlot?: ReactNode;
+  menuOpen?: boolean;
+  onMenuToggle: () => void;
+  openMenuLabel: string;
+  className?: string;
+}
+
+export function ConsoleTopbar({
+  brand,
+  brandHref = '/dashboard',
+  logoSrc,
+  viewLabel,
+  orgSlot,
+  menuOpen = false,
+  onMenuToggle,
+  openMenuLabel,
+  className,
+}: ConsoleTopbarProps) {
+  return (
+    <header
+      className={`${topbarChromeBase} flex h-14 items-center gap-2.5 px-4 ${className ?? ''}`}
+    >
+      <Link href={brandHref} className="flex shrink-0 items-center" aria-label={brand}>
+        {logoSrc ? <Image src={logoSrc} alt="" width={26} height={26} aria-hidden priority /> : null}
+      </Link>
+
+      {orgSlot ?? (
+        <span className="min-w-0 truncate text-sm font-medium text-ink dark:text-foreground">
+          {brand}
+        </span>
+      )}
+
+      <button
+        type="button"
+        onClick={onMenuToggle}
+        aria-expanded={menuOpen}
+        aria-label={openMenuLabel}
+        className="ml-auto inline-flex shrink-0 items-center gap-2.5 py-1.5 pl-2 font-mono text-[9px] uppercase tracking-eyebrow text-ink-soft dark:text-foreground/75"
+      >
+        <span className="max-w-[38vw] truncate">{viewLabel}</span>
+        <Menu className="size-4 text-ink dark:text-foreground" aria-hidden />
+      </button>
+    </header>
+  );
+}
+
 export interface SettingsTopbarProps {
   title: string;
   backHref?: string;

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -30,6 +30,8 @@ export { authClient } from './auth-client';
 export {
   DashboardTopbar,
   type DashboardTopbarProps,
+  ConsoleTopbar,
+  type ConsoleTopbarProps,
   SettingsTopbar,
   type SettingsTopbarProps,
 } from './components/munin-topbar';
@@ -120,6 +122,7 @@ export { CredentialEntryPage } from './pages/credential-entry';
 export { TrackersPage } from './pages/trackers';
 export { EndUsersPage } from './pages/end-users';
 export { DashboardPage } from './pages/overview';
+export { SettingsIndexPage, type SettingsIndexPageProps } from './pages/settings-index';
 export { TeamPage } from './pages/team';
 export { UsagePage } from './pages/usage';
 export { ActivityPage } from './pages/activity';
@@ -137,7 +140,23 @@ export {
   type SettingsSubNavGroup,
   type SettingsGroupExtension,
 } from './nav/settings-groups';
+export {
+  OSS_CONSOLE_GROUPS,
+  ADMIN_ROLES,
+  extendConsoleGroups,
+  visibleConsoleGroups,
+  isConsoleItemActive,
+  type ConsoleNavItem,
+  type ConsoleNavGroup,
+  type ConsoleNavCountKey,
+  type ConsoleGroupExtension,
+} from './nav/console-groups';
 export { SettingsShell, type SettingsShellProps } from './shells/settings-shell';
+export {
+  ConsoleShell,
+  type ConsoleShellProps,
+  type ConsoleNavCounts,
+} from './shells/console-shell';
 export { DashboardShell, type DashboardShellProps } from './shells/dashboard-shell';
 export {
   createSettingsIndexRedirect,

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1241,6 +1241,11 @@
         "workspace": "Workspace",
         "access": "Access",
         "monitoring": "Monitoring"
+      },
+      "roles": {
+        "owner": "Owner",
+        "admin": "Admin",
+        "member": "Support agent"
       }
     },
     "account": {
@@ -1254,6 +1259,12 @@
       "saved": "Saved",
       "errors": {
         "save": "Could not save organization."
+      }
+    },
+    "console": {
+      "groups": {
+        "admin": "Admin",
+        "workspace": "Workspace"
       }
     }
   },

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1241,6 +1241,11 @@
         "workspace": "Arbeidsområde",
         "access": "Tilgang",
         "monitoring": "Overvåking"
+      },
+      "roles": {
+        "owner": "Eier",
+        "admin": "Admin",
+        "member": "Kundebehandler"
       }
     },
     "account": {
@@ -1254,6 +1259,12 @@
       "saved": "Lagret",
       "errors": {
         "save": "Kunne ikke lagre organisasjonen."
+      }
+    },
+    "console": {
+      "groups": {
+        "admin": "Admin",
+        "workspace": "Arbeidsområde"
       }
     }
   },

--- a/packages/dashboard-pages/src/nav/console-groups.test.ts
+++ b/packages/dashboard-pages/src/nav/console-groups.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ADMIN_ROLES,
+  OSS_CONSOLE_GROUPS,
+  extendConsoleGroups,
+  isConsoleItemActive,
+  visibleConsoleGroups,
+  type ConsoleNavGroup,
+} from './console-groups';
+
+const oversight: ConsoleNavGroup = {
+  groupKey: 'oversight',
+  items: [
+    { href: '/dashboard/conversations', labelKey: 'conversations' },
+    { href: '/dashboard/learning', labelKey: 'learning', roles: ADMIN_ROLES },
+  ],
+};
+
+describe('visibleConsoleGroups', () => {
+  it('gives an owner every group', () => {
+    const visible = visibleConsoleGroups([...OSS_CONSOLE_GROUPS, oversight], 'owner');
+    expect(visible.map((g) => g.groupKey)).toEqual(['admin', 'workspace', 'oversight']);
+  });
+
+  it('drops the admin group entirely for a member rather than disabling it', () => {
+    const visible = visibleConsoleGroups([...OSS_CONSOLE_GROUPS, oversight], 'member');
+    expect(visible.map((g) => g.groupKey)).toEqual(['workspace', 'oversight']);
+  });
+
+  it('drops admin-only items but keeps the rest of their group', () => {
+    const visible = visibleConsoleGroups([oversight], 'member');
+    expect(visible[0]!.items.map((i) => i.labelKey)).toEqual(['conversations']);
+  });
+
+  it('drops a group that would render with no items left', () => {
+    const adminOnly: ConsoleNavGroup = {
+      groupKey: 'oversight',
+      items: [{ href: '/dashboard/automation', labelKey: 'automation', roles: ADMIN_ROLES }],
+    };
+    expect(visibleConsoleGroups([adminOnly], 'member')).toEqual([]);
+  });
+
+  it('shows nothing role-gated while the role is still unknown', () => {
+    expect(visibleConsoleGroups([oversight], null).map((g) => g.groupKey)).toEqual(['oversight']);
+    expect(visibleConsoleGroups([oversight], null)[0]!.items).toHaveLength(1);
+  });
+
+  it('does not mutate the group list it was given', () => {
+    const groups = [oversight];
+    visibleConsoleGroups(groups, 'member');
+    expect(groups[0]!.items).toHaveLength(2);
+  });
+});
+
+describe('extendConsoleGroups', () => {
+  it('inserts a new group before workspace so settings stays last', () => {
+    const result = extendConsoleGroups(OSS_CONSOLE_GROUPS, [
+      { groupKey: 'oversight', items: oversight.items },
+    ]);
+    expect(result.map((g) => g.groupKey)).toEqual(['admin', 'oversight', 'workspace']);
+  });
+
+  it('appends into an existing group', () => {
+    const result = extendConsoleGroups(OSS_CONSOLE_GROUPS, [
+      { groupKey: 'workspace', items: [{ href: '/dashboard/billing', labelKey: 'billing' }] },
+    ]);
+    const workspace = result.find((g) => g.groupKey === 'workspace')!;
+    expect(workspace.items.map((i) => i.labelKey)).toEqual(['settings', 'billing']);
+  });
+
+  it('honours insertBefore by href tail', () => {
+    const result = extendConsoleGroups(OSS_CONSOLE_GROUPS, [
+      {
+        groupKey: 'workspace',
+        insertBefore: 'settings',
+        items: [{ href: '/dashboard/billing', labelKey: 'billing' }],
+      },
+    ]);
+    const workspace = result.find((g) => g.groupKey === 'workspace')!;
+    expect(workspace.items.map((i) => i.labelKey)).toEqual(['billing', 'settings']);
+  });
+
+  it('leaves the base list untouched', () => {
+    extendConsoleGroups(OSS_CONSOLE_GROUPS, [
+      { groupKey: 'workspace', items: [{ href: '/dashboard/billing', labelKey: 'billing' }] },
+    ]);
+    const workspace = OSS_CONSOLE_GROUPS.find((g) => g.groupKey === 'workspace')!;
+    expect(workspace.items).toHaveLength(1);
+  });
+});
+
+describe('isConsoleItemActive', () => {
+  it('matches the overview only on an exact path so it never wins over a sibling', () => {
+    expect(isConsoleItemActive('/dashboard', '/dashboard')).toBe(true);
+    expect(isConsoleItemActive('/dashboard', '/dashboard/settings/team')).toBe(false);
+  });
+
+  it('matches a section on its own path and its children', () => {
+    expect(isConsoleItemActive('/dashboard/settings', '/dashboard/settings')).toBe(true);
+    expect(isConsoleItemActive('/dashboard/settings', '/dashboard/settings/team')).toBe(true);
+  });
+
+  it('does not match a sibling that merely shares a prefix', () => {
+    expect(isConsoleItemActive('/dashboard/learn', '/dashboard/learning')).toBe(false);
+  });
+});

--- a/packages/dashboard-pages/src/nav/console-groups.ts
+++ b/packages/dashboard-pages/src/nav/console-groups.ts
@@ -1,0 +1,107 @@
+import type { OrgRole } from '../auth/use-active-role';
+
+export type ConsoleNavCountKey = 'attention' | 'queue' | 'learning';
+
+export interface ConsoleNavItem {
+  href: string;
+  labelKey: string;
+  roles?: readonly OrgRole[];
+  countKey?: ConsoleNavCountKey;
+  noteKey?: string;
+}
+
+export interface ConsoleNavGroup {
+  groupKey: string;
+  items: ConsoleNavItem[];
+  roles?: readonly OrgRole[];
+}
+
+export const ADMIN_ROLES: readonly OrgRole[] = ['owner', 'admin'];
+
+export const OSS_CONSOLE_GROUPS: ConsoleNavGroup[] = [
+  {
+    groupKey: 'admin',
+    roles: ADMIN_ROLES,
+    items: [{ href: '/dashboard', labelKey: 'overview', roles: ADMIN_ROLES, countKey: 'queue' }],
+  },
+  {
+    groupKey: 'workspace',
+    items: [{ href: '/dashboard/settings', labelKey: 'settings' }],
+  },
+];
+
+export interface ConsoleGroupExtension {
+  groupKey: string;
+  items: ConsoleNavItem[];
+  roles?: readonly OrgRole[];
+  insertAfter?: string;
+  insertBefore?: string;
+  position?: 'start' | 'end';
+}
+
+function matchItem(item: ConsoleNavItem, key: string): boolean {
+  return item.labelKey === key || item.href.split('/').pop() === key;
+}
+
+export function extendConsoleGroups(
+  base: ConsoleNavGroup[],
+  extensions: ConsoleGroupExtension[],
+): ConsoleNavGroup[] {
+  const result = base.map((group) => ({ ...group, items: [...group.items] }));
+
+  for (const ext of extensions) {
+    let group = result.find((g) => g.groupKey === ext.groupKey);
+    if (!group) {
+      group = { groupKey: ext.groupKey, items: [], roles: ext.roles };
+      const workspaceIdx = result.findIndex((g) => g.groupKey === 'workspace');
+      if (ext.position === 'end' || workspaceIdx < 0) result.push(group);
+      else result.splice(workspaceIdx, 0, group);
+    }
+
+    if (ext.insertAfter) {
+      const idx = group.items.findIndex((item) => matchItem(item, ext.insertAfter!));
+      if (idx >= 0) {
+        group.items.splice(idx + 1, 0, ...ext.items);
+        continue;
+      }
+    }
+
+    if (ext.insertBefore) {
+      const idx = group.items.findIndex((item) => matchItem(item, ext.insertBefore!));
+      if (idx >= 0) {
+        group.items.splice(idx, 0, ...ext.items);
+        continue;
+      }
+    }
+
+    if (ext.position === 'start') {
+      group.items.unshift(...ext.items);
+      continue;
+    }
+
+    group.items.push(...ext.items);
+  }
+
+  return result;
+}
+
+function allows(roles: readonly OrgRole[] | undefined, role: OrgRole | null): boolean {
+  if (!roles) return true;
+  if (!role) return false;
+  return roles.includes(role);
+}
+
+export function visibleConsoleGroups(
+  groups: ConsoleNavGroup[],
+  role: OrgRole | null,
+): ConsoleNavGroup[] {
+  return groups
+    .filter((group) => allows(group.roles, role))
+    .map((group) => ({ ...group, items: group.items.filter((item) => allows(item.roles, role)) }))
+    .filter((group) => group.items.length > 0);
+}
+
+export function isConsoleItemActive(href: string, pathname: string): boolean {
+  if (href === '/dashboard') return pathname === '/dashboard';
+  return pathname === href || pathname.startsWith(`${href}/`);
+}

--- a/packages/dashboard-pages/src/pages/settings-index.tsx
+++ b/packages/dashboard-pages/src/pages/settings-index.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useActiveRole } from '../auth/use-active-role';
+import { Link } from '../i18n-navigation';
+import { OSS_SETTINGS_GROUPS, type SettingsSubNavGroup } from '../nav/settings-groups';
+
+export interface SettingsIndexPageProps {
+  groups?: SettingsSubNavGroup[];
+}
+
+export function SettingsIndexPage({ groups = OSS_SETTINGS_GROUPS }: SettingsIndexPageProps) {
+  const tNav = useTranslations('nav');
+  const tGroups = useTranslations('dashboard.settings.groups');
+  const tRoles = useTranslations('dashboard.settings.roles');
+  const { role } = useActiveRole();
+
+  return (
+    <div className="flex flex-col gap-7">
+      <div>
+        <h1 className="m-0 font-serif text-[36px] font-normal leading-none tracking-tight text-ink dark:text-foreground">
+          {tNav('settings')}
+        </h1>
+        {role ? (
+          <p className="mt-2 font-mono text-[9px] uppercase tracking-meta text-ink-mute dark:text-foreground/55">
+            {tRoles(role)}
+          </p>
+        ) : null}
+      </div>
+
+      {groups.map((group) => (
+        <div key={group.groupKey}>
+          <p className="mb-2 font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute dark:text-foreground/55">
+            {tGroups(group.groupKey)}
+          </p>
+          <div className="flex flex-col">
+            {group.items.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="group/srow flex min-h-12 items-center gap-3 border-b-[1px] border-rule-soft text-[15.5px] text-ink transition-colors duration-fast ease-munin hover:text-cobalt dark:border-rule-on-dark dark:text-foreground dark:hover:text-cobalt-soft"
+              >
+                <span className="truncate">{tNav(item.labelKey)}</span>
+                <ArrowRight
+                  aria-hidden
+                  className="ml-auto size-4 shrink-0 text-ink-mute transition-colors duration-fast group-hover/srow:text-cobalt dark:group-hover/srow:text-cobalt-soft"
+                />
+              </Link>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/dashboard-pages/src/shells/console-shell.tsx
+++ b/packages/dashboard-pages/src/shells/console-shell.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+import { PageSpinner, Sheet, SheetContent, cn } from '@getmunin/ui';
+import { authClient } from '../auth-client';
+import { clearActiveOrgId } from '../auth/active-org';
+import { useActiveRole } from '../auth/use-active-role';
+import { useDashboardGate } from '../auth/use-dashboard-gate';
+import { ConfirmDialogProvider } from '../components/confirm-dialog';
+import { SystemAlertsBanner } from '../components/system-alerts-banner';
+import { ConsoleTopbar } from '../components/munin-topbar';
+import { Link, usePathname, useRouter } from '../i18n-navigation';
+import { useRealtime } from '../realtime';
+import {
+  isConsoleItemActive,
+  visibleConsoleGroups,
+  type ConsoleNavCountKey,
+  type ConsoleNavGroup,
+} from '../nav/console-groups';
+
+export type ConsoleNavCounts = Partial<Record<ConsoleNavCountKey, number>>;
+
+export interface ConsoleShellProps {
+  brand: string;
+  groups: ConsoleNavGroup[];
+  logoSrc?: string;
+  orgSlot?: ReactNode;
+  counts?: ConsoleNavCounts;
+  roleNote?: ReactNode;
+  withConfirmDialog?: boolean;
+  children: ReactNode;
+}
+
+export function ConsoleShell({
+  brand,
+  groups,
+  logoSrc = '/munin-logo.png',
+  orgSlot,
+  counts,
+  roleNote,
+  withConfirmDialog = false,
+  children,
+}: ConsoleShellProps) {
+  const tNav = useTranslations('nav');
+  const tCommon = useTranslations('common');
+  const tGroups = useTranslations('dashboard.console.groups');
+  const tStatus = useTranslations('dashboard.status');
+  const pathname = usePathname();
+  const router = useRouter();
+  const { data: session } = authClient.useSession();
+  const { ready } = useDashboardGate();
+  const { role } = useActiveRole();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const { status } = useRealtime([{ channel: 'org' }], () => {});
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
+
+  if (!ready || !session) {
+    return <PageSpinner className="min-h-screen bg-background" />;
+  }
+
+  if (pathname.startsWith('/dashboard/settings')) {
+    const settingsContent = (
+      <div className="group flex min-h-screen flex-col bg-bone dark:bg-background">
+        <SystemAlertsBanner />
+        {children}
+      </div>
+    );
+    return withConfirmDialog ? (
+      <ConfirmDialogProvider>{settingsContent}</ConfirmDialogProvider>
+    ) : (
+      settingsContent
+    );
+  }
+
+  const visible = visibleConsoleGroups(groups, role);
+  const activeItem = visible
+    .flatMap((group) => group.items)
+    .find((item) => isConsoleItemActive(item.href, pathname));
+  const viewLabel = activeItem ? tNav(activeItem.labelKey) : brand;
+
+  const signOut = () => {
+    void (async () => {
+      await authClient.signOut();
+      clearActiveOrgId();
+      router.push('/login');
+    })();
+  };
+
+  const navList = (variant: 'rail' | 'sheet') => (
+    <nav className={variant === 'sheet' ? 'flex flex-col gap-6' : 'flex flex-col gap-6'}>
+      {visible.map((group) => (
+        <div key={group.groupKey}>
+          <p
+            className={cn(
+              'font-mono uppercase tracking-eyebrow text-ink-mute dark:text-foreground/55',
+              variant === 'sheet' ? 'mb-2 text-[9px]' : 'mb-2 px-5 text-[10px]',
+            )}
+          >
+            {tGroups(group.groupKey)}
+          </p>
+          <div className="flex flex-col">
+            {group.items.map((item) => {
+              const active = isConsoleItemActive(item.href, pathname);
+              const count = item.countKey ? counts?.[item.countKey] : undefined;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  aria-current={active ? 'page' : undefined}
+                  className={cn(
+                    'flex items-center gap-3 border-b-[1px] border-rule-soft transition-colors duration-fast ease-munin dark:border-rule-on-dark',
+                    variant === 'sheet'
+                      ? 'min-h-[52px] text-base'
+                      : 'border-l-2 px-5 py-2.5 text-sm',
+                    variant === 'rail' &&
+                      (active
+                        ? 'border-l-cobalt bg-paper text-ink dark:bg-card dark:text-foreground'
+                        : 'border-l-transparent text-ink-soft hover:bg-paper hover:text-ink dark:text-foreground/75 dark:hover:bg-card dark:hover:text-foreground'),
+                    variant === 'sheet' &&
+                      (active
+                        ? 'text-cobalt dark:text-cobalt-soft'
+                        : 'text-ink dark:text-foreground'),
+                  )}
+                >
+                  {variant === 'sheet' && active ? <AttentionDot /> : null}
+                  <span className="truncate">{tNav(item.labelKey)}</span>
+                  {item.noteKey ? (
+                    <span className="ml-auto font-mono text-[9px] uppercase tracking-meta text-ink-mute dark:text-foreground/55">
+                      {tNav(item.noteKey)}
+                    </span>
+                  ) : count ? (
+                    <span
+                      className={cn(
+                        'ml-auto font-mono text-[10px]',
+                        active
+                          ? 'text-cobalt dark:text-cobalt-soft'
+                          : 'text-cobalt dark:text-cobalt-soft',
+                      )}
+                    >
+                      {count}
+                    </span>
+                  ) : null}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </nav>
+  );
+
+  const userFooter = (
+    <div className="flex items-center gap-2.5 border-t-[1px] border-rule-soft px-4 py-3.5 dark:border-rule-on-dark">
+      <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-cobalt font-mono text-[8px] text-paper">
+        {initials(session.user.name || session.user.email)}
+      </span>
+      <span className="min-w-0 truncate text-[15px] text-ink dark:text-foreground">
+        {session.user.name || session.user.email}
+      </span>
+      <button
+        type="button"
+        onClick={signOut}
+        className="ml-auto shrink-0 font-mono text-[9px] uppercase tracking-meta text-ink-mute transition-colors duration-fast hover:text-ink dark:text-foreground/55 dark:hover:text-foreground"
+      >
+        {tCommon('signOut')}
+      </button>
+    </div>
+  );
+
+  const content = (
+    <div className="group flex min-h-screen flex-col bg-bone dark:bg-background">
+      <SystemAlertsBanner />
+      <div className="flex flex-1 min-h-0">
+        <aside className="sticky top-0 hidden h-screen w-[280px] shrink-0 flex-col self-start border-r-[1px] border-rule-soft bg-bone md:flex dark:border-rule-on-dark dark:bg-secondary">
+          <div className="flex items-center gap-3.5 px-5 py-5">
+            <Link href="/dashboard" aria-label={brand} className="shrink-0">
+              <Image src={logoSrc} alt={brand} width={40} height={40} priority />
+            </Link>
+            {orgSlot ?? (
+              <span className="min-w-0 truncate text-[13px] font-medium text-ink dark:text-foreground">
+                {brand}
+              </span>
+            )}
+          </div>
+          <div className="flex-1 overflow-y-auto pb-4">{navList('rail')}</div>
+          <div className="mx-3.5 mb-3.5 flex items-center gap-2 border-[1px] border-rule-soft px-3 py-2.5 font-mono text-[10px] uppercase tracking-meta text-ink-soft dark:border-rule-on-dark dark:text-foreground/75">
+            <span
+              className={cn(
+                'size-1.5 shrink-0 rounded-full',
+                status === 'connected' ? 'bg-cobalt' : 'bg-ink-mute',
+              )}
+              aria-hidden
+            />
+            {tStatus(status)}
+          </div>
+          {userFooter}
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <ConsoleTopbar
+            brand={brand}
+            logoSrc={logoSrc}
+            viewLabel={viewLabel}
+            orgSlot={orgSlot}
+            menuOpen={menuOpen}
+            onMenuToggle={() => setMenuOpen((o) => !o)}
+            openMenuLabel={tNav('openMenu')}
+            className="md:hidden"
+          />
+          <main className="flex-1 overflow-x-clip bg-paper dark:bg-background">{children}</main>
+        </div>
+      </div>
+
+      <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
+        <SheetContent side="right" className="w-full max-w-none p-0 md:hidden">
+          <div className="flex h-full flex-col bg-paper dark:bg-background">
+            <div className="flex h-14 shrink-0 items-center gap-2.5 border-b-[1px] border-rule-soft px-4 dark:border-rule-on-dark">
+              <Image src={logoSrc} alt="" width={26} height={26} aria-hidden />
+              <span className="min-w-0 truncate text-sm font-medium text-ink dark:text-foreground">
+                {brand}
+              </span>
+            </div>
+            <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-4 py-5">
+              {navList('sheet')}
+              {roleNote ? (
+                <p className="m-0 font-serif text-lg italic leading-snug text-ink-soft dark:text-foreground/75">
+                  {roleNote}
+                </p>
+              ) : null}
+            </div>
+            {userFooter}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+
+  return withConfirmDialog ? <ConfirmDialogProvider>{content}</ConfirmDialogProvider> : content;
+}
+
+function AttentionDot() {
+  return (
+    <span
+      aria-hidden
+      className="size-[7px] shrink-0 rounded-full bg-cobalt shadow-[0_0_0_3px_rgb(var(--munin-accent)/0.22)]"
+    />
+  );
+}
+
+function initials(label: string): string {
+  const parts = label.trim().split(/[\s@.]+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return `${parts[0]![0]!}${parts[parts.length - 1]![0]!}`.toUpperCase();
+}

--- a/packages/dashboard-pages/src/shells/dashboard-shell.tsx
+++ b/packages/dashboard-pages/src/shells/dashboard-shell.tsx
@@ -1,55 +1,41 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useTranslations } from 'next-intl';
-import { PageSpinner } from '@getmunin/ui';
-import { authClient } from '../auth-client';
-import { useDashboardGate } from '../auth/use-dashboard-gate';
-import { SystemAlertsBanner } from '../components/system-alerts-banner';
-import { ConfirmDialogProvider } from '../components/confirm-dialog';
-import { DashboardTopbar } from '../components/munin-topbar';
-import { usePathname } from '../i18n-navigation';
+import { ConsoleShell, type ConsoleNavCounts } from './console-shell';
+import { OSS_CONSOLE_GROUPS, type ConsoleNavGroup } from '../nav/console-groups';
 
 export interface DashboardShellProps {
   brand: string;
   logoSrc?: string;
   leftSlot?: ReactNode;
+  groups?: ConsoleNavGroup[];
+  counts?: ConsoleNavCounts;
+  roleNote?: ReactNode;
   withConfirmDialog?: boolean;
   children: ReactNode;
 }
 
 export function DashboardShell({
   brand,
-  logoSrc = '/munin-logo.png',
+  logoSrc,
   leftSlot,
+  groups = OSS_CONSOLE_GROUPS,
+  counts,
+  roleNote,
   withConfirmDialog = false,
   children,
 }: DashboardShellProps) {
-  const tNav = useTranslations('nav');
-  const pathname = usePathname();
-  const { data: session } = authClient.useSession();
-  const { ready } = useDashboardGate();
-
-  if (!ready || !session) {
-    return <PageSpinner className="min-h-screen bg-background" />;
-  }
-
-  const inSettings = pathname.startsWith('/dashboard/settings');
-
-  const content = (
-    <div className="group flex min-h-screen flex-col bg-bone dark:bg-background">
-      <SystemAlertsBanner />
-      {!inSettings && (
-        <DashboardTopbar
-          brand={brand}
-          logoSrc={logoSrc}
-          leftSlot={leftSlot}
-          settingsLabel={tNav('settings')}
-        />
-      )}
-      <main className="flex-1 overflow-x-clip bg-paper dark:bg-background">{children}</main>
-    </div>
+  return (
+    <ConsoleShell
+      brand={brand}
+      logoSrc={logoSrc}
+      groups={groups}
+      orgSlot={leftSlot}
+      counts={counts}
+      roleNote={roleNote}
+      withConfirmDialog={withConfirmDialog}
+    >
+      {children}
+    </ConsoleShell>
   );
-
-  return withConfirmDialog ? <ConfirmDialogProvider>{content}</ConfirmDialogProvider> : content;
 }


### PR DESCRIPTION
First of six PRs implementing the Oversight console designs (desktop + mobile) as one coherent IA change.

## What this adds

A console shell that replaces the topbar-only chrome:

- **≥md** — a persistent 280px sidebar carrying the mark, grouped nav, connection status and the user footer. No topbar; the sidebar is the whole chrome.
- **<md** — the sidebar collapses into a full-screen nav sheet behind a single glyph, so the screen stays a single editorial column. No tab bar.

Nav is a registry in `nav/console-groups.ts`, mirroring the existing `settings-groups` extension hook, so a host app adds destinations without patching the shell.

## Role gating by omission

`visibleConsoleGroups` drops role-gated items *and* any group left empty, so a member sees no Admin group at all rather than a disabled one. That is what the design asks for — "agents never see Overview, Automation, or Learning" — and it is enforced in the registry rather than per-view.

## Injected organization switcher

The sidebar and the mobile topbar both render an `orgSlot` beside the mark. `DashboardShell` maps its existing `leftSlot` onto it, so a host app that injects its own organization switcher keeps working unchanged.

## Settings index

`/dashboard/settings` was a redirect to Team. It is now a real grouped index page, which is what gives a phone a settings list to navigate from (mobile frame 05). Desktop keeps the rail beside it, so the page reads as a settings landing.

## Not in this PR

Conversations, Automation and Learning are deliberately absent from the nav — each arrives with the PR that builds its view, so no PR in the stack ships a nav entry pointing at an unstyled route.

## Testing

`console-groups.test.ts` covers role visibility, empty-group collapse, non-mutation, the extension hook's ordering, and active-path matching (an exact match for the overview so it never wins over a sibling). 100 tests pass in the package; typecheck clean for the package and the app.