### PR TITLE
feat(dashboard): rework the admin overview for the Oversight design

### DIFF
--- a/.changeset/oversight-admin-overview.md
+++ b/.changeset/oversight-admin-overview.md
@@ -1,0 +1,21 @@
+---
+'@getmunin/dashboard-pages': minor
+---
+
+Admin overview reworked for the Oversight design. Two summary rows sit above the queue —
+live conversations and pending learning — and the queue and scheduled rows stack into
+meta / title / note / actions on a phone instead of truncating a single line.
+
+Row actions are no longer hover-only. They stay hidden until hover on a fine pointer, as
+before, but are permanently visible wherever the pointer is coarse, because a touch
+screen has no hover state and the buttons were simply unreachable there.
+
+Queue rows also gain **Schedule** for the kinds whose approve path accepts a time
+(outreach proposals and CMS drafts), which opens the item's own scheduler rather than
+duplicating a datetime picker in the row.
+
+Fixes a scheduling bug along the way: the overview passed an argument-less approve handler
+to the queue drawer, so a send time chosen in the outreach scheduler was dropped and the
+proposal went out immediately.
+
+Usage tiles now sit two-up on a phone instead of collapsing to a single column.

--- a/packages/dashboard-pages/src/components/dashboard/inbox-data.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-data.ts
@@ -147,6 +147,7 @@ export function useInboxData(): InboxController {
   const [cmsDetails, setCmsDetails] = useState<Record<string, CmsDraftDetailDto>>({});
   const [convDrawer, setConvDrawer] = useState<ConvDrawer>(null);
   const [queueDrawer, setQueueDrawer] = useState<QueueItem | null>(null);
+  const [queueScheduleIntent, setQueueScheduleIntent] = useState(false);
   const [scheduledDrawer, setScheduledDrawer] = useState<ScheduledItem | null>(null);
   const [cancelTarget, setCancelTarget] = useState<ScheduledItem | null>(null);
   const [reply, setReply] = useState('');
@@ -689,6 +690,16 @@ export function useInboxData(): InboxController {
     [loadInbox, translateErr],
   );
 
+  const openQueueDrawer = useCallback((next: QueueItem | null) => {
+    setQueueScheduleIntent(false);
+    setQueueDrawer(next);
+  }, []);
+
+  const openQueueScheduler = useCallback((item: QueueItem) => {
+    setQueueScheduleIntent(true);
+    setQueueDrawer(item);
+  }, []);
+
   return {
     items,
     details,
@@ -701,7 +712,9 @@ export function useInboxData(): InboxController {
     convDrawer,
     setConvDrawer,
     queueDrawer,
-    setQueueDrawer,
+    setQueueDrawer: openQueueDrawer,
+    queueScheduleIntent,
+    openQueueScheduler,
     scheduledDrawer,
     setScheduledDrawer,
     cancelTarget,

--- a/packages/dashboard-pages/src/components/dashboard/inbox-helpers.test.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-helpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { canScheduleQueueItem, clearKey, truncate } from './inbox-helpers';
+
+describe('canScheduleQueueItem', () => {
+  it('offers a time only for the kinds whose approve endpoint takes one', () => {
+    expect(canScheduleQueueItem({ kind: 'cms' })).toBe(true);
+    expect(canScheduleQueueItem({ kind: 'outreach' })).toBe(true);
+  });
+
+  it('withholds it from kinds that apply immediately', () => {
+    expect(canScheduleQueueItem({ kind: 'kb' })).toBe(false);
+    expect(canScheduleQueueItem({ kind: 'crm' })).toBe(false);
+    expect(canScheduleQueueItem({ kind: 'feedback' })).toBe(false);
+  });
+});
+
+describe('truncate', () => {
+  it('leaves a string that already fits alone', () => {
+    expect(truncate('short', 10)).toBe('short');
+  });
+
+  it('never exceeds the requested length, ellipsis included', () => {
+    expect(truncate('abcdefghij', 5)).toHaveLength(5);
+  });
+});
+
+describe('clearKey', () => {
+  it('returns the same object when the key is absent so renders do not churn', () => {
+    const obj = { a: 1 };
+    expect(clearKey(obj, 'b')).toBe(obj);
+  });
+
+  it('returns a copy without the key when it is present', () => {
+    const obj = { a: 1, b: 2 };
+    expect(clearKey(obj, 'b')).toEqual({ a: 1 });
+    expect(obj).toEqual({ a: 1, b: 2 });
+  });
+});

--- a/packages/dashboard-pages/src/components/dashboard/inbox-helpers.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-helpers.ts
@@ -1,6 +1,10 @@
 import type { useTranslations } from 'next-intl';
-import type { CrmContactSummary, FeedbackOutboxDto } from './queue-drawers/types';
+import type { CrmContactSummary, FeedbackOutboxDto, QueueItem } from './queue-drawers/types';
 import type { ConversationDetail, LiveSummary } from './inbox-types';
+
+export function canScheduleQueueItem(item: Pick<QueueItem, 'kind'>): boolean {
+  return item.kind === 'cms' || item.kind === 'outreach';
+}
 
 export const contactLabel = (c: CrmContactSummary) => c.name ?? c.email ?? c.id;
 

--- a/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-sections.tsx
@@ -20,7 +20,7 @@ import { DrawerHeader, DrawerLoadFailed, RowCode } from './queue-drawers/shared'
 import { queueCodeKey } from './queue-drawers/types';
 import type { QueueItem, ScheduledItem } from './queue-drawers/types';
 import { useInboxData } from './inbox-data';
-import { truncate } from './inbox-helpers';
+import { canScheduleQueueItem, truncate } from './inbox-helpers';
 import { ConversationDrawer, InlineActionError } from './inbox-conv-drawers';
 import type {
   ConvActionError,
@@ -31,6 +31,17 @@ import type {
 
 export { useInboxData };
 export type { ConvActionError, InboxController, QueueItem, ScheduledItem };
+
+const rowShellClass =
+  'flex cursor-pointer flex-col gap-2 px-1 py-3.5 transition-colors duration-fast ease-munin sm:flex-row sm:items-center sm:gap-4 sm:px-4 sm:py-3 sm:hover:bg-paper-deep dark:sm:hover:bg-secondary';
+
+const rowAgeClass =
+  'hidden h-7 shrink-0 items-center whitespace-nowrap font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute sm:flex';
+
+const rowActionsClass =
+  'flex shrink-0 items-center gap-2 focus-within:flex sm:hidden [@media(hover:none)]:!flex';
+
+const rowButtonClass = 'max-sm:min-h-11 max-sm:flex-1';
 
 export function LiveNowSection({ controller }: { controller: InboxController }) {
   const t = useTranslations('dashboard.overview.liveNow');
@@ -81,7 +92,8 @@ export function LiveNowSection({ controller }: { controller: InboxController }) 
 
 export function QueueSection({ controller }: { controller: InboxController }) {
   const t = useTranslations('dashboard.overview.queue');
-  const { queue, pending, setQueueDrawer, approveQueue, dismissQueue } = controller;
+  const { queue, pending, setQueueDrawer, openQueueScheduler, approveQueue, dismissQueue } =
+    controller;
   if (queue.length === 0) return null;
 
   return (
@@ -102,6 +114,7 @@ export function QueueSection({ controller }: { controller: InboxController }) {
             pending={pending}
             onOpen={() => setQueueDrawer(q)}
             onApprove={() => void approveQueue(q)}
+            onSchedule={() => openQueueScheduler(q)}
             onDismiss={() => void dismissQueue(q)}
           />
         ))}
@@ -237,7 +250,7 @@ function ScheduledRow({
   return (
     <li className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
       <div
-        className="group/srow flex items-center gap-4 px-4 py-3 transition-colors duration-fast ease-munin hover:bg-paper-deep cursor-pointer dark:hover:bg-secondary"
+        className={`group/srow ${rowShellClass}`}
         onClick={onOpen}
         role="button"
         tabIndex={0}
@@ -248,19 +261,33 @@ function ScheduledRow({
           }
         }}
       >
-        <RowCode kind={item.kind}>{tQueue(queueCodeKey(item.kind))}</RowCode>
-        <div className="min-w-0 flex-1 truncate">
-          <span className="text-sm font-medium text-ink dark:text-foreground">{item.title}</span>
-          <span className="ml-2 text-sm text-ink-mute"> — {item.snippet}</span>
+        <div className="flex min-w-0 items-center gap-3 sm:flex-1 sm:gap-4">
+          <RowCode kind={item.kind}>{tQueue(queueCodeKey(item.kind))}</RowCode>
+          <span className="ml-auto whitespace-nowrap font-mono text-[10px] uppercase tracking-eyebrow text-ink dark:text-foreground sm:hidden">
+            {countdown(item.at)}
+          </span>
+          <div className="hidden min-w-0 flex-1 truncate sm:block">
+            <span className="text-sm font-medium text-ink dark:text-foreground">{item.title}</span>
+            <span className="ml-2 text-sm text-ink-mute"> — {item.snippet}</span>
+          </div>
         </div>
-        <span className="flex h-7 shrink-0 items-center whitespace-nowrap font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute group-hover/srow:hidden">
-          {countdown(item.at)}
-        </span>
-        <div
-          className="hidden shrink-0 items-center gap-2 group-hover/srow:flex focus-within:flex"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Button variant="outline" size="sm" onClick={onCancel} disabled={pending}>
+
+        <div className="flex flex-col gap-1.5 sm:hidden">
+          <span className="text-[15px] leading-snug text-ink [text-wrap:pretty] dark:text-foreground">
+            {item.title}
+          </span>
+          <span className="text-[13px] leading-snug text-ink-mute">{item.snippet}</span>
+        </div>
+
+        <span className={`${rowAgeClass} group-hover/srow:hidden`}>{countdown(item.at)}</span>
+        <div className={`${rowActionsClass} group-hover/srow:flex`} onClick={stopRowClick}>
+          <Button
+            variant="outline"
+            size="sm"
+            className={rowButtonClass}
+            onClick={onCancel}
+            disabled={pending}
+          >
             {t('cancel')}
           </Button>
         </div>
@@ -278,6 +305,7 @@ export function InboxDrawers({ controller }: { controller: InboxController }) {
     queue,
     queueDrawer,
     setQueueDrawer,
+    queueScheduleIntent,
     scheduled,
     scheduledDrawer,
     setScheduledDrawer,
@@ -378,7 +406,8 @@ export function InboxDrawers({ controller }: { controller: InboxController }) {
               loadError={queueDetailErrors[queueDrawer.id]}
               onRetry={() => reloadQueueDetail(queueDrawer.id)}
               pending={pending}
-              onApprove={() => void approveQueue(queueDrawer)}
+              autoOpenScheduler={queueScheduleIntent}
+              onApprove={(sendAt) => void approveQueue(queueDrawer, sendAt)}
               onDismiss={() => void dismissQueue(queueDrawer)}
               onSave={(body) => saveQueue(queueDrawer, body)}
               onSaveCmsDraft={(data) => saveCmsDraft(queueDrawer, data)}
@@ -536,12 +565,14 @@ function QueueRow({
   pending,
   onOpen,
   onApprove,
+  onSchedule,
   onDismiss,
 }: {
   item: QueueItem;
   pending: boolean;
   onOpen: () => void;
   onApprove: () => void;
+  onSchedule: () => void;
   onDismiss: () => void;
 }) {
   const t = useTranslations('dashboard.overview.queue');
@@ -549,7 +580,7 @@ function QueueRow({
   return (
     <li className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
       <div
-        className="group/qrow flex items-center gap-4 px-4 py-3 transition-colors duration-fast ease-munin hover:bg-paper-deep cursor-pointer dark:hover:bg-secondary"
+        className={`group/qrow ${rowShellClass}`}
         onClick={onOpen}
         role="button"
         tabIndex={0}
@@ -560,26 +591,52 @@ function QueueRow({
           }
         }}
       >
-        <RowCode kind={item.kind}>{t(queueCodeKey(item.kind))}</RowCode>
-        <div className="min-w-0 flex-1 truncate">
-          <span className="text-sm font-medium text-ink dark:text-foreground">{item.title}</span>
-          <span className="ml-2 text-sm text-ink-mute"> — {item.snippet}</span>
+        <div className="flex min-w-0 items-center gap-3 sm:flex-1 sm:gap-4">
+          <RowCode kind={item.kind}>{t(queueCodeKey(item.kind))}</RowCode>
+          <span className="ml-auto font-mono text-[10px] uppercase tracking-eyebrow text-ink dark:text-foreground sm:hidden">
+            {age(item.createdAt)}
+          </span>
+          <div className="hidden min-w-0 flex-1 truncate sm:block">
+            <span className="text-sm font-medium text-ink dark:text-foreground">{item.title}</span>
+            <span className="ml-2 text-sm text-ink-mute"> — {item.snippet}</span>
+          </div>
         </div>
-        <span className="flex h-7 shrink-0 items-center font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute group-hover/qrow:hidden">
-          {age(item.createdAt)}
-        </span>
-        <div
-          className="hidden shrink-0 items-center gap-2 group-hover/qrow:flex focus-within:flex"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Button variant="accent" size="sm" onClick={onApprove} disabled={pending}>
+
+        <div className="flex flex-col gap-1.5 sm:hidden">
+          <span className="text-[15px] leading-snug text-ink [text-wrap:pretty] dark:text-foreground">
+            {item.title}
+          </span>
+          <span className="text-[13px] leading-snug text-ink-mute">{item.snippet}</span>
+        </div>
+
+        <span className={`${rowAgeClass} group-hover/qrow:hidden`}>{age(item.createdAt)}</span>
+        <div className={`${rowActionsClass} group-hover/qrow:flex`} onClick={stopRowClick}>
+          <Button variant="accent" size="sm" className={rowButtonClass} onClick={onApprove} disabled={pending}>
             {t('approve')}
           </Button>
-          <Button variant="outline" size="sm" onClick={onDismiss} disabled={pending}>
-            {t('dismiss')}
+          {canScheduleQueueItem(item) ? (
+            <Button size="sm" className={rowButtonClass} onClick={onSchedule} disabled={pending}>
+              {t('schedule')}
+            </Button>
+          ) : null}
+          <Button
+            variant="outline"
+            size="sm"
+            className={`${rowButtonClass} max-sm:w-[52px] max-sm:flex-none`}
+            onClick={onDismiss}
+            disabled={pending}
+          >
+            <span className="sm:hidden" aria-hidden>
+              ✕
+            </span>
+            <span className="max-sm:sr-only">{t('dismiss')}</span>
           </Button>
         </div>
       </div>
     </li>
   );
+}
+
+function stopRowClick(e: { stopPropagation: () => void }) {
+  e.stopPropagation();
 }

--- a/packages/dashboard-pages/src/components/dashboard/inbox-types.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-types.ts
@@ -106,6 +106,8 @@ export interface InboxController {
   setConvDrawer: (next: ConvDrawer) => void;
   queueDrawer: QueueItem | null;
   setQueueDrawer: (next: QueueItem | null) => void;
+  queueScheduleIntent: boolean;
+  openQueueScheduler: (item: QueueItem) => void;
   scheduledDrawer: ScheduledItem | null;
   setScheduledDrawer: (next: ScheduledItem | null) => void;
   cancelTarget: ScheduledItem | null;

--- a/packages/dashboard-pages/src/components/dashboard/overview-stats.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/overview-stats.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@getmunin/ui';
+import { Link } from '../../i18n-navigation';
+
+interface StatRowProps {
+  count: number;
+  label: string;
+  note: string;
+  href?: string;
+  linkLabel: string;
+  live?: boolean;
+  divided?: boolean;
+}
+
+export interface OverviewStatsProps {
+  liveCount: number;
+  learningCount: number;
+  liveHref?: string;
+  learningHref?: string;
+}
+
+export function OverviewStats({
+  liveCount,
+  learningCount,
+  liveHref,
+  learningHref,
+}: OverviewStatsProps) {
+  const t = useTranslations('dashboard.overview.stats');
+
+  return (
+    <section className="border-y-[1px] border-rule-soft dark:border-rule-on-dark">
+      <StatRow
+        count={liveCount}
+        label={t('liveLabel')}
+        note={t('liveNote')}
+        href={liveHref}
+        linkLabel={t('openConversations')}
+        live
+      />
+      <StatRow
+        count={learningCount}
+        label={t('learningLabel')}
+        note={t('learningNote')}
+        href={learningHref}
+        linkLabel={t('openLearning')}
+        divided
+      />
+    </section>
+  );
+}
+
+function StatRow({ count, label, note, href, linkLabel, live, divided }: StatRowProps) {
+  const rowClass = cn(
+    'flex items-center gap-3.5 px-1 py-3.5',
+    divided && 'border-t-[1px] border-rule-soft dark:border-rule-on-dark',
+    href && 'transition-colors duration-fast ease-munin hover:bg-paper-deep dark:hover:bg-secondary',
+  );
+
+  const body = (
+    <>
+      <span
+        aria-hidden
+        className={cn(
+          'shrink-0 rounded-full',
+          live
+            ? 'size-2 bg-cobalt shadow-[0_0_0_3px_rgb(var(--munin-accent)/0.22)] dark:bg-cobalt-soft'
+            : 'size-[9px] border-[1.5px] border-ink dark:border-foreground',
+        )}
+      />
+      <span className="shrink-0 font-serif text-[32px] leading-none text-ink dark:text-foreground">
+        {count}
+      </span>
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-mono text-[9px] uppercase tracking-meta text-ink-mute dark:text-foreground/55">
+          {label}
+        </span>
+        <span className="truncate text-[13.5px] text-ink dark:text-foreground">{note}</span>
+      </span>
+      {href ? (
+        <ArrowRight
+          aria-hidden
+          className="ml-auto size-4 shrink-0 text-cobalt dark:text-cobalt-soft"
+        />
+      ) : null}
+    </>
+  );
+
+  if (!href) return <div className={rowClass}>{body}</div>;
+
+  return (
+    <Link href={href} aria-label={linkLabel} className={rowClass}>
+      {body}
+    </Link>
+  );
+}

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/cms.tsx
@@ -54,6 +54,7 @@ export function CmsQueueDrawer({
   onRetry,
   pending,
   readOnly = false,
+  autoOpenScheduler = false,
   scheduledAt: scheduledPublishAt,
   onApprove,
   onDismiss,
@@ -70,6 +71,7 @@ export function CmsQueueDrawer({
   onRetry: () => void;
   pending: boolean;
   readOnly?: boolean;
+  autoOpenScheduler?: boolean;
   scheduledAt?: string;
   onApprove: () => void;
   onDismiss: () => void;
@@ -94,7 +96,7 @@ export function CmsQueueDrawer({
   const [editing, setEditing] = useState(false);
   const [editedData, setEditedData] = useState<EditableData>(initialData);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>(EMPTY_FIELD_ERRORS);
-  const [schedulerOpen, setSchedulerOpen] = useState(false);
+  const [schedulerOpen, setSchedulerOpen] = useState(autoOpenScheduler && !readOnly);
   const [scheduledAt, setScheduledAt] = useState('');
   const [scheduleError, setScheduleError] = useState<string | null>(null);
 

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/index.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/index.tsx
@@ -83,6 +83,7 @@ export function QueueDrawer({
   onSchedule,
   onPreview,
   onClose,
+  autoOpenScheduler,
 }: {
   item: QueueItem;
   kbBody?: string;
@@ -99,6 +100,7 @@ export function QueueDrawer({
   onSchedule: (scheduledAt: string) => Promise<void>;
   onPreview: () => void;
   onClose: () => void;
+  autoOpenScheduler?: boolean;
 }) {
   switch (item.kind) {
     case 'kb':
@@ -131,6 +133,7 @@ export function QueueDrawer({
         <OutreachQueueDrawer
           item={item}
           pending={pending}
+          autoOpenScheduler={autoOpenScheduler}
           onApprove={onApprove}
           onDismiss={onDismiss}
           onSave={onSave}
@@ -162,6 +165,7 @@ export function QueueDrawer({
           onSchedule={onSchedule}
           onPreview={onPreview}
           onClose={onClose}
+          autoOpenScheduler={autoOpenScheduler}
         />
       );
   }

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/outreach.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/outreach.tsx
@@ -29,6 +29,7 @@ export function OutreachQueueDrawer({
   item,
   pending,
   readOnly = false,
+  autoOpenScheduler = false,
   onApprove,
   onDismiss,
   onSave,
@@ -38,6 +39,7 @@ export function OutreachQueueDrawer({
   item: { id: string; title: string; snippet: string; createdAt: string; raw: OutreachProposalDto };
   pending: boolean;
   readOnly?: boolean;
+  autoOpenScheduler?: boolean;
   onApprove: (sendAt?: string | null) => void;
   onDismiss: () => void;
   onSave: (body: string) => Promise<void>;
@@ -52,7 +54,7 @@ export function OutreachQueueDrawer({
   const originalDraftBody = item.raw.originalDraftBody ?? null;
   const [editing, setEditing] = useState(false);
   const [editedBody, setEditedBody] = useState(initialBody);
-  const [schedulerOpen, setSchedulerOpen] = useState(false);
+  const [schedulerOpen, setSchedulerOpen] = useState(autoOpenScheduler && !readOnly);
   const [sendAt, setSendAt] = useState('');
   const [scheduleError, setScheduleError] = useState<string | null>(null);
   const proposedSendAt = futureDate(item.raw.proposedSendAt);

--- a/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
@@ -40,7 +40,7 @@ export function UsageKpis({ summary }: UsageKpisProps) {
         </Link>
       </div>
 
-      <div className="grid gap-3.5 grid-cols-[repeat(auto-fit,minmax(180px,1fr))]">
+      <div className="grid grid-cols-2 gap-3.5 sm:grid-cols-[repeat(auto-fit,minmax(180px,1fr))]">
         <Kpi
           label={t('mcpCalls')}
           value={summary?.mcpCalls.current}

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -272,7 +272,8 @@
         "feedbackSnippetAttributed": "{scope} feedback — attributed",
         "feedbackScopeFallback": "Munin",
         "kindKbRevision": "KB · REVISION",
-        "kbSnippetRevision": "Revision to “{title}”."
+        "kbSnippetRevision": "Revision to “{title}”.",
+        "schedule": "Schedule"
       },
       "scheduled": {
         "eyebrow": "Scheduled",
@@ -445,6 +446,14 @@
           "closed": "closed",
           "spam": "spam"
         }
+      },
+      "stats": {
+        "liveLabel": "Live now · with support",
+        "liveNote": "Handled in the console",
+        "learningLabel": "Learning · knowledge",
+        "learningNote": "Proposals from agent edits",
+        "openConversations": "Open conversations",
+        "openLearning": "Open learning"
       }
     },
     "activity": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -272,7 +272,8 @@
         "feedbackSnippetAttributed": "{scope}-tilbakemelding — med navn",
         "feedbackScopeFallback": "Munin",
         "kindKbRevision": "KB · ENDRING",
-        "kbSnippetRevision": "Endring i «{title}»."
+        "kbSnippetRevision": "Endring i «{title}».",
+        "schedule": "Tidfest"
       },
       "scheduled": {
         "eyebrow": "Planlagt",
@@ -445,6 +446,14 @@
           "closed": "lukket",
           "spam": "spam"
         }
+      },
+      "stats": {
+        "liveLabel": "Pågår nå · med kundestøtte",
+        "liveNote": "Håndteres i konsollet",
+        "learningLabel": "Læring · kunnskap",
+        "learningNote": "Forslag fra agentendringer",
+        "openConversations": "Åpne samtaler",
+        "openLearning": "Åpne læring"
       }
     },
     "activity": {

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { api } from '../api';
 import { useRealtime } from '../realtime';
 import { DashboardHero } from '../components/dashboard/dashboard-hero';
+import { OverviewStats } from '../components/dashboard/overview-stats';
 import { GetStarted } from '../components/dashboard/get-started';
 import { RecentConversationsSection } from '../components/dashboard/recent-conversations';
 import { UsageKpis, type UsageSummary } from '../components/dashboard/usage-kpis';
@@ -60,6 +61,11 @@ export function DashboardPage() {
         date={new Date()}
         liveCount={inbox.items.length}
         queueCount={inbox.queue.length}
+      />
+
+      <OverviewStats
+        liveCount={inbox.items.length}
+        learningCount={inbox.queue.filter((q) => q.kind === 'kb').length}
       />
 
       <LiveNowSection controller={inbox} />


### PR DESCRIPTION
Second of six PRs implementing the Oversight console designs. Stacked on #858.

## Summary rows

The design puts two summary rows above the queue — live conversations "with support", and pending learning. Both render counts from data the overview already loads, so nothing new is fetched.

Their arrows are deliberately absent for now: the destinations arrive in the Conversations and Learning PRs, and `OverviewStats` takes an optional `href` per row so those PRs wire them up without touching the layout. No PR in the stack ships a link to a route that does not exist yet.

## Hover-only actions were unreachable on touch

`QueueRow` and `ScheduledRow` hid their actions behind `group-hover/…:flex`. The preset sets `hoverOnlyWhenSupported`, so on a phone that variant never fires — approve, dismiss and cancel were not reachable at all, which is exactly what the mobile design calls out ("touch has no hover state").

Actions now stay hover-revealed on fine pointers, unchanged on desktop, and are permanently visible wherever the pointer is coarse.

## Stacked rows below sm

Rows go from one truncated line to meta / title / note / full-width 44px actions, with the age moving up into the meta line. Dismiss collapses to a glyph with an accessible label so three actions fit a 390px row.

## Schedule as a row action

The design shows Approve / Schedule / Dismiss on the row. Schedule appears only for the kinds whose approve path actually accepts a time — outreach proposals and CMS drafts — and opens the item's own scheduler via a new `openQueueScheduler` on the inbox controller, rather than duplicating a datetime picker in the row.

## Bug fixed on the way

The overview passed `onApprove={() => void approveQueue(queueDrawer)}` to the queue drawer, dropping the `sendAt` the drawer passes in. `approveQueue` and the `/v1/outreach/proposals/:id/approve` endpoint both support it, so an outreach proposal scheduled from the drawer was sending **immediately** instead of at the chosen time.

## Testing

`inbox-helpers.test.ts` covers which kinds offer a time. 106 tests pass; typecheck and lint clean.