### PR TITLE
feat(dashboard): review queue as its own destination

### DIFF
--- a/.changeset/oversight-review-queue.md
+++ b/.changeset/oversight-review-queue.md
@@ -1,0 +1,16 @@
+---
+'@getmunin/dashboard-pages': minor
+---
+
+Conversations becomes a destination of its own. `/dashboard/conversations` is the review
+queue — search, then Needs you / In progress / Open, with claim state on every row. From
+`lg` up it is the design's two-pane console, list beside detail; below that it is a list
+that opens `/dashboard/conversations/[id]` as a full screen with the actions pinned to the
+bottom, because a phone has no room for two panes.
+
+The conversation detail body is now one component with three presentations — drawer, pane
+and page — so the overview drawer, the desktop pane and the mobile route cannot drift
+apart.
+
+Search filters the loaded page on the client across customer, subject, preview and
+`#displayId`; there is no conversation-search endpoint to call yet.

--- a/apps/web/app/[locale]/dashboard/conversations/[id]/page.tsx
+++ b/apps/web/app/[locale]/dashboard/conversations/[id]/page.tsx
@@ -1,0 +1,6 @@
+import { ConversationDetailPage } from '@getmunin/dashboard-pages';
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <ConversationDetailPage conversationId={id} />;
+}

--- a/apps/web/app/[locale]/dashboard/conversations/page.tsx
+++ b/apps/web/app/[locale]/dashboard/conversations/page.tsx
@@ -1,0 +1,1 @@
+export { ConversationsPage as default } from '@getmunin/dashboard-pages';

--- a/packages/dashboard-pages/src/components/dashboard/conversation-queue.test.ts
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-queue.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildQueueSections,
+  firstRowId,
+  matchesQuery,
+  toRow,
+  type ConversationListItem,
+} from './conversation-queue';
+import type { LiveSummary } from './inbox-types';
+
+function item(overrides: Partial<ConversationListItem> = {}): ConversationListItem {
+  return {
+    id: 'ccv_1',
+    displayId: 1,
+    status: 'open',
+    channelId: 'chn_1',
+    endUserId: 'anders@example.com',
+    contactId: null,
+    topicId: null,
+    assigneeUserId: null,
+    subject: 'Payslip upload keeps failing',
+    lastMessageAt: '2026-08-27T09:00:00.000Z',
+    needsHumanAttention: false,
+    needsHumanAttentionAt: null,
+    updatedAt: '2026-08-27T09:00:00.000Z',
+    createdAt: '2026-08-27T08:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function live(overrides: Partial<LiveSummary> = {}): LiveSummary {
+  return {
+    ...item({ needsHumanAttention: true, needsHumanAttentionAt: '2026-08-27T09:50:00.000Z' }),
+    latestEndUserMessage: { body: 'It is a scan, around 14 MB.', createdAt: '2026-08-27T09:52:00Z' },
+    claim: null,
+    ...overrides,
+  };
+}
+
+describe('buildQueueSections', () => {
+  it('splits assigned from unassigned once attention is not the question', () => {
+    const sections = buildQueueSections({
+      live: [],
+      list: [
+        item({ id: 'a', assigneeUserId: 'usr_1' }),
+        item({ id: 'b', assigneeUserId: null }),
+      ],
+      query: '',
+    });
+    expect(sections.map((s) => s.key)).toEqual(['inProgress', 'open']);
+    expect(sections[0]!.rows.map((r) => r.id)).toEqual(['a']);
+    expect(sections[1]!.rows.map((r) => r.id)).toEqual(['b']);
+  });
+
+  it('never lists a conversation twice when it is both live and in the page', () => {
+    const sections = buildQueueSections({
+      live: [live({ id: 'dup' })],
+      list: [item({ id: 'dup', needsHumanAttention: true })],
+      query: '',
+    });
+    const ids = sections.flatMap((s) => s.rows.map((r) => r.id));
+    expect(ids).toEqual(['dup']);
+  });
+
+  it('prefers the live copy, which is the one carrying a message preview', () => {
+    const sections = buildQueueSections({
+      live: [live({ id: 'dup' })],
+      list: [item({ id: 'dup', needsHumanAttention: true, lastInboundPreview: 'from the list' })],
+      query: '',
+    });
+    expect(sections[0]!.rows[0]!.preview).toBe('It is a scan, around 14 MB.');
+  });
+
+  it('routes an attention-flagged list row to needsYou even when it is assigned', () => {
+    const sections = buildQueueSections({
+      live: [],
+      list: [item({ id: 'a', needsHumanAttention: true, assigneeUserId: 'usr_1' })],
+      query: '',
+    });
+    expect(sections.map((s) => s.key)).toEqual(['needsYou']);
+  });
+
+  it('drops a section that has no rows rather than rendering an empty heading', () => {
+    const sections = buildQueueSections({ live: [], list: [], query: '' });
+    expect(sections).toEqual([]);
+  });
+
+  it('sorts each section newest first', () => {
+    const sections = buildQueueSections({
+      live: [],
+      list: [
+        item({ id: 'older', lastMessageAt: '2026-08-27T08:00:00.000Z' }),
+        item({ id: 'newer', lastMessageAt: '2026-08-27T10:00:00.000Z' }),
+      ],
+      query: '',
+    });
+    expect(sections[0]!.rows.map((r) => r.id)).toEqual(['newer', 'older']);
+  });
+
+  it('filters every section by the query and drops the ones left empty', () => {
+    const sections = buildQueueSections({
+      live: [live({ id: 'l', subject: 'Payslip upload' })],
+      list: [item({ id: 'a', assigneeUserId: 'usr_1', subject: 'Rate differs' })],
+      query: 'payslip',
+    });
+    expect(sections.map((s) => s.key)).toEqual(['needsYou']);
+  });
+});
+
+describe('matchesQuery', () => {
+  const row = toRow(item({ displayId: 47512, endUserId: 'ingrid@example.com' }));
+
+  it('matches on customer, subject and preview, case-insensitively', () => {
+    expect(matchesQuery(row, 'INGRID')).toBe(true);
+    expect(matchesQuery(row, 'payslip')).toBe(true);
+  });
+
+  it('matches on the display id with its hash', () => {
+    expect(matchesQuery(row, '#47512')).toBe(true);
+  });
+
+  it('treats a blank or whitespace query as no filter', () => {
+    expect(matchesQuery(row, '')).toBe(true);
+    expect(matchesQuery(row, '   ')).toBe(true);
+  });
+
+  it('does not match unrelated text', () => {
+    expect(matchesQuery(row, 'refinancing')).toBe(false);
+  });
+});
+
+describe('firstRowId', () => {
+  it('picks the first row of the first non-empty section for the desktop pane', () => {
+    const sections = buildQueueSections({
+      live: [],
+      list: [item({ id: 'a', assigneeUserId: 'usr_1' }), item({ id: 'b' })],
+      query: '',
+    });
+    expect(firstRowId(sections)).toBe('a');
+  });
+
+  it('is null when nothing is listed', () => {
+    expect(firstRowId([])).toBeNull();
+  });
+});

--- a/packages/dashboard-pages/src/components/dashboard/conversation-queue.ts
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-queue.ts
@@ -1,0 +1,114 @@
+import type { ConversationSummary, LiveSummary } from './inbox-types';
+
+export type QueueSectionKey = 'needsYou' | 'inProgress' | 'open';
+
+export type ConversationListItem = ConversationSummary;
+
+export interface QueueRowModel {
+  id: string;
+  displayId: number;
+  channelType: string | null;
+  subject: string | null;
+  who: string | null;
+  preview: string | null;
+  at: string;
+  assigneeUserId: string | null;
+  needsHumanAttention: boolean;
+}
+
+export interface ConversationQueueSection {
+  key: QueueSectionKey;
+  rows: QueueRowModel[];
+}
+
+function rowAt(item: ConversationListItem): string {
+  return item.needsHumanAttentionAt ?? item.lastMessageAt ?? item.updatedAt;
+}
+
+export function toRow(item: ConversationListItem): QueueRowModel {
+  return {
+    id: item.id,
+    displayId: item.displayId,
+    channelType: item.channelType ?? null,
+    subject: item.subject,
+    who: item.endUserId,
+    preview: item.lastInboundPreview ?? null,
+    at: rowAt(item),
+    assigneeUserId: item.assigneeUserId,
+    needsHumanAttention: item.needsHumanAttention,
+  };
+}
+
+export function liveToRow(live: LiveSummary): QueueRowModel {
+  return {
+    id: live.id,
+    displayId: live.displayId,
+    channelType: live.channelType ?? null,
+    subject: live.subject,
+    who: live.endUserId ?? null,
+    preview: live.latestEndUserMessage?.body ?? null,
+    at: live.needsHumanAttentionAt ?? live.lastMessageAt ?? live.updatedAt,
+    assigneeUserId: live.claim ? live.claim.holderId : null,
+    needsHumanAttention: true,
+  };
+}
+
+function byRecency(a: QueueRowModel, b: QueueRowModel): number {
+  return Date.parse(b.at) - Date.parse(a.at);
+}
+
+export function matchesQuery(row: QueueRowModel, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === '') return true;
+  return [row.who, row.subject, row.preview, `#${row.displayId}`].some(
+    (field) => field != null && field.toLowerCase().includes(q),
+  );
+}
+
+export function buildQueueSections({
+  live,
+  list,
+  query,
+}: {
+  live: LiveSummary[];
+  list: ConversationListItem[];
+  query: string;
+}): ConversationQueueSection[] {
+  const needsYou = live.map(liveToRow);
+  const seen = new Set(needsYou.map((r) => r.id));
+
+  const inProgress: QueueRowModel[] = [];
+  const open: QueueRowModel[] = [];
+
+  for (const item of list) {
+    if (seen.has(item.id)) continue;
+    if (item.needsHumanAttention) {
+      needsYou.push(toRow(item));
+      seen.add(item.id);
+      continue;
+    }
+    seen.add(item.id);
+    (item.assigneeUserId ? inProgress : open).push(toRow(item));
+  }
+
+  return (
+    [
+      { key: 'needsYou' as const, rows: needsYou },
+      { key: 'inProgress' as const, rows: inProgress },
+      { key: 'open' as const, rows: open },
+    ] satisfies ConversationQueueSection[]
+  )
+    .map((section) => ({
+      key: section.key,
+      rows: section.rows.filter((row) => matchesQuery(row, query)).sort(byRecency),
+    }))
+    .filter((section) => section.rows.length > 0);
+}
+
+export function firstRowId(sections: ConversationQueueSection[]): string | null {
+  for (const section of sections) {
+    const first = section.rows[0];
+    if (first) return first.id;
+  }
+  return null;
+}

--- a/packages/dashboard-pages/src/components/dashboard/conversation-row.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-row.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@getmunin/ui';
+import { useRelative } from '../../lib/use-relative';
+import type { QueueRowModel } from './conversation-queue';
+
+export interface ConversationRowProps {
+  row: QueueRowModel;
+  active?: boolean;
+  viewerUserId: string | null;
+  viewerName?: string | null;
+  assigneeName?: string | null;
+  onOpen: () => void;
+}
+
+export function ConversationRow({
+  row,
+  active,
+  viewerUserId,
+  viewerName,
+  assigneeName,
+  onOpen,
+}: ConversationRowProps) {
+  const t = useTranslations('dashboard.conversations');
+  const tDrawer = useTranslations('dashboard.overview.drawer');
+  const age = useRelative();
+
+  const claimedByViewer = row.assigneeUserId != null && row.assigneeUserId === viewerUserId;
+  const who = row.who ?? tDrawer('endUserFallback');
+  const subject = row.subject ?? tDrawer('conversationFallback', { id: row.displayId });
+
+  return (
+    <li className="border-b-[1px] border-rule-soft dark:border-rule-on-dark">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onOpen}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onOpen();
+          }
+        }}
+        className={cn(
+          'flex cursor-pointer flex-col gap-1.5 py-3.5 pl-3 pr-1 transition-colors duration-fast ease-munin',
+          active
+            ? 'border-l-2 border-l-cobalt bg-paper-deep pl-2.5 dark:bg-secondary'
+            : 'border-l-2 border-l-transparent hover:bg-paper-deep dark:hover:bg-secondary',
+        )}
+      >
+        <span className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-meta text-ink-mute dark:text-foreground/55">
+          {row.needsHumanAttention ? (
+            <span
+              aria-hidden
+              className="size-[7px] shrink-0 rounded-full bg-cobalt shadow-[0_0_0_3px_rgb(var(--munin-accent)/0.22)] dark:bg-cobalt-soft"
+            />
+          ) : null}
+          <span className="truncate">{row.channelType ?? t('channelFallback')}</span>
+          <span className="ml-auto shrink-0 text-ink dark:text-foreground">{age(row.at)}</span>
+        </span>
+
+        <span
+          className={cn(
+            'text-[15px] leading-snug text-ink [text-wrap:pretty] dark:text-foreground',
+            row.needsHumanAttention && 'font-medium',
+          )}
+        >
+          {who} — {subject}
+        </span>
+
+        {row.preview ? (
+          <span className="line-clamp-2 text-[13px] leading-snug text-ink-mute dark:text-foreground/55">
+            {row.preview}
+          </span>
+        ) : null}
+
+        <span className="mt-0.5 flex items-center gap-2">
+          <ClaimAvatar
+            claimedByViewer={claimedByViewer}
+            assigned={row.assigneeUserId != null}
+            name={(claimedByViewer ? viewerName : assigneeName) ?? null}
+          />
+          <span className="truncate font-mono text-[9px] uppercase tracking-meta text-ink-mute dark:text-foreground/55">
+            {row.assigneeUserId == null
+              ? t('unclaimed')
+              : claimedByViewer
+                ? t('claimedByYou')
+                : assigneeName
+                  ? t('claimedBy', { who: assigneeName })
+                  : t('claimed')}
+          </span>
+        </span>
+      </div>
+    </li>
+  );
+}
+
+function ClaimAvatar({
+  claimedByViewer,
+  assigned,
+  name,
+}: {
+  claimedByViewer: boolean;
+  assigned: boolean;
+  name: string | null;
+}) {
+  if (!assigned) {
+    return (
+      <span
+        aria-hidden
+        className="inline-flex size-6 shrink-0 items-center justify-center rounded-full border border-dashed border-ink-mute font-mono text-[9px] text-ink-mute"
+      >
+        —
+      </span>
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'inline-flex size-6 shrink-0 items-center justify-center rounded-full font-mono text-[8px] text-paper',
+        claimedByViewer ? 'bg-cobalt' : 'bg-ink dark:bg-foreground dark:text-background',
+      )}
+    >
+      {rowInitials(name)}
+    </span>
+  );
+}
+
+function rowInitials(name: string | null): string {
+  if (!name) return '·';
+  const parts = name.trim().split(/[\s@.]+/).filter(Boolean);
+  if (parts.length === 0) return '·';
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return `${parts[0]![0]!}${parts[parts.length - 1]![0]!}`.toUpperCase();
+}

--- a/packages/dashboard-pages/src/components/dashboard/inbox-conv-drawers.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-conv-drawers.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Unplug, User } from 'lucide-react';
+import { ArrowLeft, Unplug, User } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button, Pill } from '@getmunin/ui';
 import { useRelative } from '../../lib/use-relative';
@@ -75,19 +75,13 @@ function retryHandler(
   return null;
 }
 
-export function ConversationDrawer({
-  detail,
-  reply,
-  setReply,
-  pending,
-  actionError,
-  onSend,
-  onTakeOver,
-  onRelease,
-  onCloseConv,
-  onClose,
-  onClearActionError,
-}: {
+export type ConversationDetailVariant = 'drawer' | 'pane' | 'page';
+
+export function ConversationDrawer(props: ConversationDetailViewProps) {
+  return <ConversationDetailView {...props} />;
+}
+
+export interface ConversationDetailViewProps {
   detail: ConversationDetail;
   reply: string;
   setReply: (v: string) => void;
@@ -99,7 +93,25 @@ export function ConversationDrawer({
   onCloseConv: () => void;
   onClose: () => void;
   onClearActionError: () => void;
-}) {
+  variant?: ConversationDetailVariant;
+  backLabel?: string;
+}
+
+export function ConversationDetailView({
+  detail,
+  reply,
+  setReply,
+  pending,
+  actionError,
+  onSend,
+  onTakeOver,
+  onRelease,
+  onCloseConv,
+  onClose,
+  onClearActionError,
+  variant = 'drawer',
+  backLabel,
+}: ConversationDetailViewProps) {
   const t = useTranslations('dashboard.overview.drawer');
   const age = useRelative();
   const claimed = detail.claim !== null;
@@ -145,27 +157,50 @@ export function ConversationDrawer({
     if (reply.trim() && !pending) submit();
   });
 
+  const title = detail.subject ?? t('conversationFallback', { id: detail.displayId });
+  const meta =
+    detail.needsHumanAttention && detail.needsHumanAttentionAt
+      ? t('metaConv', { who: endUserLabel, age: age(detail.needsHumanAttentionAt) })
+      : t('metaConvFull', { who: endUserLabel, status: detail.status });
+  const claimPill = claimed ? (
+    <Pill tone="review" className="before:hidden">
+      <User className="size-[9px]" /> {t('pillTakenOver')}
+    </Pill>
+  ) : null;
+
   return (
     <>
-      <DrawerHeader
-        pillTone={detail.needsHumanAttention ? 'live' : detail.status === 'open' ? 'ink' : 'draft'}
-        pillLabel={detail.needsHumanAttention ? t('pillLive') : detail.status}
-        title={detail.subject ?? t('conversationFallback', { id: detail.displayId })}
-        meta={
-          detail.needsHumanAttention && detail.needsHumanAttentionAt
-            ? t('metaConv', { who: endUserLabel, age: age(detail.needsHumanAttentionAt) })
-            : t('metaConvFull', { who: endUserLabel, status: detail.status })
-        }
-        rightExtra={
-          claimed ? (
-            <Pill tone="review" className="before:hidden">
-              <User className="size-[9px]" /> {t('pillTakenOver')}
-            </Pill>
-          ) : null
-        }
-        onClose={onClose}
-        closeLabel={t('close')}
-      />
+      {variant === 'page' ? (
+        <>
+          <div className="flex h-14 shrink-0 items-center gap-2.5 border-b-[1px] border-rule-soft px-4 dark:border-rule-on-dark">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center gap-2.5 py-1.5 font-mono text-[10px] uppercase tracking-eyebrow text-ink-soft dark:text-foreground/75"
+            >
+              <ArrowLeft className="size-4 shrink-0 text-ink dark:text-foreground" aria-hidden />
+              {backLabel ?? t('close')}
+            </button>
+            <span className="ml-auto shrink-0">{claimPill}</span>
+          </div>
+          <div className="shrink-0 px-4 pb-1 pt-4">
+            <h2 className="m-0 font-serif text-[26px] font-normal leading-tight text-ink dark:text-foreground">
+              {title}
+            </h2>
+            <p className="mt-1.5 text-[12.5px] text-ink-mute dark:text-foreground/55">{meta}</p>
+          </div>
+        </>
+      ) : (
+        <DrawerHeader
+          pillTone={detail.needsHumanAttention ? 'live' : detail.status === 'open' ? 'ink' : 'draft'}
+          pillLabel={detail.needsHumanAttention ? t('pillLive') : detail.status}
+          title={title}
+          meta={meta}
+          rightExtra={claimPill}
+          onClose={variant === 'pane' ? undefined : onClose}
+          closeLabel={t('close')}
+        />
+      )}
 
       <div ref={messagesRef} className="flex-1 space-y-3 overflow-y-auto px-6 py-5">
         {thread.map((m) => (

--- a/packages/dashboard-pages/src/components/dashboard/inbox-types.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-types.ts
@@ -22,6 +22,7 @@ export interface ConversationSummary {
   displayId: number;
   status: Status;
   channelId: string;
+  channelType?: string;
   endUserId: string | null;
   contactId: string | null;
   topicId: string | null;
@@ -30,6 +31,7 @@ export interface ConversationSummary {
   lastMessageAt: string | null;
   needsHumanAttention: boolean;
   needsHumanAttentionAt: string | null;
+  lastInboundPreview?: string | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/packages/dashboard-pages/src/components/dashboard/queue-drawers/shared.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-drawers/shared.tsx
@@ -160,7 +160,7 @@ export function DrawerHeader({
   title: string;
   meta?: string;
   rightExtra?: React.ReactNode;
-  onClose: () => void;
+  onClose?: () => void;
   closeLabel: string;
 }) {
   return (
@@ -180,6 +180,7 @@ export function DrawerHeader({
             </p>
           )}
         </div>
+        {onClose ? (
         <button
           type="button"
           onClick={onClose}
@@ -188,6 +189,7 @@ export function DrawerHeader({
         >
           {closeLabel}
         </button>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -122,6 +122,11 @@ export { CredentialEntryPage } from './pages/credential-entry';
 export { TrackersPage } from './pages/trackers';
 export { EndUsersPage } from './pages/end-users';
 export { DashboardPage } from './pages/overview';
+export { ConversationsPage } from './pages/conversations';
+export {
+  ConversationDetailPage,
+  type ConversationDetailPageProps,
+} from './pages/conversation-detail';
 export { SettingsIndexPage, type SettingsIndexPageProps } from './pages/settings-index';
 export { TeamPage } from './pages/team';
 export { UsagePage } from './pages/usage';

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1273,8 +1273,29 @@
     "console": {
       "groups": {
         "admin": "Admin",
-        "workspace": "Workspace"
+        "workspace": "Workspace",
+        "oversight": "Oversight"
       }
+    },
+    "conversations": {
+      "eyebrow": "Conversations",
+      "title": "What needs you, <em>first.</em>",
+      "searchPlaceholder": "Search customer or subject…",
+      "sections": {
+        "needsYou": "Needs you",
+        "inProgress": "In progress",
+        "open": "Open"
+      },
+      "emptyTitle": "Nothing in the queue.",
+      "emptyBody": "When a conversation needs a human, it lands here first.",
+      "paneEmpty": "Select a conversation.",
+      "backToQueue": "Queue",
+      "unclaimed": "Unclaimed",
+      "claimed": "Claimed",
+      "claimedByYou": "Claimed by you",
+      "claimedBy": "With {who}",
+      "channelFallback": "Conversation",
+      "detailFailedTitle": "Could not open that conversation."
     }
   },
   "agentSetup": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1273,8 +1273,29 @@
     "console": {
       "groups": {
         "admin": "Admin",
-        "workspace": "Arbeidsområde"
+        "workspace": "Arbeidsområde",
+        "oversight": "Oppfølging"
       }
+    },
+    "conversations": {
+      "eyebrow": "Samtaler",
+      "title": "Hva trenger deg <em>først.</em>",
+      "searchPlaceholder": "Søk kunde eller emne…",
+      "sections": {
+        "needsYou": "Trenger deg",
+        "inProgress": "Under arbeid",
+        "open": "Åpne"
+      },
+      "emptyTitle": "Ingenting i køen.",
+      "emptyBody": "Når en samtale trenger et menneske, havner den her først.",
+      "paneEmpty": "Velg en samtale.",
+      "backToQueue": "Kø",
+      "unclaimed": "Ikke tatt",
+      "claimed": "Tatt",
+      "claimedByYou": "Tatt av deg",
+      "claimedBy": "Hos {who}",
+      "channelFallback": "Samtale",
+      "detailFailedTitle": "Kunne ikke åpne samtalen."
     }
   },
   "agentSetup": {

--- a/packages/dashboard-pages/src/nav/console-groups.test.ts
+++ b/packages/dashboard-pages/src/nav/console-groups.test.ts
@@ -8,45 +8,50 @@ import {
   type ConsoleNavGroup,
 } from './console-groups';
 
-const oversight: ConsoleNavGroup = {
-  groupKey: 'oversight',
+const reports: ConsoleNavGroup = {
+  groupKey: 'reports',
   items: [
-    { href: '/dashboard/conversations', labelKey: 'conversations' },
-    { href: '/dashboard/learning', labelKey: 'learning', roles: ADMIN_ROLES },
+    { href: '/dashboard/reports', labelKey: 'reports' },
+    { href: '/dashboard/reports/spend', labelKey: 'spend', roles: ADMIN_ROLES },
   ],
 };
 
 describe('visibleConsoleGroups', () => {
   it('gives an owner every group', () => {
-    const visible = visibleConsoleGroups([...OSS_CONSOLE_GROUPS, oversight], 'owner');
-    expect(visible.map((g) => g.groupKey)).toEqual(['admin', 'workspace', 'oversight']);
+    const visible = visibleConsoleGroups([...OSS_CONSOLE_GROUPS, reports], 'owner');
+    expect(visible.map((g) => g.groupKey)).toEqual([
+      'admin',
+      'oversight',
+      'workspace',
+      'reports',
+    ]);
   });
 
   it('drops the admin group entirely for a member rather than disabling it', () => {
-    const visible = visibleConsoleGroups([...OSS_CONSOLE_GROUPS, oversight], 'member');
-    expect(visible.map((g) => g.groupKey)).toEqual(['workspace', 'oversight']);
+    const visible = visibleConsoleGroups([...OSS_CONSOLE_GROUPS, reports], 'member');
+    expect(visible.map((g) => g.groupKey)).toEqual(['oversight', 'workspace', 'reports']);
   });
 
   it('drops admin-only items but keeps the rest of their group', () => {
-    const visible = visibleConsoleGroups([oversight], 'member');
-    expect(visible[0]!.items.map((i) => i.labelKey)).toEqual(['conversations']);
+    const visible = visibleConsoleGroups([reports], 'member');
+    expect(visible[0]!.items.map((i) => i.labelKey)).toEqual(['reports']);
   });
 
   it('drops a group that would render with no items left', () => {
     const adminOnly: ConsoleNavGroup = {
-      groupKey: 'oversight',
-      items: [{ href: '/dashboard/automation', labelKey: 'automation', roles: ADMIN_ROLES }],
+      groupKey: 'reports',
+      items: [{ href: '/dashboard/reports/spend', labelKey: 'spend', roles: ADMIN_ROLES }],
     };
     expect(visibleConsoleGroups([adminOnly], 'member')).toEqual([]);
   });
 
   it('shows nothing role-gated while the role is still unknown', () => {
-    expect(visibleConsoleGroups([oversight], null).map((g) => g.groupKey)).toEqual(['oversight']);
-    expect(visibleConsoleGroups([oversight], null)[0]!.items).toHaveLength(1);
+    expect(visibleConsoleGroups([reports], null).map((g) => g.groupKey)).toEqual(['reports']);
+    expect(visibleConsoleGroups([reports], null)[0]!.items).toHaveLength(1);
   });
 
   it('does not mutate the group list it was given', () => {
-    const groups = [oversight];
+    const groups = [reports];
     visibleConsoleGroups(groups, 'member');
     expect(groups[0]!.items).toHaveLength(2);
   });
@@ -55,9 +60,14 @@ describe('visibleConsoleGroups', () => {
 describe('extendConsoleGroups', () => {
   it('inserts a new group before workspace so settings stays last', () => {
     const result = extendConsoleGroups(OSS_CONSOLE_GROUPS, [
-      { groupKey: 'oversight', items: oversight.items },
+      { groupKey: 'reports', items: reports.items },
     ]);
-    expect(result.map((g) => g.groupKey)).toEqual(['admin', 'oversight', 'workspace']);
+    expect(result.map((g) => g.groupKey)).toEqual([
+      'admin',
+      'oversight',
+      'reports',
+      'workspace',
+    ]);
   });
 
   it('appends into an existing group', () => {

--- a/packages/dashboard-pages/src/nav/console-groups.ts
+++ b/packages/dashboard-pages/src/nav/console-groups.ts
@@ -25,6 +25,12 @@ export const OSS_CONSOLE_GROUPS: ConsoleNavGroup[] = [
     items: [{ href: '/dashboard', labelKey: 'overview', roles: ADMIN_ROLES, countKey: 'queue' }],
   },
   {
+    groupKey: 'oversight',
+    items: [
+      { href: '/dashboard/conversations', labelKey: 'conversations', countKey: 'attention' },
+    ],
+  },
+  {
     groupKey: 'workspace',
     items: [{ href: '/dashboard/settings', labelKey: 'settings' }],
   },

--- a/packages/dashboard-pages/src/pages/conversation-detail.tsx
+++ b/packages/dashboard-pages/src/pages/conversation-detail.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+import { Button, PageSpinner } from '@getmunin/ui';
+import { ConversationDetailView } from '../components/dashboard/inbox-conv-drawers';
+import { useInboxData } from '../components/dashboard/inbox-data';
+import { EmptyCallout } from '../components/empty-callout';
+import { useRouter } from '../i18n-navigation';
+
+export interface ConversationDetailPageProps {
+  conversationId: string;
+}
+
+export function ConversationDetailPage({ conversationId }: ConversationDetailPageProps) {
+  const t = useTranslations('dashboard.conversations');
+  const tCommon = useTranslations('common');
+  const inbox = useInboxData();
+  const router = useRouter();
+  const { reloadDetail } = inbox;
+
+  useEffect(() => {
+    void reloadDetail(conversationId);
+  }, [conversationId, reloadDetail]);
+
+  const detail = inbox.details[conversationId];
+  const detailError = inbox.detailErrors[conversationId];
+  const back = () => router.push('/dashboard/conversations');
+
+  if (detailError && !detail) {
+    return (
+      <div className="px-4 py-12">
+        <EmptyCallout title={t('detailFailedTitle')} body={detailError} />
+        <div className="mt-4 flex justify-center gap-2">
+          <Button size="sm" variant="accent" onClick={() => void reloadDetail(conversationId)}>
+            {tCommon('retry')}
+          </Button>
+          <Button size="sm" variant="outline" onClick={back}>
+            {t('backToQueue')}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!detail) return <PageSpinner className="min-h-[70vh]" />;
+
+  return (
+    <div className="flex min-h-[calc(100vh_-_3.5rem)] flex-col md:min-h-screen">
+      <ConversationDetailView
+        variant="page"
+        backLabel={t('backToQueue')}
+        detail={detail}
+        reply={inbox.reply}
+        setReply={inbox.setReply}
+        pending={inbox.pending}
+        actionError={inbox.actionError?.conversationId === detail.id ? inbox.actionError : null}
+        onSend={(body, fromDraftId) =>
+          void inbox.send(detail.id, body, { fromDraftId, claim: true })
+        }
+        onTakeOver={() => void inbox.takeOver(detail.id)}
+        onRelease={() => void inbox.release(detail.id)}
+        onCloseConv={() => {
+          void inbox.closeConv(detail.id).then(back);
+        }}
+        onClose={back}
+        onClearActionError={inbox.clearActionError}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard-pages/src/pages/conversations.tsx
+++ b/packages/dashboard-pages/src/pages/conversations.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { api } from '../api';
+import { authClient } from '../auth-client';
+import { isOwnerOrAdmin, useActiveRole } from '../auth/use-active-role';
+import { ConversationRow } from '../components/dashboard/conversation-row';
+import {
+  buildQueueSections,
+  firstRowId,
+  type ConversationListItem,
+} from '../components/dashboard/conversation-queue';
+import { ConversationDetailView } from '../components/dashboard/inbox-conv-drawers';
+import { useInboxData } from '../components/dashboard/inbox-data';
+import { EmptyCallout } from '../components/empty-callout';
+import { LoadFailed } from '../components/load-failed';
+import { nativeFieldClass } from '../components/page-shell';
+import { useInboxLoadFailedProps } from '../lib/use-load-failed-props';
+import { useRealtime } from '../realtime';
+import { useRouter } from '../i18n-navigation';
+
+const PAGE_LIMIT = 50;
+
+interface ConversationListResponse {
+  items: ConversationListItem[];
+  nextCursor: string | null;
+}
+
+interface MemberDto {
+  userId: string;
+  name: string | null;
+  email: string;
+}
+
+export function ConversationsPage() {
+  const t = useTranslations('dashboard.conversations');
+  const inbox = useInboxData();
+  const router = useRouter();
+  const buildLoadFailedProps = useInboxLoadFailedProps();
+  const { data: session } = authClient.useSession();
+  const { role } = useActiveRole();
+
+  const [list, setList] = useState<ConversationListItem[]>([]);
+  const [query, setQuery] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [names, setNames] = useState<Record<string, string>>({});
+
+  const loadList = useCallback(async () => {
+    try {
+      const page = await api<ConversationListResponse>(
+        `/v1/conversations?status=open&limit=${PAGE_LIMIT}`,
+      );
+      setList(page.items);
+    } catch (err) {
+      console.warn('[conversations] list fetch failed:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadList();
+  }, [loadList]);
+
+  useEffect(() => {
+    if (!isOwnerOrAdmin(role)) return;
+    void api<MemberDto[]>('/v1/orgs/me/members')
+      .then((members) => {
+        setNames(
+          Object.fromEntries(members.map((m) => [m.userId, m.name?.trim() || m.email])),
+        );
+      })
+      .catch(() => setNames({}));
+  }, [role]);
+
+  useRealtime([{ channel: 'org' }], (event) => {
+    if (event.type.startsWith('conversation.')) void loadList();
+  });
+
+  const sections = useMemo(
+    () => buildQueueSections({ live: inbox.items, list, query }),
+    [inbox.items, list, query],
+  );
+
+  const fallbackId = firstRowId(sections);
+  const paneId = selectedId ?? fallbackId;
+  const { reloadDetail } = inbox;
+
+  useEffect(() => {
+    if (paneId) void reloadDetail(paneId);
+  }, [paneId, reloadDetail]);
+
+  const detail = paneId ? inbox.details[paneId] : undefined;
+  const viewerUserId = session?.user.id ?? null;
+  const viewerName = session?.user.name || session?.user.email || null;
+
+  if (inbox.loadError && !inbox.hasLoadedOnce) {
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center px-4 py-12 md:px-10">
+        <LoadFailed
+          {...buildLoadFailedProps(inbox.loadError, () => void inbox.retryLoad(), inbox.retrying)}
+        />
+      </div>
+    );
+  }
+
+  const listColumn = (
+    <div className="flex min-h-0 min-w-0 flex-col lg:border-r-[1px] lg:border-rule-soft dark:lg:border-rule-on-dark">
+      <div className="shrink-0 px-4 pt-8 md:px-8">
+        <p className="font-mono text-[9px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+          {t('eyebrow')}
+        </p>
+        <h1 className="mt-2 font-serif text-[34px] font-normal leading-[1.02] tracking-tight text-ink lg:text-[40px] dark:text-foreground">
+          {t.rich('title', { em: (chunks) => <em className="italic text-cobalt">{chunks}</em> })}
+        </h1>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t('searchPlaceholder')}
+          aria-label={t('searchPlaceholder')}
+          className={`${nativeFieldClass} mt-5 min-h-11`}
+        />
+      </div>
+
+      <div className="mt-4 min-h-0 flex-1 overflow-y-auto px-4 pb-8 md:px-8">
+        {sections.length === 0 ? (
+          <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
+        ) : (
+          sections.map((section) => (
+            <section key={section.key}>
+              <div className="flex items-baseline justify-between gap-4 border-b-[1px] border-ink pb-2 pt-5 dark:border-rule-on-dark">
+                <h2 className="font-mono text-[9px] uppercase tracking-eyebrow text-ink dark:text-foreground">
+                  {t(`sections.${section.key}`)} · {section.rows.length}
+                </h2>
+              </div>
+              <ul>
+                {section.rows.map((row) => (
+                  <ConversationRow
+                    key={row.id}
+                    row={row}
+                    active={row.id === paneId}
+                    viewerUserId={viewerUserId}
+                    viewerName={viewerName}
+                    assigneeName={row.assigneeUserId ? names[row.assigneeUserId] : null}
+                    onOpen={() => {
+                      if (window.matchMedia('(min-width: 1024px)').matches) setSelectedId(row.id);
+                      else router.push(`/dashboard/conversations/${row.id}`);
+                    }}
+                  />
+                ))}
+              </ul>
+            </section>
+          ))
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="grid min-h-[calc(100vh_-_3.5rem)] grid-cols-1 md:min-h-screen lg:grid-cols-[1.05fr_1.4fr]">
+      {listColumn}
+      <div className="hidden min-h-0 min-w-0 flex-col bg-paper-deep lg:flex dark:bg-secondary">
+        {detail ? (
+          <ConversationDetailView
+            variant="pane"
+            detail={detail}
+            reply={inbox.reply}
+            setReply={inbox.setReply}
+            pending={inbox.pending}
+            actionError={
+              inbox.actionError?.conversationId === detail.id ? inbox.actionError : null
+            }
+            onSend={(body, fromDraftId) =>
+              void inbox.send(detail.id, body, { fromDraftId, claim: true })
+            }
+            onTakeOver={() => void inbox.takeOver(detail.id)}
+            onRelease={() => void inbox.release(detail.id)}
+            onCloseConv={() => void inbox.closeConv(detail.id)}
+            onClose={() => setSelectedId(null)}
+            onClearActionError={inbox.clearActionError}
+          />
+        ) : (
+          <p className="px-8 py-16 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            {t('paneEmpty')}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -66,6 +66,7 @@ export function DashboardPage() {
       <OverviewStats
         liveCount={inbox.items.length}
         learningCount={inbox.queue.filter((q) => q.kind === 'kb').length}
+        liveHref="/dashboard/conversations"
       />
 
       <LiveNowSection controller={inbox} />


### PR DESCRIPTION
Third of six PRs implementing the Oversight console designs. Stacked on #859.

## Routes

- `/dashboard/conversations` — the review queue.
- `/dashboard/conversations/[id]` — one conversation, full screen.

Conversations also joins the console nav, under a new **Oversight** group.

## Two presentations of one queue

From `lg` up: the design's two-pane console, `1.05fr` list beside `1.4fr` detail, with the first row selected so the pane is never empty on arrival.

Below `lg`: list only. A row navigates to the detail route, which carries a back-to-queue header and the action stack pinned to the bottom — the mobile design's list-then-detail, since a phone has no room for two panes.

## One detail body, three presentations

`ConversationDrawer` became `ConversationDetailView` with a `variant` of `drawer | pane | page`. The overview drawer, the desktop pane and the mobile route all render it, so they cannot drift apart. Only the header differs; `DrawerHeader`'s close button is now optional because the pane never closes.

## Section rules are pinned by tests

`buildQueueSections` is pure, and `conversation-queue.test.ts` locks the behaviour that is easy to regress:

- a conversation that is both live and in the page is listed **once**, and prefers the live copy — that is the one carrying a message preview
- an attention-flagged row goes to Needs you even when it is assigned
- empty sections are dropped rather than rendered as bare headings
- each section sorts newest first

## Role-aware assignee names

`/v1/orgs/me/members` is `@RequireRole('owner','admin')`, so an agent cannot resolve who holds a claim. The page only asks for members when the role allows it and otherwise shows a generic claimed state — no failed request on the agent's own landing page.

## Known gaps, deliberate

- **Search is client-side** over the loaded page (customer, subject, preview, `#displayId`). There is no conversation-search endpoint; adding one is its own change.
- **Nav counts** are declared (`countKey`) but nothing supplies them yet — whoever renders the shell passes `counts`. A dedicated count endpoint would avoid a third `/v1/inbox` fetch from the layout.
- **Presence** stays out, as agreed.

## Testing

119 tests pass. Typecheck clean for the package and the app; lint clean.