### PR TITLE
feat(dashboard): learning view over KB curation

### DIFF
--- a/.changeset/oversight-learning.md
+++ b/.changeset/oversight-learning.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Learning becomes a view of its own at `/dashboard/learning`: what is waiting on review, and
+what was recently decided. A revision proposal renders its before/after inline rather than
+only inside a drawer, so the edit an agent wants to make is readable at a glance.
+
+Adds `GET /v1/kb/curation/decisions` — a thin wrapper over the existing
+`listCurationDecisions` service method, which until now was reachable only through the
+`kb_list_curation_decisions` MCP tool. The dashboard needs it for the decided list and the
+seven-day count.

--- a/apps/web/app/[locale]/dashboard/learning/page.tsx
+++ b/apps/web/app/[locale]/dashboard/learning/page.tsx
@@ -1,0 +1,1 @@
+export { LearningPage as default } from '@getmunin/dashboard-pages';

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -5628,6 +5628,45 @@
         ]
       }
     },
+    "/v1/kb/curation/decisions": {
+      "get": {
+        "operationId": "KbCurationDecisionsController_list",
+        "parameters": [
+          {
+            "name": "outcome",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "KbCurationDecisions"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/kb/spaces": {
       "get": {
         "operationId": "KbSpacesController_list",

--- a/packages/backend-core/src/control/control.module.ts
+++ b/packages/backend-core/src/control/control.module.ts
@@ -22,7 +22,11 @@ import { KbModule } from '../modules/kb/kb.module.ts';
 import { CuratorModule } from '../modules/curator/curator.module.ts';
 import { CuratorJobsController } from './curator-jobs.controller.ts';
 import { ConvChannelsController } from './conv-channels.controller.ts';
-import { KbCandidatesController, KbSpacesController } from './kb-candidates.controller.ts';
+import {
+  KbCandidatesController,
+  KbCurationDecisionsController,
+  KbSpacesController,
+} from './kb-candidates.controller.ts';
 import { KbTransferController } from './kb-transfer.controller.ts';
 import { CrmTransferController } from './crm-transfer.controller.ts';
 import { ConvTransferController } from './conv-transfer.controller.ts';
@@ -109,6 +113,7 @@ import { ConnectorsModule } from '../modules/connectors/connectors.module.ts';
     OutreachProposalsController,
     CuratorJobsController,
     KbCandidatesController,
+    KbCurationDecisionsController,
     KbSpacesController,
     KbTransferController,
     CrmTransferController,

--- a/packages/backend-core/src/control/kb-candidates.controller.test.ts
+++ b/packages/backend-core/src/control/kb-candidates.controller.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { parseDecisionQuery } from './kb-candidates.controller.ts';
+
+describe('parseDecisionQuery', () => {
+  it('passes nothing through when neither filter is given', () => {
+    expect(parseDecisionQuery()).toEqual({});
+  });
+
+  it('accepts both outcomes', () => {
+    expect(parseDecisionQuery('published')).toEqual({ outcome: 'published' });
+    expect(parseDecisionQuery('dismissed')).toEqual({ outcome: 'dismissed' });
+  });
+
+  it('rejects an unknown outcome with a code-prefixed message instead of a 500', () => {
+    expect(() => parseDecisionQuery('approved')).toThrow(BadRequestException);
+    expect(() => parseDecisionQuery('approved')).toThrow(/kb_invalid: unknown outcome: approved/);
+  });
+
+  it('parses a numeric limit', () => {
+    expect(parseDecisionQuery(undefined, '20')).toEqual({ limit: 20 });
+    expect(parseDecisionQuery('published', '5')).toEqual({ outcome: 'published', limit: 5 });
+  });
+
+  it('rejects a limit that is not a positive integer', () => {
+    for (const bad of ['0', '-1', '2.5', 'twenty', '']) {
+      expect(() => parseDecisionQuery(undefined, bad)).toThrow(BadRequestException);
+    }
+  });
+});

--- a/packages/backend-core/src/control/kb-candidates.controller.ts
+++ b/packages/backend-core/src/control/kb-candidates.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
@@ -25,6 +26,7 @@ import {
   KbNotFoundError,
   type CurationCandidateDto,
   type CurationCandidateSummary,
+  type CurationDecisionDto,
   type DocumentDto,
   type SpaceDto,
 } from '../modules/kb/kb.service.ts';
@@ -140,6 +142,48 @@ export class KbCandidatesController {
       }),
     );
     return { dismissed: true };
+  }
+}
+
+interface DecisionListResponse {
+  items: CurationDecisionDto[];
+}
+
+const DecisionOutcomeSchema = z.enum(['dismissed', 'published']);
+
+export function parseDecisionQuery(
+  outcome?: string,
+  limit?: string,
+): { outcome?: 'dismissed' | 'published'; limit?: number } {
+  const parsedOutcome = outcome ? DecisionOutcomeSchema.safeParse(outcome) : null;
+  if (parsedOutcome && !parsedOutcome.success) {
+    throw new BadRequestException(`kb_invalid: unknown outcome: ${outcome}`);
+  }
+  if (limit === undefined) {
+    return parsedOutcome?.success ? { outcome: parsedOutcome.data } : {};
+  }
+  const parsedLimit = Number(limit);
+  if (!Number.isInteger(parsedLimit) || parsedLimit <= 0) {
+    throw new BadRequestException(`kb_invalid: limit must be a positive integer: ${limit}`);
+  }
+  return parsedOutcome?.success
+    ? { outcome: parsedOutcome.data, limit: parsedLimit }
+    : { limit: parsedLimit };
+}
+
+@Controller('v1/kb/curation/decisions')
+@UseGuards(AuthGuard, ControlPlaneGuard)
+@UseInterceptors(TenancyInterceptor, AuditInterceptor)
+export class KbCurationDecisionsController {
+  constructor(private readonly kb: KbService) {}
+
+  @Get()
+  async list(
+    @Query('outcome') outcome?: string,
+    @Query('limit') limit?: string,
+  ): Promise<DecisionListResponse> {
+    const items = await this.kb.listCurationDecisions(parseDecisionQuery(outcome, limit));
+    return { items };
   }
 }
 

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -127,6 +127,7 @@ export {
   ConversationDetailPage,
   type ConversationDetailPageProps,
 } from './pages/conversation-detail';
+export { LearningPage } from './pages/learning';
 export { SettingsIndexPage, type SettingsIndexPageProps } from './pages/settings-index';
 export { TeamPage } from './pages/team';
 export { UsagePage } from './pages/usage';

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -189,7 +189,8 @@
     "openMenu": "Open menu",
     "closeMenu": "Close menu",
     "organization": "Organization",
-    "integrations": "Integrations"
+    "integrations": "Integrations",
+    "learning": "Learning"
   },
   "dashboard": {
     "runnerStatusBanner": {
@@ -1296,6 +1297,30 @@
       "claimedBy": "With {who}",
       "channelFallback": "Conversation",
       "detailFailedTitle": "Could not open that conversation."
+    },
+    "learning": {
+      "eyebrow": "Learning · knowledge and agent edits",
+      "title": "Every edit <em>teaches.</em>",
+      "statPending": "{count} pending review",
+      "statDecided": "{count} decided · 7 days",
+      "pendingHeading": "Waiting on you",
+      "decidedHeading": "Recently decided",
+      "emptyTitle": "Nothing to review.",
+      "emptyBody": "Proposals appear here when an agent learns something worth keeping.",
+      "typeProposal": "KB proposal",
+      "typeRevision": "KB revision",
+      "diffUnchanged": "No textual change.",
+      "review": "Review →",
+      "dismiss": "Dismiss",
+      "outcome": {
+        "published": "Published",
+        "dismissed": "Dismissed"
+      },
+      "actor": {
+        "user": "by a person",
+        "agent": "by an agent",
+        "system": "by Munin"
+      }
     }
   },
   "agentSetup": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -189,7 +189,8 @@
     "openMenu": "Åpne meny",
     "closeMenu": "Lukk meny",
     "organization": "Organisasjon",
-    "integrations": "Integrasjoner"
+    "integrations": "Integrasjoner",
+    "learning": "Læring"
   },
   "dashboard": {
     "runnerStatusBanner": {
@@ -1296,6 +1297,30 @@
       "claimedBy": "Hos {who}",
       "channelFallback": "Samtale",
       "detailFailedTitle": "Kunne ikke åpne samtalen."
+    },
+    "learning": {
+      "eyebrow": "Læring · kunnskap og agentendringer",
+      "title": "Hver endring <em>lærer bort.</em>",
+      "statPending": "{count} til gjennomgang",
+      "statDecided": "{count} avgjort · 7 dager",
+      "pendingHeading": "Venter på deg",
+      "decidedHeading": "Nylig avgjort",
+      "emptyTitle": "Ingenting å gå gjennom.",
+      "emptyBody": "Forslag dukker opp her når en agent lærer noe verdt å beholde.",
+      "typeProposal": "KB-forslag",
+      "typeRevision": "KB-revisjon",
+      "diffUnchanged": "Ingen tekstlig endring.",
+      "review": "Gå gjennom →",
+      "dismiss": "Avslå",
+      "outcome": {
+        "published": "Publisert",
+        "dismissed": "Avslått"
+      },
+      "actor": {
+        "user": "av en person",
+        "agent": "av en agent",
+        "system": "av Munin"
+      }
     }
   },
   "agentSetup": {

--- a/packages/dashboard-pages/src/nav/console-groups.ts
+++ b/packages/dashboard-pages/src/nav/console-groups.ts
@@ -28,6 +28,12 @@ export const OSS_CONSOLE_GROUPS: ConsoleNavGroup[] = [
     groupKey: 'oversight',
     items: [
       { href: '/dashboard/conversations', labelKey: 'conversations', countKey: 'attention' },
+      {
+        href: '/dashboard/learning',
+        labelKey: 'learning',
+        roles: ADMIN_ROLES,
+        countKey: 'learning',
+      },
     ],
   },
   {

--- a/packages/dashboard-pages/src/pages/learning.tsx
+++ b/packages/dashboard-pages/src/pages/learning.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { BodyDiff, Button } from '@getmunin/ui';
+import { api } from '../api';
+import { EmptyCallout } from '../components/empty-callout';
+import { LoadFailed } from '../components/load-failed';
+import { useInboxData } from '../components/dashboard/inbox-data';
+import { InboxDrawers } from '../components/dashboard/inbox-sections';
+import { useInboxLoadFailedProps } from '../lib/use-load-failed-props';
+import { useRelative } from '../lib/use-relative';
+import { useRealtime } from '../realtime';
+import type { KbCandidateDto, QueueItem } from '../components/dashboard/queue-drawers/types';
+
+const DECISION_LIMIT = 20;
+
+interface CurationDecisionDto {
+  id: string;
+  candidateDocumentId: string;
+  title: string;
+  outcome: 'dismissed' | 'published';
+  reason: string | null;
+  decidedByActorType: string;
+  decidedAt: string;
+}
+
+interface DecisionListResponse {
+  items: CurationDecisionDto[];
+}
+
+export function LearningPage() {
+  const t = useTranslations('dashboard.learning');
+  const inbox = useInboxData();
+  const buildLoadFailedProps = useInboxLoadFailedProps();
+  const age = useRelative();
+
+  const [decisions, setDecisions] = useState<CurationDecisionDto[]>([]);
+  const [bodies, setBodies] = useState<Record<string, KbCandidateDto>>({});
+
+  const loadDecisions = useCallback(async () => {
+    try {
+      const page = await api<DecisionListResponse>(
+        `/v1/kb/curation/decisions?limit=${DECISION_LIMIT}`,
+      );
+      setDecisions(page.items);
+    } catch (err) {
+      console.warn('[learning] decisions fetch failed:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadDecisions();
+  }, [loadDecisions]);
+
+  useRealtime([{ channel: 'org' }], (event) => {
+    if (event.type.startsWith('kb.')) void loadDecisions();
+  });
+
+  const candidates = useMemo(
+    () => inbox.queue.filter((item): item is QueueItem & { kind: 'kb' } => item.kind === 'kb'),
+    [inbox.queue],
+  );
+
+  const revisionIds = useMemo(
+    () => candidates.filter((c) => c.raw.revisesDocumentId).map((c) => c.id),
+    [candidates],
+  );
+
+  useEffect(() => {
+    for (const id of revisionIds) {
+      if (bodies[id] !== undefined) continue;
+      void api<KbCandidateDto>(`/v1/kb/curation/candidates/${id}`)
+        .then((dto) => setBodies((prev) => ({ ...prev, [id]: dto })))
+        .catch(() => {});
+    }
+  }, [revisionIds, bodies]);
+
+  const decidedLast7Days = decisions.filter(
+    (d) => Date.parse(d.decidedAt) > Date.now() - 7 * 24 * 60 * 60 * 1000,
+  ).length;
+
+  if (inbox.loadError && !inbox.hasLoadedOnce) {
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center px-4 py-12 md:px-10">
+        <LoadFailed
+          {...buildLoadFailedProps(inbox.loadError, () => void inbox.retryLoad(), inbox.retrying)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8 md:px-10 md:py-11">
+      <header>
+        <p className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute dark:text-foreground/55">
+          {t('eyebrow')}
+        </p>
+        <h1 className="mt-2 font-serif text-[38px] font-normal leading-[1.02] tracking-tight text-ink md:text-[48px] dark:text-foreground">
+          {t.rich('title', { em: (chunks) => <em className="italic text-cobalt">{chunks}</em> })}
+        </h1>
+        <p className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[9px] uppercase tracking-meta text-ink-mute dark:text-foreground/55">
+          <span>{t('statPending', { count: candidates.length })}</span>
+          <span aria-hidden>·</span>
+          <span>{t('statDecided', { count: decidedLast7Days })}</span>
+        </p>
+      </header>
+
+      <section className="mt-9">
+        <div className="flex items-baseline justify-between gap-4 border-b-[1px] border-ink pb-2.5 dark:border-rule-on-dark">
+          <h2 className="font-mono text-[10px] uppercase tracking-eyebrow text-ink dark:text-foreground">
+            {t('pendingHeading')} · {candidates.length}
+          </h2>
+        </div>
+        {candidates.length === 0 ? (
+          <div className="pt-6">
+            <EmptyCallout title={t('emptyTitle')} body={t('emptyBody')} />
+          </div>
+        ) : (
+          <ul>
+            {candidates.map((item) => {
+              const detail = bodies[item.id];
+              const isRevision = item.raw.revisesDocumentId != null;
+              return (
+                <li
+                  key={item.id}
+                  className="flex flex-col gap-2 border-b-[1px] border-rule-soft py-4 dark:border-rule-on-dark"
+                >
+                  <span className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-meta text-ink-mute dark:text-foreground/55">
+                    <span>{isRevision ? t('typeRevision') : t('typeProposal')}</span>
+                    <span aria-hidden>·</span>
+                    <span className="truncate">
+                      {item.raw.proposedTargetSpaceSlug ?? item.raw.revisesDocumentTitle ?? ''}
+                    </span>
+                    <span className="ml-auto shrink-0 text-ink dark:text-foreground">
+                      {age(item.createdAt)}
+                    </span>
+                  </span>
+
+                  <span className="text-[15px] leading-snug text-ink [text-wrap:pretty] dark:text-foreground">
+                    {item.title}
+                  </span>
+
+                  {isRevision && detail?.revisesDocumentBody != null && detail.body != null ? (
+                    <BodyDiff
+                      before={detail.revisesDocumentBody}
+                      after={detail.body}
+                      unchangedLabel={t('diffUnchanged')}
+                    />
+                  ) : (
+                    <span className="text-[13px] leading-snug text-ink-mute dark:text-foreground/55">
+                      {item.snippet}
+                    </span>
+                  )}
+
+                  <span className="mt-1 flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      variant="accent"
+                      className="max-sm:min-h-11 max-sm:flex-1"
+                      onClick={() => inbox.setQueueDrawer(item)}
+                      disabled={inbox.pending}
+                    >
+                      {t('review')}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="max-sm:min-h-11 max-sm:flex-1"
+                      onClick={() => void inbox.dismissQueue(item)}
+                      disabled={inbox.pending}
+                    >
+                      {t('dismiss')}
+                    </Button>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {decisions.length > 0 && (
+        <section className="mt-10">
+          <div className="flex items-baseline justify-between gap-4 border-b-[1px] border-ink pb-2.5 dark:border-rule-on-dark">
+            <h2 className="font-mono text-[10px] uppercase tracking-eyebrow text-ink dark:text-foreground">
+              {t('decidedHeading')}
+            </h2>
+          </div>
+          <ul>
+            {decisions.map((d) => (
+              <li
+                key={d.id}
+                className="flex flex-col gap-1.5 border-b-[1px] border-rule-soft py-3.5 dark:border-rule-on-dark"
+              >
+                <span className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-meta text-ink-mute dark:text-foreground/55">
+                  <span
+                    className={
+                      d.outcome === 'published'
+                        ? 'text-cobalt dark:text-cobalt-soft'
+                        : 'text-ink-mute'
+                    }
+                  >
+                    {t(`outcome.${d.outcome}`)}
+                  </span>
+                  <span aria-hidden>·</span>
+                  <span className="truncate">{t(`actor.${actorKey(d.decidedByActorType)}`)}</span>
+                  <span className="ml-auto shrink-0 text-ink dark:text-foreground">
+                    {age(d.decidedAt)}
+                  </span>
+                </span>
+                <span className="text-[14.5px] leading-snug text-ink [text-wrap:pretty] dark:text-foreground">
+                  {d.title}
+                </span>
+                {d.reason ? (
+                  <span className="text-[13px] leading-snug text-ink-mute dark:text-foreground/55">
+                    {d.reason}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <InboxDrawers controller={inbox} />
+    </div>
+  );
+}
+
+function actorKey(actorType: string): 'user' | 'agent' | 'system' {
+  if (actorType === 'user') return 'user';
+  if (actorType === 'system') return 'system';
+  return 'agent';
+}

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -67,6 +67,7 @@ export function DashboardPage() {
         liveCount={inbox.items.length}
         learningCount={inbox.queue.filter((q) => q.kind === 'kb').length}
         liveHref="/dashboard/conversations"
+        learningHref="/dashboard/learning"
       />
 
       <LiveNowSection controller={inbox} />


### PR DESCRIPTION
Fourth of six PRs implementing the Oversight console designs. Stacked on #860.

## The view

`/dashboard/learning` — what is waiting on review, and what was recently decided. Joins the console nav under **Oversight**, admin-only, and the overview's learning stat row now links to it (that row landed unlinked in #859 precisely so this PR could wire it).

A revision proposal renders its before/after **inline** using the existing `BodyDiff`, rather than only inside a drawer, so the edit an agent wants to make is readable at a glance. Bodies are fetched per revision candidate — only for revisions, since a fresh proposal has nothing to diff against.

Approve still goes through the existing KB queue drawer, which already handles the publish-revision path with its version preconditions. Dismiss is inline on the row.

## New endpoint

`GET /v1/kb/curation/decisions`, a thin wrapper over the existing `KbService.listCurationDecisions`. That method was already there and already tested; until now it was reachable only through the `kb_list_curation_decisions` MCP tool, so the dashboard had no way to show the decided list or the seven-day count.

Query parsing is extracted as `parseDecisionQuery` and tested: an unknown outcome and a non-positive-integer limit each raise a `kb_invalid:`-prefixed `400` before reaching the service, rather than surfacing as a bare 500.

`openapi.json` regenerated. The generator marks optional query params `required: true` — that is a pre-existing quirk affecting every existing list endpoint (`/v1/conversations`, `/v1/activity`), so this endpoint is consistent with them and I have not special-cased it.

## Not included

The design's header also counts **prompt changes**. Those live as document versions in the `agent-runtime` KB space and would need their own read path; the stat is omitted rather than faked, so the header shows pending-review and decided-in-7-days only.

## Testing

5 new backend tests; 119 dashboard tests still pass. Typecheck clean across `backend-core`, `dashboard-pages` and the app.

Note for reviewers: `packages/db/dist` was stale on this branch point and made `backend-core` typecheck fail on `extractionSchema` — unrelated to these changes, fixed by `pnpm -F @getmunin/db build`.