### PR TITLE
feat(dashboard): Oversight card layout and role-consistent settings

### DIFF
--- a/.changeset/oversight-settings-panes.md
+++ b/.changeset/oversight-settings-panes.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/dashboard-pages': minor
+---
+
+Settings cards adopt the Oversight card layout: status sits beside the kind rather than under
+the name, and the footer is ruled with its meta on the left and its actions on the right. One
+change, applied everywhere the shared card is used — Channels, Trackers and Integrations.
+
+Also closes a role gap. Settings panes have always been admin-only and redirect anyone else
+back, but the console nav was offering the link to every role, so a support agent got a menu
+entry that bounced them. Workspace is now admin-gated in the nav, the overview sends a
+non-admin to the review queue instead of rendering an admin landing page, and the mobile
+menu sheet explains the reduced set rather than leaving it unexplained.

--- a/apps/web/app/[locale]/dashboard/layout.tsx
+++ b/apps/web/app/[locale]/dashboard/layout.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import { DashboardShell, useActiveMembership } from '@getmunin/dashboard-pages';
+import { useTranslations } from 'next-intl';
+import { DashboardShell, isOwnerOrAdmin, useActiveMembership } from '@getmunin/dashboard-pages';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const { membership } = useActiveMembership();
+  const tNav = useTranslations('nav');
   const brand = membership?.name?.trim() || 'Munin';
+  const isAgent = membership != null && !isOwnerOrAdmin(membership.role);
 
   return (
-    <DashboardShell brand={brand} withConfirmDialog>
+    <DashboardShell brand={brand} roleNote={isAgent ? tNav('agentScopeNote') : undefined} withConfirmDialog>
       {children}
     </DashboardShell>
   );

--- a/packages/dashboard-pages/src/components/card-kit.tsx
+++ b/packages/dashboard-pages/src/components/card-kit.tsx
@@ -92,28 +92,32 @@ export function SettingsCard({
       )}
     >
       <div className="flex items-center gap-2">
-        <span className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+        <span className="truncate font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
           {kind}
         </span>
-        {menu ? <div className="ml-auto flex-none">{menu}</div> : null}
+        <div className="ml-auto flex flex-none items-center gap-1.5">
+          {status}
+          {menu}
+        </div>
       </div>
-      <div className="mt-1 flex flex-col items-start gap-1">
-        <span className="max-w-full truncate text-sm font-medium text-ink dark:text-foreground">
+      <div className="mt-1.5">
+        <span className="block max-w-full truncate text-[15px] font-medium text-ink dark:text-foreground">
           {name}
           {qualifier ? (
             <span className="font-mono text-[13px] tracking-tight text-ink-mute"> · {qualifier}</span>
           ) : null}
         </span>
-        {status}
       </div>
       {children ? <div className="mt-2.5 flex-1">{children}</div> : <div className="flex-1" />}
       {footerAction || footerMeta ? (
-        <div className="mt-3 flex items-center gap-2.5">
-          {footerAction}
+        <div className="mt-3 flex flex-wrap items-center gap-2.5 border-t-[1px] border-rule-soft pt-3 dark:border-rule-on-dark">
           {footerMeta ? (
-            <span className="ml-auto font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+            <span className="min-w-0 truncate font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
               {footerMeta}
             </span>
+          ) : null}
+          {footerAction ? (
+            <div className="ml-auto flex flex-none items-center gap-2">{footerAction}</div>
           ) : null}
         </div>
       ) : null}

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -191,7 +191,8 @@
     "organization": "Organization",
     "integrations": "Integrations",
     "learning": "Learning",
-    "automation": "Automation"
+    "automation": "Automation",
+    "agentScopeNote": "A support agent sees Conversations and nothing else. The rest is not drawn for them."
   },
   "dashboard": {
     "runnerStatusBanner": {

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -191,7 +191,8 @@
     "organization": "Organisasjon",
     "integrations": "Integrasjoner",
     "learning": "Læring",
-    "automation": "Automatisering"
+    "automation": "Automatisering",
+    "agentScopeNote": "En kundebehandler ser Samtaler og ingenting annet. Resten tegnes ikke for dem."
   },
   "dashboard": {
     "runnerStatusBanner": {

--- a/packages/dashboard-pages/src/nav/console-groups.test.ts
+++ b/packages/dashboard-pages/src/nav/console-groups.test.ts
@@ -27,9 +27,16 @@ describe('visibleConsoleGroups', () => {
     ]);
   });
 
-  it('drops the admin group entirely for a member rather than disabling it', () => {
+  it('leaves a member with oversight only, since every other group is admin-gated', () => {
     const visible = visibleConsoleGroups([...OSS_CONSOLE_GROUPS, reports], 'member');
-    expect(visible.map((g) => g.groupKey)).toEqual(['oversight', 'workspace', 'reports']);
+    expect(visible.map((g) => g.groupKey)).toEqual(['oversight', 'reports']);
+  });
+
+  it('never offers a member a settings link that would bounce them back', () => {
+    const visible = visibleConsoleGroups(OSS_CONSOLE_GROUPS, 'member');
+    const hrefs = visible.flatMap((g) => g.items.map((i) => i.href));
+    expect(hrefs).not.toContain('/dashboard/settings');
+    expect(hrefs).not.toContain('/dashboard');
   });
 
   it('drops admin-only items but keeps the rest of their group', () => {

--- a/packages/dashboard-pages/src/nav/console-groups.ts
+++ b/packages/dashboard-pages/src/nav/console-groups.ts
@@ -43,7 +43,8 @@ export const OSS_CONSOLE_GROUPS: ConsoleNavGroup[] = [
   },
   {
     groupKey: 'workspace',
-    items: [{ href: '/dashboard/settings', labelKey: 'settings' }],
+    roles: ADMIN_ROLES,
+    items: [{ href: '/dashboard/settings', labelKey: 'settings', roles: ADMIN_ROLES }],
   },
 ];
 

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '../api';
+import { isOwnerOrAdmin, useActiveRole } from '../auth/use-active-role';
+import { useRouter } from '../i18n-navigation';
 import { useRealtime } from '../realtime';
 import { DashboardHero } from '../components/dashboard/dashboard-hero';
 import { OverviewStats } from '../components/dashboard/overview-stats';
@@ -20,6 +22,8 @@ import {
 
 export function DashboardPage() {
   const inbox = useInboxData();
+  const router = useRouter();
+  const { role, loading: roleLoading } = useActiveRole();
   const [summary, setSummary] = useState<UsageSummary | null>(null);
   const buildLoadFailedProps = useInboxLoadFailedProps();
 
@@ -32,6 +36,12 @@ export function DashboardPage() {
   useEffect(() => {
     loadSummary();
   }, [loadSummary]);
+
+  useEffect(() => {
+    if (!roleLoading && role !== null && !isOwnerOrAdmin(role)) {
+      router.replace('/dashboard/conversations');
+    }
+  }, [roleLoading, role, router]);
 
   useRealtime([{ channel: 'org' }], (event) => {
     if (

--- a/packages/dashboard-pages/src/shells/settings-shell.tsx
+++ b/packages/dashboard-pages/src/shells/settings-shell.tsx
@@ -106,7 +106,7 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
           </div>
         </aside>
 
-        <div className="flex-1 min-w-0 space-y-10 bg-paper px-6 py-8 md:px-12 md:py-10 dark:bg-background">
+        <div className="flex-1 min-w-0 space-y-10 bg-paper px-4 py-8 md:px-12 md:py-10 dark:bg-background">
           {children}
         </div>
       </div>


### PR DESCRIPTION
Last of six PRs implementing the Oversight console designs. Stacked on #862.

## Card layout

The design's Channels card puts status beside the kind, not under the name, and closes with a ruled footer — meta on the left, actions on the right. `SettingsCard` is shared (that was the point of #851), so Channels, Trackers and Integrations all pick the change up together.

Channels already had **Edit** as a visible footer action, so nothing was hidden behind hover there. The `⋯` menu stays for the extras that have no room on a card face (rotate key, rotate identity secret).

Settings content also drops to a 16px gutter on phones, matching the console pages in the rest of the stack.

## A role gap this stack opened

`SettingsShell` has always been admin-only and redirects anyone else to `/dashboard`. PR #858 put Settings in the console nav for every role, so a support agent got a menu entry that bounced them straight back — worse than not showing it.

Three fixes, all consistent with the design:

- **Workspace is admin-gated in the nav**, so the link is not drawn for a member.
- **The overview sends a non-admin to the review queue** instead of rendering an admin landing page. This is what the desktop design does too — its initial view is `role === 'agent' ? 'queue' : 'overview'`.
- **The mobile menu sheet renders the role note**, so a shorter menu reads as deliberate rather than broken. `roleNote` was added to the shell in #858 and had no caller until now.

Two tests pin it: a member sees only the Oversight group, and no nav href a member is offered would bounce them.

## Deliberately not done

The design also sketches non-Channels settings panes as generic name / value / tag rows. The real panes — Team, API keys, End-users, Trackers, Integrations — are purpose-built and richer than that; flattening them to generic rows would lose function, so I left them alone.

The design's mobile menu also implies a support agent can open Settings. Nothing in OSS settings is usable by a member today (`PATCH /v1/orgs/me` and every other pane are `@RequireRole('owner','admin')`), so rather than ship an empty page I gated the link and made the reduced menu explain itself. A member-facing settings surface — own profile, notification preferences — is a separate piece of work.

## Testing

120 dashboard tests pass; typecheck and lint clean for the package and the app.