### PR TITLE
fix(slack): name a customer from their end-user identity

### DIFF
--- a/.changeset/slack-end-user-identity-fallback.md
+++ b/.changeset/slack-end-user-identity-fallback.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Slack now names a customer from their end-user identity when the contact row is bare.
+
+The Slack bridge resolved a customer's display name from `conv_contacts` alone — name, then email, then phone — and fell back to the literal "Customer" when all three were null. Every other read of a conversation goes through `ConvService.getConversation`, which falls back to the linked `end_users` row (`contactEmail: row.contactEmail ?? row.endUserEmail`). Two chains, one conversation, different answers.
+
+That gap is reachable on the widget's normal identity path. A visitor who chats anonymously first gets a contact row with no name or email; when they later verify, `findOrCreateContact` and `claimAnonymousIdentityInTx` stamp `endUserId` and `metadata.externalId` onto that row but never backfill `email` or `name`. The identity carries the address, the contact does not — so the dashboard showed the customer's email while Slack showed "Customer", with nothing misconfigured on either side.
+
+`loadConversation` now loads the linked end user and merges the two the same way the conversation DTO does, so the thread parent's `*From:*` line, the per-message speaker name and the Slack avatar initial all agree with the dashboard. "Customer" is once again reserved for a genuinely unidentified visitor.

--- a/packages/backend-core/src/modules/slack/slack-bridge.integration.test.ts
+++ b/packages/backend-core/src/modules/slack/slack-bridge.integration.test.ts
@@ -299,6 +299,55 @@ function actionIds(blocks: unknown[] | undefined): string[] {
     expect(messageLink?.origin).toBe('mirrored');
   });
 
+  it('names an end user from the linked identity when the contact row carries no name or email', async () => {
+    const api = new FakeSlackApi();
+    const worker = new SlackBridgeWorker(db, api);
+    const claimedEmail = `claimed-${randomUUID()}@example.com`;
+    const [endUser] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: randomUUID(), email: claimedEmail })
+      .returning();
+    const [bareContact] = await db
+      .insert(schema.convContacts)
+      .values({ orgId, endUserId: endUser!.id, metadata: { externalId: endUser!.externalId } })
+      .returning();
+    displayIdSeq += 1;
+    const [conversation] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        displayId: displayIdSeq,
+        channelId,
+        contactId: bareContact!.id,
+        endUserId: endUser!.id,
+      })
+      .returning();
+    const [message] = await db
+      .insert(schema.convMessages)
+      .values({
+        orgId,
+        conversationId: conversation!.id,
+        authorType: 'end_user',
+        authorId: bareContact!.id,
+        body: 'Test',
+      })
+      .returning();
+
+    await enqueue('conversation.created', conversation!.id, { conversationId: conversation!.id });
+    await enqueue('conversation.message.received', conversation!.id, {
+      conversationId: conversation!.id,
+      messageId: message!.id,
+      authorType: 'end_user',
+      internal: false,
+    });
+
+    await worker.tick();
+    const [parent, reply] = api.posted;
+    expect(parent!.text).toContain(claimedEmail);
+    expect(reply!.username).toBe(claimedEmail);
+    expect(reply!.username).not.toBe('Customer');
+  });
+
   it('never posts a message that already has a slack ts (loop prevention)', async () => {
     const api = new FakeSlackApi();
     const worker = new SlackBridgeWorker(db, api);

--- a/packages/backend-core/src/modules/slack/slack-bridge.worker.ts
+++ b/packages/backend-core/src/modules/slack/slack-bridge.worker.ts
@@ -1014,18 +1014,32 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
             .limit(1)
         )[0]
       : undefined;
+    const endUser = conversation.endUserId
+      ? (
+          await this.db
+            .select({
+              name: schema.endUsers.name,
+              email: schema.endUsers.email,
+              phone: schema.endUsers.phone,
+            })
+            .from(schema.endUsers)
+            .where(eq(schema.endUsers.id, conversation.endUserId))
+            .limit(1)
+        )[0]
+      : undefined;
 
+    const phone = contact?.phone ?? endUser?.phone ?? null;
     const snapshot: ConversationSnapshot = {
       displayId: conversation.displayId,
       subject: conversation.subject,
       channelType: channel?.type ?? 'unknown',
       channelName: channel?.name ?? null,
-      contactName: contact?.name ?? null,
-      contactEmail: contact?.email ?? null,
-      contactPhone: contact?.phone ? formatPhoneNumber(contact.phone) : null,
+      contactName: contact?.name ?? endUser?.name ?? null,
+      contactEmail: contact?.email ?? endUser?.email ?? null,
+      contactPhone: phone ? formatPhoneNumber(phone) : null,
       dashboardUrl: `${readWebBaseUrl()}/dashboard`,
     };
-    return { conversation, contact: contact ?? null, snapshot };
+    return { conversation, snapshot };
   }
 
   private async authorName(
@@ -1035,10 +1049,8 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
   ): Promise<string | null> {
     if (kind === 'user') return await this.userName(authorId);
     if (kind === 'end_user') {
-      if (context.contact?.name) return context.contact.name;
-      if (context.contact?.email) return context.contact.email;
-      if (context.contact?.phone) return formatPhoneNumber(context.contact.phone);
-      return null;
+      const { contactName, contactEmail, contactPhone } = context.snapshot;
+      return contactName ?? contactEmail ?? contactPhone ?? null;
     }
     if (kind === 'agent') {
       const [assistant] = await this.db
@@ -1112,7 +1124,6 @@ export class SlackBridgeWorker implements OnModuleInit, OnModuleDestroy {
 
 interface ConversationContext {
   conversation: typeof schema.convConversations.$inferSelect;
-  contact: typeof schema.convContacts.$inferSelect | null;
   snapshot: ConversationSnapshot;
 }
 


### PR DESCRIPTION
Slack mirrored an identity-verified widget visitor as the literal **"Customer"** while the dashboard, for the same conversation, showed their email address. Nothing was misconfigured on either side — the two surfaces read identity through different chains.

## The two chains

`ConvService.getConversation` merges the contact row with the linked end user (`conv.service.ts:647-649`):

```ts
contactEmail: row.contactEmail ?? row.endUserEmail ?? null,
contactName: row.contactName ?? row.endUserName ?? null,
contactPhone: row.contactPhone ?? row.endUserPhone ?? null,
```

The Slack bridge read `conv_contacts` alone, then gave up:

```ts
if (context.contact?.name) return context.contact.name;
if (context.contact?.email) return context.contact.email;
if (context.contact?.phone) return formatPhoneNumber(context.contact.phone);
return null;                       // → speakerIdentity() → "Customer"
```

## Why the contact row is bare

This is reachable on the widget's ordinary identity path, not an exotic state. A visitor who chats anonymously first gets a contact row with no name or email. When they verify later, `findOrCreateContact` (`widget-ingest.service.ts:806-808`) and `claimAnonymousIdentityInTx` (`:1024-1031`) stamp `endUserId` and `metadata.externalId` onto that row — but never backfill `email` or `name`. `verifyIdentity` returns `{ mode: 'verified', externalId }` and nothing else, so the address only ever lands on `end_users`.

Confirmed against a live record: `identity_resolve` returns `email: ola.nordmann+…@example.no, name: null`, and `conv_get_conversation` reports that same email — but only because the DTO merges it in. The raw `conv_contacts.email` is null, which is exactly what Slack was reading.

## The fix

`loadConversation` now loads the linked end user and merges it the same way the conversation DTO does. `authorName` reads the merged snapshot rather than the raw contact, so the thread parent's `*From:*` line, the per-message speaker name and the avatar initial all agree with the dashboard. `"Customer"` goes back to meaning a genuinely unidentified visitor.

`ConversationContext` drops its `contact` field — the merged snapshot was its only reader.

## Testing

New integration test seeds a bare contact linked to an end user that carries an email, and asserts the mirrored speaker is that address. Verified it fails without the fix:

```
AssertionError: expected ':speech_balloon: *New conversation #1…'
  to contain 'claimed-974340b8-…@example.com'
```

- Slack module suite: 180/180 passing
- Workspace typecheck + eslint clean
- Ran against a throwaway DB, since dropped

## Deliberately out of scope

- **The contact rows stay bare.** This fixes the read side only. Backfilling `conv_contacts.email`/`name` at claim time would fix the data too, but it changes widget write behavior and deserves its own PR.
- **`data-munin-visitor-name` is absent from `skill://conv/setup-chat-widget`.** It's documented on the docs site but not in the skill, so an agent provisioning a widget won't pass it — worth adding, but it was never the cause here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

