### PR TITLE
fix(conv): require the owning identity to mutate a claimed widget session

### DIFF
--- a/.changeset/widget-session-ownership-check.md
+++ b/.changeset/widget-session-ownership-check.md
@@ -1,0 +1,21 @@
+---
+'@getmunin/backend-core': patch
+---
+
+A widget session credential alone no longer mutates an identity-verified visitor's conversation.
+
+Three widget endpoints gated their ownership check on the caller's own claim:
+
+```ts
+if (identity.mode === 'verified') {
+  // …compare contact.metadata.externalId against identity.externalId
+}
+```
+
+Present no identity headers and the branch never runs. On a channel where `requireVerifiedIdentity` is `false` — the default, and the only configuration where verified and anonymous sessions coexist — `verifyIdentity` returns `{ mode: 'anonymous' }` rather than throwing, so a caller holding nothing but a `sessionId` skipped the check entirely and was treated as the session's owner. `PATCH /v1/widget/visitor` would then rewrite the `conv_contacts` row of an identity-verified person, and `end_users.email` with it; the two voice paths would start a call and post call events on their conversation.
+
+The session id is a bearer credential by design, but it is a weaker one than the identity HMAC, and it was buying identity-owner authority.
+
+The check is now driven by the state of the row being written rather than by what the caller volunteered: a contact claimed by a real `externalId` (anything that is not an `anon:…` placeholder) requires a matching verified identity, and an unclaimed contact stays open to the anonymous session that owns it. `assertContactIdentityOwnership` is shared by all three sites so they cannot drift apart again. The verified-caller branch is unchanged — only the previously unguarded anonymous path is refused, with each endpoint keeping the error code it already returned (`session_not_owned`, `conversation_identity_mismatch`).
+
+The bundled widget is unaffected: `setVisitorEmail` and `voiceStart` already attach `verifiedExternalId` + `userHash` from a live `getIdentity()` closure, which is populated both from the server-rendered embed attributes and after a runtime `window.mn.widget.identify()`. A custom server-to-server integration that patches a verified session without replaying the identity pair will now get a 403 and must send it.

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -336,18 +336,7 @@ export class WidgetIngestService {
     }
     const contactId = conv[0].contactId;
 
-    if (identity.mode === 'verified') {
-      const contact = await tx
-        .select({ metadata: schema.convContacts.metadata })
-        .from(schema.convContacts)
-        .where(eq(schema.convContacts.id, contactId))
-        .limit(1);
-      const contactExternalId = (contact[0]?.metadata as { externalId?: string } | undefined)
-        ?.externalId;
-      if (contactExternalId !== identity.externalId) {
-        throw new ForbiddenException('session_not_owned');
-      }
-    }
+    await assertContactIdentityOwnership(tx, contactId, identity, 'session_not_owned');
 
     const patch: Record<string, unknown> = {};
     if (input.email) patch.email = input.email.trim().toLowerCase();
@@ -1186,6 +1175,30 @@ function originMatches(allowlistEntry: string, origin: string): boolean {
   } catch {
     return false;
   }
+}
+
+export async function assertContactIdentityOwnership(
+  tx: Tx,
+  contactId: string,
+  identity: IdentityResolution,
+  errorCode: string,
+): Promise<void> {
+  const [row] = await tx
+    .select({ metadata: schema.convContacts.metadata })
+    .from(schema.convContacts)
+    .where(eq(schema.convContacts.id, contactId))
+    .limit(1);
+  const externalId = (row?.metadata as { externalId?: unknown } | null)?.externalId;
+  const claimedBy =
+    typeof externalId === 'string' && externalId.length > 0 && !externalId.startsWith('anon:')
+      ? externalId
+      : null;
+
+  if (identity.mode === 'verified') {
+    if (claimedBy !== identity.externalId) throw new ForbiddenException(errorCode);
+    return;
+  }
+  if (claimedBy) throw new ForbiddenException(errorCode);
 }
 
 export function verifyIdentity(

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.integration.test.ts
@@ -311,6 +311,50 @@ const skipReason = TEST_URL
     expect(JSON.stringify(json)).toContain('conversation_session_mismatch');
   });
 
+  it('rejects voice/start on an identity-claimed conversation from a caller presenting no identity', async () => {
+    const [claimedEndUser] = await db
+      .insert(schema.endUsers)
+      .values({ orgId, externalId: 'eu-claimed-wv', name: 'Claimed' })
+      .returning();
+    const [claimedContact] = await db
+      .insert(schema.convContacts)
+      .values({
+        orgId,
+        endUserId: claimedEndUser!.id,
+        name: 'Claimed',
+        metadata: { externalId: 'eu-claimed-wv' },
+      })
+      .returning();
+    const [claimedConv] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        displayId: 990,
+        channelId: widgetChannelId,
+        contactId: claimedContact!.id,
+        endUserId: claimedEndUser!.id,
+        status: 'open',
+        metadata: { sessionId: 'claimed_session_wv' },
+      })
+      .returning();
+
+    try {
+      const { status, json } = await call({
+        channelId: widgetChannelId,
+        conversationId: claimedConv!.id,
+        sessionId: 'claimed_session_wv',
+      });
+      expect(status).toBe(403);
+      expect(JSON.stringify(json)).toContain('conversation_identity_mismatch');
+    } finally {
+      await db
+        .delete(schema.convConversations)
+        .where(eq(schema.convConversations.id, claimedConv!.id));
+      await db.delete(schema.convContacts).where(eq(schema.convContacts.id, claimedContact!.id));
+      await db.delete(schema.endUsers).where(eq(schema.endUsers.id, claimedEndUser!.id));
+    }
+  });
+
   it('rejects when the bound widget channel has been deactivated', async () => {
     await db
       .update(schema.convChannels)

--- a/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-voice.service.ts
@@ -46,7 +46,12 @@ import type {
   WidgetVoiceStartInputT,
   WidgetVoiceStartResult,
 } from './widget.types.ts';
-import { enforceOriginAllowlist, loadWidgetChannel, verifyIdentity } from './widget-ingest.service.ts';
+import {
+  assertContactIdentityOwnership,
+  enforceOriginAllowlist,
+  loadWidgetChannel,
+  verifyIdentity,
+} from './widget-ingest.service.ts';
 
 const HISTORY_TURN_LIMIT = 20;
 const PROMPT_CACHE_TTL_MS = 60_000;
@@ -344,16 +349,13 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
     if (convSessionId !== input.sessionId) {
       throw new ForbiddenException('conversation_session_mismatch');
     }
-    if (identity.mode === 'verified' && conv.contactId) {
-      const [contactRow] = await tx
-        .select({ metadata: schema.convContacts.metadata })
-        .from(schema.convContacts)
-        .where(eq(schema.convContacts.id, conv.contactId))
-        .limit(1);
-      const contactExt = (contactRow?.metadata as { externalId?: unknown } | null)?.externalId;
-      if (contactExt !== identity.externalId) {
-        throw new ForbiddenException('conversation_identity_mismatch');
-      }
+    if (conv.contactId) {
+      await assertContactIdentityOwnership(
+        tx,
+        conv.contactId,
+        identity,
+        'conversation_identity_mismatch',
+      );
     }
     if (!conv.endUserId) {
       return { available: false, reason: 'conversation_has_no_end_user' };
@@ -439,16 +441,13 @@ export class WidgetVoiceService implements OnModuleInit, OnModuleDestroy {
       if (convSessionId !== input.sessionId) {
         throw new ForbiddenException('conversation_session_mismatch');
       }
-      if (identity.mode === 'verified' && conv.contactId) {
-        const [contactRow] = await tx
-          .select({ metadata: schema.convContacts.metadata })
-          .from(schema.convContacts)
-          .where(eq(schema.convContacts.id, conv.contactId))
-          .limit(1);
-        const contactExt = (contactRow?.metadata as { externalId?: unknown } | null)?.externalId;
-        if (contactExt !== identity.externalId) {
-          throw new ForbiddenException('conversation_identity_mismatch');
-        }
+      if (conv.contactId) {
+        await assertContactIdentityOwnership(
+          tx,
+          conv.contactId,
+          identity,
+          'conversation_identity_mismatch',
+        );
       }
 
       let body: string;

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -1543,6 +1543,79 @@ const skipReason = TEST_URL
     expect(endUsers[0]?.metadata).toMatchObject({ anonymous: true, emailSource: 'visitor' });
   });
 
+  it('rejects PATCH /visitor on a claimed session from a caller presenting no identity', async () => {
+    const sid = `vis_owned_${Date.now()}`;
+    const externalId = `user_owned_${Date.now()}`;
+    const userHash = signHmac(externalId, identityVerificationSecret);
+    await call('POST', '/v1/widget/messages', widgetKey, {
+      channelId,
+      sessionId: sid,
+      verifiedExternalId: externalId,
+      userHash,
+      visitor: { email: 'owner@example.com' },
+      messages: [{ role: 'end_user', body: 'mine' }],
+    });
+
+    const res = await call('PATCH', '/v1/widget/visitor', widgetKey, {
+      channelId,
+      sessionId: sid,
+      email: 'attacker@example.com',
+    });
+    expect(res.status).toBe(403);
+
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+    const contacts = await db
+      .select({ email: schema.convContacts.email })
+      .from(schema.convContacts)
+      .where(
+        and(
+          eq(schema.convContacts.orgId, orgId),
+          sql`${schema.convContacts.metadata}->>'externalId' = ${externalId}`,
+        ),
+      );
+    expect(contacts[0]?.email).toBe('owner@example.com');
+  });
+
+  it('allows PATCH /visitor on a claimed session from the identity that owns it', async () => {
+    const sid = `vis_owner_ok_${Date.now()}`;
+    const externalId = `user_owner_ok_${Date.now()}`;
+    const userHash = signHmac(externalId, identityVerificationSecret);
+    await call('POST', '/v1/widget/messages', widgetKey, {
+      channelId,
+      sessionId: sid,
+      verifiedExternalId: externalId,
+      userHash,
+      messages: [{ role: 'end_user', body: 'mine' }],
+    });
+
+    const res = await call('PATCH', '/v1/widget/visitor', widgetKey, {
+      channelId,
+      sessionId: sid,
+      verifiedExternalId: externalId,
+      userHash,
+      email: 'owner-updated@example.com',
+    });
+    expect(res.status).toBe(200);
+    expect((res.json as { email: string | null }).email).toBe('owner-updated@example.com');
+  });
+
+  it('still allows PATCH /visitor on an unclaimed anonymous session', async () => {
+    const sid = `vis_anon_ok_${Date.now()}`;
+    await call('POST', '/v1/widget/messages', widgetKey, {
+      channelId,
+      sessionId: sid,
+      messages: [{ role: 'end_user', body: 'anon' }],
+    });
+
+    const res = await call('PATCH', '/v1/widget/visitor', widgetKey, {
+      channelId,
+      sessionId: sid,
+      email: 'anon-ok@example.com',
+    });
+    expect(res.status).toBe(200);
+    expect((res.json as { email: string | null }).email).toBe('anon-ok@example.com');
+  });
+
   it('rejects PATCH /visitor with mismatched channelId', async () => {
     const res = await call('PATCH', '/v1/widget/visitor', widgetKey, {
       channelId: 'cch_nonexistent',


### PR DESCRIPTION
Surfaced by the security review of #884, which correctly classified it as **pre-existing on `main`** rather than something that PR introduced. Filing it separately as suggested.

## The bug

Three widget endpoints gated their ownership check on the caller's own claim:

```ts
if (identity.mode === 'verified') {
  // …compare contact.metadata.externalId against identity.externalId
}
```

Present no identity headers and the branch never runs. The guard is opt-in, and the attacker chooses whether to opt in.

This is only reachable when `requireVerifiedIdentity` is `false` — but that's the default, and it's the *only* configuration where verified and anonymous sessions coexist on one channel. With it set, `verifyIdentity` throws `identity_required` before any of this; without it, it returns `{ mode: 'anonymous' }` and the caller is treated as the session's owner.

**Impact** — a caller holding nothing but a `sessionId`, against an identity-verified visitor:

| Endpoint | What it could do |
|---|---|
| `PATCH /v1/widget/visitor` (`widget-ingest.service.ts:339`) | Rewrite their `conv_contacts` row, and `end_users.email` with it |
| `voice/start` (`widget-voice.service.ts:347`) | Start a voice call on their conversation |
| voice call events (`widget-voice.service.ts:442`) | Post call-started / call-ended messages into their thread |

The session id *is* a bearer credential by design — it moved to a header in 4.x precisely to keep it out of access logs. But it's a weaker credential than the identity HMAC, and here it was buying identity-owner authority.

## The fix

The check is now driven by the state of the row being written, not by what the caller volunteered. A contact claimed by a real `externalId` (anything that isn't an `anon:…` placeholder, matching the existing convention in `claimAnonymousIdentityInTx`) requires a matching verified identity; an unclaimed contact stays open to the anonymous session that owns it.

`assertContactIdentityOwnership` is shared by all three call sites so they can't drift apart again. The verified-caller branch is behaviourally identical — an `anon:` or absent `externalId` failed the old `!==` comparison too. Only the previously unguarded anonymous path is refused, and each endpoint keeps the error code it already returned.

## Compatibility

The bundled widget is unaffected. Both `setVisitorEmail` and `voiceStart` (`apps/chat-widget/src/api.ts:230`, `:261`) already attach `verifiedExternalId` + `userHash` from `deps.getIdentity?.()`, a live closure over `identity` in `widget.ts:47` that is populated from the server-rendered embed attributes *and* reassigned after a runtime `window.mn.widget.identify()`. I traced this before tightening the check specifically to confirm the mid-flight-claim case still sends identity.

A custom server-to-server integration that patches a verified session without replaying the identity pair will now get a 403 and must send it.

## Testing

Four new integration tests — the block plus regression guards that both legitimate paths still work (owning identity allowed; unclaimed anonymous session allowed), and the voice equivalent.

Verified each fails without the fix:

```
PATCH /visitor:  AssertionError: expected 200 to be 403
voice/start:     AssertionError: expected 201 to be 403
```

The first one is the exploit executing successfully on `main`. Conv + realtime suites: **441 passing across 40 files**. Typecheck + eslint clean.

Branched from `main`, independent of #882/#883/#884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
