### PR TITLE
fix(agent-runtime): call Anthropic's native Messages API so prompt caching works

### DIFF
--- a/.changeset/anthropic-native-provider.md
+++ b/.changeset/anthropic-native-provider.md
@@ -1,0 +1,18 @@
+---
+"@getmunin/agent-runtime": minor
+"@getmunin/agent-host": patch
+---
+
+Call Anthropic's native Messages API instead of its OpenAI compatibility endpoint, so prompt caching actually works.
+
+Orgs configured with the Anthropic provider preset were hitting `https://api.anthropic.com/v1/chat/completions` — the OpenAI SDK compatibility layer, which does not support prompt caching and silently ignores unsupported fields. Every `cache_control` marker the runtime emitted was being dropped, so the cache hit rate was zero and each request re-processed the whole system prompt and tool catalog at full price. The compat layer also returns an empty `usage.prompt_tokens_details`, so there was no signal that any of it was happening.
+
+`anthropicNativeProvider` posts to `/messages` with `x-api-key` + `anthropic-version`, and `defaultProvider` routes `api.anthropic.com` to it while everything else (OpenRouter, OpenAI, self-hosted vLLM) keeps using the OpenAI-compatible provider. Three cache breakpoints per request: the tool catalog and the system blocks at a 1-hour TTL, since both are shared across every conversation in an org, and the newest turn at the default 5-minute TTL, so each iteration of a tool loop reads the previous iteration's prefix instead of re-processing the whole history. That last one matters most for tool-heavy turns, where KB search and conversation-export results dominate the prompt.
+
+Assistant turns now round-trip their raw content blocks through `ChatMessage.providerContentBlocks`, so `thinking` blocks are echoed back byte-for-byte with their signatures. Without that, models where adaptive thinking is on by default reject the follow-up request that carries tool results. Cache breakpoints are only ever attached to `text` and `tool_result` blocks, never to a block we echo verbatim.
+
+`ProviderUsage` gains `cache_read_input_tokens` and `cache_creation_input_tokens` from the native response, and prompt tokens are reported as uncached + cache-read + cache-write so token metering still sees the full prompt. Nothing reads the two cache counters yet — threading them into `AgentReply` and per-org usage is a follow-up.
+
+The per-conversation context moves out of the cached prefix. `conv` used to append `You are replying in conversationId: <id>` to the end of the system prompt, which made the whole prefix — org system prompt, company profile, channel descriptor — vary per conversation and never share a cache entry. It is now passed as `AgentConfig.volatileSystemPrompt` and emitted as a trailing system block flagged `ChatMessage.volatile`, and the provider puts the breakpoint after the last non-volatile block (the same treatment the history-truncation note now gets). The stable prefix is shared by every conversation in an org. This helps the OpenRouter path too, whose breakpoint sits on the first system block and was previously carrying the conversation id along with it.
+
+Also drops `api.anthropic.com` from the OpenAI-compatible provider's cache auto-detection, which was the source of the false confidence, and moves the shared rate-limit retry and `ProviderError` classification into `providers/transport.ts` so both providers use one implementation.

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -34,7 +34,7 @@ import {
   composeToolHandles,
   createConversationHandler,
   createPromptResolver,
-  openAiCompatibleProvider,
+  defaultProvider,
   openHttpMcpClient,
   runSkillPass,
   type ExternalToolSource,
@@ -351,7 +351,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
   }
 
   private meteringProvider(id: string, orgId: string): Provider {
-    return createMeteringProvider(openAiCompatibleProvider, (totalTokens) => {
+    return createMeteringProvider(defaultProvider, (totalTokens) => {
       const rateLimit = this.rateLimit;
       if (!rateLimit) return;
       void runWithServiceContext(

--- a/packages/agent-host/src/web-import.handler.ts
+++ b/packages/agent-host/src/web-import.handler.ts
@@ -1,8 +1,8 @@
 import {
   WebCrawler,
   classifyProviderError,
+  defaultProvider,
   fenceUntrusted,
-  openAiCompatibleProvider,
   probeUrl,
   sanitizeAttributeValue,
   type CrawledPage,
@@ -414,7 +414,7 @@ async function generateCompanyProfile(opts: {
   const userPrompt = buildProfileUserPrompt(opts.siteTitle, opts.siteUrl, opts.pages);
 
   try {
-    const callProvider = opts.providerImpl ?? openAiCompatibleProvider;
+    const callProvider = opts.providerImpl ?? defaultProvider;
     const response = await callProvider({
       config: {
         provider: { baseUrl: opts.provider.baseUrl, apiKey: opts.provider.apiKey },

--- a/packages/agent-runtime/src/audit.ts
+++ b/packages/agent-runtime/src/audit.ts
@@ -1,4 +1,4 @@
-import { openAiCompatibleProvider } from './providers/openai-compatible.ts';
+import { defaultProvider } from './providers/default-provider.ts';
 import type { ChatMessage, Provider, ProviderConfig } from './types.ts';
 
 export type AuditAction =
@@ -67,7 +67,7 @@ Each entry in \`actions\` is one of the action shapes below. Multiple actions ca
 `;
 
 export async function auditConversation(args: AuditConversationArgs): Promise<AuditVerdict> {
-  const provider = args.providerImpl ?? openAiCompatibleProvider;
+  const provider = args.providerImpl ?? defaultProvider;
   const systemPrompt = buildSystemPrompt(args.topicCatalog);
   const userPrompt = buildUserPrompt(
     args.question,

--- a/packages/agent-runtime/src/conversation-handler.test.ts
+++ b/packages/agent-runtime/src/conversation-handler.test.ts
@@ -188,7 +188,7 @@ describe('createConversationHandler', () => {
     });
     handler.handle({ conversationId: 'conv_1', authorType: 'agent' });
     await handler.flush();
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+     
     expect(rest.getConversation).not.toHaveBeenCalled();
   });
 
@@ -1223,7 +1223,45 @@ describe('createConversationHandler', () => {
     handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
     await handler.flush();
 
-    expect(captured[0]).toMatch(/^JUST_BASE\n\n\[Conversation context\]/);
+    expect(captured[0]).toBe('JUST_BASE');
+  });
+
+  it('keeps the per-conversation context out of the cacheable system prefix', async () => {
+    const rest = buildRest();
+    const calls: Array<Array<{ content: string; volatile?: boolean }>> = [];
+    const stubProvider: Provider = ({ messages }) => {
+      calls.push(
+        messages
+          .filter((m) => m.role === 'system')
+          .map((m) => ({ content: m.content ?? '', volatile: m.volatile })),
+      );
+      return Promise.resolve({
+        message: { role: 'assistant', content: 'ok' },
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        finishReason: 'stop',
+      });
+    };
+
+    const handler = createConversationHandler({
+      config: baseConfig,
+      rest,
+      prompts: buildPrompts({ system: 'JUST_BASE' }),
+      openMcp: () => Promise.resolve(buildMcp()),
+      logger: silentLogger,
+      scheduler: noDelayScheduler,
+      provider: stubProvider,
+    });
+
+    handler.handle({ conversationId: 'conv_1', authorType: 'end_user' });
+    await handler.flush();
+
+    const systemBlocks = calls[0] ?? [];
+    const stable = systemBlocks.filter((m) => !m.volatile);
+    const volatileBlocks = systemBlocks.filter((m) => m.volatile);
+    expect(stable.some((m) => m.content.includes('conv_1'))).toBe(false);
+    expect(volatileBlocks).toHaveLength(1);
+    expect(volatileBlocks[0]?.content).toContain('conversationId: conv_1');
+    expect(systemBlocks[systemBlocks.length - 1]?.volatile).toBe(true);
   });
 
   it('proceeds with the reply when beforeGenerate throws (fail-open like the curator)', async () => {

--- a/packages/agent-runtime/src/conversation-handler.ts
+++ b/packages/agent-runtime/src/conversation-handler.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { auditConversation, type AuditAction, type AuditTopic } from './audit.ts';
 import { deriveMessageComponents } from './message-components.ts';
 import { deriveRetrievedDocumentIds } from './kb-citations.ts';
-import { classifyProviderError, type ProviderErrorCode } from './providers/openai-compatible.ts';
+import { classifyProviderError, type ProviderErrorCode } from './providers/transport.ts';
 import { runAgent } from './runtime.ts';
 import type {
   ConversationMessage,
@@ -266,11 +266,11 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
     const companyBlock = companyContext
       ? `\n\n[Company context]\n${COMPANY_CONTEXT_NOTE}\n${fenceUntrusted('company_context', companyContext)}`
       : '';
-    const conversationContext = `\n\n[Conversation context]\nYou are replying in conversationId: ${conversationId}. Pass this exact value to any tool that asks for \`conversationId\` — never substitute placeholders like "current" or "this".`;
+    const conversationContext = `[Conversation context]\nYou are replying in conversationId: ${conversationId}. Pass this exact value to any tool that asks for \`conversationId\` — never substitute placeholders like "current" or "this".`;
     const namePreamble = assistantNamePreamble(detail.assistantName);
     const systemBody = channelDescriptor
-      ? `${baseSystem}${companyBlock}\n\n${channelDescriptor}${conversationContext}`
-      : `${baseSystem}${companyBlock}${conversationContext}`;
+      ? `${baseSystem}${companyBlock}\n\n${channelDescriptor}`
+      : `${baseSystem}${companyBlock}`;
     const systemPrompt = `${namePreamble}${systemBody}`;
 
     if (deps.beforeGenerate) {
@@ -304,6 +304,7 @@ export function createConversationHandler(deps: ConversationHandlerDeps): Conver
             },
             model: deps.config.model,
             systemPrompt,
+            volatileSystemPrompt: conversationContext,
             maxToolIterations: deps.config.maxToolIterations,
             maxHistoryChars: deps.config.maxHistoryChars,
           },

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -6,13 +6,18 @@ export {
   sanitizeToolName,
   RESERVED_FRAMING_TAGS,
 } from './untrusted.ts';
+export { openAiCompatibleProvider } from './providers/openai-compatible.ts';
 export {
-  openAiCompatibleProvider,
+  anthropicNativeProvider,
+  isAnthropicNativeBaseUrl,
+} from './providers/anthropic-native.ts';
+export { defaultProvider, selectProvider } from './providers/default-provider.ts';
+export {
   ProviderError,
   classifyProviderError,
   type ProviderErrorCode,
   type ProviderErrorClassification,
-} from './providers/openai-compatible.ts';
+} from './providers/transport.ts';
 export { createStubProvider, type StubProviderHandle, type StubScript } from './providers/stub.ts';
 export { mcpToolsToChatTools, flattenToolResult } from './mcp-tool-translation.ts';
 export {

--- a/packages/agent-runtime/src/providers/anthropic-native.test.ts
+++ b/packages/agent-runtime/src/providers/anthropic-native.test.ts
@@ -1,0 +1,481 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import * as core from '@getmunin/core';
+import {
+  anthropicNativeProvider,
+  isAnthropicNativeBaseUrl,
+  fromNativeContent,
+  toNativeMessages,
+  toNativeSystem,
+  toNativeTools,
+  toProviderUsage,
+} from './anthropic-native.ts';
+import { selectProvider } from './default-provider.ts';
+import { openAiCompatibleProvider } from './openai-compatible.ts';
+import type { ChatMessage, ChatToolCall, ChatToolDefinition } from '../types.ts';
+
+interface CapturedRequest {
+  url?: string;
+  headers?: Record<string, string>;
+  body?: Record<string, unknown>;
+}
+
+function stubSafeFetch(
+  captured: CapturedRequest,
+  response: unknown,
+  status = 200,
+): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(
+    (url: string, init: { body?: unknown; headers?: Record<string, string> }) => {
+      captured.url = url;
+      captured.headers = init.headers;
+      captured.body = JSON.parse(init.body as string) as Record<string, unknown>;
+      return Promise.resolve({
+        ok: status >= 200 && status < 300,
+        status,
+        json: () => Promise.resolve(response),
+        text: () =>
+          Promise.resolve(
+            typeof response === 'string' ? response : JSON.stringify(response),
+          ),
+      });
+    },
+  );
+  vi.spyOn(core, 'safeFetch').mockImplementation(fn as unknown as typeof core.safeFetch);
+  return fn;
+}
+
+const okResponse = {
+  content: [{ type: 'text', text: 'hello' }],
+  stop_reason: 'end_turn',
+  usage: { input_tokens: 10, output_tokens: 3 },
+};
+
+function call(
+  overrides: Partial<Parameters<typeof anthropicNativeProvider>[0]> = {},
+): Promise<unknown> {
+  return anthropicNativeProvider({
+    config: {
+      provider: { baseUrl: 'https://api.anthropic.com/v1', apiKey: 'sk-ant-xxx' },
+      model: 'claude-haiku-4-5',
+      systemPrompt: 'sys',
+    },
+    messages: [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+    ],
+    tools: [],
+    ...overrides,
+  });
+}
+
+describe('provider selection', () => {
+  it('routes api.anthropic.com to the native provider so cache_control is honoured', () => {
+    expect(selectProvider('https://api.anthropic.com/v1')).toBe(anthropicNativeProvider);
+    expect(isAnthropicNativeBaseUrl('https://api.anthropic.com/v1/')).toBe(true);
+  });
+
+  it('routes every other backend to the OpenAI-compatible provider', () => {
+    expect(selectProvider('https://openrouter.ai/api/v1')).toBe(openAiCompatibleProvider);
+    expect(selectProvider('https://api.openai.com/v1')).toBe(openAiCompatibleProvider);
+  });
+});
+
+describe('anthropicNativeProvider request', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('posts to /messages with the native auth and version headers', async () => {
+    const captured: CapturedRequest = {};
+    stubSafeFetch(captured, okResponse);
+
+    await call();
+
+    expect(captured.url).toBe('https://api.anthropic.com/v1/messages');
+    expect(captured.headers).toMatchObject({
+      'x-api-key': 'sk-ant-xxx',
+      'anthropic-version': '2023-06-01',
+    });
+    expect(captured.headers?.authorization).toBeUndefined();
+  });
+
+  it('always sends max_tokens, which the native API requires', async () => {
+    const captured: CapturedRequest = {};
+    stubSafeFetch(captured, okResponse);
+
+    await call();
+
+    expect(captured.body?.max_tokens).toBe(8192);
+  });
+
+  it('prefers a configured max_tokens over the default', async () => {
+    const captured: CapturedRequest = {};
+    stubSafeFetch(captured, okResponse);
+
+    await call({
+      config: {
+        provider: { baseUrl: 'https://api.anthropic.com/v1', apiKey: 'k' },
+        model: 'claude-haiku-4-5',
+        systemPrompt: 'sys',
+        maxTokens: 1234,
+      },
+    });
+
+    expect(captured.body?.max_tokens).toBe(1234);
+  });
+
+  it('hoists system messages out of the messages array into system blocks', async () => {
+    const captured: CapturedRequest = {};
+    stubSafeFetch(captured, okResponse);
+
+    await call({
+      messages: [
+        { role: 'system', content: 'first' },
+        { role: 'system', content: 'second' },
+        { role: 'user', content: 'hi' },
+      ],
+    });
+
+    const system = captured.body?.system as Array<Record<string, unknown>>;
+    expect(system).toHaveLength(2);
+    expect(system[0]).toEqual({ type: 'text', text: 'first' });
+    const messages = captured.body?.messages as Array<{ role: string }>;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.role).toBe('user');
+  });
+
+  it('omits system and tools when there are none', async () => {
+    const captured: CapturedRequest = {};
+    stubSafeFetch(captured, okResponse);
+
+    await call({ messages: [{ role: 'user', content: 'hi' }], tools: [] });
+
+    expect(captured.body).not.toHaveProperty('system');
+    expect(captured.body).not.toHaveProperty('tools');
+  });
+
+  it('drops response_format, which the native API does not accept', async () => {
+    const captured: CapturedRequest = {};
+    stubSafeFetch(captured, okResponse);
+
+    await call({
+      config: {
+        provider: { baseUrl: 'https://api.anthropic.com/v1', apiKey: 'k' },
+        model: 'claude-haiku-4-5',
+        systemPrompt: 'sys',
+        responseFormat: 'json_object',
+      },
+    });
+
+    expect(captured.body).not.toHaveProperty('response_format');
+  });
+
+  it('surfaces a non-2xx response as a classified ProviderError', async () => {
+    const captured: CapturedRequest = {};
+    stubSafeFetch(captured, { error: 'invalid x-api-key' }, 401);
+
+    const err = await call().catch((e: unknown) => e);
+
+    expect(err).toMatchObject({ name: 'ProviderError', code: 'provider_auth', status: 401 });
+  });
+});
+
+describe('cache breakpoints', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('caches the tools+system prefix for an hour and the turn prefix for five minutes', async () => {
+    const captured: CapturedRequest = {};
+    stubSafeFetch(captured, okResponse);
+
+    await call({
+      messages: [
+        { role: 'system', content: 'stable' },
+        { role: 'system', content: 'note' },
+        { role: 'user', content: 'hi' },
+      ],
+      tools: [
+        { type: 'function', function: { name: 'a', description: 'a', parameters: {} } },
+        { type: 'function', function: { name: 'b', description: 'b', parameters: {} } },
+      ],
+    });
+
+    const system = captured.body?.system as Array<Record<string, unknown>>;
+    expect(system[0]?.cache_control).toBeUndefined();
+    expect(system[1]?.cache_control).toEqual({ type: 'ephemeral', ttl: '1h' });
+
+    const tools = captured.body?.tools as Array<Record<string, unknown>>;
+    expect(tools[0]?.cache_control).toBeUndefined();
+    expect(tools[1]?.cache_control).toEqual({ type: 'ephemeral', ttl: '1h' });
+
+    const messages = captured.body?.messages as Array<{ content: Array<Record<string, unknown>> }>;
+    expect(messages[0]?.content[0]?.cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('breaks after the last stable system block so volatile context stays outside the prefix', () => {
+    const blocks = toNativeSystem([
+      { role: 'system', content: 'org prompt' },
+      { role: 'system', content: 'untrusted-data note' },
+      { role: 'system', content: 'conversationId: conv_1', volatile: true },
+    ]) as Array<Record<string, unknown>>;
+
+    expect(blocks[0]?.cache_control).toBeUndefined();
+    expect(blocks[1]?.cache_control).toEqual({ type: 'ephemeral', ttl: '1h' });
+    expect(blocks[2]?.cache_control).toBeUndefined();
+    expect(blocks[2]?.text).toBe('conversationId: conv_1');
+  });
+
+  it('skips the system breakpoint entirely when every block is volatile', () => {
+    const blocks = toNativeSystem([
+      { role: 'system', content: 'conversationId: conv_1', volatile: true },
+    ]) as Array<Record<string, unknown>>;
+
+    expect(blocks[0]?.cache_control).toBeUndefined();
+  });
+
+  it('moves the turn breakpoint to the newest tool results so the next iteration reads them', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: null, tool_calls: [toolCall('c1', 'kb_search')] },
+      { role: 'tool', tool_call_id: 'c1', content: 'docs' },
+    ];
+
+    const native = toNativeMessages(messages);
+
+    expect(native).toHaveLength(3);
+    const first = native[0]?.content[0] as Record<string, unknown>;
+    expect(first.cache_control).toBeUndefined();
+    const last = native[2]?.content[0] as Record<string, unknown>;
+    expect(last.cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('never marks a signed thinking block, which must be echoed back byte-for-byte', () => {
+    const native = toNativeMessages([
+      { role: 'user', content: 'hi' },
+      {
+        role: 'assistant',
+        content: null,
+        providerContentBlocks: [{ type: 'thinking', thinking: '', signature: 'sig' }],
+      },
+    ]);
+
+    expect(native[1]?.content).toEqual([
+      { type: 'thinking', thinking: '', signature: 'sig' },
+    ]);
+  });
+
+  it('emits no cache_control when caching is explicitly disabled', () => {
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+    ];
+    const tools: ChatToolDefinition[] = [
+      { type: 'function', function: { name: 'a', parameters: {} } },
+    ];
+
+    expect(toNativeSystem(messages, false)).toEqual([{ type: 'text', text: 'sys' }]);
+    expect(toNativeTools(tools, false)).toEqual([{ name: 'a', input_schema: {} }]);
+    const native = toNativeMessages(messages, false);
+    expect(native[0]?.content[0]).toEqual({ type: 'text', text: 'hi' });
+  });
+});
+
+describe('toNativeMessages', () => {
+  it('translates an assistant tool call into a tool_use block', () => {
+    const native = toNativeMessages(
+      [
+        { role: 'user', content: 'hi' },
+        {
+          role: 'assistant',
+          content: 'let me look',
+          tool_calls: [toolCall('c1', 'kb_search', '{"q":"pricing"}')],
+        },
+      ],
+      false,
+    );
+
+    expect(native[1]).toEqual({
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'let me look' },
+        { type: 'tool_use', id: 'c1', name: 'kb_search', input: { q: 'pricing' } },
+      ],
+    });
+  });
+
+  it('merges parallel tool results into one user message', () => {
+    const native = toNativeMessages(
+      [
+        { role: 'user', content: 'hi' },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [toolCall('c1', 'a'), toolCall('c2', 'b')],
+        },
+        { role: 'tool', tool_call_id: 'c1', content: 'r1' },
+        { role: 'tool', tool_call_id: 'c2', content: 'r2' },
+      ],
+      false,
+    );
+
+    expect(native).toHaveLength(3);
+    expect(native[2]).toEqual({
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'c1', content: 'r1' },
+        { type: 'tool_result', tool_use_id: 'c2', content: 'r2' },
+      ],
+    });
+  });
+
+  it('echoes an assistant turn back verbatim so thinking blocks keep their signatures', () => {
+    const blocks = [
+      { type: 'thinking', thinking: '', signature: 'sig-abc' },
+      { type: 'tool_use', id: 'c1', name: 'kb_search', input: {} },
+    ];
+    const native = toNativeMessages(
+      [
+        { role: 'user', content: 'hi' },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [toolCall('c1', 'kb_search')],
+          providerContentBlocks: blocks,
+        },
+      ],
+      false,
+    );
+
+    expect(native[1]?.content).toEqual(blocks);
+  });
+
+  it('prepends a user turn when history opens with an assistant message', () => {
+    const native = toNativeMessages(
+      [{ role: 'assistant', content: 'we emailed you earlier' }],
+      false,
+    );
+
+    expect(native[0]?.role).toBe('user');
+    expect(native).toHaveLength(2);
+    expect(native[1]?.role).toBe('assistant');
+  });
+
+  it('skips empty messages, which the native API rejects as empty content', () => {
+    const native = toNativeMessages(
+      [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: '' },
+        { role: 'user', content: '' },
+      ],
+      false,
+    );
+
+    expect(native).toHaveLength(1);
+    expect(native[0]).toEqual({ role: 'user', content: [{ type: 'text', text: 'hi' }] });
+  });
+});
+
+describe('fromNativeContent', () => {
+  it('splits text and tool_use blocks, ignoring thinking blocks', () => {
+    const { text, toolCalls } = fromNativeContent([
+      { type: 'thinking', thinking: '' },
+      { type: 'text', text: 'checking' },
+      { type: 'tool_use', id: 'c1', name: 'kb_search', input: { q: 'x' } },
+    ]);
+
+    expect(text).toBe('checking');
+    expect(toolCalls).toEqual([
+      { id: 'c1', type: 'function', function: { name: 'kb_search', arguments: '{"q":"x"}' } },
+    ]);
+  });
+
+  it('returns empty text when the turn is only tool calls', () => {
+    const { text, toolCalls } = fromNativeContent([
+      { type: 'tool_use', id: 'c1', name: 'a', input: {} },
+    ]);
+
+    expect(text).toBe('');
+    expect(toolCalls).toHaveLength(1);
+  });
+});
+
+describe('anthropicNativeProvider response', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports tool_calls and keeps the raw blocks for the next request', async () => {
+    const captured: CapturedRequest = {};
+    const content = [
+      { type: 'thinking', thinking: '', signature: 'sig' },
+      { type: 'tool_use', id: 'c1', name: 'kb_search', input: { q: 'x' } },
+    ];
+    stubSafeFetch(captured, { content, stop_reason: 'tool_use', usage: {} });
+
+    const res = (await call()) as {
+      finishReason: string;
+      message: ChatMessage;
+    };
+
+    expect(res.finishReason).toBe('tool_calls');
+    expect(res.message.tool_calls).toHaveLength(1);
+    expect(res.message.providerContentBlocks).toEqual(content);
+  });
+
+  it('maps stop reasons onto the runtime finish reasons', async () => {
+    const cases: Array<[string, string]> = [
+      ['end_turn', 'stop'],
+      ['stop_sequence', 'stop'],
+      ['max_tokens', 'length'],
+      ['refusal', 'error'],
+    ];
+    for (const [stopReason, expected] of cases) {
+      const captured: CapturedRequest = {};
+      stubSafeFetch(captured, {
+        content: [{ type: 'text', text: 'x' }],
+        stop_reason: stopReason,
+      });
+      const res = (await call()) as { finishReason: string };
+      expect(res.finishReason).toBe(expected);
+      vi.restoreAllMocks();
+    }
+  });
+});
+
+describe('toProviderUsage', () => {
+  it('counts cached tokens as prompt tokens so metering sees the whole prompt', () => {
+    expect(
+      toProviderUsage({
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_input_tokens: 800,
+        cache_creation_input_tokens: 50,
+      }),
+    ).toEqual({
+      prompt_tokens: 950,
+      completion_tokens: 20,
+      total_tokens: 970,
+      cache_read_input_tokens: 800,
+      cache_creation_input_tokens: 50,
+    });
+  });
+
+  it('defaults the cache counters to zero when the response omits them', () => {
+    expect(toProviderUsage({ input_tokens: 5, output_tokens: 1 })).toEqual({
+      prompt_tokens: 5,
+      completion_tokens: 1,
+      total_tokens: 6,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    });
+  });
+
+  it('passes through an absent usage object', () => {
+    expect(toProviderUsage(undefined)).toBeUndefined();
+  });
+});
+
+function toolCall(id: string, name: string, args = '{}'): ChatToolCall {
+  return { id, type: 'function', function: { name, arguments: args } };
+}

--- a/packages/agent-runtime/src/providers/anthropic-native.ts
+++ b/packages/agent-runtime/src/providers/anthropic-native.ts
@@ -1,0 +1,311 @@
+import { stripTrailingSlashes } from '@getmunin/types';
+import { postJsonWithRateLimitRetry, ProviderError, throwProviderError } from './transport.ts';
+import type {
+  ChatMessage,
+  ChatToolCall,
+  ChatToolDefinition,
+  Provider,
+  ProviderResponse,
+  ProviderUsage,
+} from '../types.ts';
+
+const ANTHROPIC_VERSION = '2023-06-01';
+const DEFAULT_MAX_TOKENS = 8192;
+const HISTORY_START_MARKER = '[Conversation history begins.]';
+
+const CACHE_TURN = { type: 'ephemeral' } as const;
+const CACHE_PREFIX = { type: 'ephemeral', ttl: '1h' } as const;
+
+type CacheControl = typeof CACHE_TURN | typeof CACHE_PREFIX;
+
+interface NativeTextBlock {
+  type: 'text';
+  text: string;
+}
+
+interface NativeToolUseBlock {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+interface NativeToolResultBlock {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string;
+}
+
+export interface NativeMessage {
+  role: 'user' | 'assistant';
+  content: unknown[];
+}
+
+interface NativeUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+}
+
+interface NativeResponse {
+  content?: unknown[];
+  stop_reason?: string;
+  usage?: NativeUsage;
+}
+
+export function isAnthropicNativeBaseUrl(baseUrl: string): boolean {
+  return /api\.anthropic\.com/i.test(baseUrl);
+}
+
+export const anthropicNativeProvider: Provider = async ({
+  config,
+  messages,
+  tools,
+  abortSignal,
+}) => {
+  const url = `${stripTrailingSlashes(config.provider.baseUrl)}/messages`;
+  const cacheEnabled = config.enablePromptCache !== false;
+
+  const system = toNativeSystem(messages, cacheEnabled);
+  const body: Record<string, unknown> = {
+    model: config.model,
+    max_tokens: config.maxTokens ?? DEFAULT_MAX_TOKENS,
+    messages: toNativeMessages(messages, cacheEnabled),
+  };
+  if (system.length > 0) body.system = system;
+  if (tools.length > 0) body.tools = toNativeTools(tools, cacheEnabled);
+  if (typeof config.temperature === 'number') body.temperature = config.temperature;
+
+  const res = await postJsonWithRateLimitRetry({
+    url,
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': config.provider.apiKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+    },
+    body: JSON.stringify(body),
+    abortSignal,
+  });
+  if (!res.ok) await throwProviderError(res);
+
+  const json = (await res.json()) as NativeResponse;
+  const content = Array.isArray(json.content) ? json.content : [];
+  if (content.length === 0 && !json.stop_reason) {
+    throw new ProviderError('provider returned no content', 0);
+  }
+
+  const { text, toolCalls } = fromNativeContent(content);
+  const message: ChatMessage = {
+    role: 'assistant',
+    content: text.length > 0 ? text : null,
+    providerContentBlocks: content,
+  };
+  if (toolCalls.length > 0) message.tool_calls = toolCalls;
+
+  return {
+    message,
+    usage: toProviderUsage(json.usage),
+    finishReason: toFinishReason(json.stop_reason, toolCalls.length),
+  };
+};
+
+export function toNativeSystem(messages: ChatMessage[], cacheEnabled = true): unknown[] {
+  const blocks: unknown[] = [];
+  let lastStable = -1;
+  for (const m of messages) {
+    if (m.role !== 'system') continue;
+    if (typeof m.content !== 'string' || m.content.length === 0) continue;
+    if (!m.volatile) lastStable = blocks.length;
+    const block: NativeTextBlock = { type: 'text', text: m.content };
+    blocks.push(block);
+  }
+  if (!cacheEnabled || lastStable < 0) return blocks;
+  return markAt(blocks, lastStable, CACHE_PREFIX);
+}
+
+export function toNativeTools(tools: ChatToolDefinition[], cacheEnabled = true): unknown[] {
+  const mapped: unknown[] = tools.map((tool) => {
+    const spec: Record<string, unknown> = {
+      name: tool.function.name,
+      input_schema: tool.function.parameters,
+    };
+    if (tool.function.description) spec.description = tool.function.description;
+    return spec;
+  });
+  return cacheEnabled ? markLast(mapped, CACHE_PREFIX) : mapped;
+}
+
+export function toNativeMessages(
+  messages: ChatMessage[],
+  cacheEnabled = true,
+): NativeMessage[] {
+  const out: NativeMessage[] = [];
+  let openToolResults: NativeMessage | null = null;
+
+  for (const m of messages) {
+    if (m.role === 'system') continue;
+
+    if (m.role === 'tool') {
+      const block: NativeToolResultBlock = {
+        type: 'tool_result',
+        tool_use_id: m.tool_call_id ?? '',
+        content: m.content ?? '',
+      };
+      if (openToolResults) {
+        openToolResults.content.push(block);
+      } else {
+        openToolResults = { role: 'user', content: [block] };
+        out.push(openToolResults);
+      }
+      continue;
+    }
+
+    openToolResults = null;
+
+    if (m.role === 'assistant') {
+      const content = assistantContent(m);
+      if (content.length > 0) out.push({ role: 'assistant', content });
+      continue;
+    }
+
+    if (typeof m.content === 'string' && m.content.length > 0) {
+      const block: NativeTextBlock = { type: 'text', text: m.content };
+      out.push({ role: 'user', content: [block] });
+    }
+  }
+
+  if (out.length === 0 || out[0]?.role !== 'user') {
+    const block: NativeTextBlock = { type: 'text', text: HISTORY_START_MARKER };
+    out.unshift({ role: 'user', content: [block] });
+  }
+
+  if (!cacheEnabled) return out;
+
+  const last = out[out.length - 1];
+  if (!last) return out;
+  return [
+    ...out.slice(0, -1),
+    { ...last, content: markLastContentBlock(last.content, CACHE_TURN) },
+  ];
+}
+
+function assistantContent(m: ChatMessage): unknown[] {
+  if (m.providerContentBlocks && m.providerContentBlocks.length > 0) {
+    return m.providerContentBlocks;
+  }
+  const content: unknown[] = [];
+  if (typeof m.content === 'string' && m.content.length > 0) {
+    const block: NativeTextBlock = { type: 'text', text: m.content };
+    content.push(block);
+  }
+  for (const call of m.tool_calls ?? []) {
+    const block: NativeToolUseBlock = {
+      type: 'tool_use',
+      id: call.id,
+      name: call.function.name,
+      input: parseToolArguments(call.function.arguments),
+    };
+    content.push(block);
+  }
+  return content;
+}
+
+export function fromNativeContent(content: unknown[]): {
+  text: string;
+  toolCalls: ChatToolCall[];
+} {
+  const textParts: string[] = [];
+  const toolCalls: ChatToolCall[] = [];
+
+  for (const raw of content) {
+    if (!raw || typeof raw !== 'object') continue;
+    const block = raw as { type?: unknown; text?: unknown; id?: unknown; name?: unknown; input?: unknown };
+    if (block.type === 'text' && typeof block.text === 'string' && block.text.length > 0) {
+      textParts.push(block.text);
+      continue;
+    }
+    if (block.type === 'tool_use' && typeof block.id === 'string' && typeof block.name === 'string') {
+      toolCalls.push({
+        id: block.id,
+        type: 'function',
+        function: {
+          name: block.name,
+          arguments: JSON.stringify(
+            block.input && typeof block.input === 'object' ? block.input : {},
+          ),
+        },
+      });
+    }
+  }
+
+  return { text: textParts.join('\n'), toolCalls };
+}
+
+export function toProviderUsage(usage: NativeUsage | undefined): ProviderUsage | undefined {
+  if (!usage) return undefined;
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+  const promptTokens = (usage.input_tokens ?? 0) + cacheRead + cacheWrite;
+  const completionTokens = usage.output_tokens ?? 0;
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens + completionTokens,
+    cache_read_input_tokens: cacheRead,
+    cache_creation_input_tokens: cacheWrite,
+  };
+}
+
+function toFinishReason(
+  stopReason: string | undefined,
+  toolCallCount: number,
+): ProviderResponse['finishReason'] {
+  switch (stopReason) {
+    case 'tool_use':
+      return 'tool_calls';
+    case 'end_turn':
+    case 'stop_sequence':
+      return 'stop';
+    case 'max_tokens':
+      return 'length';
+    default:
+      return toolCallCount > 0 ? 'tool_calls' : 'error';
+  }
+}
+
+function parseToolArguments(raw: string): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function markLast(blocks: unknown[], cacheControl: CacheControl): unknown[] {
+  if (blocks.length === 0) return blocks;
+  return markAt(blocks, blocks.length - 1, cacheControl);
+}
+
+function markAt(blocks: unknown[], index: number, cacheControl: CacheControl): unknown[] {
+  const target = blocks[index];
+  if (!target || typeof target !== 'object') return blocks;
+  return blocks.map((block, i) =>
+    i === index ? { ...target, cache_control: cacheControl } : block,
+  );
+}
+
+const CACHEABLE_BLOCK_TYPES = new Set(['text', 'tool_result']);
+
+function markLastContentBlock(blocks: unknown[], cacheControl: CacheControl): unknown[] {
+  const last = blocks[blocks.length - 1];
+  if (!last || typeof last !== 'object') return blocks;
+  const type = (last as { type?: unknown }).type;
+  if (typeof type !== 'string' || !CACHEABLE_BLOCK_TYPES.has(type)) return blocks;
+  return markLast(blocks, cacheControl);
+}

--- a/packages/agent-runtime/src/providers/default-provider.ts
+++ b/packages/agent-runtime/src/providers/default-provider.ts
@@ -1,0 +1,10 @@
+import { anthropicNativeProvider, isAnthropicNativeBaseUrl } from './anthropic-native.ts';
+import { openAiCompatibleProvider } from './openai-compatible.ts';
+import type { Provider } from '../types.ts';
+
+export function selectProvider(baseUrl: string): Provider {
+  return isAnthropicNativeBaseUrl(baseUrl) ? anthropicNativeProvider : openAiCompatibleProvider;
+}
+
+export const defaultProvider: Provider = (args) =>
+  selectProvider(args.config.provider.baseUrl)(args);

--- a/packages/agent-runtime/src/providers/openai-compatible.test.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import * as core from '@getmunin/core';
 import {
-  parseRetryAfterMs,
-  rateLimitRetryDelayMs,
   shouldEnablePromptCache,
   withSystemPromptCache,
   withToolsCache,
@@ -33,7 +31,7 @@ describe('openAiCompatibleProvider request body', () => {
     vi.restoreAllMocks();
   });
 
-  it('emits cache_control on system + last tool when targeting Anthropic', async () => {
+  it('emits cache_control on system + last tool when targeting Claude via OpenRouter', async () => {
     const captured: { url?: string; body?: Record<string, unknown> } = {};
     stubSafeFetch((url, init) => {
       captured.url = url;
@@ -50,8 +48,8 @@ describe('openAiCompatibleProvider request body', () => {
 
     await openAiCompatibleProvider({
       config: {
-        provider: { baseUrl: 'https://api.anthropic.com/v1', apiKey: 'sk-ant-xxx' },
-        model: 'claude-haiku-4-5',
+        provider: { baseUrl: 'https://openrouter.ai/api/v1', apiKey: 'sk-or-xxx' },
+        model: 'anthropic/claude-haiku-4.5',
         systemPrompt: 'sys',
       },
       messages: [
@@ -181,54 +179,14 @@ describe('openAiCompatibleProvider rate-limit retries', () => {
   });
 });
 
-describe('rateLimitRetryDelayMs', () => {
-  it('grows exponentially across attempts', () => {
-    const half = (): number => 0;
-    expect(rateLimitRetryDelayMs(null, 0, half)).toBe(500);
-    expect(rateLimitRetryDelayMs(null, 1, half)).toBe(1_000);
-    expect(rateLimitRetryDelayMs(null, 2, half)).toBe(2_000);
-  });
-
-  it('jitters so that concurrent callers do not retry in lockstep', () => {
-    expect(rateLimitRetryDelayMs(null, 0, () => 0)).toBe(500);
-    expect(rateLimitRetryDelayMs(null, 0, () => 1)).toBe(1_000);
-  });
-
-  it('never waits less than the provider asked for', () => {
-    expect(rateLimitRetryDelayMs('3', 0, () => 0)).toBe(3_000);
-  });
-
-  it('caps the wait', () => {
-    expect(rateLimitRetryDelayMs('600', 4, () => 1)).toBe(15_000);
-  });
-});
-
-describe('parseRetryAfterMs', () => {
-  it('reads delay-seconds', () => {
-    expect(parseRetryAfterMs('2')).toBe(2_000);
-  });
-
-  it('reads an HTTP date', () => {
-    const at = new Date(Date.now() + 4_000).toUTCString();
-    const ms = parseRetryAfterMs(at);
-    expect(ms).toBeGreaterThan(2_000);
-    expect(ms).toBeLessThanOrEqual(5_000);
-  });
-
-  it('returns null for a missing or unparseable header', () => {
-    expect(parseRetryAfterMs(null)).toBeNull();
-    expect(parseRetryAfterMs('soon')).toBeNull();
-  });
-});
-
 describe('shouldEnablePromptCache', () => {
-  it('auto-enables for Anthropic native endpoint', () => {
+  it('does not auto-enable for api.anthropic.com, whose compat layer ignores cache_control', () => {
     expect(
       shouldEnablePromptCache({
         provider: { baseUrl: 'https://api.anthropic.com/v1' },
         model: 'claude-haiku-4-5',
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('auto-enables for OpenRouter with anthropic/* model', () => {
@@ -261,8 +219,8 @@ describe('shouldEnablePromptCache', () => {
   it('explicit false overrides auto-detection', () => {
     expect(
       shouldEnablePromptCache({
-        provider: { baseUrl: 'https://api.anthropic.com/v1' },
-        model: 'claude-haiku-4-5',
+        provider: { baseUrl: 'https://openrouter.ai/api/v1' },
+        model: 'anthropic/claude-haiku-4.5',
         enablePromptCache: false,
       }),
     ).toBe(false);

--- a/packages/agent-runtime/src/providers/openai-compatible.ts
+++ b/packages/agent-runtime/src/providers/openai-compatible.ts
@@ -1,4 +1,4 @@
-import { safeFetch } from '@getmunin/core';
+import { postJsonWithRateLimitRetry, ProviderError, throwProviderError } from './transport.ts';
 import type { ChatMessage, ChatToolDefinition, Provider, ProviderResponse } from '../types.ts';
 import { stripTrailingSlashes } from '@getmunin/types';
 
@@ -17,10 +17,6 @@ interface OpenAIResponse {
 }
 
 const CACHE_CONTROL = { type: 'ephemeral' } as const;
-
-const RATE_LIMIT_MAX_RETRIES = 4;
-const RATE_LIMIT_BASE_DELAY_MS = 500;
-const RATE_LIMIT_MAX_DELAY_MS = 15_000;
 
 export const openAiCompatibleProvider: Provider = async ({
   config,
@@ -44,19 +40,16 @@ export const openAiCompatibleProvider: Provider = async ({
     body.response_format = { type: 'json_object' };
   }
 
-  const res = await postChatCompletion({
+  const res = await postJsonWithRateLimitRetry({
     url,
-    apiKey: config.provider.apiKey,
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${config.provider.apiKey}`,
+    },
     body: JSON.stringify(body),
     abortSignal,
   });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new ProviderError(
-      `provider returned ${res.status}: ${text.slice(0, 500)}`,
-      res.status,
-    );
-  }
+  if (!res.ok) await throwProviderError(res);
 
   const json = (await res.json()) as OpenAIResponse;
   const choice = json.choices[0];
@@ -80,117 +73,6 @@ export const openAiCompatibleProvider: Provider = async ({
   };
 };
 
-async function postChatCompletion(args: {
-  url: string;
-  apiKey: string;
-  body: string;
-  abortSignal?: AbortSignal;
-}): Promise<Awaited<ReturnType<typeof safeFetch>>> {
-  for (let attempt = 0; ; attempt++) {
-    const res = await safeFetch(args.url, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        authorization: `Bearer ${args.apiKey}`,
-      },
-      body: args.body,
-      signal: args.abortSignal,
-    });
-    if (res.status !== 429 || attempt >= RATE_LIMIT_MAX_RETRIES) return res;
-    const retryAfter = res.headers.get('retry-after');
-    await sleep(rateLimitRetryDelayMs(retryAfter, attempt), args.abortSignal);
-  }
-}
-
-export function rateLimitRetryDelayMs(
-  retryAfter: string | null,
-  attempt: number,
-  random: () => number = Math.random,
-): number {
-  const backoff = Math.min(RATE_LIMIT_BASE_DELAY_MS * 2 ** attempt, RATE_LIMIT_MAX_DELAY_MS);
-  const requested = parseRetryAfterMs(retryAfter);
-  const wait = requested === null ? backoff : Math.max(requested, backoff);
-  return Math.min(RATE_LIMIT_MAX_DELAY_MS, Math.round(wait * (1 + random())));
-}
-
-export function parseRetryAfterMs(retryAfter: string | null): number | null {
-  if (!retryAfter) return null;
-  const seconds = Number(retryAfter);
-  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
-  const at = Date.parse(retryAfter);
-  return Number.isFinite(at) ? Math.max(0, at - Date.now()) : null;
-}
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(abortReason(signal));
-      return;
-    }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    const onAbort = (): void => {
-      clearTimeout(timer);
-      reject(abortReason(signal));
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
-
-function abortReason(signal?: AbortSignal): Error {
-  return signal?.reason instanceof Error ? signal.reason : new Error('aborted');
-}
-
-export type ProviderErrorCode =
-  | 'provider_auth'
-  | 'provider_regional'
-  | 'provider_rate_limit'
-  | 'provider_model_not_found'
-  | 'provider_other';
-
-export class ProviderError extends Error {
-  override readonly name = 'ProviderError';
-  readonly code: ProviderErrorCode;
-  constructor(
-    message: string,
-    public readonly status: number,
-  ) {
-    super(message);
-    this.code = classifyByStatus(status, message);
-  }
-}
-
-function classifyByStatus(status: number, message: string): ProviderErrorCode {
-  if (status === 401) return 'provider_auth';
-  if (status === 403) {
-    if (/region|regional/i.test(message)) return 'provider_regional';
-    return 'provider_auth';
-  }
-  if (status === 429) return 'provider_rate_limit';
-  if (status === 404 && /not[_ ]?found|model/i.test(message)) {
-    return 'provider_model_not_found';
-  }
-  return 'provider_other';
-}
-
-export interface ProviderErrorClassification {
-  code: ProviderErrorCode;
-  message: string;
-  status?: number;
-}
-
-export function classifyProviderError(err: unknown): ProviderErrorClassification {
-  if (err instanceof ProviderError) {
-    return { code: err.code, message: err.message, status: err.status };
-  }
-  if (err instanceof Error) {
-    return { code: 'provider_other', message: err.message };
-  }
-  return { code: 'provider_other', message: String(err) };
-}
-
 export function shouldEnablePromptCache(config: {
   provider: { baseUrl: string };
   model: string;
@@ -202,9 +84,7 @@ export function shouldEnablePromptCache(config: {
 }
 
 function isAnthropicCompatibleBackend(baseUrl: string, model: string): boolean {
-  if (/api\.anthropic\.com/i.test(baseUrl)) return true;
-  if (/openrouter\.ai/i.test(baseUrl) && /^anthropic\//i.test(model)) return true;
-  return false;
+  return /openrouter\.ai/i.test(baseUrl) && /^anthropic\//i.test(model);
 }
 
 export function withSystemPromptCache(messages: ChatMessage[]): unknown[] {

--- a/packages/agent-runtime/src/providers/transport.test.ts
+++ b/packages/agent-runtime/src/providers/transport.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { parseRetryAfterMs, rateLimitRetryDelayMs } from './transport.ts';
+
+describe('rateLimitRetryDelayMs', () => {
+  it('grows exponentially across attempts', () => {
+    const half = (): number => 0;
+    expect(rateLimitRetryDelayMs(null, 0, half)).toBe(500);
+    expect(rateLimitRetryDelayMs(null, 1, half)).toBe(1_000);
+    expect(rateLimitRetryDelayMs(null, 2, half)).toBe(2_000);
+  });
+
+  it('jitters so that concurrent callers do not retry in lockstep', () => {
+    expect(rateLimitRetryDelayMs(null, 0, () => 0)).toBe(500);
+    expect(rateLimitRetryDelayMs(null, 0, () => 1)).toBe(1_000);
+  });
+
+  it('never waits less than the provider asked for', () => {
+    expect(rateLimitRetryDelayMs('3', 0, () => 0)).toBe(3_000);
+  });
+
+  it('caps the wait', () => {
+    expect(rateLimitRetryDelayMs('600', 4, () => 1)).toBe(15_000);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('reads delay-seconds', () => {
+    expect(parseRetryAfterMs('2')).toBe(2_000);
+  });
+
+  it('reads an HTTP date', () => {
+    const at = new Date(Date.now() + 4_000).toUTCString();
+    const ms = parseRetryAfterMs(at);
+    expect(ms).toBeGreaterThan(2_000);
+    expect(ms).toBeLessThanOrEqual(5_000);
+  });
+
+  it('returns null for a missing or unparseable header', () => {
+    expect(parseRetryAfterMs(null)).toBeNull();
+    expect(parseRetryAfterMs('soon')).toBeNull();
+  });
+});

--- a/packages/agent-runtime/src/providers/transport.ts
+++ b/packages/agent-runtime/src/providers/transport.ts
@@ -1,0 +1,123 @@
+import { safeFetch } from '@getmunin/core';
+
+const RATE_LIMIT_MAX_RETRIES = 4;
+const RATE_LIMIT_BASE_DELAY_MS = 500;
+const RATE_LIMIT_MAX_DELAY_MS = 15_000;
+
+export async function postJsonWithRateLimitRetry(args: {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+  abortSignal?: AbortSignal;
+}): Promise<Awaited<ReturnType<typeof safeFetch>>> {
+  for (let attempt = 0; ; attempt++) {
+    const res = await safeFetch(args.url, {
+      method: 'POST',
+      headers: args.headers,
+      body: args.body,
+      signal: args.abortSignal,
+    });
+    if (res.status !== 429 || attempt >= RATE_LIMIT_MAX_RETRIES) return res;
+    const retryAfter = res.headers.get('retry-after');
+    await sleep(rateLimitRetryDelayMs(retryAfter, attempt), args.abortSignal);
+  }
+}
+
+export function rateLimitRetryDelayMs(
+  retryAfter: string | null,
+  attempt: number,
+  random: () => number = Math.random,
+): number {
+  const backoff = Math.min(RATE_LIMIT_BASE_DELAY_MS * 2 ** attempt, RATE_LIMIT_MAX_DELAY_MS);
+  const requested = parseRetryAfterMs(retryAfter);
+  const wait = requested === null ? backoff : Math.max(requested, backoff);
+  return Math.min(RATE_LIMIT_MAX_DELAY_MS, Math.round(wait * (1 + random())));
+}
+
+export function parseRetryAfterMs(retryAfter: string | null): number | null {
+  if (!retryAfter) return null;
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const at = Date.parse(retryAfter);
+  return Number.isFinite(at) ? Math.max(0, at - Date.now()) : null;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortReason(signal));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(abortReason(signal));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function abortReason(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error ? signal.reason : new Error('aborted');
+}
+
+export type ProviderErrorCode =
+  | 'provider_auth'
+  | 'provider_regional'
+  | 'provider_rate_limit'
+  | 'provider_model_not_found'
+  | 'provider_other';
+
+export class ProviderError extends Error {
+  override readonly name = 'ProviderError';
+  readonly code: ProviderErrorCode;
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.code = classifyByStatus(status, message);
+  }
+}
+
+function classifyByStatus(status: number, message: string): ProviderErrorCode {
+  if (status === 401) return 'provider_auth';
+  if (status === 403) {
+    if (/region|regional/i.test(message)) return 'provider_regional';
+    return 'provider_auth';
+  }
+  if (status === 429) return 'provider_rate_limit';
+  if (status === 404 && /not[_ ]?found|model/i.test(message)) {
+    return 'provider_model_not_found';
+  }
+  return 'provider_other';
+}
+
+export interface ProviderErrorClassification {
+  code: ProviderErrorCode;
+  message: string;
+  status?: number;
+}
+
+export function classifyProviderError(err: unknown): ProviderErrorClassification {
+  if (err instanceof ProviderError) {
+    return { code: err.code, message: err.message, status: err.status };
+  }
+  if (err instanceof Error) {
+    return { code: 'provider_other', message: err.message };
+  }
+  return { code: 'provider_other', message: String(err) };
+}
+
+export async function throwProviderError(
+  res: Awaited<ReturnType<typeof safeFetch>>,
+): Promise<never> {
+  const text = await res.text().catch(() => '');
+  throw new ProviderError(
+    `provider returned ${res.status}: ${text.slice(0, 500)}`,
+    res.status,
+  );
+}

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -1,5 +1,5 @@
 import { flattenToolResult, mcpToolsToChatTools } from './mcp-tool-translation.ts';
-import { openAiCompatibleProvider } from './providers/openai-compatible.ts';
+import { defaultProvider } from './providers/default-provider.ts';
 import { fenceUntrusted, sanitizeToolName } from './untrusted.ts';
 import type {
   AgentConfig,
@@ -35,7 +35,7 @@ export async function runAgent({
   history,
   mcp,
   abortSignal,
-  provider = openAiCompatibleProvider,
+  provider = defaultProvider,
 }: RunAgentArgs): Promise<AgentReply> {
   const tools = mcpToolsToChatTools(await mcp.listTools());
   const compacted = compactHistory(history, config.maxHistoryChars ?? DEFAULT_MAX_HISTORY_CHARS);
@@ -47,7 +47,11 @@ export async function runAgent({
     messages.push({
       role: 'system',
       content: `[Note: ${compacted.truncated} earlier message(s) in this conversation were omitted from the context window due to length. Do not invent details about them; ask the user to repeat anything you need.]`,
+      volatile: true,
     });
+  }
+  if (config.volatileSystemPrompt) {
+    messages.push({ role: 'system', content: config.volatileSystemPrompt, volatile: true });
   }
   for (const msg of compacted.history) messages.push(historyToChatMessage(msg));
 

--- a/packages/agent-runtime/src/skill-pass.ts
+++ b/packages/agent-runtime/src/skill-pass.ts
@@ -1,5 +1,5 @@
 import { assistantNamePreamble } from './conversation-handler.ts';
-import { classifyProviderError, type ProviderErrorCode } from './providers/openai-compatible.ts';
+import { classifyProviderError, type ProviderErrorCode } from './providers/transport.ts';
 import { runAgent } from './runtime.ts';
 import type { McpTool, McpToolHandle, McpToolResult, Provider } from './types.ts';
 

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -15,6 +15,7 @@ export interface AgentConfig {
   provider: ProviderConfig;
   model: string;
   systemPrompt: string;
+  volatileSystemPrompt?: string;
   maxToolIterations?: number;
   maxTokens?: number;
   temperature?: number;
@@ -63,6 +64,8 @@ export interface ChatMessage {
   name?: string;
   tool_call_id?: string;
   tool_calls?: ChatToolCall[];
+  providerContentBlocks?: unknown[];
+  volatile?: boolean;
 }
 
 export interface ChatToolCall {
@@ -87,6 +90,8 @@ export interface ProviderUsage {
   prompt_tokens?: number;
   completion_tokens?: number;
   total_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
 }
 
 export interface ProviderResponse {


### PR DESCRIPTION
Anthropic emailed us that Threll.ai's prompt cache hit rate is low, estimating up to 59% of direct API spend recoverable. It was zero, and the cause was the transport.

## The bug

Orgs on the Anthropic provider preset were hitting `https://api.anthropic.com/v1/chat/completions` — Anthropic's **OpenAI SDK compatibility layer**, which [does not support prompt caching](https://platform.claude.com/docs/en/cli-sdks-libraries/libraries/openai-sdk) and silently ignores unsupported fields. The runtime has emitted `cache_control` markers since the caching work landed, and `isAnthropicCompatibleBackend()` explicitly turned them on for `api.anthropic.com` — every one of them was dropped on the floor.

It was invisible from our side too: the compat layer returns `usage.prompt_tokens_details` as always empty, and `runtime.ts` only accumulated `prompt_tokens`/`completion_tokens`, so we had no cache counters anywhere. OpenRouter with an `anthropic/*` model was the only path where caching actually worked, which is why this went unnoticed — that's the default preset.

## The fix

`anthropicNativeProvider` posts to `/messages` with `x-api-key` + `anthropic-version`, translating the runtime's OpenAI-shaped `ChatMessage` both ways: system messages hoisted into `system` blocks, `tool_calls` → `tool_use`, `role:'tool'` → `tool_result` (parallel results merged into one user message so the model isn't trained out of parallel calls), `stop_reason` → the runtime's finish reasons. `defaultProvider` routes `api.anthropic.com` there and leaves every other backend — OpenRouter, OpenAI, self-hosted — on the compat provider. Dispatch is per-request on base URL, so the metering wrapper in `runner.service.ts` is unchanged.

**Three cache breakpoints per request** (max is 4):

| Breakpoint | TTL | Why |
|---|---|---|
| Last tool | 1h | Tool catalog is identical for every conversation in an org |
| Last non-volatile system block | 1h | Org prompt + company profile + channel descriptor, likewise |
| Newest turn | 5m (default) | Each tool-loop iteration reads the previous iteration's prefix |

**The per-conversation context moves out of the cached prefix.** `conv` appended `You are replying in conversationId: <id>` to the end of the system prompt, which made the entire prefix vary per conversation and never share an entry. It now travels as `AgentConfig.volatileSystemPrompt`, is emitted as a trailing block flagged `ChatMessage.volatile` (as is the history-truncation note), and the breakpoint lands after the last non-volatile block. This helps the OpenRouter path too, whose breakpoint sits on the first system block and was carrying the conversation id with it.

Two things surfaced while building that weren't in the original diagnosis:

- **`max_tokens` is required** on the native API and nothing in the conversation path sets it — defaults to 8192.
- **Adaptive thinking is on by default** on current models, and dropping `thinking` blocks from an assistant turn makes the follow-up carrying tool results fail. Assistant turns now round-trip their raw blocks via `ChatMessage.providerContentBlocks` and are echoed byte-for-byte; breakpoints only ever attach to `text`/`tool_result` blocks, never to a block we echo verbatim.

Also drops `api.anthropic.com` from the compat provider's cache auto-detection — the source of the false confidence — and moves the shared rate-limit retry and `ProviderError` classification into `providers/transport.ts` so both providers use one implementation.

## Verified against the live API

`claude-haiku-4-5`, real key:

```
turn 1                     prompt=7820  cache_write=7817  cache_read=0
turn 2 (tool result)       prompt=7927  cache_write=105   cache_read=7817
turn 3 (new conversation)  prompt=7816  cache_write=346   cache_read=7467
```

Turn 1 writes the prefix (previously always 0). Turn 2 reads all 7817 and writes only the 105-token incremental turn — the tool-loop win. Turn 3, on a **different** conversationId, still reads 7467 of the shared prefix, which is the volatile-block split working; before it, that read would have been 0. The tool round-trip is confirmed end-to-end (Haiku called `kb_search`, the `tool_result` was accepted, the reply used it correctly).

Four shapes the native API validates strictly and the compat layer tolerated — history opening with an assistant turn, assistant-only history, empty message bodies, no system blocks — all accepted.

Automated: 514 agent-runtime + 73 agent-host tests, typecheck and lint clean. 27 new tests cover request shape, headers, breakpoint placement and TTLs, the stable/volatile boundary, the thinking echo, parallel tool-result merging, assistant-first history, stop-reason and usage mapping, and 401 → `provider_auth`.

## Not verified

**The thinking-block echo never triggered live.** Haiku 4.5 doesn't think by default; Sonnet 5 declined on a trivial task; Opus 5 returned no thinking blocks even on a reasoning-heavy prompt. With our request shape — no `thinking` parameter, so `display` defaults to omitted — the API returns none at all. So `providerContentBlocks` is verified to round-trip what the API actually returns (`text` + `tool_use`, byte-for-byte), but the thinking case is defensive rather than exercised. It only becomes load-bearing if we opt into `thinking: {display: 'summarized'}`, which nothing in `AgentConfig` can currently request.

## Follow-ups (not in this PR)

- `ProviderUsage` now carries `cache_read_input_tokens` / `cache_creation_input_tokens`, but nothing reads them. Threading them into `AgentReply` and per-org usage is what would let us confirm the hit rate from the dashboard instead of the Console.
- The audit pass's JSON mode stays off on Anthropic (native has no `response_format`; `audit.ts` already skipped it and `parseVerdict` handles prose-wrapped JSON). Structured outputs would be a genuine upgrade there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
