### PR TITLE
fix(conv): admit 30 MiB relay messages and drop the relay per-IP throttle

### DIFF
--- a/.changeset/email-relay-body-limit-and-throttle.md
+++ b/.changeset/email-relay-body-limit-and-throttle.md
@@ -1,0 +1,9 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Make `POST /v1/conversations/email/relay` actually accept the 30 MiB it advertises, and stop throttling it per client IP.
+
+The controller checked the decoded message against a 30 MiB cap, but the global JSON body parser in `createApp` is capped at 4mb, and a base64 relay envelope is ~1.37× the message — so any email over roughly 3 MB was answered by Express with `413 request entity too large` before the controller ran. The relay path now gets its own route-scoped `express.json` parser mounted ahead of the global one, sized from the same constant (`EMAIL_RELAY_BODY_LIMIT_BYTES` = base64 expansion of `EMAIL_RELAY_MAX_RAW_BYTES` plus 1 MiB of envelope, ≈41 MiB) and setting `req.rawBody` the way Nest's `rawBody: true` does, so HMAC verification is unchanged. The global 4mb limit still applies everywhere else. A request on that path without an `x-munin-relay-signature` header is refused 401 before the body is read, so unsigned traffic cannot make the server buffer 40 MB per request.
+
+The controller was also declared with `throttle: true`, which applies the public per-IP throttle (60/min, 1000/hour). All customers' relayed mail arrives from the operator's one or two MX addresses, so that was a platform-wide ceiling of 1000 inbound emails per hour. The endpoint authenticates every request by HMAC, so the IP throttle is dropped.

--- a/packages/backend-core/src/bootstrap-app.ts
+++ b/packages/backend-core/src/bootstrap-app.ts
@@ -7,11 +7,18 @@ import { createReadStream, existsSync } from 'node:fs';
 import { readFile, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import type { Request, Response, NextFunction } from 'express';
+import type { IncomingMessage } from 'node:http';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import { STORAGE } from './common/storage/storage.token.ts';
 import { ORG_HEADER, stripTrailingSlashes } from '@getmunin/types';
+import {
+  EMAIL_RELAY_BODY_LIMIT_BYTES,
+  EMAIL_RELAY_PATH,
+  EMAIL_RELAY_SIGNATURE_HEADER,
+} from './modules/conv/email/email-relay.constants.ts';
 
 const JSON_BODY_LIMIT = '4mb';
+const EMAIL_RELAY_BODY_LIMIT = EMAIL_RELAY_BODY_LIMIT_BYTES;
 
 const DEFAULT_DEV_WEB_ORIGINS = ['http://localhost:3000', 'http://127.0.0.1:3000'];
 
@@ -56,6 +63,7 @@ export async function createApp(
     rawBody: true,
     ...nestOpts,
   });
+  app.use(EMAIL_RELAY_PATH, emailRelaySignatureGateMiddleware, emailRelayBodyParser());
   app.useBodyParser('json', { limit: JSON_BODY_LIMIT, type: ['application/json', 'text/plain'] });
   app.useBodyParser('urlencoded', { extended: true, limit: JSON_BODY_LIMIT });
   const trustProxy = readTrustProxySetting();
@@ -88,6 +96,28 @@ export async function createApp(
   app.use(brandIconMiddleware(resolvedIconDir));
 
   return app;
+}
+
+export function emailRelaySignatureGateMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (req.method !== 'POST' || typeof req.headers[EMAIL_RELAY_SIGNATURE_HEADER] === 'string') {
+    next();
+    return;
+  }
+  res.status(401).json({ statusCode: 401, message: 'relay signature missing' });
+}
+
+function emailRelayBodyParser() {
+  return express.json({
+    limit: EMAIL_RELAY_BODY_LIMIT,
+    type: ['application/json', 'text/plain'],
+    verify: (req: IncomingMessage, _res, buf: Buffer) => {
+      (req as IncomingMessage & { rawBody?: Buffer }).rawBody = buf;
+    },
+  });
 }
 
 export function isPublicCorsPath(path: string): boolean {

--- a/packages/backend-core/src/modules/conv/email/email-relay.constants.ts
+++ b/packages/backend-core/src/modules/conv/email/email-relay.constants.ts
@@ -1,0 +1,7 @@
+export const EMAIL_RELAY_CONTROLLER_PATH = 'v1/conversations/email';
+export const EMAIL_RELAY_ROUTE = 'relay';
+export const EMAIL_RELAY_PATH = `/${EMAIL_RELAY_CONTROLLER_PATH}/${EMAIL_RELAY_ROUTE}`;
+export const EMAIL_RELAY_SIGNATURE_HEADER = 'x-munin-relay-signature';
+export const EMAIL_RELAY_MAX_RAW_BYTES = 30 * 1024 * 1024;
+export const EMAIL_RELAY_BODY_LIMIT_BYTES =
+  Math.ceil(EMAIL_RELAY_MAX_RAW_BYTES / 3) * 4 + 1024 * 1024;

--- a/packages/backend-core/src/modules/conv/email/email-relay.controller.ts
+++ b/packages/backend-core/src/modules/conv/email/email-relay.controller.ts
@@ -10,17 +10,21 @@ import {
 import type { Request } from 'express';
 import { verifyHmac } from '@getmunin/core';
 import { PublicController } from '../../../common/auth/auth.guard.ts';
+import {
+  EMAIL_RELAY_CONTROLLER_PATH,
+  EMAIL_RELAY_MAX_RAW_BYTES,
+  EMAIL_RELAY_ROUTE,
+  EMAIL_RELAY_SIGNATURE_HEADER,
+} from './email-relay.constants.ts';
 import { EmailRelayService, type RelayIngestOutcome } from './email-relay.service.ts';
 
-const MAX_RAW_BYTES = 30 * 1024 * 1024;
-
-@PublicController('v1/conversations/email', { throttle: true })
+@PublicController(EMAIL_RELAY_CONTROLLER_PATH)
 export class EmailRelayController {
   private readonly logger = new Logger(EmailRelayController.name);
 
   constructor(@Inject(EmailRelayService) private readonly relay: EmailRelayService) {}
 
-  @Post('relay')
+  @Post(EMAIL_RELAY_ROUTE)
   async receive(@Req() req: RawBodyRequest<Request>): Promise<{ status: string }> {
     const secret = process.env.MUNIN_EMAIL_RELAY_SECRET;
     if (!secret) {
@@ -28,7 +32,7 @@ export class EmailRelayController {
     }
 
     const rawBody = req.rawBody ?? Buffer.alloc(0);
-    const signature = headerOne(req.headers['x-munin-relay-signature']);
+    const signature = headerOne(req.headers[EMAIL_RELAY_SIGNATURE_HEADER]);
     if (!signature || !verifyHmac(rawBody, secret, signature)) {
       throw new HttpException('relay signature invalid', HttpStatus.UNAUTHORIZED);
     }
@@ -37,7 +41,7 @@ export class EmailRelayController {
     if (!payload) {
       throw new HttpException('relay payload invalid', HttpStatus.BAD_REQUEST);
     }
-    if (payload.raw.byteLength > MAX_RAW_BYTES) {
+    if (payload.raw.byteLength > EMAIL_RELAY_MAX_RAW_BYTES) {
       throw new HttpException('message too large', HttpStatus.PAYLOAD_TOO_LARGE);
     }
 

--- a/packages/backend-core/src/modules/conv/email/email-relay.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email-relay.integration.test.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { NestFactory } from '@nestjs/core';
 import type { INestApplication } from '@nestjs/common';
 import type { AddressInfo } from 'node:net';
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
@@ -8,6 +7,8 @@ import { buildApiKey, hashSecret, keyPrefix, signHmac } from '@getmunin/core';
 import { createDb, runMigrations, schema } from '@getmunin/db';
 import { sql, and, eq } from 'drizzle-orm';
 import { AppModule } from '../../../app.module.ts';
+import { createApp } from '../../../bootstrap-app.ts';
+import { EMAIL_RELAY_MAX_RAW_BYTES } from './email-relay.constants.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
@@ -62,7 +63,7 @@ const RELAY_DOMAIN = 'in.getmunin.test';
         scopes: ['*'],
       });
 
-      app = await NestFactory.create(AppModule, { logger: false, rawBody: true });
+      app = await createApp(AppModule, { logger: false });
       await app.listen(0, '127.0.0.1');
       const server = app.getHttpServer() as { address(): AddressInfo | string | null };
       const address = server.address();
@@ -94,19 +95,49 @@ const RELAY_DOMAIN = 'in.getmunin.test';
 
     async function postRelay(
       payload: Record<string, unknown>,
-      opts?: { signature?: string },
+      opts?: { signature?: string | null },
     ): Promise<{ status: number; body: string }> {
       const body = JSON.stringify(payload);
-      const signature = opts?.signature ?? signHmac(Buffer.from(body, 'utf8'), RELAY_SECRET);
+      const signature =
+        opts?.signature === undefined
+          ? signHmac(Buffer.from(body, 'utf8'), RELAY_SECRET)
+          : opts.signature;
+      const headers: Record<string, string> = { 'content-type': 'application/json' };
+      if (signature !== null) headers['x-munin-relay-signature'] = signature;
       const res = await fetch(`${baseUrl}/v1/conversations/email/relay`, {
         method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'x-munin-relay-signature': signature,
-        },
+        headers,
         body,
       });
       return { status: res.status, body: await res.text() };
+    }
+
+    function rawWithAttachment(messageId: string, attachmentBytes: number): string {
+      const boundary = 'relay-it-boundary';
+      const attachment = Buffer.alloc(attachmentBytes, 0x41)
+        .toString('base64')
+        .replace(/(.{76})/g, '$1\r\n');
+      return [
+        'From: Kari Nordmann <kari@example.test>',
+        `To: <${relayAddress}>`,
+        'Subject: Quarterly report attached',
+        `Message-ID: <${messageId}>`,
+        `Content-Type: multipart/mixed; boundary="${boundary}"`,
+        '',
+        `--${boundary}`,
+        'Content-Type: text/plain; charset="utf-8"',
+        '',
+        'Please find the quarterly report attached.',
+        '',
+        `--${boundary}`,
+        'Content-Type: application/octet-stream; name="report.bin"',
+        'Content-Transfer-Encoding: base64',
+        'Content-Disposition: attachment; filename="report.bin"',
+        '',
+        attachment,
+        `--${boundary}--`,
+        '',
+      ].join('\r\n');
     }
 
     function rawForwarded(): string {
@@ -257,6 +288,70 @@ const RELAY_DOMAIN = 'in.getmunin.test';
         .from(schema.convMessages)
         .where(eq(schema.convMessages.orgId, orgId));
       expect(messages).toHaveLength(1);
+    });
+
+    it('ingests a message far above the 4mb global JSON body limit', async () => {
+      const raw = Buffer.from(rawWithAttachment('big-1@example.test', 4_800_000));
+      expect(raw.byteLength).toBeGreaterThan(6 * 1024 * 1024);
+
+      const res = await postRelay({ recipient: relayAddress, raw: raw.toString('base64') });
+      expect(res.status).toBe(201);
+      expect(res.body).toContain('ingested');
+
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      const messages = await db
+        .select()
+        .from(schema.convMessages)
+        .where(
+          and(
+            eq(schema.convMessages.orgId, orgId),
+            sql`${schema.convMessages.metadata}->>'inboundMessageId' = 'big-1@example.test'`,
+          ),
+        );
+      expect(messages).toHaveLength(1);
+      expect(messages[0]!.body).toContain('quarterly report attached');
+    });
+
+    it('rejects an unsigned oversized post before the controller runs', async () => {
+      const raw = Buffer.from(rawWithAttachment('big-2@example.test', 4_800_000));
+      const res = await postRelay(
+        { recipient: relayAddress, raw: raw.toString('base64') },
+        { signature: null },
+      );
+      expect(res.status).toBe(401);
+      expect(res.body).toContain('relay signature missing');
+
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      const messages = await db
+        .select()
+        .from(schema.convMessages)
+        .where(
+          and(
+            eq(schema.convMessages.orgId, orgId),
+            sql`${schema.convMessages.metadata}->>'inboundMessageId' = 'big-2@example.test'`,
+          ),
+        );
+      expect(messages).toHaveLength(0);
+    });
+
+    it('still refuses a message over the relay maximum with the controller 413', async () => {
+      const raw = Buffer.alloc(EMAIL_RELAY_MAX_RAW_BYTES + 1, 0x41);
+      const res = await postRelay({ recipient: relayAddress, raw: raw.toString('base64') });
+      expect(res.status).toBe(413);
+      expect(res.body).toContain('message too large');
+    });
+
+    it('is not throttled per client IP: 65 signed posts in a minute all get through', async () => {
+      const statuses: number[] = [];
+      for (let i = 0; i < 65; i++) {
+        const res = await postRelay({
+          recipient: `nobody-${i}@in.getmunin.test`,
+          raw: Buffer.from(rawForwarded()).toString('base64'),
+        });
+        statuses.push(res.status);
+      }
+      expect(statuses).not.toContain(429);
+      expect(new Set(statuses)).toEqual(new Set([201]));
     });
   },
 );


### PR DESCRIPTION
Stacked on #890. Two defects found while planning the hosted inbound MX that will feed `POST /v1/conversations/email/relay`.

## 1. The 30 MiB relay cap was unreachable

`bootstrap-app.ts` registers the global JSON parser at `4mb`. A base64 JSON envelope is ~1.37× the message, so any email over ~3 MB got Express's `{"statusCode":413,"message":"request entity too large"}` before the controller ran. Verified against the deployed 5.14 API: a 5 MB POST is refused by Nest, while a 35 MB POST passes the platform ingress untouched, so the global parser was the only limit.

Fix: a new `email-relay.constants.ts` is the single source for the path, signature header and limits (`EMAIL_RELAY_MAX_RAW_BYTES` = 30 MiB, `EMAIL_RELAY_BODY_LIMIT_BYTES` ≈ 41 MiB derived from it). Bootstrap mounts, on exactly that path and ahead of the global parser:

- a gate that answers `401 relay signature missing` for a POST without `x-munin-relay-signature` before any body is read, so unsigned traffic cannot make the server buffer 40 MB per request;
- a route-scoped `express.json` with the larger limit whose `verify` sets `req.rawBody` exactly as Nest's own raw-body parser does.

body-parser 2.3.0 skips a request whose body has already been read, so the global `4mb` parser never re-parses this route and stays untouched for everything else.

## 2. Per-IP throttling capped the whole platform's inbound mail

The controller was `@PublicController(..., { throttle: true })`: 60/min and 1000/hour per client IP. Every customer's forwarded mail arrives from the operator's one or two MX addresses, so that was a platform-wide ceiling of 1000 emails an hour. The endpoint is HMAC-authenticated, so the throttle added nothing; it is removed. Signature verification still precedes any DB work.

## Tests

The integration test now boots via `createApp(AppModule)` — the previous `NestFactory.create` never exercised bootstrap's parsers. New cases:

- ~6.2 MiB signed message → 201 `ingested`, row present
- same payload unsigned → 401 `relay signature missing`, no row
- 30 MiB + 1 raw → 413 `message too large` from the controller, not Express
- 65 consecutive signed posts → all 201, none 429

Negative control: with `{ throttle: true }` restored and the route-scoped mount removed, exactly these four fail. Full backend-core suite green (153 files, 1980 tests).

Changeset: `@getmunin/backend-core` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)