### PR TITLE
ci: keep a stalled pnpm bootstrap from cancelling a green run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,11 @@ jobs:
   build:
     name: lint · typecheck · test · build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # A healthy run takes ~11 min. pnpm/action-setup bootstraps with `npm ci`,
+    # which has sat silent for 7 min on a hung registry fetch before succeeding;
+    # a 15 min budget then cancelled the Test step and skipped release. The
+    # step-level budget on every setup step below fails a stall fast instead.
+    timeout-minutes: 25
 
     permissions:
       contents: read
@@ -59,6 +63,7 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        timeout-minutes: 3
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -133,6 +138,7 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        timeout-minutes: 3
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -206,6 +212,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        timeout-minutes: 3
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -247,6 +254,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        timeout-minutes: 3
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:


### PR DESCRIPTION
## Problem

Three of four first attempts on `main` today (2026-09-04) lost ~7 minutes inside `pnpm/action-setup`, a step that normally takes 4 s. The build job then ran out of its 15-minute budget during **Test**, GitHub reported the job as *cancelled* rather than failed, `release (changesets)` was *skipped*, and a green push produced no publish until a manual `gh run rerun --failed`.

| Run | pnpm/action-setup | Outcome |
|---|---|---|
| [33863649886](https://github.com/getmunin/munin/actions/runs/33863649886/attempts/1) attempt 1 | 10:32:46Z → 10:39:49Z (**7m03s**) | Test cancelled 10:47:36Z, release skipped; rerun passed in 9m34s |
| [33867350482](https://github.com/getmunin/munin/actions/runs/33867350482/attempts/1) attempt 1 | 11:19:14Z → 11:26:18Z (**7m04s**) | Test cancelled 11:34:09Z, release skipped; rerun passed in 11m15s |
| [33863399119](https://github.com/getmunin/munin/actions/runs/33863399119) | 10:28:52Z → cancelled 10:32:21Z | Superseded by the next push via the concurrency group, not a stall |

The stall is not specific to the build job. In 33863649886 the **e2e** job's setup also took 7m03s (it survived only because e2e has more slack), and in 33867350482 the **license policy** job's setup took 7m08s, turning a 30-second job into a 7.5-minute one.

## What the logs show

`pnpm/action-setup` v6.0.10 bootstraps by writing a `package.json` for `pnpm@11.19.0`, running `npm ci` against registry.npmjs.org, then `pnpm self-update 10.28.0` to reach the `packageManager` version. In all three stalled jobs the log is identical:

```
##[group]Running self-installer...
                                   <- seven minutes of nothing ->
added 1 package in 7m
Checking for updates...
Switching pnpm from v11.19.0 to v10.28.0...
... | Progress: resolved 1, reused 0, downloaded 1, added 1, done
Successfully updated pnpm to v10.28.0
```

No retry or HTTP error is logged, and the self-update download that follows completes in under a second. Three independent runners landing within five seconds of each other points at a timeout inside npm on a hung registry connection, not slow transfer.

The alternative install shapes don't avoid that path, so this PR doesn't switch to them: `standalone: true` runs the same `npm ci` (for `@pnpm/exe`), and corepack fetches from the same registry while being deprecated on the Node 24 that `.nvmrc` (`lts/krypton`) resolves to. No upstream issue tracks this and v6.0.10 (2026-08-03) is the latest release.

## Change

Two edits to `.github/workflows/ci.yml`, nothing else touched:

- **Build job `timeout-minutes: 15 → 25`.** A healthy run takes 9–11 min, so 15 left no room for the stall; 25 lets a run that absorbed one still finish and publish.
- **`timeout-minutes: 3` on every `pnpm/action-setup` step** (build, release, licenses, e2e). A genuine stall now fails that step at three minutes, visibly and attributed to the right step, instead of silently spending the job's budget so that Test gets cancelled downstream. The release job is included because a stall there would block publishing just the same.

## Verification

- `actionlint` 1.7.12: no findings.
- YAML parse asserting `jobs.build.timeout-minutes == 25` and that all four `pnpm/action-setup` steps carry `timeout-minutes: 3`.
- `grep -nA1 'pnpm/action-setup@'` shows the step timeout on every occurrence.

No changeset: nothing under `packages/` changed (same as #887).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
