### PR TITLE
fix(web): format phone numbers on the end-user list

### DIFF
--- a/.changeset/tall-pans-brake.md
+++ b/.changeset/tall-pans-brake.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Format phone numbers on the end-user list the same way the rest of the dashboard does — an end user identified only by phone now shows `+47 911 05 891` instead of the raw E.164 string.

--- a/packages/dashboard-pages/src/pages/end-users.tsx
+++ b/packages/dashboard-pages/src/pages/end-users.tsx
@@ -8,6 +8,7 @@ import { LoadFailed } from '../components/load-failed';
 import { TableSkeleton } from '../components/skeleton';
 import { EmptyCallout } from '../components/empty-callout';
 import { useLoadGate } from '../lib/use-load-gate';
+import { formatPhoneNumber } from '../lib/format-phone';
 import { useSettingsLoadFailedProps } from '../lib/use-load-failed-props';
 import { notify } from '../lib/notify';
 import { Button, Hero, Input, SectionHead, cn } from '@getmunin/ui';
@@ -140,7 +141,7 @@ export function EndUsersPage() {
                     <div className="flex items-center gap-3">
                       <Avatar name={eu.name} email={eu.email} />
                       <div className="text-sm font-medium text-ink dark:text-foreground">
-                        {eu.name ?? eu.email ?? eu.phone ?? '—'}
+                        {eu.name ?? eu.email ?? (eu.phone ? formatPhoneNumber(eu.phone) : null) ?? '—'}
                       </div>
                     </div>
                   </td>


### PR DESCRIPTION
The end-user list rendered `eu.phone` raw, so an end user identified only by phone showed up as `+4712345678` while every other phone surface in the dashboard runs through `formatPhoneNumber` (libphonenumber-js `formatInternational`).

Now it reads `+47 12 34 56 78`.

Two things deliberately left alone:

- The **External ID** column keeps `phone:+4712345678` raw — it's a machine identifier in mono type, sitting next to `email:…` and `anon:…`.
- The search filter still matches the stored E.164 value, so spaced digits won't hit. Easy to add if that turns out to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


