### PR TITLE
feat(auth): members reach the inbox and nothing else

### DIFF
--- a/.changeset/member-role-control-plane-lockdown.md
+++ b/.changeset/member-role-control-plane-lockdown.md
@@ -1,0 +1,54 @@
+---
+'@getmunin/core': patch
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+Deny the control plane to `member` sessions by default, and open the inbox back up explicitly.
+
+The console has presented `member` as an inbox-only role since the oversight rebuild —
+`OSS_CONSOLE_GROUPS` marks Overview, Automation, Review and Settings `adminOnly`,
+`/dashboard` redirects members to `/dashboard/conversations`, and `SettingsShell`
+bounces any non-admin. The backend never agreed. `RoleGuard` refuses `'member'` as a
+gate on purpose ("all org members pass"), so the only closed routes were the ~20
+carrying `@RequireRole('owner', 'admin')`. Everything else was open to a member with a
+session cookie: `GET /v1/crm/export`, `/v1/kb/export`, `/v1/conv/export` (every message
+body in the org), `/v1/cms/transfer/export`, `/v1/analytics/export/events`, their `POST
+…/import` counterparts, the whole Review feed *including* its writes —
+`kb/curation/candidates/{id}/publish`, `crm/merge-proposals/{id}/apply`,
+`cms/drafts/{id}/approve` and `outreach/proposals/{id}/approve`, which is the human gate
+that actually sends mail in the org's name — plus `/v1/curator/jobs` and its
+claim/fail/progress endpoints, `/v1/inbox`, `/v1/overview/*`, `/v1/activity`,
+`/v1/orgs/me`, `/v1/orgs/me/roster` and `/v1/skills`. UI-level hiding, no authorization.
+
+Enumerating the closed set was the wrong shape: it is ~60 routes, it grows with every
+new controller, and a controller added tomorrow joins the open side silently — which is
+how this drifted in the first place. So the default is inverted instead.
+`ControlPlaneGuard` — already on all 37 control-plane controllers, unlike `RoleGuard`,
+which 21 of them never applied — now admits a user actor only when their role in the
+active org is `owner` or `admin`, or when the route opts in with `@AllowMember()`. An
+unrecognized future role starts closed rather than open. Refusals carry
+`code: 'member_forbidden'` with an `errors.member_forbidden` entry in both locales,
+since a member who types an admin URL will see it.
+
+The member surface is now eleven routes, pinned by `member-surface.test.ts` so widening
+it has to be a deliberate diff: the eight inbox routes the conversation pane actually
+calls (`queue`, `{id}`, `messages`, `status`, `take-over`, `release`, `request-draft`,
+`clear-draft`), `/v1/me/memberships` for role and org resolution, `/v1/overview/setup`
+for the first-run copy, and `/v1/oauth/pending-org` so a member can still authorize a
+connector — `gateOauthGrantsByRole` already assumed members complete that flow and just
+lose `mcp:admin`.
+
+Session credentials now carry the resolved membership role on `ActorIdentity.orgRole`,
+so the common path costs no extra query. The guard falls back to reading `org_members`
+when a credential arrives without one, which is what keeps a host that builds its own
+session credentials — cloud — protected rather than locked out.
+
+Two consequences worth naming. The console's queue badge came from `/v1/inbox`, which
+mixes live conversations with the review feed and is now admin-only, so the shell reads
+`/v1/conversations/queue` for non-admins instead and shows no review count; the badge
+keeps working for members rather than silently sitting at zero. And the realtime
+gateway is untouched: it authenticates its own WebSocket upgrade outside Nest guards, so
+a member's socket still receives `kb.*` and `crm.merge_proposal.*` event notifications on
+the org channel. Those carry ids and types rather than record bodies, and closing that
+seam is follow-up work.

--- a/packages/backend-core/src/common/auth/control-plane.guard.test.ts
+++ b/packages/backend-core/src/common/auth/control-plane.guard.test.ts
@@ -1,19 +1,61 @@
 import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
-import { describe, expect, it } from 'vitest';
+import type { Reflector } from '@nestjs/core';
+import type { Db } from '@getmunin/db';
+import { describe, expect, it, vi } from 'vitest';
 import type { ResolvedCredential } from '@getmunin/core';
-import { ControlPlaneGuard } from './control-plane.guard.ts';
+import { ControlPlaneGuard, MEMBER_FORBIDDEN_CODE } from './control-plane.guard.ts';
 
 function makeCtx(credential?: ResolvedCredential) {
   return {
     switchToHttp: () => ({ getRequest: () => ({ credential }) }),
+    getHandler: () => () => undefined,
+    getClass: () => class {},
   } as never;
 }
 
-function actor(overrides: Partial<{ type: string; scopes: string[]; audiences: string[] }>) {
+function reflector(allowMember = false): Reflector {
+  return { getAllAndOverride: () => allowMember } as unknown as Reflector;
+}
+
+function unusedDb(): Db {
+  return {
+    execute: () => {
+      throw new Error('db must not be queried when the actor already carries its org role');
+    },
+  } as unknown as Db;
+}
+
+function dbReturningRole(role: string | null): Db {
+  return {
+    execute: vi.fn().mockResolvedValue(undefined),
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve(role === null ? [] : [{ role }]),
+        }),
+      }),
+    }),
+  } as unknown as Db;
+}
+
+function actor(
+  overrides: Partial<{
+    type: string;
+    scopes: string[];
+    audiences: string[];
+    orgRole: string;
+    orgId: string;
+    userId: string;
+  }>,
+) {
   const a = {
     type: 'user',
     scopes: ['*'],
     audiences: ['admin'],
+    orgRole: 'owner',
+    orgId: 'org_1',
+    userId: 'usr_1',
+    id: 'usr_1',
     ...overrides,
   };
   return {
@@ -23,56 +65,104 @@ function actor(overrides: Partial<{ type: string; scopes: string[]; audiences: s
   } as never;
 }
 
+function guard(opts: { allowMember?: boolean; db?: Db } = {}): ControlPlaneGuard {
+  return new ControlPlaneGuard(reflector(opts.allowMember ?? false), opts.db ?? unusedDb());
+}
+
 describe('ControlPlaneGuard', () => {
-  it('rejects unauthenticated requests', () => {
-    const guard = new ControlPlaneGuard();
-    expect(() => guard.canActivate(makeCtx())).toThrow(UnauthorizedException);
+  it('rejects unauthenticated requests', async () => {
+    await expect(guard().canActivate(makeCtx())).rejects.toThrow(UnauthorizedException);
   });
 
-  it('admits a session-cookie user (no audience on credential)', () => {
-    const guard = new ControlPlaneGuard();
-    const cred = { actor: actor({ type: 'user' }) } as ResolvedCredential;
-    expect(guard.canActivate(makeCtx(cred))).toBe(true);
+  it('admits an owner on a session cookie (no audience on credential)', async () => {
+    const cred = { actor: actor({ orgRole: 'owner' }) } as ResolvedCredential;
+    await expect(guard().canActivate(makeCtx(cred))).resolves.toBe(true);
   });
 
-  it('rejects an OAuth-derived user actor (credential has MCP audience)', () => {
-    const guard = new ControlPlaneGuard();
+  it('admits an admin on a session cookie', async () => {
+    const cred = { actor: actor({ orgRole: 'admin' }) } as ResolvedCredential;
+    await expect(guard().canActivate(makeCtx(cred))).resolves.toBe(true);
+  });
+
+  it('rejects an OAuth-derived user actor (credential has MCP audience)', async () => {
     const cred = {
-      actor: actor({ type: 'user' }),
+      actor: actor({}),
       audience: 'https://api.example.com/mcp',
     } as ResolvedCredential;
-    expect(() => guard.canActivate(makeCtx(cred))).toThrow(ForbiddenException);
+    await expect(guard().canActivate(makeCtx(cred))).rejects.toThrow(ForbiddenException);
   });
 
-  it('admits an admin_agent with admin audience and wildcard scope', () => {
-    const guard = new ControlPlaneGuard();
+  it('rejects a member on a route that does not opt in', async () => {
+    const cred = { actor: actor({ orgRole: 'member' }) } as ResolvedCredential;
+    await expect(guard().canActivate(makeCtx(cred))).rejects.toThrow(ForbiddenException);
+  });
+
+  it('carries a translatable code so the dashboard can explain the refusal', async () => {
+    const cred = { actor: actor({ orgRole: 'member' }) } as ResolvedCredential;
+    await guard()
+      .canActivate(makeCtx(cred))
+      .then(
+        () => expect.unreachable('member should not pass'),
+        (err: ForbiddenException) => {
+          expect((err.getResponse() as { code: string }).code).toBe(MEMBER_FORBIDDEN_CODE);
+        },
+      );
+  });
+
+  it('admits a member on a route marked @AllowMember()', async () => {
+    const cred = { actor: actor({ orgRole: 'member' }) } as ResolvedCredential;
+    await expect(guard({ allowMember: true }).canActivate(makeCtx(cred))).resolves.toBe(true);
+  });
+
+  it('rejects a role it does not recognize, so a new role starts closed', async () => {
+    const cred = { actor: actor({ orgRole: 'analyst' }) } as ResolvedCredential;
+    await expect(guard().canActivate(makeCtx(cred))).rejects.toThrow(ForbiddenException);
+  });
+
+  it('reads the role from the database when the credential does not carry one', async () => {
+    const cred = { actor: actor({ orgRole: undefined }) } as ResolvedCredential;
+    await expect(
+      guard({ db: dbReturningRole('admin') }).canActivate(makeCtx(cred)),
+    ).resolves.toBe(true);
+  });
+
+  it('rejects a user whose membership is gone', async () => {
+    const cred = { actor: actor({ orgRole: undefined }) } as ResolvedCredential;
+    await expect(
+      guard({ db: dbReturningRole(null) }).canActivate(makeCtx(cred)),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('admits an admin_agent with admin audience and wildcard scope', async () => {
     const cred = {
       actor: actor({ type: 'admin_agent', scopes: ['*'], audiences: ['admin'] }),
     } as ResolvedCredential;
-    expect(guard.canActivate(makeCtx(cred))).toBe(true);
+    await expect(guard().canActivate(makeCtx(cred))).resolves.toBe(true);
   });
 
-  it('rejects an admin_agent without admin audience', () => {
-    const guard = new ControlPlaneGuard();
+  it('rejects an admin_agent without admin audience', async () => {
     const cred = {
       actor: actor({ type: 'admin_agent', scopes: ['*'], audiences: ['self_service'] }),
     } as ResolvedCredential;
-    expect(() => guard.canActivate(makeCtx(cred))).toThrow(ForbiddenException);
+    await expect(guard().canActivate(makeCtx(cred))).rejects.toThrow(ForbiddenException);
   });
 
-  it('rejects an admin_agent without wildcard scope', () => {
-    const guard = new ControlPlaneGuard();
+  it('rejects an admin_agent without wildcard scope', async () => {
     const cred = {
       actor: actor({ type: 'admin_agent', scopes: ['kb:read'], audiences: ['admin'] }),
     } as ResolvedCredential;
-    expect(() => guard.canActivate(makeCtx(cred))).toThrow(ForbiddenException);
+    await expect(guard().canActivate(makeCtx(cred))).rejects.toThrow(ForbiddenException);
   });
 
-  it('rejects widget_agent, end_user_agent, and other actor types', () => {
-    const guard = new ControlPlaneGuard();
+  it('admits a system actor', async () => {
+    const cred = { actor: actor({ type: 'system' }) } as ResolvedCredential;
+    await expect(guard().canActivate(makeCtx(cred))).resolves.toBe(true);
+  });
+
+  it('rejects widget_agent, end_user_agent, and other actor types', async () => {
     for (const type of ['widget_agent', 'end_user_agent', 'partner']) {
       const cred = { actor: actor({ type }) } as ResolvedCredential;
-      expect(() => guard.canActivate(makeCtx(cred))).toThrow(ForbiddenException);
+      await expect(guard().canActivate(makeCtx(cred))).rejects.toThrow(ForbiddenException);
     }
   });
 });

--- a/packages/backend-core/src/common/auth/control-plane.guard.ts
+++ b/packages/backend-core/src/common/auth/control-plane.guard.ts
@@ -2,14 +2,33 @@ import {
   CanActivate,
   ExecutionContext,
   ForbiddenException,
+  Inject,
   Injectable,
+  SetMetadata,
   UnauthorizedException,
 } from '@nestjs/common';
-import type { ResolvedCredential } from '@getmunin/core';
+import { Reflector } from '@nestjs/core';
+import type { ActorIdentity, ResolvedCredential } from '@getmunin/core';
+import { schema, type Db } from '@getmunin/db';
+import { and, eq, sql } from 'drizzle-orm';
+import { DB } from '../db/db.module.ts';
+
+export const ALLOW_MEMBER = 'munin:allow-member';
+export const AllowMember = (): MethodDecorator & ClassDecorator =>
+  SetMetadata(ALLOW_MEMBER, true);
+
+export const MEMBER_FORBIDDEN_CODE = 'member_forbidden';
+
+const ADMIN_ROLES: ReadonlySet<string> = new Set(['owner', 'admin']);
 
 @Injectable()
 export class ControlPlaneGuard implements CanActivate {
-  canActivate(context: ExecutionContext): boolean {
+  constructor(
+    private readonly reflector: Reflector,
+    @Inject(DB) private readonly db: Db,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context
       .switchToHttp()
       .getRequest<{ credential?: ResolvedCredential }>();
@@ -27,6 +46,7 @@ export class ControlPlaneGuard implements CanActivate {
           'OAuth bearer tokens cannot access control-plane routes; use a session cookie or an admin API key',
         );
       }
+      await this.assertRoleAdmitted(context, actor);
       return true;
     }
     if (actor.type === 'admin_agent') {
@@ -43,5 +63,34 @@ export class ControlPlaneGuard implements CanActivate {
     throw new ForbiddenException(
       `actor type "${actor.type}" cannot access control-plane routes`,
     );
+  }
+
+  private async assertRoleAdmitted(
+    context: ExecutionContext,
+    actor: ActorIdentity,
+  ): Promise<void> {
+    const allowsMember = this.reflector.getAllAndOverride<boolean>(ALLOW_MEMBER, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (allowsMember) return;
+
+    const role = actor.orgRole ?? (await this.readOrgRole(actor.orgId, actor.userId ?? actor.id));
+    if (role && ADMIN_ROLES.has(role)) return;
+
+    throw new ForbiddenException({
+      message: `${MEMBER_FORBIDDEN_CODE}: this route is restricted to owners and admins; your role in this organization is "${role ?? 'none'}"`,
+      code: MEMBER_FORBIDDEN_CODE,
+    });
+  }
+
+  private async readOrgRole(orgId: string, userId: string): Promise<string | null> {
+    await this.db.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+    const rows = await this.db
+      .select({ role: schema.orgMembers.role })
+      .from(schema.orgMembers)
+      .where(and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.userId, userId)))
+      .limit(1);
+    return rows[0]?.role ?? null;
   }
 }

--- a/packages/backend-core/src/common/auth/member-surface.test.ts
+++ b/packages/backend-core/src/common/auth/member-surface.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+const EXPECTED_MEMBER_SURFACE = [
+  'v1/conversations GET queue',
+  'v1/conversations GET :id',
+  'v1/conversations POST :id/messages',
+  'v1/conversations POST :id/status',
+  'v1/conversations POST :id/take-over',
+  'v1/conversations POST :id/release',
+  'v1/conversations POST :id/clear-draft',
+  'v1/conversations POST :id/request-draft',
+  'v1/me/memberships <whole controller>',
+  'v1/oauth/pending-org <whole controller>',
+  'v1/overview GET setup',
+];
+
+function controllerFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...controllerFiles(full));
+      continue;
+    }
+    if (entry.endsWith('.controller.ts')) out.push(full);
+  }
+  return out;
+}
+
+function controllerPath(lines: string[]): string {
+  for (const line of lines) {
+    const hit = /@Controller\(\s*'([^']*)'/.exec(line);
+    if (hit) return hit[1]!;
+  }
+  return '<unknown>';
+}
+
+function memberRoutes(source: string): string[] {
+  const lines = source.split('\n');
+  const base = controllerPath(lines);
+  const found: string[] = [];
+
+  lines.forEach((line, index) => {
+    if (!line.includes('@AllowMember()')) return;
+    for (let i = index - 1; i >= 0; i -= 1) {
+      const prev = lines[i]!;
+      const route = /@(Get|Post|Patch|Put|Delete)\(\s*'?([^')]*)'?\s*\)/.exec(prev);
+      if (route) {
+        found.push(`${base} ${route[1]!.toUpperCase()} ${route[2] || '/'}`);
+        return;
+      }
+      if (/^export class/.test(prev) || /@Controller\(/.test(prev)) break;
+    }
+    found.push(`${base} <whole controller>`);
+  });
+
+  return found;
+}
+
+describe('the member-reachable control plane is a closed list, because ControlPlaneGuard denies members by default', () => {
+  it('only the inbox and the per-user session routes carry @AllowMember() — widening it has to be a deliberate diff here', () => {
+    const actual = controllerFiles(SRC_ROOT).flatMap((file) =>
+      memberRoutes(readFileSync(file, 'utf8')),
+    );
+    expect([...actual].sort()).toEqual([...EXPECTED_MEMBER_SURFACE].sort());
+  });
+});

--- a/packages/backend-core/src/control/control-plane.integration.test.ts
+++ b/packages/backend-core/src/control/control-plane.integration.test.ts
@@ -1237,4 +1237,71 @@ interface OrgFixture {
       expect(body.message).toContain('conv_channel_config_invalid:');
     });
   });
+
+  describe('a member session reaches the inbox and nothing else', () => {
+    let memberCookie: Record<string, string>;
+
+    beforeAll(async () => {
+      const label = `cp-member-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+      const [user] = await db
+        .insert(schema.users)
+        .values({ email: `${label}@example.com`, name: 'Member User' })
+        .returning();
+      await db
+        .insert(schema.orgMembers)
+        .values({ orgId: orgA.id, userId: user!.id, role: 'member', isDefault: true });
+      const token = randomToken(32);
+      await db.insert(schema.sessions).values({
+        userId: user!.id,
+        token,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      });
+      memberCookie = cookieHeaders(token);
+    });
+
+    const denied = [
+      '/v1/crm/export',
+      '/v1/kb/export',
+      '/v1/conv/export',
+      '/v1/outreach/export',
+      '/v1/cms/transfer/export',
+      '/v1/kb/curation/candidates',
+      '/v1/crm/merge-proposals',
+      '/v1/outreach/proposals',
+      '/v1/curator/jobs',
+      '/v1/inbox',
+      '/v1/overview/backlog',
+      '/v1/orgs/me',
+      '/v1/orgs/me/roster',
+      '/v1/activity',
+      '/v1/skills',
+    ];
+
+    it.each(denied)('answers 403 with a translatable code on %s', async (path) => {
+      const res = await fetch(`${baseUrl}${path}`, { headers: memberCookie });
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { code?: string };
+      expect(body.code).toBe('member_forbidden');
+    });
+
+    it.each(['/v1/conversations/queue', '/v1/me/memberships', '/v1/overview/setup'])(
+      'still serves %s',
+      async (path) => {
+        const res = await fetch(`${baseUrl}${path}`, { headers: memberCookie });
+        expect(res.status).toBe(200);
+      },
+    );
+
+    it('leaves the bulk export open to an owner session', async () => {
+      const res = await fetch(`${baseUrl}/v1/crm/export`, {
+        headers: cookieHeaders(orgA.sessionToken),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('leaves an unrestricted admin key untouched', async () => {
+      const res = await fetch(`${baseUrl}/v1/crm/export`, { headers: authHeaders(orgA.adminKey) });
+      expect(res.status).toBe(200);
+    });
+  });
 });

--- a/packages/backend-core/src/control/conversations.controller.ts
+++ b/packages/backend-core/src/control/conversations.controller.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 import { getCurrentContext } from '@getmunin/core';
 import { MessageComponentsSchema } from '@getmunin/types';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
-import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
+import { AllowMember, ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 import { RoleGuard } from './role.guard.ts';
@@ -181,6 +181,7 @@ export class ConversationsController {
   }
 
   @Get('queue')
+  @AllowMember()
   async queue(
     @Query('status') status?: string,
     @Query('assigneeUserId') assigneeUserId?: string,
@@ -283,6 +284,7 @@ export class ConversationsController {
   }
 
   @Get(':id')
+  @AllowMember()
   async get(@Param('id') id: string): Promise<ConversationDetailResponse> {
     const detail = await translate(() => this.conv.getConversation(id));
     const claim = await this.claims.getActiveClaim(id);
@@ -296,6 +298,7 @@ export class ConversationsController {
 
   @Post(':id/messages')
   @HttpCode(201)
+  @AllowMember()
   async reply(@Param('id') id: string, @Body() input: SendReplyBody): Promise<MessageDto> {
     const ctx = getCurrentContext();
     const actor = ctx.actor!;
@@ -356,6 +359,7 @@ export class ConversationsController {
 
   @Post(':id/status')
   @HttpCode(200)
+  @AllowMember()
   async status(
     @Param('id') id: string,
     @Body() input: ChangeStatusBody,
@@ -379,6 +383,7 @@ export class ConversationsController {
 
   @Post(':id/take-over')
   @HttpCode(200)
+  @AllowMember()
   async takeOver(
     @Param('id') id: string,
     @Body() input: TakeOverBody,
@@ -392,6 +397,7 @@ export class ConversationsController {
 
   @Post(':id/release')
   @HttpCode(200)
+  @AllowMember()
   async release(@Param('id') id: string): Promise<{ released: boolean }> {
     await translate(() => this.claims.release({ conversationId: id }));
     return { released: true };
@@ -432,12 +438,14 @@ export class ConversationsController {
 
   @Post(':id/clear-draft')
   @HttpCode(200)
+  @AllowMember()
   async clearDraft(@Param('id') id: string): Promise<{ cleared: number }> {
     return translate(() => this.conv.clearDraftReply(id));
   }
 
   @Post(':id/request-draft')
   @HttpCode(202)
+  @AllowMember()
   async requestDraft(@Param('id') id: string): Promise<{ requested: boolean }> {
     return translate(() => this.conv.requestDraft(id));
   }

--- a/packages/backend-core/src/control/memberships.controller.ts
+++ b/packages/backend-core/src/control/memberships.controller.ts
@@ -14,7 +14,7 @@ import { schema } from '@getmunin/db';
 import { and, asc, eq, sql } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
-import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
+import { AllowMember, ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 
@@ -34,6 +34,7 @@ interface MembershipDto {
 @Controller('v1/me/memberships')
 @UseGuards(AuthGuard, ControlPlaneGuard)
 @UseInterceptors(TenancyInterceptor, AuditInterceptor)
+@AllowMember()
 export class MembershipsController {
   @Get()
   async list(): Promise<MembershipDto[]> {

--- a/packages/backend-core/src/control/overview.controller.ts
+++ b/packages/backend-core/src/control/overview.controller.ts
@@ -3,7 +3,7 @@ import { schema } from '@getmunin/db';
 import { and, eq, sql } from 'drizzle-orm';
 import { getCurrentContext } from '@getmunin/core';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
-import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
+import { AllowMember, ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { AuditInterceptor } from '../common/audit/audit.interceptor.ts';
 import { CURATION_INBOX_SLUG } from '../modules/kb/kb.service.ts';
@@ -33,6 +33,7 @@ export class OverviewController {
   ) {}
 
   @Get('setup')
+  @AllowMember()
   setup(): Promise<SetupStateDto> {
     return this.setupState.read();
   }

--- a/packages/backend-core/src/oauth/oauth-pending-org.controller.ts
+++ b/packages/backend-core/src/oauth/oauth-pending-org.controller.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { getCurrentContext } from '@getmunin/core';
 import { AuthGuard } from '../common/auth/auth.guard.ts';
-import { ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
+import { AllowMember, ControlPlaneGuard } from '../common/auth/control-plane.guard.ts';
 import { TenancyInterceptor } from '../common/tenancy/tenancy.interceptor.ts';
 import { hasOrgScopeAssociationKey, orgScopeStore } from '../auth/org-scope-store.ts';
 
@@ -26,6 +26,7 @@ interface CookieCarryingRequest {
 @Controller('v1/oauth/pending-org')
 @UseGuards(AuthGuard, ControlPlaneGuard)
 @UseInterceptors(TenancyInterceptor)
+@AllowMember()
 export class OAuthPendingOrgController {
   @Get()
   @Header('cache-control', 'no-store')

--- a/packages/core/src/request/context.ts
+++ b/packages/core/src/request/context.ts
@@ -23,6 +23,7 @@ export class ActorIdentity {
     public readonly partnerId?: string,
     public readonly userId?: string,
     public readonly clientId?: string,
+    public readonly orgRole?: string,
   ) {}
 
   hasScope(scope: string): boolean {

--- a/packages/core/src/request/credentials.ts
+++ b/packages/core/src/request/credentials.ts
@@ -50,6 +50,7 @@ const WIDGET_ALLOWED_SCOPES: ReadonlySet<string> = new Set(['conv:widget:write']
 function sessionCredential(
   session: typeof schema.sessions.$inferSelect,
   orgId: string,
+  orgRole: string,
 ): ResolvedCredential {
   const actor = new ActorIdentity(
     'user',
@@ -61,6 +62,8 @@ function sessionCredential(
     session.id,
     undefined,
     session.userId,
+    undefined,
+    orgRole,
   );
   return { actor, expiresAt: session.expiresAt };
 }
@@ -227,7 +230,7 @@ export class CredentialResolver {
     if (requestedOrgId) {
       const requested = memberships.find((m) => m.orgId === requestedOrgId);
       if (!requested) throw new OrgAccessDeniedError(requestedOrgId);
-      return sessionCredential(session, requested.orgId);
+      return sessionCredential(session, requested.orgId, requested.role);
     }
 
     const membership =
@@ -235,7 +238,7 @@ export class CredentialResolver {
       [...memberships].sort((a, b) => +a.createdAt - +b.createdAt)[0];
     if (!membership) return null;
 
-    return sessionCredential(session, membership.orgId);
+    return sessionCredential(session, membership.orgId, membership.role);
   }
 
   async resolveSessionUserId(rawToken: string): Promise<string | null> {

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1947,6 +1947,7 @@
     "claim_held_by_other": "Another teammate already holds this conversation.",
     "conv_draft_pending": "A draft is already waiting for review.",
     "conv_draft_request_invalid": "The agent can't draft here — the conversation is closed, has no customer to reply to, or the agent is switched off.",
+    "member_forbidden": "That's limited to owners and admins. Ask an owner if you need access.",
     "NETWORK_ERROR": "Couldn't reach Munin. Check your connection.",
     "SIGNUP_NOT_ALLOWED": "Signup is restricted on this Munin instance. Ask an admin to invite you.",
     "SIGNUP_DOMAIN_NOT_ALLOWED": "Your email domain isn't on the allowlist, and there's no pending invitation for this address. Ask an admin to invite you.",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1947,6 +1947,7 @@
     "claim_held_by_other": "En kollega har allerede denne samtalen.",
     "conv_draft_pending": "En kladd venter allerede på gjennomgang.",
     "conv_draft_request_invalid": "Agenten kan ikke lage utkast her – samtalen er lukket, mangler en kunde å svare, eller agenten er slått av.",
+    "member_forbidden": "Dette er forbeholdt eiere og administratorer. Spør en eier hvis du trenger tilgang.",
     "NETWORK_ERROR": "Fikk ikke kontakt med Munin. Sjekk tilkoblingen din.",
     "SIGNUP_NOT_ALLOWED": "Registrering er begrenset på denne Munin-installasjonen. Be en administrator om å invitere deg.",
     "SIGNUP_DOMAIN_NOT_ALLOWED": "E-postdomenet ditt er ikke på listen, og det finnes ingen ventende invitasjon for denne adressen. Be en administrator om å invitere deg.",

--- a/packages/dashboard-pages/src/shells/console-shell.tsx
+++ b/packages/dashboard-pages/src/shells/console-shell.tsx
@@ -47,10 +47,17 @@ const REFRESH_PREFIXES = [
   'cms.entry.',
 ];
 
-function useConsoleData(): { badges: ConsoleBadges } {
+function useConsoleData(isAdmin: boolean, roleLoading: boolean): { badges: ConsoleBadges } {
   const [badges, setBadges] = useState<ConsoleBadges>(EMPTY_BADGES);
 
   const load = useCallback(() => {
+    if (roleLoading) return;
+    if (!isAdmin) {
+      void api<{ items: unknown[] }>('/v1/conversations/queue?status=open&limit=100')
+        .then((res) => setBadges({ queue: res.items.length, review: 0 }))
+        .catch(() => undefined);
+      return;
+    }
     void api<InboxQueueResponse>('/v1/inbox')
       .then((res) =>
         setBadges({
@@ -64,7 +71,7 @@ function useConsoleData(): { badges: ConsoleBadges } {
         }),
       )
       .catch(() => undefined);
-  }, []);
+  }, [isAdmin, roleLoading]);
 
   useEffect(() => {
     load();
@@ -210,7 +217,7 @@ function ConsoleShellInner({
   const router = useRouter();
   const { data: session } = authClient.useSession();
   const { role, loading: roleLoading } = useActiveRole();
-  const { badges } = useConsoleData();
+  const { badges } = useConsoleData(isOwnerOrAdmin(role), roleLoading);
   const backAction = useMobileBackAction();
   const [menuOpen, setMenuOpen] = useState(false);
 


### PR DESCRIPTION
The console has presented `member` as an inbox-only role since the oversight rebuild: `OSS_CONSOLE_GROUPS` marks Overview, Automation, Review and Settings `adminOnly`, `/dashboard` redirects members to `/dashboard/conversations`, and `SettingsShell` bounces any non-admin. The backend never agreed.

`RoleGuard` refuses `'member'` as a gate on purpose — *"not a meaningful gate (all org members pass)"* — so the only closed routes were the ~20 carrying `@RequireRole('owner', 'admin')`. Probed against a real member session on a local dev org, everything below answered 200:

| Open to a `member` session | |
|---|---|
| Bulk exports | `/v1/crm/export`, `/v1/kb/export`, `/v1/conv/export` (every message body in the org), `/v1/cms/transfer/export`, `/v1/analytics/export/events` — plus every matching `POST …/import`, so not just read exposure |
| Review feed **and its writes** | `kb/curation/candidates/{id}/publish` + `publish-revision` + `dismiss`, `crm/merge-proposals/{id}/apply`, `cms/drafts/{id}/approve` + `schedule`, and `outreach/proposals/{id}/approve` — the human gate that actually sends mail in the org's name |
| Agent plumbing | `/v1/curator/jobs` + `claim` / `fail` / `progress`, `conversations/{id}/runner-claim` |
| Org surface | `/v1/inbox`, `/v1/overview/*`, `/v1/activity`, `/v1/orgs/me`, `/v1/orgs/me/roster`, `/v1/skills`, `/v1/crm/segments` |

UI-level hiding, not authorization.

## Approach

Enumerating the closed set was the wrong shape: ~60 routes, growing with every new controller, each one joining the open side silently — which is how this drifted in the first place. So the default is inverted.

`ControlPlaneGuard` — already on all 37 control-plane controllers, unlike `RoleGuard`, which 21 of them never applied — now admits a user actor only when their role in the active org is `owner` or `admin`, or when the route opts in with the new `@AllowMember()`. An unrecognized future role starts closed rather than open. Refusals carry `code: 'member_forbidden'` with an `errors.member_forbidden` entry in both locales, since a member who types an admin URL will see it.

The member surface is now eleven routes, pinned by `member-surface.test.ts` so widening it has to be a deliberate diff:

- the eight inbox routes the conversation pane actually calls — `queue`, `{id}`, `messages`, `status`, `take-over`, `release`, `request-draft`, `clear-draft`
- `/v1/me/memberships`, without which the dashboard can't resolve that the viewer *is* a member
- `/v1/overview/setup` for the first-run copy on the conversations page
- `/v1/oauth/pending-org`, so a member can still authorize a connector — `gateOauthGrantsByRole` already assumed members complete that flow and simply lose `mcp:admin`

Session credentials now carry the resolved membership role on `ActorIdentity.orgRole` (threaded from the membership `resolveSessionToken` already reads), so the common path costs no extra query. The guard falls back to reading `org_members` when a credential arrives without one — deliberate, because cloud builds its own session credentials via the exported `readMembershipsForUser` / `resolvePinnedMembership`, and a hard deny on a missing role would lock out cloud *owners* rather than just members.

One UI consequence: the console's queue badge came from `/v1/inbox`, which mixes live conversations with the review feed and is now admin-only. The shell reads `/v1/conversations/queue` for non-admins instead, so the badge keeps working for members rather than silently sitting at zero.

## Verification

- `control-plane.integration.test.ts` — 20 new cases against the real Nest app over HTTP with a seeded member session: 403 + `member_forbidden` on all five exports, the four review feeds, curator jobs, inbox, overview/backlog, orgs/me, roster, activity and skills; 200 on the three allowed routes; owner session and unrestricted admin key still 200 on `/v1/crm/export`. **132 passed.**
- `control-plane.guard.test.ts` rewritten for the async/DI signature, plus member, unknown-role, DB-fallback and missing-membership cases — 15 passed.
- Full `backend-core` **2132 passed**; core 538, dashboard-pages 153, agent-runtime 542, mcp-toolkit 76, db 24, apps/backend 20. `pnpm typecheck` and `pnpm lint` clean.

## Two things this does not close

**munin-cloud needs a pass before this ships.** Any cloud-only control-plane controller inherits deny-by-default, which is the point — but a member-facing cloud route will start 403ing, and that repo is untouched here. The DB fallback means nobody is locked out incorrectly; it is specifically member-reachable cloud routes that need `@AllowMember()`.

**Realtime is untouched.** The WebSocket gateway authenticates its own upgrade outside Nest guards, so a member's socket still receives `kb.*` and `crm.merge_proposal.*` notifications on the org channel. Those carry types and ids rather than record bodies — metadata, not data — but it is the remaining seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
