### PR TITLE
feat(dashboard): name a caller by their phone number

### DIFF
--- a/.changeset/console-phone-identity.md
+++ b/.changeset/console-phone-identity.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Name a caller by their phone number instead of "Anonymous visitor".
+
+A voice conversation usually carries a number and nothing else — no name, no email — so every call in the queue read "Anonymous visitor", indistinguishable from the next one, while the number itself sat unformatted in the thread header. The queue read model now returns `customerPhone` (contact phone, falling back to the end user's), and the queue row, the thread header and every inbound bubble in the thread resolve identity through one `customerIdentity` helper: name, then email, then the phone formatted with `libphonenumber-js` (`+47 95 03 94 93`). Queue search matches the raw number, so pasting a caller ID from a missed call finds the conversation. The thread header drops its separate phone chip when the title already is that number, and an unparseable number is shown as written rather than hidden.
+
+Only the fallback moved. A message that carries its own `authorName` still shows it, and "Anonymous" remains the label when the conversation genuinely has no name, email or number — a widget visitor who never identified themselves.
+
+The API keeps the raw E.164 string; formatting is a dashboard concern.

--- a/packages/backend-core/src/modules/conv/conv.service.test.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.test.ts
@@ -1001,13 +1001,22 @@ const skipReason = TEST_URL
     const userActor = () =>
       new ActorIdentity('user', userId, orgId, ['*'], ['admin'], undefined, undefined, undefined, userId);
 
-    async function seedQueueConversation(opts?: { withContact?: boolean; withTopic?: boolean }) {
+    async function seedQueueConversation(opts?: {
+      withContact?: boolean;
+      withTopic?: boolean;
+      endUser?: { name?: string | null; email?: string | null; phone?: string | null };
+    }) {
       const suffix = randomUUID().slice(0, 8);
       const ch = await insertChannel({ type: 'chat', vendor: 'munin', name: `queue-${suffix}` });
       await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
       const [endUser] = await db
         .insert(schema.endUsers)
-        .values({ orgId, email: `anders-${suffix}@example.com`, name: 'Anders Vik' })
+        .values({
+          orgId,
+          email: `anders-${suffix}@example.com`,
+          name: 'Anders Vik',
+          ...opts?.endUser,
+        })
         .returning();
       const [contact] =
         opts?.withContact === false
@@ -1080,6 +1089,19 @@ const skipReason = TEST_URL
       expect(item!.claim).toBeNull();
       expect(item!.noteCount).toBe(0);
       expect(item!.hasPendingDraft).toBe(false);
+    });
+
+    it('carries the caller phone number for a queue row with no name or email', async () => {
+      const { conv } = await seedQueueConversation({
+        withContact: false,
+        withTopic: false,
+        endUser: { name: null, email: null, phone: '+4795039493' },
+      });
+      const page = await run(() => svc.listConversationQueuePage({}));
+      const item = page.items.find((i) => i.id === conv.id);
+      expect(item!.customerName).toBeNull();
+      expect(item!.customerEmail).toBeNull();
+      expect(item!.customerPhone).toBe('+4795039493');
     });
 
     it('an internal note must not bump last_message_at or reorder the queue', async () => {

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -159,6 +159,7 @@ export interface ConversationQueueItem extends ConversationSummary {
   channelType: string;
   customerName: string | null;
   customerEmail: string | null;
+  customerPhone: string | null;
   topicName: string | null;
   topicSlug: string | null;
   topicAgentMode: AgentMode | null;
@@ -643,8 +644,10 @@ export class ConvService {
         channelType: schema.convChannels.type,
         contactName: schema.convContacts.name,
         contactEmail: schema.convContacts.email,
+        contactPhone: schema.convContacts.phone,
         endUserName: schema.endUsers.name,
         endUserEmail: schema.endUsers.email,
+        endUserPhone: schema.endUsers.phone,
         topicName: schema.convTopics.name,
         topicSlug: schema.convTopics.slug,
         topicAgentMode: schema.convTopics.agentMode,
@@ -739,6 +742,7 @@ export class ConvService {
         channelType: row.channelType,
         customerName: row.contactName ?? row.endUserName ?? null,
         customerEmail: row.contactEmail ?? row.endUserEmail ?? null,
+        customerPhone: row.contactPhone ?? row.endUserPhone ?? null,
         topicName: row.topicName,
         topicSlug: row.topicSlug,
         topicAgentMode: (row.topicAgentMode as AgentMode | null) ?? null,

--- a/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
@@ -10,6 +10,8 @@ import { useConversationTyping } from '../../realtime';
 import { useCmdEnter } from './queue-panes/shared';
 import { MessageBubble, startsAuthorGroup } from './inbox-message-bubble';
 import { participantHues, participantKey } from './inbox-identity';
+import { customerIdentity } from './inbox-helpers';
+import { formatPhoneNumber } from '../../lib/format-phone';
 import { LoadFailed } from '../load-failed';
 import { TestConversationBanner } from './test-conversation-banner';
 import { usePaneLoadFailedProps } from '../../lib/use-load-failed-props';
@@ -224,8 +226,13 @@ export function ConversationPane({
     );
   }
 
-  const customer =
-    item?.customerName ?? detail.contactName ?? detail.contactEmail ?? t('anonymous');
+  const customerPhone = detail.contactPhone ? formatPhoneNumber(detail.contactPhone) : null;
+  const caller = customerIdentity({
+    name: item?.customerName ?? detail.contactName,
+    email: detail.contactEmail,
+    phone: detail.contactPhone,
+  });
+  const customer = caller ?? t('anonymous');
   const composerTitle = detail.subject ?? customer;
   const composerMeta = [item?.topicName, detail.subject ? customer : null]
     .filter((v): v is string => !!v)
@@ -319,7 +326,7 @@ export function ConversationPane({
     `#${detail.displayId}`,
     item?.topicName ?? null,
     originLine,
-    detail.contactPhone,
+    customerPhone === customer ? null : customerPhone,
   ].filter((v): v is string => !!v);
 
   const editedByYou = canReply && tab === 'reply' && dirty;
@@ -469,6 +476,7 @@ export function ConversationPane({
             showAuthor={startsAuthorGroup(m, arr[i - 1])}
             viewerUserId={viewerUserId}
             hue={hues.get(participantKey(m))}
+            endUserLabel={caller}
           />
         ))}
         {visitorTyping ? (

--- a/packages/dashboard-pages/src/components/dashboard/conversation-queue.test.ts
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-queue.test.ts
@@ -29,6 +29,7 @@ function item(overrides: Partial<QueueItemDto>): QueueItemDto {
     agentMode: 'draft_only',
     customerName: 'Anders Vik',
     customerEmail: 'anders@example.com',
+    customerPhone: null,
     topicName: null,
     topicSlug: null,
     topicAgentMode: null,
@@ -105,6 +106,11 @@ describe('matchesQueueSearch', () => {
     expect(matchesQueueSearch(row, 'document req')).toBe(true);
     expect(matchesQueueSearch(row, 'refinancing')).toBe(false);
     expect(matchesQueueSearch(row, '  ')).toBe(true);
+  });
+
+  it('matches the raw phone number of a caller who has no name or email', () => {
+    const row = item({ customerName: null, customerEmail: null, customerPhone: '+4795039493' });
+    expect(matchesQueueSearch(row, '4795039493')).toBe(true);
   });
 });
 

--- a/packages/dashboard-pages/src/components/dashboard/conversation-queue.ts
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-queue.ts
@@ -36,6 +36,7 @@ export interface QueueItemDto {
   agentMode: 'auto' | 'draft_only' | 'off';
   customerName: string | null;
   customerEmail: string | null;
+  customerPhone: string | null;
   topicName: string | null;
   topicSlug: string | null;
   topicAgentMode: 'auto' | 'draft_only' | 'off' | null;
@@ -109,7 +110,14 @@ export function partitionQueue(
 export function matchesQueueSearch(item: QueueItemDto, query: string): boolean {
   const q = query.trim().toLowerCase();
   if (!q) return true;
-  return [item.customerName, item.customerEmail, item.subject, item.lastInboundPreview, item.topicName]
+  return [
+    item.customerName,
+    item.customerEmail,
+    item.customerPhone,
+    item.subject,
+    item.lastInboundPreview,
+    item.topicName,
+  ]
     .filter((v): v is string => typeof v === 'string')
     .some((v) => v.toLowerCase().includes(q));
 }

--- a/packages/dashboard-pages/src/components/dashboard/conversation-row.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-row.tsx
@@ -5,6 +5,7 @@ import { Pill, cn } from '@getmunin/ui';
 import { useRelative } from '../../lib/use-relative';
 import type { QueueItemDto } from './conversation-queue';
 import { initialsOf } from '../../lib/initials';
+import { customerLabel } from './inbox-helpers';
 import { QueueRow, RowNote, RowTime } from './queue-row';
 
 function ClaimFace({
@@ -74,9 +75,10 @@ export function ConversationRow({
         </Pill>
       }
       emphasizeTitle={showsAttention}
-      title={`${item.customerName ?? item.customerEmail ?? t('anonymous')}${
-        item.subject ? ` — ${item.subject}` : ''
-      }`}
+      title={`${customerLabel(
+        { name: item.customerName, email: item.customerEmail, phone: item.customerPhone },
+        t('anonymous'),
+      )}${item.subject ? ` — ${item.subject}` : ''}`}
       meta={item.lastInboundPreview || undefined}
       extra={
         <>

--- a/packages/dashboard-pages/src/components/dashboard/inbox-helpers.test.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-helpers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { customerIdentity, customerLabel } from './inbox-helpers';
+
+describe('customerIdentity', () => {
+  it('is null when nothing identifies the customer, so callers can pick their own wording', () => {
+    expect(customerIdentity({ name: null, email: null, phone: null })).toBeNull();
+    expect(customerIdentity({})).toBeNull();
+  });
+
+  it('formats a phone-only caller', () => {
+    expect(customerIdentity({ phone: '+4795039493' })).toBe('+47 95 03 94 93');
+  });
+});
+
+describe('customerLabel', () => {
+  it('prefers name, then email, then a formatted phone number', () => {
+    expect(
+      customerLabel({ name: 'Anders Vik', email: 'anders@example.com', phone: '+4795039493' }, '—'),
+    ).toBe('Anders Vik');
+    expect(customerLabel({ email: 'anders@example.com', phone: '+4795039493' }, '—')).toBe(
+      'anders@example.com',
+    );
+    expect(customerLabel({ phone: '+4795039493' }, '—')).toBe('+47 95 03 94 93');
+  });
+
+  it('keeps an unparseable phone number as written rather than dropping it', () => {
+    expect(customerLabel({ phone: '12345' }, '—')).toBe('12345');
+  });
+
+  it('falls back when nothing identifies the customer', () => {
+    expect(customerLabel({ name: null, email: null, phone: null }, 'Anonymous visitor')).toBe(
+      'Anonymous visitor',
+    );
+  });
+});

--- a/packages/dashboard-pages/src/components/dashboard/inbox-helpers.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-helpers.ts
@@ -1,7 +1,24 @@
 import type { useTranslations } from 'next-intl';
+import { formatPhoneNumber } from '../../lib/format-phone';
 import type { CrmContactSummary, FeedbackOutboxDto } from './queue-panes/types';
 
 export const contactLabel = (c: CrmContactSummary) => c.name ?? c.email ?? c.id;
+
+export interface CustomerIdentity {
+  name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+}
+
+export function customerIdentity(customer: CustomerIdentity): string | null {
+  return (
+    customer.name ?? customer.email ?? (customer.phone ? formatPhoneNumber(customer.phone) : null)
+  );
+}
+
+export function customerLabel(customer: CustomerIdentity, fallback: string): string {
+  return customerIdentity(customer) ?? fallback;
+}
 
 export function feedbackSnippet(
   f: FeedbackOutboxDto,

--- a/packages/dashboard-pages/src/components/dashboard/inbox-message-bubble.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-message-bubble.tsx
@@ -52,11 +52,13 @@ export function MessageBubble({
   showAuthor = true,
   viewerUserId = null,
   hue,
+  endUserLabel = null,
 }: {
   message: MessageDto;
   showAuthor?: boolean;
   viewerUserId?: string | null;
   hue?: number;
+  endUserLabel?: string | null;
 }) {
   const t = useTranslations('dashboard.overview.drawer');
   const role = messageRole(message, viewerUserId);
@@ -70,7 +72,7 @@ export function MessageBubble({
       </div>
     );
   }
-  const label = bubbleLabel(message, t);
+  const label = bubbleLabel(message, t, endUserLabel);
   if (message.internal) {
     return (
       <div
@@ -160,9 +162,10 @@ function formatSeenAt(iso: string): string {
 function bubbleLabel(
   message: MessageDto,
   t: ReturnType<typeof useTranslations<'dashboard.overview.drawer'>>,
+  endUserLabel: string | null = null,
 ): string {
   if (message.authorName) return message.authorName;
-  if (message.authorType === 'end_user') return t('anonymousVisitor');
+  if (message.authorType === 'end_user') return endUserLabel ?? t('anonymousVisitor');
   return message.authorType;
 }
 


### PR DESCRIPTION
A voice conversation arrives with a phone number and nothing else — no name, no email — so the console showed a wall of identical **Anonymous visitor** rows, while the number itself sat unformatted (`+4799999999`) in the thread header meta line. Picking the right call out of the queue was impossible.

## What changed

`ConversationQueueItem` now carries `customerPhone`, resolved the same way the detail endpoint already resolves `contactPhone`: the linked contact's phone, falling back to the end user's. The API keeps the raw E.164 string — formatting is a dashboard concern.

On the dashboard, three places used to spell out their own fallback chain. They now share one helper in `inbox-helpers.ts`:

- `customerIdentity()` → name, then email, then the phone run through `libphonenumber-js` (`+47 99 99 99 99`), or `null`
- `customerLabel()` → the same, with a caller-supplied fallback

Applied to:

- **Queue row** — a call reads `+47 99 99 99 99` instead of `Anonymous visitor`.
- **Thread header** — the title resolves the same way, and the separate phone chip in the meta line is dropped when the title already *is* that number (it was duplicating it in exactly the anonymous-caller case). Otherwise it is now formatted.
- **Inbound message bubbles** — `MessageBubble` takes an `endUserLabel`, used only where the old code hardcoded the anonymous string. A message that carries its own `authorName` still shows it, so `startsAuthorGroup` grouping is unaffected.

Queue search matches the raw number too, so a caller ID pasted from a missed call finds the conversation.

Only the fallback moved: `Anonymous` stays the label when the conversation genuinely has no name, email or number — a widget visitor who never identified themselves. An unparseable number is shown as written rather than hidden.

## Tests

- `inbox-helpers.test.ts` (new) — the precedence chain, an unparseable number surviving as written, `customerIdentity` returning `null` so callers pick their own wording.
- `conversation-queue.test.ts` — queue search matching a raw number on a row with no name or email.
- `conv.service.test.ts` — a queue row for a phone-only end user carries `customerPhone` with `customerName`/`customerEmail` null.

`pnpm typecheck` clean; dashboard-pages 170/170; `conv.service.test.ts` 75/75 against a migrated local DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

