### PR TITLE
feat(dashboard): render first run on the server, and one loading gate for every console page

### DIFF
--- a/.changeset/first-run-no-skeleton-flash.md
+++ b/.changeset/first-run-no-skeleton-flash.md
@@ -1,0 +1,15 @@
+---
+'@getmunin/dashboard-pages': minor
+---
+
+A first-run workspace now renders its onboarding steps in the server HTML, with no spinner and no skeleton in front of it, and every console page decides that the same way.
+
+The dashboard shell used to withhold every page behind a `PageSpinner` until four client fetches — session, membership, agent config, setup state — had all landed, and Dashboard and Automation then held a skeleton until a second fetch (usage summary, automation summary) landed on top of that. `readDashboardBootstrap()` now does that work on the server: a new `@getmunin/dashboard-pages/server` export reads the session cookie, fetches memberships, agent config and setup state in parallel, and feeds them to a `DashboardBootstrapProvider` that seeds `useActiveMembership`, `useAgentConfigStatus` and `useSetupState`. With those seeded the gate is satisfied on the first render, so the shell, the sidebar and the first-run scene are all in the initial HTML.
+
+The bootstrap is deliberately conservative and returns `null` — falling back to the existing client path unchanged — when there is no session cookie, when any fetch fails or exceeds 1.5s, when setup is incomplete (that user belongs on `/setup`, and the redirect stays client-side), or when the user belongs to more than one org. The active-org pin lives in `sessionStorage`, which a server render cannot see, so for a multi-org user the server cannot tell which org to fetch; single-tenant OSS deployments always take the fast path.
+
+On that fallback path `SetupStateProvider` now mounts alongside the spinner rather than behind it, so the setup fetch runs beside the gate's own fetches instead of queueing after them. It takes an `enabled` flag, and `useRealtime` an `enabled` option, so a signed-out visitor still opens no socket and fetches nothing.
+
+Dashboard, Conversations, Review and Automation now share one `useFirstRunGate()` returning a single `view` of `loading | firstRun | content`, replacing four different hand-rolled conditions. A page narrows first run with its own emptiness rule — `topicCount === 0` on Automation, nothing pending on Review — and returns `null` from that rule when it cannot decide yet, which reads as `loading` rather than a wrong guess. Dashboard passes `content: inbox.hasLoadedOnce` so its own data gates only the content branch, never the first-run branch, and it names its skeleton once instead of twice. Automation additionally reads its topic count from the setup snapshot rather than from the automation summary, so deciding first run needs one request instead of two.
+
+`useDashboardGate` also drops its duplicate `roleLoading` term — `useActiveRole` returns `useActiveMembership`'s own loading flag — in favour of three named booleans, and the three copies of "fetch JSON from the API forwarding the caller's cookie" in `setup-gate.ts`, `server-session.ts` and the new bootstrap now share one `fetchJsonWithCookie` helper.

--- a/apps/web/app/[locale]/dashboard/dashboard-chrome.tsx
+++ b/apps/web/app/[locale]/dashboard/dashboard-chrome.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { DashboardShell, useActiveMembership } from '@getmunin/dashboard-pages';
+
+export function DashboardChrome({ children }: { children: React.ReactNode }) {
+  const { membership } = useActiveMembership();
+  const brand = membership?.name?.trim() || 'Munin';
+
+  return (
+    <DashboardShell brand={brand} withConfirmDialog>
+      {children}
+    </DashboardShell>
+  );
+}

--- a/apps/web/app/[locale]/dashboard/layout.tsx
+++ b/apps/web/app/[locale]/dashboard/layout.tsx
@@ -1,14 +1,13 @@
-'use client';
+import { DashboardBootstrapProvider } from '@getmunin/dashboard-pages';
+import { readDashboardBootstrap } from '@getmunin/dashboard-pages/server';
+import { DashboardChrome } from './dashboard-chrome';
 
-import { DashboardShell, useActiveMembership } from '@getmunin/dashboard-pages';
-
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const { membership } = useActiveMembership();
-  const brand = membership?.name?.trim() || 'Munin';
+export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const bootstrap = await readDashboardBootstrap();
 
   return (
-    <DashboardShell brand={brand} withConfirmDialog>
-      {children}
-    </DashboardShell>
+    <DashboardBootstrapProvider value={bootstrap}>
+      <DashboardChrome>{children}</DashboardChrome>
+    </DashboardBootstrapProvider>
   );
 }

--- a/packages/dashboard-pages/src/auth/api-cookie-fetch.ts
+++ b/packages/dashboard-pages/src/auth/api-cookie-fetch.ts
@@ -1,0 +1,28 @@
+const DEFAULT_TIMEOUT_MS = 1500;
+
+export function resolveApiUrl(apiUrl?: string): string {
+  const raw = apiUrl ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+  let end = raw.length;
+  while (end > 0 && raw[end - 1] === '/') end -= 1;
+  return raw.slice(0, end);
+}
+
+export async function fetchJsonWithCookie<T>(
+  path: string,
+  cookie: string,
+  options: { apiUrl?: string; timeoutMs?: number; label?: string } = {},
+): Promise<T | null> {
+  const url = `${resolveApiUrl(options.apiUrl)}${path}`;
+  try {
+    const res = await fetch(url, {
+      headers: { cookie },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn(`[${options.label ?? 'api-cookie-fetch'}] fetch failed`, path, err);
+    return null;
+  }
+}

--- a/packages/dashboard-pages/src/auth/dashboard-bootstrap.tsx
+++ b/packages/dashboard-pages/src/auth/dashboard-bootstrap.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+import type { SetupStateDto } from '../components/first-run/setup-snapshot';
+import type { ActiveMembership } from './use-active-role';
+
+export interface DashboardBootstrap {
+  membership: ActiveMembership;
+  providerConfigured: boolean;
+  setup: SetupStateDto;
+}
+
+const DashboardBootstrapContext = createContext<DashboardBootstrap | null>(null);
+
+export function DashboardBootstrapProvider({
+  value,
+  children,
+}: {
+  value: DashboardBootstrap | null;
+  children: ReactNode;
+}) {
+  return (
+    <DashboardBootstrapContext.Provider value={value}>{children}</DashboardBootstrapContext.Provider>
+  );
+}
+
+export function useDashboardBootstrap(): DashboardBootstrap | null {
+  return useContext(DashboardBootstrapContext);
+}

--- a/packages/dashboard-pages/src/auth/read-dashboard-bootstrap.ts
+++ b/packages/dashboard-pages/src/auth/read-dashboard-bootstrap.ts
@@ -1,0 +1,49 @@
+import 'server-only';
+import { cookies } from 'next/headers';
+import type { SetupStateDto } from '../components/first-run/setup-snapshot';
+import { fetchJsonWithCookie } from './api-cookie-fetch';
+import type { DashboardBootstrap } from './dashboard-bootstrap';
+import { isSetupIncomplete, type AgentConfigStatusDto, type MembershipDto } from './setup-status';
+
+type OrgRole = 'owner' | 'admin' | 'member';
+
+interface OrgMembershipDto extends MembershipDto {
+  slug: string;
+}
+
+function read<T>(path: string, cookie: string): Promise<T | null> {
+  return fetchJsonWithCookie<T>(path, cookie, { label: 'dashboard-bootstrap' });
+}
+
+export async function readDashboardBootstrap(): Promise<DashboardBootstrap | null> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.toString();
+  if (!cookie) return null;
+
+  const [memberships, config, setup] = await Promise.all([
+    read<OrgMembershipDto[]>('/v1/me/memberships', cookie),
+    read<AgentConfigStatusDto>('/v1/agent-config', cookie),
+    read<SetupStateDto>('/v1/overview/setup', cookie),
+  ]);
+  if (!memberships || !config || !setup) return null;
+
+  const active = memberships.length === 1 ? memberships[0] : null;
+  if (!active || !isOrgRole(active.role)) return null;
+  if (isSetupIncomplete(config, memberships)) return null;
+
+  return {
+    membership: {
+      orgId: active.orgId,
+      name: active.name,
+      slug: active.slug,
+      role: active.role,
+      isDefault: active.isDefault,
+    },
+    providerConfigured: config.providerConfigured,
+    setup,
+  };
+}
+
+function isOrgRole(value: string): value is OrgRole {
+  return value === 'owner' || value === 'admin' || value === 'member';
+}

--- a/packages/dashboard-pages/src/auth/server-session.ts
+++ b/packages/dashboard-pages/src/auth/server-session.ts
@@ -2,9 +2,10 @@ import 'server-only';
 import { cookies } from 'next/headers';
 import { redirect as externalRedirect } from 'next/navigation';
 import { redirect } from '../i18n-navigation';
+import { fetchJsonWithCookie, resolveApiUrl } from './api-cookie-fetch';
 import { oauthResumeFromSearchParams, safeRedirect } from './post-signin-redirect';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+const SERVER_FETCH = { label: 'server-session' };
 
 type OrgRole = 'owner' | 'admin' | 'member';
 
@@ -20,20 +21,6 @@ interface AgentConfigStatusDto {
   providerConfigured: boolean;
 }
 
-async function fetchWithCookies<T>(path: string, cookieHeader: string): Promise<T | null> {
-  try {
-    const res = await fetch(`${API_URL}${path}`, {
-      headers: { cookie: cookieHeader },
-      cache: 'no-store',
-    });
-    if (!res.ok) return null;
-    return (await res.json()) as T;
-  } catch (err) {
-    console.warn('[server-session] fetch failed', path, err);
-    return null;
-  }
-}
-
 export interface ServerSession {
   user: { id: string; email?: string | null } & Record<string, unknown>;
   session: { id: string } & Record<string, unknown>;
@@ -44,7 +31,7 @@ export async function getServerSession(): Promise<ServerSession | null> {
   const cookieHeader = cookieStore.toString();
   if (!cookieHeader) return null;
   try {
-    const res = await fetch(`${API_URL}/auth/get-session`, {
+    const res = await fetch(`${resolveApiUrl()}/auth/get-session`, {
       headers: { cookie: cookieHeader },
       cache: 'no-store',
     });
@@ -80,8 +67,8 @@ export async function redirectIfSetupIncomplete(opts: {
   if (!cookieHeader) return;
 
   const [config, memberships] = await Promise.all([
-    fetchWithCookies<AgentConfigStatusDto>('/v1/agent-config', cookieHeader),
-    fetchWithCookies<MembershipDto[]>('/v1/me/memberships', cookieHeader),
+    fetchJsonWithCookie<AgentConfigStatusDto>('/v1/agent-config', cookieHeader, SERVER_FETCH),
+    fetchJsonWithCookie<MembershipDto[]>('/v1/me/memberships', cookieHeader, SERVER_FETCH),
   ]);
   if (!config || !memberships) return;
 

--- a/packages/dashboard-pages/src/auth/use-active-role.ts
+++ b/packages/dashboard-pages/src/auth/use-active-role.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { api } from '../api';
 import { authClient } from '../auth-client';
 import { getActiveOrgId } from './active-org';
+import { useDashboardBootstrap } from './dashboard-bootstrap';
 
 export type OrgRole = 'owner' | 'admin' | 'member';
 
@@ -73,10 +74,14 @@ export function useActiveMembership(): {
   loading: boolean;
   error: string | null;
 } {
+  const bootstrap = useDashboardBootstrap();
+  const seeded = bootstrap !== null;
   const { data: session, isPending } = authClient.useSession();
   const userId = session?.user?.id ?? null;
-  const [membership, setMembership] = useState<ActiveMembership | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [membership, setMembership] = useState<ActiveMembership | null>(
+    bootstrap?.membership ?? null,
+  );
+  const [loading, setLoading] = useState(!seeded);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -87,7 +92,7 @@ export function useActiveMembership(): {
       setLoading(false);
       return;
     }
-    setLoading(true);
+    if (!seeded) setLoading(true);
     setError(null);
     fetchActiveMembership(userId)
       .then((m) => {
@@ -105,7 +110,7 @@ export function useActiveMembership(): {
     return () => {
       cancelled = true;
     };
-  }, [userId, isPending]);
+  }, [userId, isPending, seeded]);
 
   return { membership, loading, error };
 }

--- a/packages/dashboard-pages/src/auth/use-agent-config-status.ts
+++ b/packages/dashboard-pages/src/auth/use-agent-config-status.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { api } from '../api';
+import { useDashboardBootstrap } from './dashboard-bootstrap';
 
 interface AgentConfigStatusDto {
   providerConfigured: boolean;
@@ -12,8 +13,11 @@ export function useAgentConfigStatus(): {
   loading: boolean;
   error: string | null;
 } {
-  const [configured, setConfigured] = useState<boolean | null>(null);
-  const [loading, setLoading] = useState(true);
+  const bootstrap = useDashboardBootstrap();
+  const [configured, setConfigured] = useState<boolean | null>(
+    bootstrap?.providerConfigured ?? null,
+  );
+  const [loading, setLoading] = useState(bootstrap === null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/packages/dashboard-pages/src/auth/use-dashboard-gate.ts
+++ b/packages/dashboard-pages/src/auth/use-dashboard-gate.ts
@@ -3,22 +3,32 @@
 import { useEffect } from 'react';
 import { usePathname, useRouter } from '../i18n-navigation';
 import { authClient } from '../auth-client';
-import { isOwnerOrAdmin, useActiveMembership, useActiveRole, type OrgRole } from './use-active-role';
+import { useDashboardBootstrap } from './dashboard-bootstrap';
+import { isOwnerOrAdmin, useActiveMembership, type OrgRole } from './use-active-role';
 import { useAgentConfigStatus } from './use-agent-config-status';
 
 const EXEMPT_PREFIXES = ['/dashboard/account', '/dashboard/oauth/consent'];
 
-export function useDashboardGate(): { ready: boolean; role: OrgRole | null } {
+export function useDashboardGate(): {
+  ready: boolean;
+  signedIn: boolean;
+  role: OrgRole | null;
+} {
   const router = useRouter();
   const pathname = usePathname();
+  const bootstrap = useDashboardBootstrap();
   const { data: session, isPending } = authClient.useSession();
-  const { role, loading: roleLoading } = useActiveRole();
   const { membership, loading: membershipLoading } = useActiveMembership();
   const { configured, loading: configLoading } = useAgentConfigStatus();
 
+  const role = membership?.role ?? null;
   const exempt = EXEMPT_PREFIXES.some((p) => pathname?.startsWith(p));
   const orgNamed = membership ? membership.name.trim().length > 0 : null;
-  const setupIncomplete = configured === false || orgNamed === false;
+
+  const signedIn = bootstrap !== null || (!isPending && !!session);
+  const accountLoaded = !membershipLoading && !configLoading;
+  const mustFinishSetup =
+    (configured === false || orgNamed === false) && isOwnerOrAdmin(role);
 
   useEffect(() => {
     if (isPending) return;
@@ -26,32 +36,14 @@ export function useDashboardGate(): { ready: boolean; role: OrgRole | null } {
       router.push('/login');
       return;
     }
-    if (exempt) return;
-    if (roleLoading || configLoading || membershipLoading) return;
-    if (setupIncomplete && isOwnerOrAdmin(role)) {
+    if (exempt || !accountLoaded) return;
+    if (mustFinishSetup) {
       const search = typeof window !== 'undefined' ? window.location.search : '';
       router.push(search ? `/setup${search}` : '/setup');
     }
-  }, [
-    isPending,
-    session,
-    roleLoading,
-    configLoading,
-    membershipLoading,
-    setupIncomplete,
-    role,
-    exempt,
-    router,
-  ]);
+  }, [isPending, session, exempt, accountLoaded, mustFinishSetup, router]);
 
-  const ready =
-    !isPending &&
-    !!session &&
-    (exempt ||
-      (!roleLoading &&
-        !configLoading &&
-        !membershipLoading &&
-        (!setupIncomplete || !isOwnerOrAdmin(role))));
+  const ready = signedIn && (exempt || (accountLoaded && !mustFinishSetup));
 
-  return { ready, role };
+  return { ready, signedIn, role };
 }

--- a/packages/dashboard-pages/src/components/first-run/first-run-view.test.ts
+++ b/packages/dashboard-pages/src/components/first-run/first-run-view.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFirstRunView } from './first-run-view';
+import type { SetupState } from './use-setup-state';
+
+function setupState(overrides: Partial<SetupState> = {}): SetupState {
+  return {
+    known: true,
+    stage: 'active',
+    liveChannels: [],
+    pendingChannels: [],
+    agentConnected: false,
+    externalMcpCallCount: 0,
+    lastExternalMcpCallAt: null,
+    conversationCount: 0,
+    topicCount: 0,
+    knowledgeDocumentCount: 0,
+    loading: false,
+    isFirstRun: false,
+    reload: async () => {},
+    ...overrides,
+  };
+}
+
+describe('resolveFirstRunView', () => {
+  it('waits while the setup snapshot is still loading', () => {
+    expect(resolveFirstRunView(setupState({ loading: true }))).toBe('loading');
+  });
+
+  it('shows first run as soon as setup resolves, without waiting for page content', () => {
+    const setup = setupState({ isFirstRun: true, stage: 'listening' });
+    expect(resolveFirstRunView(setup, { content: false })).toBe('firstRun');
+  });
+
+  it('waits for page content only once first run is ruled out', () => {
+    expect(resolveFirstRunView(setupState(), { content: false })).toBe('loading');
+    expect(resolveFirstRunView(setupState(), { content: true })).toBe('content');
+  });
+
+  it('lets a page narrow first run to its own emptiness rule', () => {
+    const setup = setupState({ isFirstRun: true, topicCount: 3 });
+    expect(resolveFirstRunView(setup, { firstRun: (s) => s.topicCount === 0 })).toBe('content');
+    expect(resolveFirstRunView(setup, { firstRun: () => true })).toBe('firstRun');
+  });
+
+  it('waits rather than guessing when the page cannot decide first run yet', () => {
+    const setup = setupState({ isFirstRun: true });
+    expect(resolveFirstRunView(setup, { firstRun: () => null })).toBe('loading');
+  });
+
+  it('never consults the page rules for a workspace past first run', () => {
+    const setup = setupState({ isFirstRun: false });
+    expect(resolveFirstRunView(setup, { firstRun: () => null })).toBe('content');
+  });
+});

--- a/packages/dashboard-pages/src/components/first-run/first-run-view.ts
+++ b/packages/dashboard-pages/src/components/first-run/first-run-view.ts
@@ -1,0 +1,23 @@
+import type { SetupState } from './use-setup-state';
+
+export type FirstRunView = 'loading' | 'firstRun' | 'content';
+
+export interface FirstRunGateOptions {
+  firstRun?: (setup: SetupState) => boolean | null;
+  content?: boolean;
+}
+
+export function resolveFirstRunView(
+  setup: SetupState,
+  options: FirstRunGateOptions = {},
+): FirstRunView {
+  if (setup.loading) return 'loading';
+
+  if (setup.isFirstRun) {
+    const narrowed = options.firstRun ? options.firstRun(setup) : true;
+    if (narrowed === null) return 'loading';
+    if (narrowed) return 'firstRun';
+  }
+
+  return options.content === false ? 'loading' : 'content';
+}

--- a/packages/dashboard-pages/src/components/first-run/index.ts
+++ b/packages/dashboard-pages/src/components/first-run/index.ts
@@ -6,6 +6,12 @@ export {
   type SetupStage,
   type SetupState,
 } from './use-setup-state';
+export {
+  resolveFirstRunView,
+  type FirstRunGateOptions,
+  type FirstRunView,
+} from './first-run-view';
+export { useFirstRunGate, type FirstRunGate } from './use-first-run-gate';
 export { toSetupSnapshot, type SetupSnapshot, type SetupStateDto } from './setup-snapshot';
 export {
   FIRST_RUN_DOCS,

--- a/packages/dashboard-pages/src/components/first-run/use-first-run-gate.ts
+++ b/packages/dashboard-pages/src/components/first-run/use-first-run-gate.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { resolveFirstRunView, type FirstRunGateOptions, type FirstRunView } from './first-run-view';
+import { useSetupState, type SetupState } from './use-setup-state';
+
+export interface FirstRunGate {
+  view: FirstRunView;
+  setup: SetupState;
+}
+
+export function useFirstRunGate(options: FirstRunGateOptions = {}): FirstRunGate {
+  const setup = useSetupState();
+  return { view: resolveFirstRunView(setup, options), setup };
+}

--- a/packages/dashboard-pages/src/components/first-run/use-setup-state.tsx
+++ b/packages/dashboard-pages/src/components/first-run/use-setup-state.tsx
@@ -11,6 +11,7 @@ import {
   type ReactNode,
 } from 'react';
 import { api } from '../../api';
+import { useDashboardBootstrap } from '../../auth/dashboard-bootstrap';
 import { usePathname } from '../../i18n-navigation';
 import { useRealtime, type SubscriptionChannel } from '../../realtime';
 import { toSetupSnapshot, type SetupSnapshot, type SetupStateDto } from './setup-snapshot';
@@ -36,8 +37,14 @@ const ORG_SUBSCRIPTION: readonly SubscriptionChannel[] = [{ channel: 'org' }];
 
 const SetupStateContext = createContext<SetupState | null>(null);
 
-export function SetupStateProvider({ children }: { children: ReactNode }) {
-  const value = useFetchSetupState(true);
+export function SetupStateProvider({
+  enabled = true,
+  children,
+}: {
+  enabled?: boolean;
+  children: ReactNode;
+}) {
+  const value = useFetchSetupState(enabled);
   return <SetupStateContext.Provider value={value}>{children}</SetupStateContext.Provider>;
 }
 
@@ -48,8 +55,9 @@ export function useSetupState(): SetupState {
 }
 
 function useFetchSetupState(enabled: boolean): SetupState {
-  const [dto, setDto] = useState<SetupStateDto | null>(null);
-  const [loading, setLoading] = useState(true);
+  const bootstrap = useDashboardBootstrap();
+  const [dto, setDto] = useState<SetupStateDto | null>(bootstrap?.setup ?? null);
+  const [loading, setLoading] = useState(bootstrap === null);
   const startedAt = useRef(0);
   const pathname = usePathname();
 
@@ -71,9 +79,13 @@ function useFetchSetupState(enabled: boolean): SetupState {
     revalidate();
   }, [revalidate, pathname]);
 
-  useRealtime(ORG_SUBSCRIPTION, (event) => {
-    if (REFRESH_PREFIXES.some((prefix) => event.type.startsWith(prefix))) revalidate();
-  });
+  useRealtime(
+    ORG_SUBSCRIPTION,
+    (event) => {
+      if (REFRESH_PREFIXES.some((prefix) => event.type.startsWith(prefix))) revalidate();
+    },
+    { enabled },
+  );
 
   return useMemo(() => {
     const snapshot = toSetupSnapshot(dto);

--- a/packages/dashboard-pages/src/index.ts
+++ b/packages/dashboard-pages/src/index.ts
@@ -96,6 +96,11 @@ export {
   type ActiveMembership,
 } from './auth/use-active-role';
 export { useAgentConfigStatus } from './auth/use-agent-config-status';
+export {
+  DashboardBootstrapProvider,
+  useDashboardBootstrap,
+  type DashboardBootstrap,
+} from './auth/dashboard-bootstrap';
 export { useDashboardGate } from './auth/use-dashboard-gate';
 export { useSetupGate } from './auth/use-setup-gate';
 export { safeRedirect, resumeOauthAuthorizeUrl } from './auth/post-signin-redirect';

--- a/packages/dashboard-pages/src/pages/automation.tsx
+++ b/packages/dashboard-pages/src/pages/automation.tsx
@@ -19,7 +19,7 @@ import { notify } from '../lib/notify';
 import { useTranslateError } from '../i18n/translate-error';
 import { useRealtime } from '../realtime';
 import { LoadFailed } from '../components/load-failed';
-import { AutomationFirstRun, useSetupState } from '../components/first-run';
+import { AutomationFirstRun, useFirstRunGate } from '../components/first-run';
 import { useInboxLoadFailedProps } from '../lib/use-load-failed-props';
 
 type TopicMode = 'auto' | 'draft_only' | 'off' | null;
@@ -73,7 +73,7 @@ function autoIsSending(row: TopicAutomationRow): boolean {
 export function AutomationPage() {
   const t = useTranslations('dashboard.console.automation');
   const translateErr = useTranslateError();
-  const setup = useSetupState();
+  const gate = useFirstRunGate({ firstRun: (s) => s.topicCount === 0 });
   const buildLoadFailedProps = useInboxLoadFailedProps();
   const [summary, setSummary] = useState<AutomationSummary | null>(null);
   const [loadError, setLoadError] = useState<ApiError | null>(null);
@@ -176,8 +176,7 @@ export function AutomationPage() {
     );
   }
 
-  const firstRunUndecided = setup.loading || (setup.isFirstRun && summary === null);
-  if (firstRunUndecided) {
+  if (gate.view === 'loading') {
     return (
       <div className="flex min-h-full flex-col">
         <ConsoleHeroSkeleton actions />
@@ -187,7 +186,7 @@ export function AutomationPage() {
       </div>
     );
   }
-  if (setup.isFirstRun && topics.length === 0) return <AutomationFirstRun setup={setup} />;
+  if (gate.view === 'firstRun') return <AutomationFirstRun setup={gate.setup} />;
 
   const autoRate = summary?.autoRate7d;
   const editingPct = editing ? uneditedPct(editing) : null;

--- a/packages/dashboard-pages/src/pages/conversations.tsx
+++ b/packages/dashboard-pages/src/pages/conversations.tsx
@@ -18,7 +18,7 @@ import { ConversationPane } from '../components/dashboard/conversation-pane';
 import { ConsoleSectionLabel } from '../components/console-section-label';
 import { ConsoleListEmpty } from '../components/console-empty';
 import { ConsoleRowsSkeleton, ConsoleSplitSkeleton } from '../components/console-skeleton';
-import { ConversationsFirstRun, useSetupState } from '../components/first-run';
+import { ConversationsFirstRun, useFirstRunGate } from '../components/first-run';
 import { useProvideMobileBack } from '../shells/mobile-back';
 
 const FADE_FLOOR = 0.55;
@@ -33,7 +33,8 @@ export function ConversationsPage({ selectedId = null }: { selectedId?: string |
     pathname.match(/^\/dashboard\/conversations\/([^/]+)/)?.[1] ??
     (onQueueRoute ? null : selectedId);
   const queue = useConversationQueue(routeSelectedId);
-  const setup = useSetupState();
+  const gate = useFirstRunGate();
+  const setup = gate.setup;
   const buildLoadFailedProps = useInboxLoadFailedProps();
   const { data: session } = authClient.useSession();
   const viewerUserId = session?.user?.id ?? null;
@@ -103,8 +104,8 @@ export function ConversationsPage({ selectedId = null }: { selectedId?: string |
     );
   }
 
-  if (setup.loading) return <ConsoleSplitSkeleton grid={SPLIT_GRID} />;
-  if (setup.isFirstRun) return <ConversationsFirstRun setup={setup} />;
+  if (gate.view === 'loading') return <ConsoleSplitSkeleton grid={SPLIT_GRID} />;
+  if (gate.view === 'firstRun') return <ConversationsFirstRun setup={gate.setup} />;
 
   const select = (id: string) => shallowGo(`/dashboard/conversations/${id}`);
 

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -10,7 +10,7 @@ import { OverviewReview } from '../components/dashboard/overview-review';
 import { UsageKpis, type UsageSummary } from '../components/dashboard/usage-kpis';
 import { LoadFailed } from '../components/load-failed';
 import { Skeleton } from '../components/skeleton';
-import { OverviewFirstRun, useSetupState } from '../components/first-run';
+import { OverviewFirstRun, useFirstRunGate } from '../components/first-run';
 import { useInboxLoadFailedProps } from '../lib/use-load-failed-props';
 import { useInboxData } from '../components/dashboard/inbox-data';
 
@@ -18,7 +18,7 @@ const OVERVIEW_SHELL = 'mx-auto max-w-4xl space-y-12 px-4 pb-16 pt-11 md:px-10';
 
 export function DashboardPage() {
   const inbox = useInboxData();
-  const setup = useSetupState();
+  const gate = useFirstRunGate({ content: inbox.hasLoadedOnce });
   const [summary, setSummary] = useState<UsageSummary | null>(null);
   const buildLoadFailedProps = useInboxLoadFailedProps();
 
@@ -53,8 +53,8 @@ export function DashboardPage() {
     );
   }
 
-  if (setup.loading || !inbox.hasLoadedOnce) return <OverviewSkeleton />;
-  if (setup.isFirstRun) return <OverviewFirstRun setup={setup} />;
+  if (gate.view === 'loading') return <OverviewSkeleton />;
+  if (gate.view === 'firstRun') return <OverviewFirstRun setup={gate.setup} />;
 
   return (
     <div className={OVERVIEW_SHELL}>

--- a/packages/dashboard-pages/src/pages/review.tsx
+++ b/packages/dashboard-pages/src/pages/review.tsx
@@ -25,7 +25,7 @@ import { useProvideMobileBack } from '../shells/mobile-back';
 import { ConsoleSectionLabel } from '../components/console-section-label';
 import { ConsoleListEmpty } from '../components/console-empty';
 import { ConsoleRowsSkeleton, ConsoleSplitSkeleton } from '../components/console-skeleton';
-import { ReviewFirstRun, useSetupState } from '../components/first-run';
+import { ReviewFirstRun, useFirstRunGate } from '../components/first-run';
 
 const ROOT = '/dashboard/review';
 const FADE_FLOOR = 0.55;
@@ -39,7 +39,6 @@ export function ReviewPage({ selectedId = null }: { selectedId?: string | null }
   const router = useRouter();
   const pathname = usePathname();
   const inbox = useInboxData();
-  const setup = useSetupState();
   const decisions = useCurationDecisions();
   const buildLoadFailedProps = useInboxLoadFailedProps();
   const { setActiveQueueItem, setActiveScheduledItem } = inbox;
@@ -105,6 +104,12 @@ export function ReviewPage({ selectedId = null }: { selectedId?: string | null }
   }, [selectedScheduled, setActiveScheduledItem]);
 
   const listLoaded = inbox.hasLoadedOnce && decisions.hasLoadedOnce;
+  const nothingToReview =
+    blocking.length === 0 &&
+    improvements.length === 0 &&
+    scheduled.length === 0 &&
+    recentDecisions.length === 0;
+  const gate = useFirstRunGate({ firstRun: () => (listLoaded ? nothingToReview : null) });
   const idsByTab: Record<ReviewTab, string[]> = useMemo(
     () => ({
       waiting: [...blocking.map((b) => b.id), ...improvements.map((c) => c.id)],
@@ -183,15 +188,9 @@ export function ReviewPage({ selectedId = null }: { selectedId?: string | null }
     );
   }
 
-  const firstRunUndecided = setup.loading || (setup.isFirstRun && !listLoaded);
-  if (firstRunUndecided) return <ConsoleSplitSkeleton grid={SPLIT_GRID} lede />;
-  const nothingToReview =
-    blocking.length === 0 &&
-    improvements.length === 0 &&
-    scheduled.length === 0 &&
-    recentDecisions.length === 0;
-  if (setup.isFirstRun && nothingToReview) {
-    return <ReviewFirstRun setup={setup} decidedCount={decisions.items.length} />;
+  if (gate.view === 'loading') return <ConsoleSplitSkeleton grid={SPLIT_GRID} lede />;
+  if (gate.view === 'firstRun') {
+    return <ReviewFirstRun setup={gate.setup} decidedCount={decisions.items.length} />;
   }
 
   const afterDecision = (ok: boolean) => {

--- a/packages/dashboard-pages/src/realtime.ts
+++ b/packages/dashboard-pages/src/realtime.ts
@@ -293,7 +293,9 @@ const client = new RealtimeClient();
 export function useRealtime(
   subscriptions: readonly SubscriptionChannel[],
   onEvent: (event: RealtimeEventRow) => void,
+  options: { enabled?: boolean } = {},
 ): { connected: boolean; status: RealtimeStatus } {
+  const enabled = options.enabled ?? true;
   const [status, setStatus] = useState<RealtimeStatus>(() => client.getStatus());
   const connected = status === 'connected';
 
@@ -306,6 +308,7 @@ export function useRealtime(
   const listenerRef = useRef<Listener | null>(null);
 
   useEffect(() => {
+    if (!enabled) return;
     const listener: Listener = {
       channels: new Set(subsRef.current.map(subKey)),
       onEvent: (event) => onEventRef.current(event),
@@ -319,7 +322,7 @@ export function useRealtime(
       listenerRef.current = null;
       unsubscribeStatus();
     };
-  }, []);
+  }, [enabled]);
 
   const subsKey = subscriptions.map(subKey).sort().join(',');
   useEffect(() => {

--- a/packages/dashboard-pages/src/server.ts
+++ b/packages/dashboard-pages/src/server.ts
@@ -4,3 +4,4 @@ export {
   redirectIfSetupIncomplete,
   type ServerSession,
 } from './auth/server-session';
+export { readDashboardBootstrap } from './auth/read-dashboard-bootstrap';

--- a/packages/dashboard-pages/src/setup-gate.ts
+++ b/packages/dashboard-pages/src/setup-gate.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import { fetchJsonWithCookie } from './auth/api-cookie-fetch';
 import {
   isSetupIncomplete,
   type AgentConfigStatusDto,
@@ -54,42 +55,18 @@ export function hasSessionCookie(cookieHeader: string): boolean {
   return cookieHeader.includes('session_token');
 }
 
-function trimTrailingSlashes(value: string): string {
-  let end = value.length;
-  while (end > 0 && value[end - 1] === '/') end -= 1;
-  return value.slice(0, end);
-}
-
-function resolveApiUrl(options: SetupGateOptions): string {
-  return trimTrailingSlashes(
-    options.apiUrl ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001',
-  );
-}
-
-async function readJson<T>(url: string, cookie: string, timeoutMs: number): Promise<T | null> {
-  try {
-    const res = await fetch(url, {
-      headers: { cookie },
-      cache: 'no-store',
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!res.ok) return null;
-    return (await res.json()) as T;
-  } catch (err) {
-    console.warn('[setup-gate] status fetch failed', url, err);
-    return null;
-  }
-}
-
 export async function fetchSetupIncomplete(
   cookie: string,
   options: SetupGateOptions,
 ): Promise<boolean> {
-  const apiUrl = resolveApiUrl(options);
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchOptions = {
+    apiUrl: options.apiUrl,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    label: 'setup-gate',
+  };
   const [config, memberships] = await Promise.all([
-    readJson<AgentConfigStatusDto>(`${apiUrl}/v1/agent-config`, cookie, timeoutMs),
-    readJson<MembershipDto[]>(`${apiUrl}/v1/me/memberships`, cookie, timeoutMs),
+    fetchJsonWithCookie<AgentConfigStatusDto>('/v1/agent-config', cookie, fetchOptions),
+    fetchJsonWithCookie<MembershipDto[]>('/v1/me/memberships', cookie, fetchOptions),
   ]);
   return isSetupIncomplete(config, memberships);
 }

--- a/packages/dashboard-pages/src/shells/dashboard-shell.tsx
+++ b/packages/dashboard-pages/src/shells/dashboard-shell.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode } from 'react';
 import { PageSpinner } from '@getmunin/ui';
-import { authClient } from '../auth-client';
 import { useDashboardGate } from '../auth/use-dashboard-gate';
 import { SystemAlertsBanner } from '../components/system-alerts-banner';
 import { SetupStateProvider } from '../components/first-run';
@@ -28,31 +27,35 @@ export function DashboardShell({
   children,
 }: DashboardShellProps) {
   const pathname = usePathname();
-  const { data: session } = authClient.useSession();
-  const { ready } = useDashboardGate();
-
-  if (!ready || !session) {
-    return <PageSpinner className="min-h-screen bg-background" />;
-  }
+  const { ready, signedIn } = useDashboardGate();
 
   const inSettings = pathname.startsWith('/dashboard/settings');
 
   const content = (
-    <SetupStateProvider>
-      <div className="group flex h-dvh flex-col bg-bone dark:bg-background">
-        <SystemAlertsBanner />
-        {inSettings ? (
-          <main className="min-h-0 flex-1 overflow-x-clip bg-paper dark:bg-background">
-            {children}
-          </main>
-        ) : (
-          <div className="min-h-0 flex-1">
-            <ConsoleShell brand={brand} brandHref={brandHref} logoSrc={logoSrc} headSlot={leftSlot}>
+    <SetupStateProvider enabled={signedIn}>
+      {ready ? (
+        <div className="group flex h-dvh flex-col bg-bone dark:bg-background">
+          <SystemAlertsBanner />
+          {inSettings ? (
+            <main className="min-h-0 flex-1 overflow-x-clip bg-paper dark:bg-background">
               {children}
-            </ConsoleShell>
-          </div>
-        )}
-      </div>
+            </main>
+          ) : (
+            <div className="min-h-0 flex-1">
+              <ConsoleShell
+                brand={brand}
+                brandHref={brandHref}
+                logoSrc={logoSrc}
+                headSlot={leftSlot}
+              >
+                {children}
+              </ConsoleShell>
+            </div>
+          )}
+        </div>
+      ) : (
+        <PageSpinner className="min-h-screen bg-background" />
+      )}
     </SetupStateProvider>
   );
 


### PR DESCRIPTION
A brand-new workspace reached its onboarding steps through two waits: the shell's `PageSpinner`, then a page skeleton. The shell withheld every page until four client fetches — session, membership, agent config, setup state — had landed, and Dashboard and Automation then held a skeleton until a *second* fetch (usage summary, automation summary) landed on top of that, even though the setup snapshot had already answered the only question that mattered.

## Server-rendered first run

`readDashboardBootstrap()` does that work on the server. A new `@getmunin/dashboard-pages/server` export reads the session cookie, fetches memberships, agent config and setup state in parallel, and feeds them to a `DashboardBootstrapProvider` that seeds `useActiveMembership`, `useAgentConfigStatus` and `useSetupState`. With those seeded the gate is satisfied on the first render, so the shell, the sidebar and the first-run scene are all in the initial HTML.

It returns `null` — falling back to the existing client path, unchanged — when there is no session cookie, when any fetch fails or exceeds 1.5s, when setup is incomplete (that user belongs on `/setup`, and the redirect stays client-side), or when the user belongs to more than one org. The active-org pin lives in `sessionStorage`, which a server render cannot see, so for a multi-org user the server cannot tell which org to fetch.

On the fallback path `SetupStateProvider` now mounts alongside the spinner rather than behind it, so the setup fetch runs beside the gate's own fetches instead of queueing after them — `/v1/overview/setup` and `/v1/me/memberships` both start at +18ms, where setup previously waited for the gate to resolve. It takes an `enabled` flag, and `useRealtime` an `enabled` option, so a signed-out visitor still opens no socket and fetches nothing.

## One gate for every console page

Dashboard, Conversations, Review and Automation share one `useFirstRunGate()` returning a single `view` of `loading | firstRun | content`, replacing four hand-rolled conditions:

| page | options |
|---|---|
| Conversations | `{}` |
| Dashboard | `{ content: inbox.hasLoadedOnce }` |
| Automation | `{ firstRun: (s) => s.topicCount === 0 }` |
| Review | `{ firstRun: () => listLoaded ? nothingToReview : null }` |

A page narrows first run with its own emptiness rule, and returns `null` from that rule when it cannot decide yet, which reads as `loading` rather than a wrong guess. `content` gates only the content branch, never the first-run branch — that separation is the original bug, now enforced in one place instead of re-derived per page, and Dashboard names its skeleton once instead of twice. Automation reads its topic count from the setup snapshot rather than the automation summary, so deciding first run needs one request instead of two.

`useDashboardGate` drops its duplicate `roleLoading` term (`useActiveRole` returns `useActiveMembership`'s own loading flag) for three named booleans, and the three copies of "fetch JSON from the API forwarding the caller's cookie" in `setup-gate.ts`, `server-session.ts` and the new bootstrap share one `fetchJsonWithCookie` helper.

## Verification

Against a seeded single-org workspace with no conversations, all four pages carry the correct first-run scene in the server HTML — zero spinners, zero skeletons, no hydration or console errors — while a multi-org user and an anonymous visitor both take the old path unchanged. 170 unit tests pass, six of them new on `resolveFirstRunView`.

Review still shows its split skeleton first: its decision needs the curation-candidate list, which the setup snapshot does not carry. That is a data dependency, not an inconsistency in the mechanism.

## Stacked on #909

An async layout suspends inside any `loading.tsx` above it, so this needs `apps/web/app/[locale]/loading.tsx` gone. A/B on one dev server: with that file restored the initial HTML opens with `Loading…` ahead of the streamed content; without it, zero spinners. Retarget to `main` if #909 lands first.

## Known trade-offs

- The server work is **additive, not a replacement** — the client still revalidates all three after hydration, so a load makes more total requests. The win is time to first meaningful paint, not request count.
- `/dashboard` now fetches `/v1/agent-config` and `/v1/me/memberships` twice server-side, once in the `withSetupGate` middleware and once in the layout. `cache()` cannot span the two. The fix is dropping the middleware gate and letting the layout own that redirect; left out because it changes redirect timing.
- `ActiveMembership.slug` is dead and always `undefined` — `/v1/me/memberships` does not return it, yet the type declares `slug: string` and nothing reads it. The new DTO mirrors that rather than inventing a value, so server and client stay identical. Removing the field from the shared type is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEtUitV5jQ1nbmwmtTML3u