### PR TITLE
fix(dashboard): one measure and one rule for both overview empty states

### DIFF
--- a/.changeset/thick-pugs-tickle.md
+++ b/.changeset/thick-pugs-tickle.md
@@ -1,0 +1,5 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Overview review empty state now uses the shared console empty component, so it wraps at the same measure as the conversations one and no longer draws a stray bottom rule.

--- a/packages/dashboard-pages/src/components/dashboard/overview-review.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/overview-review.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import { useRouter } from '../../i18n-navigation';
 import { useCountdown } from '../../lib/use-relative';
+import { ConsoleListEmpty } from '../console-empty';
 import { ConsoleSectionLabel } from '../console-section-label';
 import { ReviewRow } from './review-row';
 import { StatRow } from './overview-stat-row';
@@ -39,9 +40,7 @@ export function OverviewReview({
           {t('waiting')}
         </ConsoleSectionLabel>
         {queue.length === 0 ? (
-          <li className="border-b border-rule-soft px-5 py-5 text-[13px] leading-relaxed text-ink-soft dark:border-rule-on-dark dark:text-foreground/80">
-            {t('waitingEmpty')}
-          </li>
+          <ConsoleListEmpty body={t('waitingEmpty')} />
         ) : (
           queue
             .slice(0, WAITING_LIMIT)


### PR DESCRIPTION
The overview's two empty states didn't match: "No open conversations…" wrapped onto two lines while "Nothing waiting…" ran the full container width on one.

The conversations state goes through the shared `ConsoleListEmpty` → `ConsoleEmptyText`, which caps the measure at `max-w-[46ch]`. The review queue's was a hand-rolled `<li>` in `overview-review.tsx` with no cap — and with a `border-b` the shared component doesn't draw, which is the extra rule under it.

Routed the review state through `ConsoleListEmpty` too. Both now wrap at the same measure and neither draws a trailing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)