### PR TITLE
fix(dashboard): answer Review's first-run question from the setup snapshot

### DIFF
--- a/.changeset/review-first-run-from-setup.md
+++ b/.changeset/review-first-run-from-setup.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Review now renders its first-run scene straight from the server HTML, instead of showing a split skeleton until the review lists land.
+
+Review was the one console page whose first-run rule the setup snapshot could not answer. Deciding it needs to know that nothing is waiting anywhere in the review queue — curation candidates, merge proposals, outreach drafts and scheduled sends, CMS drafts and scheduled entries, pending feedback, recent curation decisions — and that answer only arrived with `/v1/inbox` and `/v1/kb/curation/decisions`, two client fetches after the bootstrap. So the page returned `null` from its rule, which reads as `loading`, and a brand-new workspace saw `ConsoleSplitSkeleton` before its onboarding steps.
+
+`/v1/overview/setup` now carries a `reviewQueue` of `{ hasPendingItems, lastDecisionAt }`, which the server bootstrap already fetches, so the answer is in the first render. `SetupStateService` composes it from the same service calls and the same limit that `/v1/inbox` uses, rather than re-deriving each bucket's filter, so the two cannot drift apart. It reports the facts and leaves the 30-day decided window to the page, which owns that rule.
+
+The scan runs only when the org has no conversations — exactly the window in which `isFirstRun` can be true and the field can be read — so an active workspace pays nothing for it, and a first-run one scans near-empty tables. `reviewQueue` is `null` on that path, which the page treats the same as an older backend that does not send the field at all: it waits for the lists, as before.
+
+`resolveReviewFirstRun` gives the loaded lists the final say, so a snapshot that goes stale while the page is open cannot pin Review to its first-run scene once a real item shows up.

--- a/packages/backend-core/src/control/overview.controller.integration.test.ts
+++ b/packages/backend-core/src/control/overview.controller.integration.test.ts
@@ -107,6 +107,7 @@ const skipReason = TEST_URL
     knowledgeDocumentCount: number;
     externalMcpCallCount: number;
     lastExternalMcpCallAt: string | null;
+    reviewQueue: { hasPendingItems: boolean; lastDecisionAt: string | null } | null;
   }
 
   async function getSetup(adminKey: string): Promise<SetupBody> {
@@ -163,6 +164,7 @@ const skipReason = TEST_URL
     expect(setup.knowledgeDocumentCount).toBe(0);
     expect(setup.externalMcpCallCount).toBe(0);
     expect(setup.lastExternalMcpCallAt).toBeNull();
+    expect(setup.reviewQueue).toEqual({ hasPendingItems: false, lastDecisionAt: null });
   });
 
   it('setup ignores tool calls made by the in-process agent host', async () => {
@@ -307,6 +309,14 @@ const skipReason = TEST_URL
     const b = await getSetup(adminKeyB);
     expect(b.channels).toEqual([]);
     expect(b.conversationCount).toBe(0);
+  });
+
+  it('setup skips the review-queue scan for an org past first run, and reports it for one still in it', async () => {
+    const a = await getSetup(adminKeyA);
+    expect(a.reviewQueue).toBeNull();
+
+    const b = await getSetup(adminKeyB);
+    expect(b.reviewQueue?.hasPendingItems).toBe(true);
   });
 
   it('setup excludes curation candidates from the knowledge-base count', async () => {

--- a/packages/backend-core/src/control/setup-state.service.ts
+++ b/packages/backend-core/src/control/setup-state.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
 import { schema } from '@getmunin/db';
 import { and, eq, isNotNull, ne, notInArray, notLike, or, sql } from 'drizzle-orm';
 import type { PgTable } from 'drizzle-orm/pg-core';
@@ -13,7 +13,11 @@ import {
   getCurrentContext,
 } from '@getmunin/core';
 import { ConvService, type ChannelDto } from '../modules/conv/conv.service.ts';
-import { CURATION_INBOX_SLUG } from '../modules/kb/kb.service.ts';
+import { CURATION_INBOX_SLUG, KbService } from '../modules/kb/kb.service.ts';
+import { CrmService } from '../modules/crm/crm.service.ts';
+import { OutreachService } from '../modules/outreach/outreach.service.ts';
+import { CmsService } from '../modules/cms/cms.service.ts';
+import { FeedbackService } from '../modules/feedback/feedback.service.ts';
 import { toIsoString } from '../common/iso.ts';
 
 const RESERVED_KB_SPACE_SLUGS = [
@@ -22,6 +26,11 @@ const RESERVED_KB_SPACE_SLUGS = [
   COMPANY_PROFILE_SPACE_SLUG,
 ];
 
+export interface SetupReviewQueueDto {
+  hasPendingItems: boolean;
+  lastDecisionAt: string | null;
+}
+
 export interface SetupStateDto {
   channels: ChannelDto[];
   conversationCount: number;
@@ -29,11 +38,21 @@ export interface SetupStateDto {
   knowledgeDocumentCount: number;
   externalMcpCallCount: number;
   lastExternalMcpCallAt: string | null;
+  reviewQueue: SetupReviewQueueDto | null;
 }
+
+const REVIEW_QUEUE_SCAN_LIMIT = 50;
 
 @Injectable()
 export class SetupStateService {
-  constructor(@Inject(ConvService) private readonly conv: ConvService) {}
+  constructor(
+    @Inject(ConvService) private readonly conv: ConvService,
+    @Inject(KbService) private readonly kb: KbService,
+    @Inject(CrmService) private readonly crm: CrmService,
+    @Inject(OutreachService) private readonly outreach: OutreachService,
+    @Inject(CmsService) private readonly cms: CmsService,
+    @Optional() @Inject(FeedbackService) private readonly feedback: FeedbackService | null = null,
+  ) {}
 
   async read(): Promise<SetupStateDto> {
     const [channels, conversationCount, topicCount, knowledgeDocumentCount, mcp] =
@@ -52,6 +71,42 @@ export class SetupStateService {
       knowledgeDocumentCount,
       externalMcpCallCount: mcp.count,
       lastExternalMcpCallAt: mcp.lastAt,
+      reviewQueue: conversationCount === 0 ? await this.readReviewQueue() : null,
+    };
+  }
+
+  private async readReviewQueue(): Promise<SetupReviewQueueDto> {
+    const limit = REVIEW_QUEUE_SCAN_LIMIT;
+    const [
+      candidates,
+      merges,
+      proposals,
+      approvedProposals,
+      drafts,
+      scheduledEntries,
+      feedbackItems,
+      decisions,
+    ] = await Promise.all([
+      this.kb.listCurationCandidates(limit),
+      this.crm.listMergeProposals({ status: 'pending', limit }),
+      this.outreach.listProposals({ status: 'pending', limit }),
+      this.outreach.listProposals({ status: 'approved', limit }),
+      this.cms.listDraftEntries(limit),
+      this.cms.listScheduledEntries(limit),
+      this.feedback ? this.feedback.listPending() : Promise.resolve([]),
+      this.kb.listCurationDecisions({ limit: 1 }),
+    ]);
+
+    return {
+      hasPendingItems:
+        candidates.length > 0 ||
+        merges.length > 0 ||
+        proposals.length > 0 ||
+        approvedProposals.some((proposal) => proposal.scheduledSendAt !== null) ||
+        drafts.length > 0 ||
+        scheduledEntries.length > 0 ||
+        feedbackItems.length > 0,
+      lastDecisionAt: decisions[0]?.decidedAt ?? null,
     };
   }
 

--- a/packages/dashboard-pages/src/components/dashboard/review-queue.test.ts
+++ b/packages/dashboard-pages/src/components/dashboard/review-queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { partitionReviewQueue } from './review-queue';
+import { partitionReviewQueue, resolveReviewFirstRun } from './review-queue';
 import type { QueueItem } from './queue-panes/types';
 
 function item(kind: QueueItem['kind'], id: string, createdAt: string): QueueItem {
@@ -57,5 +57,40 @@ describe('partitionReviewQueue', () => {
     ];
     partitionReviewQueue(queue);
     expect(queue.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('resolveReviewFirstRun', () => {
+  const now = new Date('2026-09-08T10:00:00.000Z').getTime();
+  const unloaded = { loaded: false, empty: false };
+
+  it('answers from the setup snapshot before the lists land, so no skeleton precedes first run', () => {
+    const setupQueue = { hasPendingItems: false, lastDecisionAt: null };
+    expect(resolveReviewFirstRun(setupQueue, unloaded, now)).toBe(true);
+  });
+
+  it('waits for the lists when the snapshot predates them', () => {
+    expect(resolveReviewFirstRun(null, unloaded, now)).toBeNull();
+  });
+
+  it('waits for the lists when the snapshot reports work waiting', () => {
+    const setupQueue = { hasPendingItems: true, lastDecisionAt: null };
+    expect(resolveReviewFirstRun(setupQueue, unloaded, now)).toBeNull();
+  });
+
+  it('waits for the lists when a decision still falls inside the decided window', () => {
+    const setupQueue = { hasPendingItems: false, lastDecisionAt: '2026-09-01T10:00:00.000Z' };
+    expect(resolveReviewFirstRun(setupQueue, unloaded, now)).toBeNull();
+  });
+
+  it('ignores a decision that has aged out of the decided window', () => {
+    const setupQueue = { hasPendingItems: false, lastDecisionAt: '2026-01-01T10:00:00.000Z' };
+    expect(resolveReviewFirstRun(setupQueue, unloaded, now)).toBe(true);
+  });
+
+  it('lets the loaded lists overrule a snapshot that has gone stale', () => {
+    const setupQueue = { hasPendingItems: false, lastDecisionAt: null };
+    expect(resolveReviewFirstRun(setupQueue, { loaded: true, empty: false }, now)).toBe(false);
+    expect(resolveReviewFirstRun(setupQueue, { loaded: true, empty: true }, now)).toBe(true);
   });
 });

--- a/packages/dashboard-pages/src/components/dashboard/review-queue.ts
+++ b/packages/dashboard-pages/src/components/dashboard/review-queue.ts
@@ -1,3 +1,5 @@
+import type { SetupReviewQueue } from '../first-run/setup-snapshot';
+import { withinDecidedWindow } from './curation-decisions';
 import type { QueueItem } from './queue-panes/types';
 
 export type KbQueueItem = QueueItem & { kind: 'kb' };
@@ -22,4 +24,16 @@ export function partitionReviewQueue(queue: QueueItem[]): ReviewPartition {
   blocking.sort((a, b) => millis(a.createdAt) - millis(b.createdAt));
   improvements.sort((a, b) => millis(b.createdAt) - millis(a.createdAt));
   return { blocking, improvements };
+}
+
+export function resolveReviewFirstRun(
+  setupQueue: SetupReviewQueue | null,
+  list: { loaded: boolean; empty: boolean },
+  now = Date.now(),
+): boolean | null {
+  if (list.loaded) return list.empty;
+  if (!setupQueue || setupQueue.hasPendingItems) return null;
+  const { lastDecisionAt } = setupQueue;
+  if (lastDecisionAt !== null && withinDecidedWindow(lastDecisionAt, now)) return null;
+  return true;
 }

--- a/packages/dashboard-pages/src/components/first-run/first-run-view.test.ts
+++ b/packages/dashboard-pages/src/components/first-run/first-run-view.test.ts
@@ -14,6 +14,7 @@ function setupState(overrides: Partial<SetupState> = {}): SetupState {
     conversationCount: 0,
     topicCount: 0,
     knowledgeDocumentCount: 0,
+    reviewQueue: null,
     loading: false,
     isFirstRun: false,
     reload: async () => {},

--- a/packages/dashboard-pages/src/components/first-run/index.ts
+++ b/packages/dashboard-pages/src/components/first-run/index.ts
@@ -12,7 +12,12 @@ export {
   type FirstRunView,
 } from './first-run-view';
 export { useFirstRunGate, type FirstRunGate } from './use-first-run-gate';
-export { toSetupSnapshot, type SetupSnapshot, type SetupStateDto } from './setup-snapshot';
+export {
+  toSetupSnapshot,
+  type SetupReviewQueue,
+  type SetupSnapshot,
+  type SetupStateDto,
+} from './setup-snapshot';
 export {
   FIRST_RUN_DOCS,
   FIRST_RUN_ROUTES,

--- a/packages/dashboard-pages/src/components/first-run/setup-snapshot.ts
+++ b/packages/dashboard-pages/src/components/first-run/setup-snapshot.ts
@@ -12,6 +12,11 @@ export interface SetupChannelDto {
   needsCredentials?: boolean;
 }
 
+export interface SetupReviewQueue {
+  hasPendingItems: boolean;
+  lastDecisionAt: string | null;
+}
+
 export interface SetupStateDto {
   channels: SetupChannelDto[];
   conversationCount: number;
@@ -19,6 +24,7 @@ export interface SetupStateDto {
   knowledgeDocumentCount: number;
   externalMcpCallCount: number;
   lastExternalMcpCallAt: string | null;
+  reviewQueue?: SetupReviewQueue | null;
 }
 
 export interface SetupChannel {
@@ -38,6 +44,7 @@ export interface SetupSnapshot {
   conversationCount: number;
   topicCount: number;
   knowledgeDocumentCount: number;
+  reviewQueue: SetupReviewQueue | null;
 }
 
 const CHANNEL_ORDER: SetupChannelType[] = ['email', 'chat', 'sms', 'voice'];
@@ -53,6 +60,7 @@ const UNKNOWN: SetupSnapshot = {
   conversationCount: 0,
   topicCount: 0,
   knowledgeDocumentCount: 0,
+  reviewQueue: null,
 };
 
 export function toSetupSnapshot(dto: SetupStateDto | null): SetupSnapshot {
@@ -73,6 +81,7 @@ export function toSetupSnapshot(dto: SetupStateDto | null): SetupSnapshot {
     conversationCount: dto.conversationCount,
     topicCount: dto.topicCount,
     knowledgeDocumentCount: dto.knowledgeDocumentCount,
+    reviewQueue: dto.reviewQueue ?? null,
   };
 }
 

--- a/packages/dashboard-pages/src/pages/review.tsx
+++ b/packages/dashboard-pages/src/pages/review.tsx
@@ -8,7 +8,10 @@ import { useInboxLoadFailedProps } from '../lib/use-load-failed-props';
 import { usePathname, useRouter } from '../i18n-navigation';
 import { useInboxData } from '../components/dashboard/inbox-data';
 import { ScheduledCancelDialog } from '../components/dashboard/scheduled-cancel-dialog';
-import { partitionReviewQueue } from '../components/dashboard/review-queue';
+import {
+  partitionReviewQueue,
+  resolveReviewFirstRun,
+} from '../components/dashboard/review-queue';
 import { ReviewRow } from '../components/dashboard/review-row';
 import { ReviewKbPane } from '../components/dashboard/review-kb-pane';
 import { ReviewBlockingPane } from '../components/dashboard/review-blocking-pane';
@@ -109,7 +112,10 @@ export function ReviewPage({ selectedId = null }: { selectedId?: string | null }
     improvements.length === 0 &&
     scheduled.length === 0 &&
     recentDecisions.length === 0;
-  const gate = useFirstRunGate({ firstRun: () => (listLoaded ? nothingToReview : null) });
+  const gate = useFirstRunGate({
+    firstRun: (setup) =>
+      resolveReviewFirstRun(setup.reviewQueue, { loaded: listLoaded, empty: nothingToReview }),
+  });
   const idsByTab: Record<ReviewTab, string[]> = useMemo(
     () => ({
       waiting: [...blocking.map((b) => b.id), ...improvements.map((c) => c.id)],


### PR DESCRIPTION
Review was the one console page that still painted a skeleton before its first-run scene. #911 moved the first-run decision onto the server for Dashboard, Conversations and Automation, but Review's rule needs to know that nothing is waiting anywhere in the review queue — curation candidates, merge proposals, outreach drafts and scheduled sends, CMS drafts and scheduled entries, pending feedback, recent curation decisions — and that answer only arrived with `/v1/inbox` and `/v1/kb/curation/decisions`, two client fetches after the bootstrap. So the page returned `null` from its rule, which reads as `loading`, and a brand-new workspace saw `ConsoleSplitSkeleton` before its onboarding steps.

## What changed

`/v1/overview/setup` now carries a `reviewQueue` of `{ hasPendingItems, lastDecisionAt }`, which the server bootstrap already fetches, so the answer is in the first render.

- `SetupStateService` composes it from the same service calls and the same limit that `/v1/inbox` uses, rather than re-deriving each bucket's filter, so the two cannot drift apart. It reports the facts and leaves the 30-day decided window to the page, which owns that rule.
- The scan runs **only when the org has no conversations** — exactly the window in which `isFirstRun` can be true and the field can be read — so an active workspace pays nothing for it, and a first-run one scans near-empty tables. `reviewQueue` is `null` on that path, which the page treats the same as an older backend that does not send the field at all: it waits for the lists, as before.
- `resolveReviewFirstRun` gives the loaded lists the final say, so a snapshot that goes stale while the page is open cannot pin Review to its first-run scene once a real item shows up.

## Verification

Against a seeded single-org workspace with no conversations (`reviewQueue: {hasPendingItems: false, lastDecisionAt: null}`):

- `/en/dashboard/review` server HTML carries the first-run scene ("Review — nothing waiting", "An empty memory"), with `animate-pulse` count 0 and no rendered `role="status"`.
- The same page for an active single-org user (40 conversations) shows no first-run scene, the real Review header in the HTML, and one row skeleton awaiting `/v1/inbox` — that path is unchanged.
- `overview.controller.integration` 10/10, including new assertions for empty → `hasPendingItems: false`, a pending candidate → `true`, and an active org → `null`. `dashboard-pages` 182/182. Lint and workspace typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEtUitV5jQ1nbmwmtTML3u