### PR TITLE
fix(auth): let a deployment name its reverse proxies so rate limiting can bucket per client IP

### DIFF
--- a/.changeset/auth-rate-limit-client-ip.md
+++ b/.changeset/auth-rate-limit-client-ip.md
@@ -1,0 +1,16 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Auth rate limiting can bucket per client IP behind a multi-hop reverse proxy.
+
+better-auth reads the client IP from `X-Forwarded-For`, and without a trusted-proxy list it only trusts a header that carries exactly **one** entry — a chain is unresolvable, because the leftmost entry is caller-controlled and nothing identifies where the caller's part of it ends. Any deployment whose platform appends its own hops therefore resolved no IP at all and fell back to `no-trusted-ip`, a single shared bucket per path: one abusive client consumed the sign-in budget for every user at once. It logged one line and otherwise looked healthy — `WARN [Better Auth]: Rate limiting could not determine a client IP`.
+
+`advanced.ipAddress` is now configurable, from two env vars or from the new `ipAddress` option on `createMuninAuthCore` (the option wins):
+
+- `MUNIN_AUTH_TRUSTED_PROXIES` — IPs or CIDR ranges of your own proxies. The chain is walked right to left, trusted hops are skipped, and the first untrusted address is the client.
+- `MUNIN_AUTH_IP_HEADERS` — headers to read instead of `x-forwarded-for`, in order, lowercased for you. For a single-value header a proxy overwrites, such as `cf-connecting-ip` behind Cloudflare.
+
+Neither is set by default, so nothing changes for an existing deployment until it opts in, and a single-proxy setup that already emits a one-entry `X-Forwarded-For` needs neither.
+
+Two properties worth knowing before choosing a value. Trusting the range your platform's hops live in stays spoof-proof, because a platform inserts the real client address *after* everything the caller sent and before its own hops — so entries a caller prepends, even ones inside the trusted range, sit to the left of the client and are never reached. And only name a header in `MUNIN_AUTH_IP_HEADERS` that your proxy *overwrites*: `x-real-ip`, `x-client-ip` and `Forwarded` are commonly passed through untouched, and trusting one of those removes the rate limit rather than fixing it.

--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,23 @@ MUNIN_ENCRYPTION_KEY=replace-me-with-strong-random-key
 # Comma-separated origins permitted to call /auth (CSRF/CORS). Defaults to
 # localhost:3000 for dev. Set this to your dashboard URL in production.
 MUNIN_AUTH_TRUSTED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+# Reverse proxies in front of /auth, as IPs or CIDR ranges. Auth rate
+# limiting buckets per client IP, and it reads that IP from
+# X-Forwarded-For. A chain with more than one entry is unresolvable
+# without this — better-auth then falls back to a single shared bucket per
+# path, so one abusive client throttles everyone. Set it to the address or
+# subnet of your own proxies (not a broad private range that could also
+# cover clients): the chain is walked right to left, trusted hops are
+# skipped, and the first untrusted address is the client. A single-proxy
+# setup that emits one-entry X-Forwarded-For needs nothing here.
+# Example: MUNIN_AUTH_TRUSTED_PROXIES=10.0.0.0/24,192.0.2.10
+# MUNIN_AUTH_TRUSTED_PROXIES=
+# Headers to read the client IP from, in order. Defaults to
+# x-forwarded-for. Set this when your proxy publishes the client in a
+# single-value header instead (behind Cloudflare: cf-connecting-ip).
+# Only ever name a header your proxy overwrites — one it merely forwards
+# is caller-controlled, and trusting it removes the rate limit entirely.
+# MUNIN_AUTH_IP_HEADERS=cf-connecting-ip
 # Session cookie name prefix; defaults to better-auth's own ("better-auth").
 # Set a distinct value per environment when environments share a registrable
 # domain (e.g. getmunin.com prod + dev.getmunin.com dev) — otherwise the

--- a/packages/backend-core/src/auth-env.ip-address.test.ts
+++ b/packages/backend-core/src/auth-env.ip-address.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getIP } from 'better-auth/api';
+import { readAuthIpAddressFromEnv } from './auth-env.ts';
+
+const SCALEWAY_CHAIN = '77.223.189.132,100.96.4.33, 100.96.5.92, 100.96.11.106';
+const SCALEWAY_CHAIN_WITH_INJECTED_HOPS =
+  '203.0.113.7, 100.96.0.1,77.223.189.132,100.96.4.21, 100.96.4.33, 100.96.16.172';
+
+describe('readAuthIpAddressFromEnv', () => {
+  const vars = ['MUNIN_AUTH_TRUSTED_PROXIES', 'MUNIN_AUTH_IP_HEADERS'] as const;
+  let original: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    original = Object.fromEntries(vars.map((v) => [v, process.env[v]]));
+    for (const v of vars) delete process.env[v];
+  });
+
+  afterEach(() => {
+    for (const v of vars) {
+      const prior = original[v];
+      if (prior === undefined) delete process.env[v];
+      else process.env[v] = prior;
+    }
+  });
+
+  it('is undefined when neither var is set, leaving better-auth on its own defaults', () => {
+    expect(readAuthIpAddressFromEnv()).toBeUndefined();
+  });
+
+  it('splits a csv proxy list and drops blanks', () => {
+    process.env.MUNIN_AUTH_TRUSTED_PROXIES = '100.64.0.0/10, ,192.0.2.10';
+    expect(readAuthIpAddressFromEnv()).toEqual({
+      trustedProxies: ['100.64.0.0/10', '192.0.2.10'],
+    });
+  });
+
+  it('lowercases header names, since better-auth looks them up on a Headers object', () => {
+    process.env.MUNIN_AUTH_IP_HEADERS = 'CF-Connecting-IP, X-Forwarded-For';
+    expect(readAuthIpAddressFromEnv()).toEqual({
+      ipAddressHeaders: ['cf-connecting-ip', 'x-forwarded-for'],
+    });
+  });
+
+  it('omits the key a var did not set rather than passing an empty list', () => {
+    process.env.MUNIN_AUTH_TRUSTED_PROXIES = '100.64.0.0/10';
+    expect(readAuthIpAddressFromEnv()).not.toHaveProperty('ipAddressHeaders');
+  });
+});
+
+describe('a forwarded chain from a serverless platform', () => {
+  it('resolves to the client when the platform hops are the trusted proxies', () => {
+    const headers = new Headers({ 'x-forwarded-for': SCALEWAY_CHAIN });
+    const resolved = getIP(headers, {
+      advanced: { ipAddress: { trustedProxies: ['100.64.0.0/10'] } },
+    });
+    expect(resolved).toBe('77.223.189.132');
+  });
+
+  it('ignores entries a caller prepended, including ones inside the trusted range', () => {
+    const headers = new Headers({ 'x-forwarded-for': SCALEWAY_CHAIN_WITH_INJECTED_HOPS });
+    const resolved = getIP(headers, {
+      advanced: { ipAddress: { trustedProxies: ['100.64.0.0/10'] } },
+    });
+    expect(resolved).toBe('77.223.189.132');
+  });
+
+  it('collapses to one shared bucket without trusted proxies, which is the bug', () => {
+    const headers = new Headers({ 'x-forwarded-for': SCALEWAY_CHAIN });
+    expect(getIP(headers, { advanced: {} })).not.toBe('77.223.189.132');
+  });
+});

--- a/packages/backend-core/src/auth-env.ts
+++ b/packages/backend-core/src/auth-env.ts
@@ -30,3 +30,28 @@ export function readTrustedOriginsFromEnv(): string[] {
   if (!env) return ['http://localhost:3000', 'http://127.0.0.1:3000'];
   return env.split(',').map((s) => s.trim()).filter(Boolean);
 }
+
+export interface AuthIpAddressEnv {
+  ipAddressHeaders?: string[];
+  trustedProxies?: string[];
+}
+
+function readList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function readAuthIpAddressFromEnv(): AuthIpAddressEnv | undefined {
+  const trustedProxies = readList(process.env.MUNIN_AUTH_TRUSTED_PROXIES);
+  const ipAddressHeaders = readList(process.env.MUNIN_AUTH_IP_HEADERS).map((h) =>
+    h.toLowerCase(),
+  );
+  if (trustedProxies.length === 0 && ipAddressHeaders.length === 0) return undefined;
+  return {
+    ...(ipAddressHeaders.length > 0 ? { ipAddressHeaders } : {}),
+    ...(trustedProxies.length > 0 ? { trustedProxies } : {}),
+  };
+}

--- a/packages/backend-core/src/auth/auth-factory.ts
+++ b/packages/backend-core/src/auth/auth-factory.ts
@@ -16,6 +16,7 @@ import {
   resolveMcpSurfaces,
   type McpSurface,
 } from '../oauth/mcp-surface.ts';
+import { readAuthIpAddressFromEnv } from '../auth-env.ts';
 import { authCookiePrefix } from './auth-cookies.ts';
 import { createDbOrgScopeStore, registerOrgScopeStore } from './org-scope-store.ts';
 import { stripTrailingSlashes } from '@getmunin/types';
@@ -77,6 +78,8 @@ export interface MuninAuthCoreOptions {
 
   rateLimit?: BetterAuthOptions['rateLimit'];
 
+  ipAddress?: NonNullable<BetterAuthOptions['advanced']>['ipAddress'];
+
   logger?: BetterAuthOptions['logger'];
 }
 
@@ -86,6 +89,7 @@ const asMuninAuth = (instance: unknown): MuninAuthInstance => instance as MuninA
 
 export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstance {
   const origins = uniqueOrigins([opts.baseUrl, ...(opts.trustedOrigins ?? [])]);
+  const ipAddress = opts.ipAddress ?? readAuthIpAddressFromEnv();
   const dashboardUrl = (opts.webBaseUrl ?? opts.trustedOrigins?.[0] ?? opts.baseUrl).replace(
     /\/+$/,
     '',
@@ -214,6 +218,7 @@ export function createMuninAuthCore(opts: MuninAuthCoreOptions): MuninAuthInstan
       advanced: {
         useSecureCookies: dashboardUrl.startsWith('https://'),
         cookiePrefix: opts.cookiePrefix ?? authCookiePrefix(),
+        ...(ipAddress ? { ipAddress } : {}),
         ...(opts.crossSubDomainCookies
           ? {
               crossSubDomainCookies: {

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -12,10 +12,12 @@ export {
 } from './auth-controller-factory.ts';
 
 export {
+  readAuthIpAddressFromEnv,
   readGoogleProviderFromEnv,
   readGithubProviderFromEnv,
   readTrustedOriginsFromEnv,
   readTurnstileCaptchaFromEnv,
+  type AuthIpAddressEnv,
   type TurnstileCaptchaEnv,
 } from './auth-env.ts';
 


### PR DESCRIPTION
Found on a live deployment: auth rate limiting was running on **one shared bucket per path** for every user at once, so a single abusive client could consume the sign-in budget for everybody. Sign-in worked, nothing errored, and the only signal was one line:

```
WARN [Better Auth]: Rate limiting could not determine a client IP and is falling back to
a single shared per-path bucket.
```

## Why it happens

better-auth reads the client IP from `X-Forwarded-For`, and with no trusted-proxy list it trusts a header only when it carries **exactly one** entry (`getIPFromHeader` in `@better-auth/core`). That is the right default: the leftmost entry is caller-controlled and nothing marks where the caller's part of the chain ends. But it means any platform that appends its own hops resolves no IP at all, and the key becomes the literal `no-trusted-ip`.

## What this adds

`advanced.ipAddress` becomes configurable, from two env vars or from a new `ipAddress` option on `createMuninAuthCore` (the option wins over the env):

| var | effect |
|---|---|
| `MUNIN_AUTH_TRUSTED_PROXIES` | IPs / CIDRs of your own proxies. The chain is walked right to left, trusted hops skipped, first untrusted address is the client. |
| `MUNIN_AUTH_IP_HEADERS` | Headers to read instead of `x-forwarded-for`, in order, lowercased for you — e.g. `cf-connecting-ip` behind Cloudflare. |

Neither is set by default, so an existing deployment behaves exactly as before until it opts in, and a single-proxy setup that already emits a one-entry `X-Forwarded-For` needs neither.

## Measured, not assumed

Against Scaleway's serverless ingress — where this was found — a probe endpoint on a real deployment reported:

```
plain          x-forwarded-for: 77.223.189.132,100.96.4.33, 100.96.5.92, 100.96.11.106
caller sends
203.0.113.7    x-forwarded-for: 203.0.113.7,77.223.189.132,100.96.4.21, 100.96.4.33, 100.96.14.93
```

Three appended hops in `100.96.0.0/16`, and **the real client address is inserted after everything the caller sent and before the platform's own hops**. That ordering is what makes trusting the platform's range spoof-proof: entries a caller prepends — including ones deliberately inside the trusted range, tested with `203.0.113.7, 100.96.0.1` — sit to the left of the client and are never reached by the right-to-left walk. Both cases are pinned in `auth-env.ip-address.test.ts` using the real chains.

On that same platform `x-real-ip`, `x-client-ip` and `Forwarded` all arrived **caller-controlled and untouched**, while `x-envoy-external-address` was overwritten. Hence the warning in the `MUNIN_AUTH_IP_HEADERS` docs to name only a header your proxy overwrites — trusting a passed-through one removes the rate limit instead of fixing it.

## Checks

`pnpm -F @getmunin/backend-core typecheck` and `eslint` clean; the 7 new tests pass. No new dependency, so no lockfile or license churn.