### PR TITLE
fix(ui): make the console's smallest type readable, and stop Tailwind dropping 75 alpha colours

### DIFF
--- a/.changeset/console-label-legibility.md
+++ b/.changeset/console-label-legibility.md
@@ -1,0 +1,65 @@
+---
+'@getmunin/dashboard-pages': patch
+'@getmunin/ui': patch
+---
+
+fix(ui): make the console's smallest type readable, and stop Tailwind silently dropping 75 alpha colours
+
+A second pass over the palette after #910, prompted by labels that still read as
+grey noise. #910 audited token *pairs*; this one audits what the browser actually
+paints, which is where the remaining failures were hiding.
+
+**Tailwind was discarding every alpha modifier on a shadcn alias.** `--foreground`,
+`--card`, `--secondary` and `--destructive` held finished colours (`rgb(15 20 25)`),
+and Tailwind can only inject `<alpha-value>` into a bare channel list — so it dropped
+the whole declaration instead. 75 utilities compiled to nothing: `dark:text-foreground/70`
+and `/80` (51 sites) left body copy, ledes, the sidebar's inactive items and the CRM
+merge pane falling back to their light-mode ink on a dark background at **1.57–1.83:1**,
+and `dark:bg-foreground/15`, `dark:bg-card/85`, `bg-destructive/5` and
+`border-destructive/40` painted nothing at all. The four aliases now resolve through
+`--foreground-rgb` / `--card-rgb` / `--secondary-rgb` / `--destructive-rgb` triples,
+with the plain alias derived from them, so no call site changed and all 75 utilities
+emit. Verified 0 → 1 occurrences each in the compiled stylesheet.
+
+**Labels get their own tier.** The console's mono uppercase labels ran 8–9.5px at
+`text-ink-mute`: 5.72:1 on paper, which clears AA and still reads as grey noise at
+that size — 81 sites in `dashboard-pages`, 15 more in the widget. They are now 10px
+`font-medium`, matching what `ui`'s own `Label`, `Table` head, `Tabs` and `Button`
+already shipped, and structural ones (section labels, column heads, field labels,
+eyebrows) take a new `--munin-fg-label` (`text-ink-label`) at 9.69:1 light / 10.99:1
+dark. Incidental metadata — timestamps, row counts — stays on the mute tier. Labels
+never shrink below 10px again: `type-floor.test.ts` fails the build on `text-[<10px]`.
+
+**Four more measured failures:**
+
+- `text-alert-bad-ink` is used both inside its tint and bare on the page (error
+  eyebrows, an inline clause, the outreach and CMS notices), and had no dark value —
+  **1.65:1** on ink. The alert family now flips as a set: bg `#331812`, ink `#F0A79B`
+  (8.36:1 on its own tint, 8.08–9.44:1 on the three dark surfaces), border `#D2685A`.
+- The activity feed's column heads and clocks used `text-paper/45` and `/50` on the
+  ink panel — **4.38:1** at 10px. Now `/70`, 9.01:1.
+- `text-ink-mute/80` on CMS block-prop labels — **3.71:1**. Now the label token.
+- `participantColor` was `oklch(0.55 …)` for both schemes — **4.36:1** worst-case on
+  paper and **3.35:1** on the dark card, as 9px semibold author names *and* a 2px
+  bubble border. Lightness moves to `--munin-participant-l`: 0.5 light, 0.74 dark.
+
+**#910's dark mute lift broke the auth pages.** `AuthShell` and everything under it
+carry no `dark:` class at all — they are fixed light paper by design — so the dark
+`--munin-fg-3` landed at **3.21:1** there (2.45:1 on the invite tint) and the dark
+`--munin-rule-field` left inputs with a near-white 1px edge on white. They now pin the
+light ramp via `.munin-light-locked`, one place to hold the opt-out as the palette moves.
+
+Guarded by `tokens.contrast.test.ts` — 63 assertions over every foreground/background
+pair the design actually meets, in light, dark and light-locked. Reverting any value
+above fails it. Verified end to end against the running dashboard by sampling
+`getComputedStyle` on every leaf text node across 21 pages in both schemes and
+compositing each colour over its real backdrop: the only remaining report is the auth
+wordmark, a false positive — it is absolutely positioned over a sibling's `bg-paper`,
+so the DOM-tree backdrop walk reads the page background instead. Also confirmed at the
+stylesheet level (each of the 75 utilities goes 0 → 1 occurrences) and at the
+computed-value level. Note when checking that yourself: Tailwind only emits classes it
+finds in source, so probing an unprefixed name reports a false failure.
+
+Not fixed, reported separately: `/dashboard/oauth/consent` renders `bg-background`
+with light-only `text-ink`, `text-ink-soft` and `border-ink` outline buttons, so its
+dark mode needs a design pass rather than a token change.

--- a/apps/chat-widget/src/styles.ts
+++ b/apps/chat-widget/src/styles.ts
@@ -14,6 +14,7 @@ const DARK_VARS = String.raw`
     --munin-ink: #F5F4F0;
     --munin-ink-soft: #C7C9D1;
     --munin-ink-mute: #9297A3;
+    --munin-ink-label: #C2C8D0;
     --munin-theme-edge: var(--munin-theme-edge-dark, var(--munin-theme));
     --munin-verdigris: #62C39C;
     --munin-verdigris-tint: #1B382A;
@@ -63,6 +64,7 @@ const BASE_CSS = String.raw`
   --munin-ink: #0F1419;
   --munin-ink-soft: #3D424A;
   --munin-ink-mute: #5E646C;
+  --munin-ink-label: #3D424A;
   --munin-verdigris: #1B7153;
   --munin-verdigris-tint: #E3F5EC;
   --munin-agent-tint: #DCE2E8;
@@ -237,10 +239,11 @@ button {
 .panel-head-meta {
   margin-top: 4px;
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
+  font-weight: 500;
   letter-spacing: .14em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--munin-header-fg) 60%, transparent);
+  color: color-mix(in srgb, var(--munin-header-fg) 75%, transparent);
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -290,10 +293,11 @@ button {
 }
 .welcome-eyebrow {
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--munin-ink-mute);
+  color: var(--munin-ink-label);
 }
 .welcome-eyebrow strong { font-weight: 500; }
 .welcome-eyebrow a { color: inherit; text-decoration: none; }
@@ -413,18 +417,19 @@ button {
 .past-meta { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex-shrink: 0; }
 .tag {
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   padding: 2px 6px;
   border-radius: var(--munin-r-tag);
 }
 .tag-open { background: var(--munin-verdigris-tint); color: var(--munin-verdigris); }
-.tag-closed { background: var(--munin-overlay); color: var(--munin-ink-mute); }
+.tag-closed { background: var(--munin-overlay); color: var(--munin-ink-label); }
 .tag-snoozed { background: var(--munin-overlay); color: var(--munin-ink-soft); }
 .past-when {
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
   color: var(--munin-ink-mute);
 }
 
@@ -480,10 +485,11 @@ button {
 .chat-sub {
   margin-top: 5px;
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--munin-ink-mute);
+  color: var(--munin-ink-label);
   display: inline-flex;
   align-items: center;
   gap: 7px;
@@ -510,17 +516,18 @@ button {
 .msg.theirs { align-self: flex-start; align-items: flex-start; }
 .msg-head {
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--munin-ink-mute);
+  color: var(--munin-ink-label);
   display: flex;
   gap: 6px;
   align-items: baseline;
 }
-.msg-who { color: var(--munin-ink-mute); font-weight: 600; }
-.msg-role { color: var(--munin-ink-mute); }
-.msg-t { color: var(--munin-ink-mute); font-family: var(--munin-mono); font-size: 9px; }
+.msg-who { color: var(--munin-ink-label); font-weight: 600; }
+.msg-role { color: var(--munin-ink-label); }
+.msg-t { color: var(--munin-ink-mute); font-family: var(--munin-mono); font-size: 10px; }
 .msg-t.mine { padding-right: 2px; }
 
 .bubble {
@@ -605,10 +612,11 @@ button {
   gap: 10px;
   align-self: stretch;
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--munin-ink-mute);
+  color: var(--munin-ink-label);
   padding: 4px 0;
 }
 .system-line { flex: 1; height: 1px; background: var(--munin-rule); }
@@ -624,10 +632,11 @@ button {
 }
 .card-eyebrow {
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--munin-ink-mute);
+  color: var(--munin-ink-label);
 }
 .card-title {
   font-family: var(--munin-sans);
@@ -719,7 +728,7 @@ button {
 }
 .counter {
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
   letter-spacing: 0.04em;
   color: var(--munin-ink-mute);
 }
@@ -753,7 +762,7 @@ button {
   color: var(--munin-ink-soft);
   background: transparent;
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   transition: border-color 120ms, background 120ms, color 120ms;
@@ -802,7 +811,7 @@ button {
 .voice-banner-timer { color: var(--munin-chrome-fg); font-variant-numeric: tabular-nums; }
 .voice-banner-muted-tag {
   margin-left: 6px;
-  font-size: 9px;
+  font-size: 10px;
   letter-spacing: 0.16em;
   color: #E0A93B;
 }
@@ -921,7 +930,7 @@ button {
   align-items: center;
   gap: 6px;
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   transition: background 120ms, border-color 120ms;
@@ -952,10 +961,11 @@ button {
 .footer-credit {
   padding: 8px 16px 10px;
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--munin-ink-mute);
+  color: var(--munin-ink-label);
   text-align: center;
   border-top: 1px solid var(--munin-rule);
   background: var(--munin-paper);
@@ -1061,7 +1071,7 @@ const PRODUCT_LIST_CSS = String.raw`
   border-radius: var(--munin-r-pill);
   padding: 3px 9px;
   font-family: var(--munin-mono);
-  font-size: 9px;
+  font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--munin-ink-soft);

--- a/packages/dashboard-pages/src/components/auth-shell/auth-epigraph.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/auth-epigraph.tsx
@@ -27,7 +27,7 @@ export function AuthEpigraph({ state, footer }: AuthEpigraphProps) {
   return (
     <aside className="relative hidden bg-bone md:flex md:items-center md:px-20 md:py-24">
       <div className="max-w-[620px]">
-        <div className="mb-[18px] font-mono text-[11px] uppercase tracking-eyebrow text-ink-mute">
+        <div className="mb-[18px] font-mono text-[11px] font-medium uppercase tracking-eyebrow text-ink-label">
           {t(`${variant}.eyebrow`)}
         </div>
         <blockquote className="m-0 font-serif italic text-[clamp(28px,2.6vw,40px)] leading-[1.2] tracking-[-0.01em] text-ink">
@@ -40,7 +40,7 @@ export function AuthEpigraph({ state, footer }: AuthEpigraphProps) {
       <div className="absolute bottom-8 right-14 inline-flex items-center gap-[18px] font-mono text-[11px] text-ink-mute">
         {footer.map((line, idx) => (
           <span key={line} className="contents">
-            {idx > 0 && <span className="text-rule-soft">·</span>}
+            {idx > 0 && <span aria-hidden>·</span>}
             <span>{line}</span>
           </span>
         ))}

--- a/packages/dashboard-pages/src/components/auth-shell/auth-invite-card.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/auth-invite-card.tsx
@@ -53,7 +53,7 @@ export function AuthInviteCard({
         <dl className="mb-6 mt-0 grid grid-cols-[auto_1fr] gap-x-[18px] gap-y-1.5 border-t-[1px] border-ink/[0.12] pt-[18px] font-mono text-[11px] tracking-wide text-ink-soft">
           {meta.map(({ label, value }) => (
             <div key={label} className="contents">
-              <dt className="text-[10px] uppercase tracking-eyebrow text-ink-mute">
+              <dt className="text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                 {label}
               </dt>
               <dd className="m-0 text-ink">{value}</dd>

--- a/packages/dashboard-pages/src/components/auth-shell/auth-shell.tsx
+++ b/packages/dashboard-pages/src/components/auth-shell/auth-shell.tsx
@@ -13,7 +13,7 @@ interface AuthShellProps {
 
 export function AuthShell({ leftZone, rightZone, variant = 'form' }: AuthShellProps) {
   return (
-    <div className="relative grid min-h-screen grid-cols-1 md:grid-cols-2">
+    <div className="munin-light-locked relative grid min-h-screen grid-cols-1 md:grid-cols-2">
       <div className="pointer-events-none absolute inset-y-0 left-1/2 hidden w-px bg-rule-soft md:block" />
 
       <Link

--- a/packages/dashboard-pages/src/components/card-kit.tsx
+++ b/packages/dashboard-pages/src/components/card-kit.tsx
@@ -92,7 +92,7 @@ export function SettingsCard({
       )}
     >
       <div className="flex items-center gap-2">
-        <span className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+        <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
           {kind}
         </span>
         {menu ? <div className="ml-auto flex-none">{menu}</div> : null}
@@ -111,7 +111,7 @@ export function SettingsCard({
         <div className="mt-3 flex items-center gap-2.5">
           {footerAction}
           {footerMeta ? (
-            <span className="ml-auto font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+            <span className="ml-auto font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {footerMeta}
             </span>
           ) : null}

--- a/packages/dashboard-pages/src/components/console-empty.tsx
+++ b/packages/dashboard-pages/src/components/console-empty.tsx
@@ -4,7 +4,7 @@ export function ConsoleEmptyText({ title, body }: { title?: ReactNode; body: Rea
   return (
     <>
       {title ? (
-        <p className="mb-1.5 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+        <p className="mb-1.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
           {title}
         </p>
       ) : null}

--- a/packages/dashboard-pages/src/components/console-hero.tsx
+++ b/packages/dashboard-pages/src/components/console-hero.tsx
@@ -27,7 +27,7 @@ export function ConsoleHero({
     >
       <div className="min-w-0 space-y-2.5">
         {eyebrow ? (
-          <div className="font-mono text-[11px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+          <div className="font-mono text-[11px] font-medium uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
             {eyebrow}
           </div>
         ) : null}

--- a/packages/dashboard-pages/src/components/console-section-label.tsx
+++ b/packages/dashboard-pages/src/components/console-section-label.tsx
@@ -8,7 +8,7 @@ export function ConsoleSectionLabel({
   children: ReactNode;
 }) {
   return (
-    <li className="flex items-baseline justify-between gap-4 border-b border-rule-soft px-5 py-3 font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute dark:border-rule-on-dark">
+    <li className="flex items-baseline justify-between gap-4 border-b border-rule-soft px-5 py-3 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label dark:border-rule-on-dark">
       <span>{children}</span>
       {note ? <span className="shrink-0 text-right">{note}</span> : null}
     </li>

--- a/packages/dashboard-pages/src/components/copy-field.tsx
+++ b/packages/dashboard-pages/src/components/copy-field.tsx
@@ -52,7 +52,7 @@ export function CopyField({
           type="button"
           onClick={() => copy(value)}
           className={cn(
-            'shrink-0 border-l font-mono text-[9px] uppercase tracking-eyebrow transition-colors duration-fast ease-munin dark:border-rule-on-dark',
+            'shrink-0 border-l font-mono text-[10px] font-medium uppercase tracking-eyebrow transition-colors duration-fast ease-munin dark:border-rule-on-dark',
             isField ? 'border-rule-soft px-3' : 'border-ink px-3.5',
             copied
               ? 'text-cobalt dark:text-cobalt-soft'

--- a/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
@@ -197,7 +197,7 @@ export function ConversationPane({
   if (!selectedId) {
     return (
       <section className="hidden min-h-0 flex-col items-start bg-paper-deep p-8 md:flex dark:bg-secondary">
-        <span className="font-mono text-[11px] uppercase tracking-eyebrow text-ink-mute">
+        <span className="font-mono text-[11px] font-medium uppercase tracking-eyebrow text-ink-label">
           {t('selectEmpty')}
         </span>
       </section>
@@ -297,7 +297,7 @@ export function ConversationPane({
   );
 
   const claimGateCaption = claim ? (
-    <span className="font-mono text-[9px] uppercase tracking-meta leading-relaxed text-ink-mute">
+    <span className="font-mono text-[10px] font-medium uppercase tracking-meta leading-relaxed text-ink-mute">
       {t('claimGateOther', { name: claimHolderName ?? t('teammate') })}
     </span>
   ) : null;
@@ -378,7 +378,7 @@ export function ConversationPane({
   const statusStrip = (
     <span
       className={cn(
-        'flex min-w-0 flex-wrap items-center gap-x-5 gap-y-1 font-mono text-[9px] uppercase tracking-meta md:ml-auto md:justify-end',
+        'flex min-w-0 flex-wrap items-center gap-x-5 gap-y-1 font-mono text-[10px] font-medium uppercase tracking-meta md:ml-auto md:justify-end',
         composerState ? 'max-md:w-full max-md:pb-2 max-md:pt-1' : 'max-md:hidden',
       )}
     >
@@ -454,7 +454,7 @@ export function ConversationPane({
               {customer}
             </div>
           ) : null}
-          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 font-mono text-[10px] uppercase tracking-meta text-ink-mute">
+          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
             {metaParts.map((part, i) => (
               <span key={`${i}-${part}`} className="flex min-w-0 items-center gap-2">
                 {i > 0 ? <span aria-hidden>·</span> : null}
@@ -574,7 +574,7 @@ export function ConversationPane({
                 {composerTitle}
               </span>
               {composerMeta ? (
-                <span className="truncate font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+                <span className="truncate font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
                   {composerMeta}
                 </span>
               ) : null}
@@ -582,7 +582,7 @@ export function ConversationPane({
             <button
               type="button"
               onClick={() => setExpanded(false)}
-              className="ml-auto flex shrink-0 items-center gap-2.5 font-mono text-[9px] uppercase tracking-eyebrow text-ink-soft dark:text-foreground/80"
+              className="ml-auto flex shrink-0 items-center gap-2.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label"
             >
               {tCommon('close')}
               <X aria-hidden className="size-4 text-ink dark:text-foreground" />
@@ -594,7 +594,7 @@ export function ConversationPane({
             type="button"
             onClick={() => setTab('reply')}
             className={cn(
-              'border-b-2 py-2.5 font-mono text-[10px] uppercase tracking-meta',
+              'border-b-2 py-2.5 font-mono text-[10px] font-medium uppercase tracking-meta',
               tab === 'reply'
                 ? 'border-cobalt text-ink dark:border-cobalt-soft dark:text-foreground'
                 : 'border-transparent text-ink-mute',
@@ -606,7 +606,7 @@ export function ConversationPane({
             type="button"
             onClick={() => setTab('note')}
             className={cn(
-              'border-b-2 py-2.5 font-mono text-[10px] uppercase tracking-meta',
+              'border-b-2 py-2.5 font-mono text-[10px] font-medium uppercase tracking-meta',
               tab === 'note'
                 ? 'border-cobalt text-ink dark:border-cobalt-soft dark:text-foreground'
                 : 'border-transparent text-ink-mute',
@@ -706,7 +706,7 @@ export function ConversationPane({
               >
                 {t('addNote')}
               </Button>
-              <span className="min-w-0 truncate font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+              <span className="min-w-0 truncate font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
                 {t('noteHint')}
               </span>
             </div>

--- a/packages/dashboard-pages/src/components/dashboard/conversation-row.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-row.tsx
@@ -22,7 +22,7 @@ function ClaimFace({
     return (
       <span
         aria-hidden
-        className="flex size-[22px] shrink-0 items-center justify-center rounded-full border border-dashed border-ink-mute font-mono text-[9px] text-ink-mute"
+        className="flex size-[22px] shrink-0 items-center justify-center rounded-full border border-dashed border-ink-mute font-mono text-[10px] text-ink-mute"
       >
         —
       </span>
@@ -33,10 +33,10 @@ function ClaimFace({
     <span
       title={claim.holderName ?? undefined}
       className={cn(
-        'flex size-[22px] shrink-0 items-center justify-center rounded-full font-mono text-[8px]',
+        'flex size-[22px] shrink-0 items-center justify-center rounded-full font-mono text-[10px]',
         isYou
           ? 'bg-ink text-paper dark:bg-foreground dark:text-background'
-          : 'bg-ink-mute text-ink',
+          : 'bg-ink-mute text-paper dark:text-ink',
       )}
     >
       {initialsOf(claim.holderName)}
@@ -85,7 +85,7 @@ export function ConversationRow({
           {item.topicName ? (
             <span
               className={cn(
-                'mt-0.5 flex items-center gap-1.5 truncate font-mono text-[9px] uppercase tracking-meta',
+                'mt-0.5 flex items-center gap-1.5 truncate font-mono text-[10px] font-medium uppercase tracking-meta',
                 item.agentMode === 'auto' ? 'text-cobalt dark:text-cobalt-soft' : 'text-ink-mute',
               )}
             >
@@ -99,7 +99,7 @@ export function ConversationRow({
             </span>
           ) : null}
           {drafting || showNoDraft ? (
-            <span className="mt-0.5 truncate font-mono text-[9px] uppercase tracking-meta text-cobalt dark:text-cobalt-soft">
+            <span className="mt-0.5 truncate font-mono text-[10px] font-medium uppercase tracking-meta text-cobalt dark:text-cobalt-soft">
               {drafting ? t('draftingBadge') : t('noDraftBadge')}
             </span>
           ) : null}

--- a/packages/dashboard-pages/src/components/dashboard/inbox-identity.test.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-identity.test.ts
@@ -115,8 +115,8 @@ describe('participantHues', () => {
 });
 
 describe('participantColor', () => {
-  it('varies hue only, holding lightness and chroma fixed', () => {
-    expect(participantColor(165)).toBe('oklch(0.55 0.105 165)');
-    expect(participantColor(315)).toBe('oklch(0.55 0.105 315)');
+  it('varies hue only, deferring lightness to the scheme-aware token so one hue reads on both', () => {
+    expect(participantColor(165)).toBe('oklch(var(--munin-participant-l) 0.105 165)');
+    expect(participantColor(315)).toBe('oklch(var(--munin-participant-l) 0.105 315)');
   });
 });

--- a/packages/dashboard-pages/src/components/dashboard/inbox-identity.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-identity.ts
@@ -7,7 +7,7 @@ export const PARTICIPANT_HUES = [165, 32, 210, 75, 315] as const;
 const PARTICIPANT_RING_MIN_HUMANS = 3;
 
 export function participantColor(hue: number): string {
-  return `oklch(0.55 0.105 ${hue})`;
+  return `oklch(var(--munin-participant-l) 0.105 ${hue})`;
 }
 
 export function messageRole(message: MessageDto, viewerUserId: string | null): MessageRole {

--- a/packages/dashboard-pages/src/components/dashboard/inbox-message-bubble.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-message-bubble.tsx
@@ -67,7 +67,7 @@ export function MessageBubble({
 
   if (role === 'system') {
     return (
-      <div className="self-center text-center font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+      <div className="self-center text-center font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
         — {message.body} —
       </div>
     );
@@ -88,7 +88,7 @@ export function MessageBubble({
       >
         <div
           className={cn(
-            'font-mono text-[9px] uppercase tracking-eyebrow',
+            'font-mono text-[10px] font-medium uppercase tracking-eyebrow',
             role === 'agent' ? 'text-ink-mute' : 'text-ink-soft dark:text-foreground/80',
           )}
         >
@@ -107,7 +107,7 @@ export function MessageBubble({
       )}
     >
       {showAuthor ? (
-        <div className="flex items-baseline gap-1.5 font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+        <div className="flex items-baseline gap-1.5 font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
           <span
             className={cn(
               'font-semibold',
@@ -143,7 +143,7 @@ export function MessageBubble({
       </div>
       {isOutbound && <MessageComponents metadata={message.metadata} />}
       {isOutbound && message.seenAt && (
-        <div className="font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+        <div className="font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
           {t('seenAt', { time: formatSeenAt(message.seenAt) })}
         </div>
       )}

--- a/packages/dashboard-pages/src/components/dashboard/inbox-product-list.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-product-list.tsx
@@ -67,7 +67,7 @@ function ProductCard({ item, viewLabel }: { item: ProductListItem; viewLabel: st
           href={item.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="self-start font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute underline underline-offset-2 hover:text-ink"
+          className="self-start font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label underline underline-offset-2 hover:text-ink"
         >
           {viewLabel} ↗
         </a>

--- a/packages/dashboard-pages/src/components/dashboard/overview-review.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/overview-review.tsx
@@ -58,7 +58,7 @@ export function OverviewReview({
         <button
           type="button"
           onClick={() => router.push(`/dashboard/review/${next.id}`)}
-          className="group flex w-full items-baseline justify-between gap-4 px-5 py-3.5 text-left font-mono text-[10px] uppercase tracking-eyebrow transition-colors duration-fast ease-munin hover:bg-paper-deep dark:hover:bg-secondary"
+          className="group flex w-full items-baseline justify-between gap-4 px-5 py-3.5 text-left font-mono text-[10px] font-medium uppercase tracking-eyebrow transition-colors duration-fast ease-munin hover:bg-paper-deep dark:hover:bg-secondary"
         >
           <span className="text-ink dark:text-foreground">
             {t('scheduled', { count: scheduled.length })}

--- a/packages/dashboard-pages/src/components/dashboard/overview-stat-row.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/overview-stat-row.tsx
@@ -51,13 +51,13 @@ export function StatRow({
         {count}
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-0.5 md:gap-1">
-        <span className="truncate font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute md:text-[10px]">
+        <span className="truncate font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
           {label}
         </span>
         <span className="text-[13.5px] text-ink md:text-[15px] dark:text-foreground">{note}</span>
       </span>
       <span className="ml-auto shrink-0 text-cobalt transition-colors duration-fast ease-munin group-hover:text-cobalt-deep dark:text-cobalt-soft">
-        <span className="hidden whitespace-nowrap font-mono text-[10px] uppercase tracking-eyebrow md:inline">
+        <span className="hidden whitespace-nowrap font-mono text-[10px] font-medium uppercase tracking-eyebrow md:inline">
           {cta}
         </span>
         <span aria-hidden className="font-mono text-base leading-none md:hidden">

--- a/packages/dashboard-pages/src/components/dashboard/pane-more-actions.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/pane-more-actions.tsx
@@ -44,7 +44,7 @@ export function MoreActionsSheet({
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="bottom" className="md:hidden">
-        <SheetTitle className="px-5 pb-2 pt-5 font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+        <SheetTitle className="px-5 pb-2 pt-5 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
           {tCommon('moreActions')}
         </SheetTitle>
         <div className="flex flex-col pb-2">

--- a/packages/dashboard-pages/src/components/dashboard/queue-panes/cms.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-panes/cms.tsx
@@ -268,7 +268,7 @@ export function CmsQueuePane({
                     href={previewUrl ?? undefined}
                     target="_blank"
                     rel="noreferrer noopener"
-                    className="ml-auto py-3 font-mono text-[9px] uppercase tracking-eyebrow text-cobalt hover:underline dark:text-cobalt-soft"
+                    className="ml-auto py-3 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-cobalt hover:underline dark:text-cobalt-soft"
                   >
                     {t('cmsOpenPreview')} <span aria-hidden>↗</span>
                   </a>
@@ -279,7 +279,7 @@ export function CmsQueuePane({
                 <div className="relative flex-1 min-h-[380px] overflow-hidden bg-bone dark:bg-secondary">
                   {previewState !== 'ready' ? (
                     <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-bone dark:bg-secondary">
-                      <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+                      <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                         {t('cmsPreviewLoading')}
                       </span>
                     </div>
@@ -312,7 +312,7 @@ export function CmsQueuePane({
                 <div className="space-y-6 px-5 py-5 md:px-7">
                   {blockedEmbed && !editing ? (
                     <div className="flex flex-col gap-1 border-l-2 border-alert-bad-border bg-alert-bad px-3 py-2">
-                      <span className="font-mono text-[9px] uppercase tracking-eyebrow text-alert-bad-ink">
+                      <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-alert-bad-ink">
                         {t('cmsPreviewBlockedEyebrow')}
                       </span>
                       <span className="text-[13px] leading-relaxed text-ink dark:text-foreground">
@@ -331,7 +331,7 @@ export function CmsQueuePane({
                   ) : previewState === 'failed' && !editing ? (
                     <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-l-2 border-alert-bad-border bg-alert-bad px-3 py-2">
                       <span className="flex min-w-0 flex-1 flex-col gap-1">
-                        <span className="font-mono text-[9px] uppercase tracking-eyebrow text-alert-bad-ink">
+                        <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-alert-bad-ink">
                           {t('cmsPreviewFailedEyebrow')}
                         </span>
                         <span className="text-[13px] leading-relaxed text-ink dark:text-foreground">
@@ -341,7 +341,7 @@ export function CmsQueuePane({
                       <button
                         type="button"
                         onClick={retryPreview}
-                        className="shrink-0 font-mono text-[9px] uppercase tracking-eyebrow text-cobalt hover:underline dark:text-cobalt-soft"
+                        className="shrink-0 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-cobalt hover:underline dark:text-cobalt-soft"
                       >
                         {tCommon('retry')} <span aria-hidden>⟳</span>
                       </button>
@@ -417,7 +417,7 @@ export function CmsQueuePane({
           <Button variant="ghost" onClick={cancelEdit} className="max-md:h-11 max-md:flex-1">
             {t('cancel')}
           </Button>
-          <span className="hidden font-mono text-[9px] uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
+          <span className="hidden font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
             {t('shortcutSave')}
           </span>
         </div>
@@ -443,7 +443,7 @@ export function CmsQueuePane({
                 }}
               >
                 <label className="flex flex-col gap-1.5">
-                  <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+                  <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                     {t('cmsScheduleLabel')}
                   </span>
                   <input
@@ -458,7 +458,7 @@ export function CmsQueuePane({
                   />
                 </label>
                 {scheduleError && (
-                  <span className="font-mono text-[10px] uppercase tracking-eyebrow text-destructive">
+                  <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-destructive">
                     {scheduleError}
                   </span>
                 )}
@@ -524,7 +524,7 @@ export function CmsQueuePane({
             >
               {t('cmsDismiss')}
             </Button>
-            <span className="hidden font-mono text-[9px] uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
+            <span className="hidden font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
               {t('shortcutCmsApprove')}
             </span>
           </div>
@@ -571,7 +571,7 @@ function ViewTab({
       onClick={onSelect}
       aria-current={active ? 'true' : undefined}
       className={cn(
-        '-mb-px flex items-center gap-1.5 border-b-2 py-3 font-mono text-[9.5px] uppercase tracking-eyebrow transition-colors duration-fast',
+        '-mb-px flex items-center gap-1.5 border-b-2 py-3 font-mono text-[10px] font-medium uppercase tracking-eyebrow transition-colors duration-fast',
         active
           ? 'border-cobalt text-ink dark:border-cobalt-soft dark:text-foreground'
           : 'border-transparent text-ink-mute hover:text-ink dark:hover:text-foreground',
@@ -614,7 +614,7 @@ function FieldSection({
     <section className="space-y-2">
       <p
         className={cn(
-          'font-mono text-[10px] uppercase tracking-eyebrow',
+          'font-mono text-[10px] font-medium uppercase tracking-eyebrow',
           error ? 'text-destructive' : 'text-ink-mute',
         )}
       >
@@ -932,7 +932,7 @@ function BlockCard({
   return (
     <div className="space-y-3 border-[1px] border-rule-soft bg-paper-deep/50 p-3 dark:border-rule-on-dark dark:bg-secondary/40">
       <div className="flex items-center justify-between gap-2">
-        <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+        <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
           {label}
         </span>
         {controls}
@@ -948,7 +948,7 @@ function BlockProp({ children }: { children: React.ReactNode }) {
 
 function BlockPropLabel({ children }: { children: React.ReactNode }) {
   return (
-    <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute/80">{children}</p>
+    <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">{children}</p>
   );
 }
 
@@ -1332,7 +1332,7 @@ function AssetFigure({
           alt={asset.altText ?? ''}
           className="size-full object-cover"
         />
-        <span className="absolute right-2 bottom-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute bg-paper/85 px-1.5 py-0.5 dark:bg-card/85">
+        <span className="absolute right-2 bottom-2 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label bg-paper/85 px-1.5 py-0.5 dark:bg-card/85">
           {aspectLabel}
         </span>
       </div>
@@ -1440,17 +1440,17 @@ function AssetDropZone({
                     : 'bg-paper/70 opacity-0 group-hover:opacity-100 dark:bg-card/70',
                 )}
               >
-                <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+                <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                   {uploading ? uploadingLabel : dragging ? activeLabel : replaceLabel}
                 </span>
               </div>
             </>
           ) : (
-            <span className="relative font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            <span className="relative font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {uploading ? uploadingLabel : dragging ? activeLabel : hintLabel}
             </span>
           )}
-          <span className="absolute right-2 bottom-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute bg-paper/85 px-1.5 py-0.5 dark:bg-card/85">
+          <span className="absolute right-2 bottom-2 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label bg-paper/85 px-1.5 py-0.5 dark:bg-card/85">
             {aspectLabel}
           </span>
         </button>

--- a/packages/dashboard-pages/src/components/dashboard/queue-panes/crm.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-panes/crm.tsx
@@ -46,7 +46,7 @@ export function CrmQueuePane({
 
       <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
         <section className="space-y-2">
-          <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+          <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
             {t('proposal')}
           </p>
           <div className="border-[1px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">

--- a/packages/dashboard-pages/src/components/dashboard/queue-panes/feedback.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-panes/feedback.tsx
@@ -52,12 +52,12 @@ export function FeedbackQueuePane({
 
       <div className="flex-1 space-y-6 overflow-y-auto px-5 py-5 md:px-7">
         <section className="space-y-2">
-          <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+          <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
             {t('proposal')}
           </p>
           <div className="border-[1px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
             <p className="whitespace-pre-wrap">{f.body}</p>
-            <p className="mt-3 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            <p className="mt-3 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {t(attributionKey, { orgName: '—', userName: '—' })}
             </p>
             <p className="mt-2 text-ink-mute text-xs">{t('feedbackApproveConfirm')}</p>

--- a/packages/dashboard-pages/src/components/dashboard/queue-panes/kb.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-panes/kb.tsx
@@ -109,7 +109,7 @@ export function KbQueuePane({
       {body !== undefined ? (
         <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
           <section className="space-y-2">
-            <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {isRevision ? t('proposalRevision') : t('proposal')}
             </p>
             {editing ? (

--- a/packages/dashboard-pages/src/components/dashboard/queue-panes/outreach.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-panes/outreach.tsx
@@ -174,7 +174,7 @@ export function OutreachQueuePane({
 
         {originalDraftBody !== null && !editing && (
           <section className="space-y-2">
-            <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {t('outreachOriginalDraft')}
             </p>
             <BodyDiff
@@ -187,7 +187,7 @@ export function OutreachQueuePane({
 
         {item.raw.kind === 'reply' && (
           <section className="space-y-2">
-            <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {t('replyFrom')}
             </p>
             <p className="border-l-2 border-cobalt pl-3 font-serif italic text-cobalt dark:border-cobalt-soft dark:text-cobalt-soft">
@@ -201,7 +201,7 @@ export function OutreachQueuePane({
         )}
 
         <section className="space-y-2">
-          <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+          <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
             {t('proposal')}
           </p>
           {editing ? (
@@ -215,7 +215,7 @@ export function OutreachQueuePane({
           ) : (
             <div className="border-[1px] border-ink bg-paper px-4 py-3 text-sm leading-relaxed dark:bg-card dark:border-rule-on-dark dark:text-foreground">
               {item.raw.draftSubject && (
-                <p className="mb-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+                <p className="mb-2 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                   {t('subject', { subject: item.raw.draftSubject })}
                 </p>
               )}
@@ -276,7 +276,7 @@ export function OutreachQueuePane({
             }}
           >
             <label className="flex flex-col gap-1.5">
-              <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+              <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                 {t('outreachScheduleLabel')}
               </span>
               <input
@@ -291,7 +291,7 @@ export function OutreachQueuePane({
               />
             </label>
             {scheduleError && (
-              <span className="font-mono text-[10px] uppercase tracking-eyebrow text-destructive">
+              <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-destructive">
                 {scheduleError}
               </span>
             )}

--- a/packages/dashboard-pages/src/components/dashboard/queue-panes/shared.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-panes/shared.tsx
@@ -40,7 +40,7 @@ export const MD_COMPONENTS: Components = {
     </div>
   ),
   th: ({ children }) => (
-    <th className="border-[1px] border-rule-soft px-2 py-1 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute dark:border-rule-on-dark">
+    <th className="border-[1px] border-rule-soft px-2 py-1 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label dark:border-rule-on-dark">
       {children}
     </th>
   ),
@@ -117,7 +117,7 @@ export function PaneLoadFailed({
       className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center"
       role="alert"
     >
-      <p className="font-mono text-[10px] uppercase tracking-eyebrow text-destructive">
+      <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-destructive">
         {eyebrow}
       </p>
       <h3 className="font-serif text-xl leading-tight text-ink dark:text-foreground">{title}</h3>
@@ -172,7 +172,7 @@ export function PaneHeader({
             {title}
           </h2>
           {meta && (
-            <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {meta}
             </p>
           )}
@@ -181,7 +181,7 @@ export function PaneHeader({
           <button
             type="button"
             onClick={onClose}
-            className="shrink-0 whitespace-nowrap font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute hover:text-ink dark:hover:text-foreground"
+            className="shrink-0 whitespace-nowrap font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label hover:text-ink dark:hover:text-foreground"
             aria-label={closeLabel}
           >
             {closeLabel}
@@ -278,7 +278,7 @@ export function ScheduledFooter({
       <Button variant="outline" size="sm" onClick={onCancel} disabled={disabled}>
         {cancelLabel}
       </Button>
-      <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+      <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
         {note}
       </span>
     </div>
@@ -327,7 +327,7 @@ export function PaneFooter({
         ))}
       </div>
       {shortcut && (
-        <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+        <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
           {shortcut}
         </span>
       )}

--- a/packages/dashboard-pages/src/components/dashboard/queue-row.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/queue-row.tsx
@@ -88,7 +88,7 @@ export function RowTime({
 
 export function RowNote({ children }: { children: ReactNode }) {
   return (
-    <span className="truncate font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+    <span className="truncate font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
       {children}
     </span>
   );

--- a/packages/dashboard-pages/src/components/dashboard/review-crm-pane.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/review-crm-pane.tsx
@@ -89,7 +89,7 @@ export function ReviewCrmPane({
             <Pill tone="ink" marker="none">
               {t(proposal.confidence === 'high' ? 'confidenceHigh' : 'confidenceMedium')}
             </Pill>
-            <span className="ml-auto font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+            <span className="ml-auto font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
               {age(item.createdAt)}
             </span>
           </div>
@@ -114,10 +114,10 @@ export function ReviewCrmPane({
 
         <div className="flex flex-col gap-2.5 border-t border-ink pt-4 dark:border-rule-on-dark">
           <div className="flex items-baseline justify-between gap-4">
-            <span className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {t('whatChanges')}
             </span>
-            <span className="shrink-0 font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+            <span className="shrink-0 font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
               {t('changeCount', { count: changes.length, total: comparableFieldCount() })}
             </span>
           </div>
@@ -135,14 +135,14 @@ export function ReviewCrmPane({
           )}
 
           <div className="flex items-baseline justify-between gap-4 border-t border-rule-soft pt-2.5 dark:border-rule-on-dark">
-            <span className="font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
               {t('untouched', { count: untouchedCount })}
             </span>
             <button
               type="button"
               onClick={() => setCompareAll((open) => !open)}
               aria-expanded={compareAll}
-              className="shrink-0 font-mono text-[9px] uppercase tracking-eyebrow text-cobalt underline-offset-[3px] hover:underline dark:text-cobalt-soft"
+              className="shrink-0 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-cobalt underline-offset-[3px] hover:underline dark:text-cobalt-soft"
             >
               {compareAll ? t('compareHide') : t('compareAll')} <span aria-hidden>→</span>
             </button>
@@ -152,11 +152,11 @@ export function ReviewCrmPane({
             <table className="w-full border-collapse border border-rule-soft text-left dark:border-rule-on-dark">
               <thead>
                 <tr className="border-b border-ink dark:border-rule-on-dark">
-                  <th className="px-3 py-2 font-mono text-[8.5px] uppercase tracking-meta text-ink-mute" />
-                  <th className="border-l border-rule-soft px-3 py-2 font-mono text-[8.5px] uppercase tracking-meta text-cobalt dark:border-rule-on-dark dark:text-cobalt-soft">
+                  <th className="px-3 py-2 font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute" />
+                  <th className="border-l border-rule-soft px-3 py-2 font-mono text-[10px] font-medium uppercase tracking-meta text-cobalt dark:border-rule-on-dark dark:text-cobalt-soft">
                     {t('columnKeeper')}
                   </th>
-                  <th className="border-l border-rule-soft px-3 py-2 font-mono text-[8.5px] uppercase tracking-meta text-ink-mute dark:border-rule-on-dark">
+                  <th className="border-l border-rule-soft px-3 py-2 font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute dark:border-rule-on-dark">
                     {t('columnArchived')}
                   </th>
                 </tr>
@@ -178,7 +178,7 @@ export function ReviewCrmPane({
                     >
                       <th
                         scope="row"
-                        className="w-[112px] px-3 py-2 align-top font-mono text-[9px] font-normal uppercase tracking-meta text-ink-mute"
+                        className="w-[112px] px-3 py-2 align-top font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute"
                       >
                         {humanizeFieldName(field)}
                       </th>
@@ -211,7 +211,7 @@ export function ReviewCrmPane({
         </div>
 
         <div className="flex flex-col gap-2 border-t border-ink pt-4 dark:border-rule-on-dark">
-          <span className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
             {t('andThen')}
           </span>
           <p className="max-w-[64ch] text-[14px] leading-relaxed text-ink dark:text-foreground">
@@ -263,7 +263,7 @@ export function ReviewCrmPane({
           >
             {t('dismiss')}
           </Button>
-          <span className="hidden font-mono text-[9px] uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
+          <span className="hidden font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
             {t('shortcutApply')}
           </span>
         </div>
@@ -282,10 +282,10 @@ function ChangeRow({
   return (
     <li className="grid grid-cols-[128px_minmax(0,1fr)] border-b border-rule-soft last:border-b-0 dark:border-rule-on-dark">
       <span className="flex flex-col items-start gap-1.5 px-3 py-3">
-        <span className="font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+        <span className="font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
           {humanizeFieldName(change.field)}
         </span>
-        <span className="border border-rule-soft px-1.5 py-[1px] font-mono text-[8.5px] uppercase tracking-meta text-ink-soft dark:border-rule-on-dark dark:text-foreground/70">
+        <span className="border border-rule-soft px-1.5 py-[1px] font-mono text-[10px] font-medium uppercase tracking-meta text-ink-soft dark:border-rule-on-dark dark:text-foreground/70">
           {t(`kind_${change.kind}`)}
         </span>
       </span>
@@ -304,11 +304,11 @@ function ChangeRow({
           </em>
         </span>
         {change.dropped.length > 0 ? (
-          <span className="font-mono text-[9px] uppercase tracking-meta text-alert-bad-ink">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-meta text-alert-bad-ink">
             {t('replacedNote', { dropped: change.dropped.join(', ') })}
           </span>
         ) : change.kind === 'replaced' ? (
-          <span className="font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
             {t('replacedNoteNoDrop')}
           </span>
         ) : null}

--- a/packages/dashboard-pages/src/components/dashboard/review-decided-pane.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/review-decided-pane.tsx
@@ -11,7 +11,7 @@ import type { CurationDecisionDto, PublishedDocument } from './curation-decision
 function Section({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-2.5">
-      <div className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">{label}</div>
+      <div className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">{label}</div>
       {children}
     </div>
   );
@@ -52,13 +52,13 @@ export function ReviewDecidedPane({
     <section className="flex min-h-0 flex-col overflow-y-auto bg-paper dark:bg-background">
       <div className="flex flex-1 flex-col gap-5 px-5 pb-8 pt-6 md:px-7">
         <div className="flex flex-col gap-2.5">
-          <div className="font-mono text-[9.5px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+          <div className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
             {published ? t('outcomePublished') : t('outcomeDismissed')}
           </div>
           <h2 className="max-w-[42ch] font-serif text-[26px] font-normal leading-[1.2] text-ink md:text-[30px] dark:text-foreground">
             {item.title}
           </h2>
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[10px] uppercase tracking-meta text-ink-mute">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
             <span>{decidedBy}</span>
             <span aria-hidden>·</span>
             <span>{age(item.decidedAt)}</span>

--- a/packages/dashboard-pages/src/components/dashboard/review-kb-pane.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/review-kb-pane.tsx
@@ -59,7 +59,7 @@ export function ReviewKbPane({
     <section className="flex min-h-0 flex-col overflow-y-auto bg-paper dark:bg-background">
       <div className="flex flex-1 flex-col gap-5 px-5 pb-8 pt-6 md:px-7">
         <div className="flex flex-col gap-2.5">
-          <div className="font-mono text-[9.5px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+          <div className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
             {isRevision
               ? t('kindRevisionOf', { title: item.raw.revisesDocumentTitle ?? item.title })
               : t('kindNew')}
@@ -67,7 +67,7 @@ export function ReviewKbPane({
           <h2 className="max-w-[42ch] font-serif text-[26px] font-normal leading-[1.2] text-ink md:text-[30px] dark:text-foreground">
             {item.title}
           </h2>
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[10px] uppercase tracking-meta text-ink-mute">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
             <span>{space}</span>
             <span aria-hidden>·</span>
             <span>{age(item.createdAt)}</span>
@@ -88,7 +88,7 @@ export function ReviewKbPane({
         <div className="flex flex-col gap-5 border-t border-rule-soft pt-5 dark:border-rule-on-dark">
           {passage ? (
             <div className="flex flex-col gap-2.5">
-              <div className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+              <div className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                 {t('changedPassage')}
               </div>
               <p className="max-w-[62ch] text-[14.5px] leading-relaxed text-ink-soft dark:text-foreground/70">
@@ -108,7 +108,7 @@ export function ReviewKbPane({
 
           <div className="flex flex-col gap-[11px]">
             {passage ? (
-              <div className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+              <div className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                 {t('bodyLabelRevision')}
               </div>
             ) : null}

--- a/packages/dashboard-pages/src/components/dashboard/review-outreach-pane.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/review-outreach-pane.tsx
@@ -158,7 +158,7 @@ export function ReviewOutreachPane({
             <Pill tone="draft" marker="none">
               {kindLabel}
             </Pill>
-            <span className="ml-auto font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+            <span className="ml-auto font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
               {proposal.campaign?.name ?? t('campaignUnknown')} · {age(item.createdAt)}
             </span>
           </div>
@@ -189,7 +189,7 @@ export function ReviewOutreachPane({
         {proposal.revisedAfterReviewAt ? (
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-l-2 border-alert-bad-border bg-alert-bad px-3 py-2">
             <span className="flex min-w-0 flex-1 flex-col gap-1">
-              <span className="font-mono text-[9px] uppercase tracking-eyebrow text-alert-bad-ink">
+              <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-alert-bad-ink">
                 {t('revisedAfterReview')}
               </span>
               <span className="text-[13px] leading-relaxed text-ink dark:text-foreground">
@@ -202,7 +202,7 @@ export function ReviewOutreachPane({
               <button
                 type="button"
                 onClick={revealDiff}
-                className="shrink-0 font-mono text-[9px] uppercase tracking-eyebrow text-cobalt underline-offset-[3px] hover:underline dark:text-cobalt-soft"
+                className="shrink-0 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-cobalt underline-offset-[3px] hover:underline dark:text-cobalt-soft"
               >
                 {t('seeDiff')} <span aria-hidden>→</span>
               </button>
@@ -239,7 +239,7 @@ export function ReviewOutreachPane({
                 {proposal.delivery?.sender ?? t('senderUnknown')}
               </span>
               {!isVoice ? (
-                <span className="ml-auto font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+                <span className="ml-auto font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
                   {t('smsSegments', { count: segments, chars: editedBody.length })}
                 </span>
               ) : null}
@@ -259,7 +259,7 @@ export function ReviewOutreachPane({
               <Markdown>{editedBody}</Markdown>
               {appendsCta || appendsUnsubscribe ? (
                 <div className="mt-1 flex flex-col gap-2 border-t border-dashed border-ink-mute pt-3">
-                  <span className="font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+                  <span className="font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
                     {t('appendedOnSend')}
                   </span>
                   {appendsCta ? (
@@ -289,7 +289,7 @@ export function ReviewOutreachPane({
               type="button"
               onClick={() => setDiffOpen((open) => !open)}
               aria-expanded={diffOpen}
-              className="flex items-baseline justify-between gap-4 border-t border-rule-soft pt-3 text-left font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute transition-colors duration-fast hover:text-ink dark:border-rule-on-dark dark:hover:text-foreground"
+              className="flex items-baseline justify-between gap-4 border-t border-rule-soft pt-3 text-left font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label transition-colors duration-fast hover:text-ink dark:border-rule-on-dark dark:hover:text-foreground"
             >
               <span>{t('diffSummary', { count: editCount })}</span>
               <span className="shrink-0 text-cobalt dark:text-cobalt-soft">
@@ -309,7 +309,7 @@ export function ReviewOutreachPane({
 
         {parsedEvidence ? (
           <div className="flex flex-col gap-2.5 border-t border-ink pt-4 dark:border-rule-on-dark">
-            <span className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {t('whyThis')}
             </span>
             {parsedEvidence.prose.map((line) => (
@@ -325,7 +325,7 @@ export function ReviewOutreachPane({
                 {parsedEvidence.kbRefs.map((ref) => (
                   <span
                     key={ref}
-                    className="border border-rule-soft px-2 py-[3px] font-mono text-[9px] tracking-meta text-ink-soft dark:border-rule-on-dark dark:text-foreground/70"
+                    className="border border-rule-soft px-2 py-[3px] font-mono text-[10px] tracking-meta text-ink-soft dark:border-rule-on-dark dark:text-foreground/70"
                   >
                     {t('kbChip', { id: ref.replace(/^kb:\/\//, '') })}
                   </span>
@@ -333,7 +333,7 @@ export function ReviewOutreachPane({
                 {parsedEvidence.chips.map((chip) => (
                   <span
                     key={`${chip.label}-${chip.value}`}
-                    className="border border-rule-soft px-2 py-[3px] font-mono text-[9px] tracking-meta text-ink-soft dark:border-rule-on-dark dark:text-foreground/70"
+                    className="border border-rule-soft px-2 py-[3px] font-mono text-[10px] tracking-meta text-ink-soft dark:border-rule-on-dark dark:text-foreground/70"
                   >
                     {chip.label} = {chip.value}
                   </span>
@@ -345,7 +345,7 @@ export function ReviewOutreachPane({
 
         {!editing ? (
           <div className="flex flex-col gap-2.5 border-t border-ink pt-4 dark:border-rule-on-dark">
-            <span className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {t('whenItGoes')}
             </span>
             <div className="flex flex-col border border-rule-soft dark:border-rule-on-dark">
@@ -382,7 +382,7 @@ export function ReviewOutreachPane({
           </div>
         ) : null}
 
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-rule-soft pt-3 font-mono text-[9.5px] uppercase tracking-meta text-ink-mute dark:border-rule-on-dark">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-rule-soft pt-3 font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute dark:border-rule-on-dark">
           <span>
             {proposal.proposedByActorType === 'user' ? t('draftedByUser') : t('draftedByAgent')} ·{' '}
             {age(item.createdAt)}
@@ -421,7 +421,7 @@ export function ReviewOutreachPane({
               <Button variant="ghost" onClick={cancelEdit} className="max-md:h-11 max-md:flex-1">
                 {t('cancel')}
               </Button>
-              <span className="hidden font-mono text-[9px] uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
+              <span className="hidden font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
                 {t('shortcutSave')}
               </span>
             </>
@@ -452,7 +452,7 @@ export function ReviewOutreachPane({
               >
                 {t('dismiss')}
               </Button>
-              <span className="hidden font-mono text-[9px] uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
+              <span className="hidden font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute md:ml-auto md:inline">
                 {t('shortcutApprove')}
               </span>
             </>
@@ -478,7 +478,7 @@ function approveLabel(
 
 function EnvelopeLabel({ children }: { children: string }) {
   return (
-    <span className="font-mono text-[9px] uppercase tracking-meta text-ink-mute">{children}</span>
+    <span className="font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">{children}</span>
   );
 }
 

--- a/packages/dashboard-pages/src/components/dashboard/scheduled-cancel-dialog.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/scheduled-cancel-dialog.tsx
@@ -62,7 +62,7 @@ export function ScheduledCancelDialog({ controller }: { controller: InboxControl
         >
           {needsReason && (
             <label className="flex flex-col gap-1.5">
-              <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+              <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                 {t('cancelReasonLabel')}
               </span>
               <input

--- a/packages/dashboard-pages/src/components/dashboard/test-conversation-banner.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/test-conversation-banner.tsx
@@ -32,7 +32,7 @@ export function TestConversationBanner({
 
   return (
     <div className="mx-5 mt-4 flex flex-wrap items-center gap-x-3.5 gap-y-2.5 border border-cobalt bg-paper px-3.5 py-2.5 md:mx-7 dark:border-cobalt-soft dark:bg-card">
-      <span className="font-mono text-[9px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+      <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
         {t('testBadge')}
       </span>
       <span className="min-w-[200px] flex-1 text-[13.5px] leading-relaxed text-ink-soft dark:text-foreground/80">

--- a/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/usage-kpis.tsx
@@ -34,7 +34,7 @@ export function UsageKpis({ summary }: UsageKpisProps) {
         </Eyebrow>
         <Link
           href="/dashboard/settings/usage"
-          className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute hover:text-cobalt transition-colors duration-fast"
+          className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label hover:text-cobalt transition-colors duration-fast"
         >
           {t('byAgentBreakdown')}
         </Link>
@@ -98,7 +98,7 @@ function Kpi({ label, value, previous, spark, format, lowerIsBetter, tone = 'acc
   const delta = formatDelta(value, previous, format, lowerIsBetter, t);
   return (
     <div className="border-[1px] border-rule-soft bg-paper px-4 py-3.5 dark:bg-card dark:border-rule-on-dark">
-      <div className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">{label}</div>
+      <div className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">{label}</div>
       <div className="font-serif text-[28px] leading-none tracking-tight my-1.5 text-ink dark:text-foreground">
         {value === undefined ? '—' : format(value)}
       </div>

--- a/packages/dashboard-pages/src/components/first-run/first-run-scene.tsx
+++ b/packages/dashboard-pages/src/components/first-run/first-run-scene.tsx
@@ -15,7 +15,7 @@ export function FirstRunScene({
   return (
     <section className="mx-auto flex w-full max-w-[780px] flex-col gap-9 px-5 pb-16 pt-12 md:gap-11 md:px-11 md:pb-20 md:pt-16">
       <header className="flex flex-col gap-4">
-        <span className="font-mono text-[11px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+        <span className="font-mono text-[11px] font-medium uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
           {eyebrow}
         </span>
         <h1 className="font-serif text-[38px] font-normal leading-[1.05] tracking-tight text-ink md:text-[52px] dark:text-foreground [&_em]:italic [&_em]:text-cobalt dark:[&_em]:text-cobalt-soft">
@@ -47,7 +47,7 @@ export function FirstRunAside({
 }) {
   return (
     <div className="flex flex-col gap-3 border-t border-ink pt-6 dark:border-rule-on-dark">
-      <div className="flex items-baseline gap-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+      <div className="flex items-baseline gap-4 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
         <span>{label}</span>
         {meta ? <span className="ml-auto tracking-meta">{meta}</span> : null}
       </div>

--- a/packages/dashboard-pages/src/components/first-run/first-run-status.tsx
+++ b/packages/dashboard-pages/src/components/first-run/first-run-status.tsx
@@ -28,7 +28,7 @@ export function FirstRunStatusList({
           key={row.key}
           className="grid grid-cols-1 gap-1.5 border-b border-rule-soft py-4 last:border-b-0 md:grid-cols-[120px_minmax(0,1fr)_auto] md:items-center md:gap-5 md:py-5 dark:border-rule-on-dark"
         >
-          <span className="flex items-center gap-2.5 font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+          <span className="flex items-center gap-2.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
             <StatusDot live={row.live === true} />
             {row.kind}
           </span>
@@ -36,7 +36,7 @@ export function FirstRunStatusList({
             {row.detail}
           </span>
           {row.meta ? (
-            <span className="font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
               {row.meta}
             </span>
           ) : null}

--- a/packages/dashboard-pages/src/components/first-run/first-run-steps.tsx
+++ b/packages/dashboard-pages/src/components/first-run/first-run-steps.tsx
@@ -31,7 +31,7 @@ export function FirstRunSteps({ steps }: { steps: FirstRunStep[] }) {
               {step.tag ? (
                 <span
                   className={cn(
-                    'font-mono text-[9px] uppercase tracking-eyebrow',
+                    'font-mono text-[10px] font-medium uppercase tracking-eyebrow',
                     step.done ? 'text-cobalt dark:text-cobalt-soft' : 'text-ink-mute',
                   )}
                 >
@@ -82,7 +82,7 @@ export function FirstRunChain({ steps }: { steps: FirstRunChainStep[] }) {
             </span>
             <span
               className={cn(
-                'mt-1 font-mono text-[9px] uppercase tracking-eyebrow md:hidden',
+                'mt-1 font-mono text-[10px] font-medium uppercase tracking-eyebrow md:hidden',
                 step.done ? 'text-cobalt dark:text-cobalt-soft' : 'text-ink-mute',
               )}
             >
@@ -91,7 +91,7 @@ export function FirstRunChain({ steps }: { steps: FirstRunChainStep[] }) {
           </div>
           <span
             className={cn(
-              'hidden font-mono text-[9px] uppercase tracking-eyebrow md:inline',
+              'hidden font-mono text-[10px] font-medium uppercase tracking-eyebrow md:inline',
               step.done ? 'text-cobalt dark:text-cobalt-soft' : 'text-ink-mute',
             )}
           >

--- a/packages/dashboard-pages/src/components/integrations/choose-tools-dialog.tsx
+++ b/packages/dashboard-pages/src/components/integrations/choose-tools-dialog.tsx
@@ -120,7 +120,7 @@ export function ChooseToolsDialog({
                         {tool.name}
                       </span>
                       {tool.destructive && (
-                        <span className="font-mono text-[10px] uppercase tracking-eyebrow text-destructive">
+                        <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-destructive">
                           {t('notReadOnly')}
                         </span>
                       )}

--- a/packages/dashboard-pages/src/components/integrations/connect-connector-dialog.tsx
+++ b/packages/dashboard-pages/src/components/integrations/connect-connector-dialog.tsx
@@ -119,7 +119,7 @@ export function ConnectConnectorDialog({
                 ? t('editVendor', { vendor: vendor.displayName })
                 : t('connectVendor', { vendor: vendor.displayName })}
             </h2>
-            <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {tc(`category.${present.categoryKey}`)}
             </span>
           </div>
@@ -127,7 +127,7 @@ export function ConnectConnectorDialog({
 
         <div className="grid grid-cols-1 sm:grid-cols-[260px_1fr]">
           <div className="flex flex-col gap-4 border-b-[1px] border-rule-soft bg-paper-deep px-7 py-6 dark:border-rule-on-dark dark:bg-secondary sm:border-b-0 sm:border-r-[1px]">
-            <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {t('whatAgentsGet')}
             </span>
             <div className="flex flex-col">

--- a/packages/dashboard-pages/src/components/load-failed.tsx
+++ b/packages/dashboard-pages/src/components/load-failed.tsx
@@ -59,7 +59,7 @@ export function LoadFailed({
       )}
     >
       <div className="space-y-3">
-        <div className="flex items-center gap-2 font-mono uppercase tracking-eyebrow text-[11px] text-alert-bad-ink">
+        <div className="flex items-center gap-2 font-mono uppercase tracking-eyebrow text-[11px] font-medium text-alert-bad-ink">
           <span
             aria-hidden
             className="size-1.5 shrink-0 rounded-full bg-alert-bad-border"
@@ -110,7 +110,7 @@ export function LoadFailed({
           {retrying ? retryingLabel : retryLabel}
         </Button>
         {autoRetryHint && (
-          <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute dark:text-foreground/60">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
             {autoRetryHint}
           </span>
         )}

--- a/packages/dashboard-pages/src/components/system-alerts-banner.tsx
+++ b/packages/dashboard-pages/src/components/system-alerts-banner.tsx
@@ -100,7 +100,7 @@ export function SystemAlertsBanner() {
       className="agent-banner sticky top-0 z-50 h-12 overflow-hidden border-b-[1px] border-ink/20 bg-amber-100 text-ink dark:bg-amber-200/90 dark:text-ink"
     >
       <div className="mx-auto flex h-full items-center gap-4 px-4 md:px-10">
-        <span className="flex shrink-0 items-center gap-2 whitespace-nowrap border-r border-ink/25 pr-3.5 font-mono text-[10px] uppercase leading-none tracking-[0.16em]">
+        <span className="flex shrink-0 items-center gap-2 whitespace-nowrap border-r border-ink/25 pr-3.5 font-mono text-[10px] font-medium uppercase leading-none tracking-[0.16em]">
           <span className="size-[7px] animate-pulse rounded-full bg-ink" aria-hidden />
           {state.tag}
         </span>
@@ -108,7 +108,7 @@ export function SystemAlertsBanner() {
         {cta && (
           <Link
             href={cta.href}
-            className="hidden h-7 shrink-0 items-center whitespace-nowrap border border-ink bg-transparent px-3 font-mono text-[10px] uppercase leading-none tracking-[0.14em] text-ink transition-colors hover:bg-ink hover:text-amber-100 md:inline-flex"
+            className="hidden h-7 shrink-0 items-center whitespace-nowrap border border-ink bg-transparent px-3 font-mono text-[10px] font-medium uppercase leading-none tracking-[0.14em] text-ink transition-colors hover:bg-ink hover:text-amber-100 md:inline-flex"
           >
             {cta.label}
           </Link>

--- a/packages/dashboard-pages/src/pages/activity.tsx
+++ b/packages/dashboard-pages/src/pages/activity.tsx
@@ -123,13 +123,13 @@ export function ActivityPage() {
       <section data-screen-label="activity · feed">
         <header className="flex items-baseline justify-between border-b-[1px] border-rule-soft dark:border-rule-on-dark pb-2 mb-0">
           <h2 className="font-serif text-2xl leading-none">{t('liveStream')}</h2>
-          <span className="font-mono text-[11px] uppercase tracking-eyebrow text-ink-mute">
+          <span className="font-mono text-[11px] font-medium uppercase tracking-eyebrow text-ink-label">
             {t('windowLabel', { count: visible.length, minutes: WINDOW_MS / 60_000 })}
           </span>
         </header>
 
         <div className="flex min-h-[12rem] flex-col bg-ink dark:bg-card text-paper dark:text-foreground font-mono text-[12px] leading-relaxed px-6 py-4">
-          <div className="grid grid-cols-[6rem_minmax(0,11rem)_minmax(0,12rem)_1fr] gap-x-6 pb-2 mb-1 border-b-[1px] border-paper/15 dark:border-rule-on-dark text-[10px] uppercase tracking-eyebrow text-paper/45 dark:text-foreground/45">
+          <div className="grid grid-cols-[6rem_minmax(0,11rem)_minmax(0,12rem)_1fr] gap-x-6 pb-2 mb-1 border-b-[1px] border-paper/15 dark:border-rule-on-dark text-[10px] font-medium uppercase tracking-eyebrow text-paper/70 dark:text-foreground/70">
             <span>{t('colTime')}</span>
             <span>{t('colType')}</span>
             <span>{t('colActor')}</span>
@@ -157,7 +157,7 @@ export function ActivityPage() {
                 key={e.id}
                 className="grid grid-cols-[6rem_minmax(0,11rem)_minmax(0,12rem)_1fr] gap-x-6 items-baseline py-0.5"
               >
-                <span className="text-paper/50 dark:text-foreground/50 whitespace-nowrap">
+                <span className="text-paper/70 dark:text-foreground/70 whitespace-nowrap">
                   {formatClock(e.createdAt)}
                 </span>
                 <span className="truncate text-cobalt-soft">{e.type}</span>
@@ -168,7 +168,7 @@ export function ActivityPage() {
               </li>
             ))}
             {hasLoadedOnce && visible.length === 0 && (
-              <li className="flex grow items-center justify-center text-paper/50 dark:text-foreground/50">
+              <li className="flex grow items-center justify-center text-paper/70 dark:text-foreground/70">
                 {t('empty')}
               </li>
             )}

--- a/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
+++ b/packages/dashboard-pages/src/pages/agent-setup-wizard.tsx
@@ -268,7 +268,7 @@ interface CuratorJobDto {
   progress: WebImportProgress | null;
 }
 
-const MONO_LABEL = 'font-mono text-[11px] uppercase tracking-[0.14em]';
+const MONO_LABEL = 'font-mono text-[11px] font-medium uppercase tracking-[0.14em]';
 
 function WebsiteImportStatus({ jobId, initialUrl }: { jobId: string; initialUrl: string | null }) {
   const t = useTranslations('agentSetup.websiteImport.status');
@@ -359,7 +359,7 @@ function WebsiteImportStatus({ jobId, initialUrl }: { jobId: string; initialUrl:
             type="button"
             onClick={() => void retry()}
             disabled={retrying || !url}
-            className="border border-rule px-3.5 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-ink transition-colors duration-base hover:bg-ink hover:text-paper disabled:opacity-50 dark:text-foreground"
+            className="border border-rule px-3.5 py-2 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink transition-colors duration-base hover:bg-ink hover:text-paper disabled:opacity-50 dark:text-foreground"
           >
             {retrying ? tCommon('saving') : t('retry')}
           </button>

--- a/packages/dashboard-pages/src/pages/agents.tsx
+++ b/packages/dashboard-pages/src/pages/agents.tsx
@@ -198,7 +198,7 @@ function Th({ children, className }: { children?: ReactNode; className?: string 
   return (
     <th
       className={cn(
-        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute font-normal',
+        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-label font-medium',
         className,
       )}
     >
@@ -218,7 +218,7 @@ function StatusChip({
   return (
     <span
       className={cn(
-        'inline-block px-2 py-0.5 font-mono text-[10px] uppercase tracking-eyebrow',
+        'inline-block px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow',
         status === 'active'
           ? 'bg-cobalt/15 text-cobalt-deep dark:bg-cobalt-soft/20 dark:text-cobalt-soft'
           : 'border-[1px] border-rule-soft dark:border-rule-on-dark text-ink-mute',

--- a/packages/dashboard-pages/src/pages/api-keys.tsx
+++ b/packages/dashboard-pages/src/pages/api-keys.tsx
@@ -190,7 +190,7 @@ function Th({ children, className }: { children?: ReactNode; className?: string 
   return (
     <th
       className={cn(
-        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute font-normal',
+        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-label font-medium',
         className,
       )}
     >

--- a/packages/dashboard-pages/src/pages/audit-log.tsx
+++ b/packages/dashboard-pages/src/pages/audit-log.tsx
@@ -262,7 +262,7 @@ function Th({ children, className }: { children?: ReactNode; className?: string 
   return (
     <th
       className={cn(
-        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute font-normal',
+        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-label font-medium',
         className,
       )}
     >
@@ -276,7 +276,7 @@ function ResultChip({ result }: { result: string | null }) {
   return (
     <span
       className={cn(
-        'inline-block px-2 py-0.5 font-mono text-[10px] uppercase tracking-eyebrow',
+        'inline-block px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow',
         result === 'ok'
           ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
           : result === 'denied'

--- a/packages/dashboard-pages/src/pages/automation.tsx
+++ b/packages/dashboard-pages/src/pages/automation.tsx
@@ -208,7 +208,7 @@ export function AutomationPage() {
             <div className="font-serif text-6xl leading-none text-ink md:text-7xl dark:text-foreground">
               {autoRate === null || autoRate === undefined ? '—' : `${Math.round(autoRate * 100)}%`}
             </div>
-            <div className="mt-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+            <div className="mt-2 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
               {t('autoRateCaption')}
             </div>
           </>
@@ -220,7 +220,7 @@ export function AutomationPage() {
           <div
             className={cn(
               GRID,
-              'border-b border-ink py-3.5 font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute max-md:hidden dark:border-rule-on-dark',
+              'border-b border-ink py-3.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label max-md:hidden dark:border-rule-on-dark',
             )}
           >
             <span>{t('colTopic')}</span>
@@ -270,7 +270,7 @@ export function AutomationPage() {
                   >
                     {pct === null ? '—' : `${pct}%`}
                   </span>
-                  <span className="font-mono text-[9px] uppercase tracking-meta text-ink-mute md:hidden">
+                  <span className="font-mono text-[10px] font-medium uppercase tracking-meta text-ink-label md:hidden">
                     {t('colUnedited')}
                   </span>
                   <span className="relative h-1 max-w-[120px] flex-1 bg-rule-soft max-md:hidden dark:bg-rule-on-dark">
@@ -286,7 +286,7 @@ export function AutomationPage() {
                 <span className="flex items-center justify-end gap-3.5 max-md:justify-between">
                   <span
                     className={cn(
-                      'font-mono text-[9.5px] uppercase tracking-meta md:text-right',
+                      'font-mono text-[10px] font-medium uppercase tracking-meta md:text-right',
                       sending
                         ? 'text-cobalt dark:text-cobalt-soft'
                         : armedButHolding
@@ -329,7 +329,7 @@ export function AutomationPage() {
           {editing ? (
             <>
               <DialogHeader>
-                <div className="font-mono text-[11px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+                <div className="font-mono text-[11px] font-medium uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
                   {t('policyFor', { name: editing.name })}
                 </div>
                 <DialogTitle className="font-serif text-3xl font-normal leading-[1.05] tracking-tight">
@@ -339,7 +339,7 @@ export function AutomationPage() {
                     ),
                   })}
                 </DialogTitle>
-                <div className="font-mono text-[10px] uppercase tracking-meta text-ink-mute">
+                <div className="font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
                   {t('dialogStats', {
                     pct: editingPct ?? 0,
                     n: editing.reviewedCount,
@@ -351,7 +351,7 @@ export function AutomationPage() {
               <div className="mb-5">
                 <label
                   htmlFor="topic-description"
-                  className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute"
+                  className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label"
                 >
                   {t('descriptionLabel')}
                 </label>
@@ -402,7 +402,7 @@ export function AutomationPage() {
                       <span className="flex min-w-0 flex-col gap-1">
                         <span
                           className={cn(
-                            'font-mono text-[11px] uppercase tracking-meta',
+                            'font-mono text-[11px] font-medium uppercase tracking-meta',
                             on ? 'text-cobalt dark:text-cobalt-soft' : 'text-ink dark:text-foreground',
                           )}
                         >
@@ -414,7 +414,7 @@ export function AutomationPage() {
                         {choice === 'auto' ? (
                           <span
                             className={cn(
-                              'font-mono text-[9px] uppercase tracking-meta',
+                              'font-mono text-[10px] font-medium uppercase tracking-meta',
                               autoSending ? 'text-cobalt dark:text-cobalt-soft' : 'text-ink-mute',
                             )}
                           >
@@ -433,7 +433,7 @@ export function AutomationPage() {
 
               {draftPolicy === 'auto' ? (
                 <div className="mt-4 border-t border-rule-soft pt-4 dark:border-rule-on-dark">
-                  <div className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+                  <div className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                     {t('gateLabel')}
                   </div>
                   <div className="mt-2.5 flex flex-wrap items-center gap-3.5">
@@ -444,7 +444,7 @@ export function AutomationPage() {
                           type="button"
                           onClick={() => setDraftGate(gate)}
                           className={cn(
-                            'whitespace-nowrap px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-meta transition-colors duration-fast ease-munin',
+                            'whitespace-nowrap px-2.5 py-1.5 font-mono text-[10px] font-medium uppercase tracking-meta transition-colors duration-fast ease-munin',
                             draftGate === gate
                               ? 'bg-ink text-paper dark:bg-foreground dark:text-background'
                               : 'text-ink-mute hover:bg-paper-deep dark:hover:bg-secondary',

--- a/packages/dashboard-pages/src/pages/channels.tsx
+++ b/packages/dashboard-pages/src/pages/channels.tsx
@@ -1474,7 +1474,7 @@ function EmailChannelDialog({
           </div>
 
           <fieldset className="space-y-3 border border-rule-soft px-3 pb-3 dark:border-rule-on-dark">
-            <legend className="px-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">{t('email.outboundLabel')}</legend>
+            <legend className="px-2 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">{t('email.outboundLabel')}</legend>
             <div className="grid gap-3 sm:grid-cols-2">
               <FormField label={t('email.host')} error={fieldErrors.smtpHost}>
                 <Input
@@ -1584,7 +1584,7 @@ function EmailChannelDialog({
           </fieldset>
 
           <fieldset className="space-y-3 border border-rule-soft px-3 pb-3 dark:border-rule-on-dark">
-            <legend className="px-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">{t('email.inboundLabel')}</legend>
+            <legend className="px-2 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">{t('email.inboundLabel')}</legend>
             <FormField label={t('email.inboundModeLabel')} hint={t(`email.inboundModeHint.${inboundMode}`)}>
               <NativeSelect
                 value={inboundMode}
@@ -2112,7 +2112,7 @@ function InlineCopyButton({ value, label }: { value: string; label: string }) {
       ) : (
         <Copy className="size-3.5" aria-hidden />
       )}
-      {copied && <span className="font-mono text-[10px] uppercase">{tCommon('copied')}</span>}
+      {copied && <span className="font-mono text-[10px] font-medium uppercase">{tCommon('copied')}</span>}
       <span aria-live="polite" className="sr-only">
         {copied ? tCommon('copied') : ''}
       </span>
@@ -2260,7 +2260,7 @@ function EmbedSnippetDialog({
                     type="button"
                     onClick={() => setLanguage(s.language)}
                     className={cn(
-                      'w-24 h-7 px-2.5 font-mono text-[11px] uppercase tracking-eyebrow border-r-[1px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
+                      'w-24 h-7 px-2.5 font-mono text-[11px] font-medium uppercase tracking-eyebrow border-r-[1px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
                       active
                         ? 'bg-ink text-paper dark:bg-foreground dark:text-background'
                         : 'bg-paper hover:bg-paper-deep dark:bg-card dark:hover:bg-secondary',

--- a/packages/dashboard-pages/src/pages/conversations.tsx
+++ b/packages/dashboard-pages/src/pages/conversations.tsx
@@ -141,7 +141,7 @@ export function ConversationsPage({ selectedId = null }: { selectedId?: string |
         )}
       >
         <header className="shrink-0 border-b border-rule-soft px-5 pb-3.5 pt-6 md:min-h-[146px] dark:border-rule-on-dark">
-          <div className="font-mono text-[11px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+          <div className="font-mono text-[11px] font-medium uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
             {t('eyebrow')}
           </div>
           <h1 className="mb-2.5 mt-1 truncate font-serif text-[28px] font-normal leading-[1.05] tracking-tight text-ink md:text-3xl dark:text-foreground">

--- a/packages/dashboard-pages/src/pages/end-users.tsx
+++ b/packages/dashboard-pages/src/pages/end-users.tsx
@@ -176,7 +176,7 @@ function Th({ children, className }: { children?: ReactNode; className?: string 
   return (
     <th
       className={cn(
-        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute font-normal',
+        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-label font-medium',
         className,
       )}
     >
@@ -187,7 +187,7 @@ function Th({ children, className }: { children?: ReactNode; className?: string 
 
 function Avatar({ name, email }: { name: string | null; email: string | null }) {
   return (
-    <span className="inline-flex size-9 items-center justify-center rounded-full bg-paper-deep dark:bg-secondary font-mono text-[11px] uppercase text-ink dark:text-foreground">
+    <span className="inline-flex size-9 items-center justify-center rounded-full bg-paper-deep dark:bg-secondary font-mono text-[11px] font-medium uppercase text-ink dark:text-foreground">
       {avatarInitials(name, email)}
     </span>
   );

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -253,7 +253,7 @@ function EditorialHeader({ flow, clientName, resourceName }: EditorialHeaderProp
   if (flow === 'expired') {
     return (
       <header className="mb-6">
-        <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-mute">
+        <div className="mb-4 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-ink-mute">
           {t('expired.eyebrow')}
         </div>
         <h1 className="font-serif text-[clamp(46px,6.6vw,72px)] font-normal leading-[0.98] tracking-[-0.02em] min-w-0 [overflow-wrap:anywhere] [word-break:break-word]">
@@ -270,7 +270,7 @@ function EditorialHeader({ flow, clientName, resourceName }: EditorialHeaderProp
   if (flow === 'blocked') {
     return (
       <header className="mb-6">
-        <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-mute">
+        <div className="mb-4 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-ink-mute">
           {t('blocked.eyebrow')}
         </div>
         <h1 className="font-serif text-[clamp(46px,6.6vw,72px)] font-normal leading-[0.98] tracking-[-0.02em] min-w-0 [overflow-wrap:anywhere] [word-break:break-word]">
@@ -288,7 +288,7 @@ function EditorialHeader({ flow, clientName, resourceName }: EditorialHeaderProp
   if (flow === 'granted') {
     return (
       <header className="mb-6">
-        <div className="mb-4 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-mute">
+        <div className="mb-4 flex items-center gap-2 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-ink-mute">
           <span className="text-cobalt">✓</span>
           <span>{t('granted.eyebrow')}</span>
         </div>
@@ -307,7 +307,7 @@ function EditorialHeader({ flow, clientName, resourceName }: EditorialHeaderProp
   if (flow === 'denied') {
     return (
       <header className="mb-6">
-        <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-mute">
+        <div className="mb-4 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-ink-mute">
           {t('denied.eyebrow')}
         </div>
         <h1 className="font-serif text-[clamp(46px,6.6vw,72px)] font-normal leading-[0.98] tracking-[-0.02em] min-w-0 [overflow-wrap:anywhere] [word-break:break-word]">
@@ -324,7 +324,7 @@ function EditorialHeader({ flow, clientName, resourceName }: EditorialHeaderProp
   }
   return (
     <header className="mb-6">
-      <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-mute">
+      <div className="mb-4 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-ink-mute">
         {t('eyebrow')}
       </div>
       <h1 className="font-serif text-[clamp(46px,6.6vw,72px)] font-normal leading-[0.98] tracking-[-0.02em] min-w-0 [overflow-wrap:anywhere] [word-break:break-word]">
@@ -376,7 +376,7 @@ function RequestPane({
 
       <div className="px-7 pt-2 pb-1">
         <div className="flex items-baseline justify-between py-4">
-          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-mute">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-mute">
             {t('scopesLabel')}
           </span>
           <span className="font-mono text-[11px] text-ink-soft">
@@ -640,7 +640,7 @@ function ScopePill({ kind, label }: { kind: 'read' | 'write'; label: string }) {
       : 'border-rule-soft text-ink-soft';
   return (
     <span
-      className={`whitespace-nowrap rounded-full border-[1px] px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.1em] ${cls}`}
+      className={`whitespace-nowrap rounded-full border-[1px] px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.1em] ${cls}`}
     >
       {label}
     </span>

--- a/packages/dashboard-pages/src/pages/review.tsx
+++ b/packages/dashboard-pages/src/pages/review.tsx
@@ -207,7 +207,7 @@ export function ReviewPage({ selectedId = null }: { selectedId?: string | null }
         )}
       >
         <header className="shrink-0 border-b border-rule-soft px-5 pb-4 pt-6 dark:border-rule-on-dark">
-          <div className="font-mono text-[11px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+          <div className="font-mono text-[11px] font-medium uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
             {t('eyebrow')}
           </div>
           <h1 className="mb-2 mt-1 font-serif text-[26px] font-normal leading-[1.05] tracking-tight text-ink md:text-[28px] dark:text-foreground">
@@ -356,7 +356,7 @@ export function ReviewPage({ selectedId = null }: { selectedId?: string | null }
         {!activeId ? (
           <section className="hidden min-h-0 flex-col bg-paper-deep md:flex dark:bg-secondary">
             {activeIds.length > 0 ? (
-              <span className="p-8 font-mono text-[11px] uppercase tracking-eyebrow text-ink-mute">
+              <span className="p-8 font-mono text-[11px] font-medium uppercase tracking-eyebrow text-ink-label">
                 {t('selectEmpty')}
               </span>
             ) : (
@@ -439,7 +439,7 @@ function PaneEmpty({
 }) {
   return (
     <div className="px-5 pt-6 md:px-7">
-      <div className="font-mono text-[11px] uppercase tracking-eyebrow text-ink-mute">
+      <div className="font-mono text-[11px] font-medium uppercase tracking-eyebrow text-ink-label">
         {eyebrow}
       </div>
       <h2 className="mb-2 mt-1 font-serif text-[26px] font-normal leading-[1.05] tracking-tight text-ink md:text-[28px] dark:text-foreground">

--- a/packages/dashboard-pages/src/pages/team.tsx
+++ b/packages/dashboard-pages/src/pages/team.tsx
@@ -437,7 +437,7 @@ function Th({ children, className }: { children?: ReactNode; className?: string 
   return (
     <th
       className={cn(
-        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute font-normal',
+        'pb-3 pr-4 font-mono text-[10px] uppercase tracking-eyebrow text-ink-label font-medium',
         className,
       )}
     >
@@ -464,7 +464,7 @@ function RoleSelect({
       <select
         value={value}
         onChange={(e) => onChange(e.target.value as MemberRole)}
-        className="appearance-none border-[1px] border-rule-field dark:border-rule-field focus-visible:border-cobalt bg-paper dark:bg-card font-mono text-[10px] uppercase tracking-eyebrow text-ink dark:text-foreground py-1.5 pl-3 pr-7 cursor-pointer focus-visible:outline-none"
+        className="appearance-none border-[1px] border-rule-field dark:border-rule-field focus-visible:border-cobalt bg-paper dark:bg-card font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink dark:text-foreground py-1.5 pl-3 pr-7 cursor-pointer focus-visible:outline-none"
       >
         <option value="owner">{labelOwner}</option>
         <option value="admin">{labelAdmin}</option>
@@ -487,7 +487,7 @@ function RoleChip({
 }) {
   const label = role === 'owner' ? t('roleOwner') : role === 'admin' ? t('roleAdmin') : t('roleMember');
   return (
-    <span className="inline-block border-[1px] border-rule-soft dark:border-rule-on-dark font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute py-1 px-2.5">
+    <span className="inline-block border-[1px] border-rule-soft dark:border-rule-on-dark font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label py-1 px-2.5">
       {label}
     </span>
   );

--- a/packages/dashboard-pages/src/pages/trackers.tsx
+++ b/packages/dashboard-pages/src/pages/trackers.tsx
@@ -321,7 +321,7 @@ function TrackerRow({
         <span className="font-serif text-[26px] leading-none tracking-tight text-ink dark:text-foreground">
           {totalViews.toLocaleString()}
         </span>
-        <span className="font-mono text-[9px] uppercase tracking-eyebrow text-ink-mute">
+        <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
           {t('viewsLabel')}
         </span>
       </div>
@@ -675,7 +675,7 @@ function EmbedSnippetDialog({
                     type="button"
                     onClick={() => setLanguage(s.language)}
                     className={cn(
-                      'w-24 h-7 px-2.5 font-mono text-[11px] uppercase tracking-eyebrow border-r-[1px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
+                      'w-24 h-7 px-2.5 font-mono text-[11px] font-medium uppercase tracking-eyebrow border-r-[1px] border-rule-soft last:border-r-0 transition-colors duration-fast ease-munin',
                       active
                         ? 'bg-ink text-paper dark:bg-foreground dark:text-background'
                         : 'bg-paper hover:bg-paper-deep dark:bg-card dark:hover:bg-secondary',

--- a/packages/dashboard-pages/src/pages/usage.tsx
+++ b/packages/dashboard-pages/src/pages/usage.tsx
@@ -181,13 +181,13 @@ function Tile({
 
   return (
     <div className="bg-paper dark:bg-card p-6 flex flex-col gap-4 min-h-[180px] border-r-[1px] border-b-[1px] border-rule-soft dark:border-rule-on-dark">
-      <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+      <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
         {label} · {period}
       </p>
       <p className="font-serif text-4xl leading-none font-normal tracking-tight text-ink dark:text-foreground">
         {tile ? format(tile.current) : '—'}
       </p>
-      <p className="font-mono text-[10px] uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
+      <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-cobalt dark:text-cobalt-soft">
         {tile
           ? delta.direction === 'up'
             ? t('deltaUp', { value: delta.label })
@@ -212,20 +212,20 @@ function ByAgentSection({ data }: { data: UsageByAgentDto | null }) {
           {t('title')}
           <span className="text-ink-mute"> · {t('rangeLabel', { days: data?.rangeDays ?? 30 })}</span>
         </h2>
-        <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+        <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
           {t('rightLabel')}
         </p>
       </div>
 
       <div className="border-t-[1px] border-rule-soft dark:border-rule-on-dark">
         <div className="grid grid-cols-[1fr_auto_auto] gap-x-12 px-1 py-3 border-b-[1px] border-rule-soft dark:border-rule-on-dark">
-          <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
             {t('colAgent')}
           </span>
-          <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute justify-self-end min-w-[7rem] text-right">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label justify-self-end min-w-[7rem] text-right">
             {t('colMcpCalls')}
           </span>
-          <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute justify-self-end min-w-[7rem] text-right">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label justify-self-end min-w-[7rem] text-right">
             {t('colLatency')}
           </span>
         </div>

--- a/packages/dashboard-pages/src/shells/console-shell.tsx
+++ b/packages/dashboard-pages/src/shells/console-shell.tsx
@@ -160,7 +160,7 @@ function UserFooter({
 
   return (
     <div className="flex shrink-0 items-center gap-2.5 border-t border-rule-soft px-4 py-3.5 dark:border-rule-on-dark">
-      <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-ink font-mono text-[8px] text-paper dark:bg-foreground dark:text-background">
+      <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-ink font-mono text-[10px] text-paper dark:bg-foreground dark:text-background">
         {initialsOf(name ?? null, email ?? '?')}
       </span>
       <span className="min-w-0 flex-1 truncate text-[15px] text-ink dark:text-foreground">
@@ -304,13 +304,13 @@ function ConsoleShellInner({
                     {backAction.title}
                   </span>
                   {backAction.meta ? (
-                    <span className="truncate font-mono text-[9px] uppercase tracking-meta text-ink-mute">
+                    <span className="truncate font-mono text-[10px] font-medium uppercase tracking-meta text-ink-mute">
                       {backAction.meta}
                     </span>
                   ) : null}
                 </span>
               ) : (
-                <span className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-soft dark:text-foreground/80">
+                <span className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
                   {backAction.label}
                 </span>
               )}
@@ -327,7 +327,7 @@ function ConsoleShellInner({
                 type="button"
                 onClick={() => setMenuOpen(true)}
                 aria-label={tNav('openMenu')}
-                className="ml-auto flex items-center gap-2.5 font-mono text-[9px] uppercase tracking-eyebrow text-ink-soft dark:text-foreground/80"
+                className="ml-auto flex items-center gap-2.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label"
               >
                 {activeItem ? <span>{tNav(activeItem.labelKey)}</span> : null}
                 <Menu aria-hidden className="size-4 text-ink dark:text-foreground" />

--- a/packages/dashboard-pages/src/shells/settings-shell.tsx
+++ b/packages/dashboard-pages/src/shells/settings-shell.tsx
@@ -41,7 +41,7 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
   const backLink = (
     <Link
       href="/dashboard"
-      className="group inline-flex items-center gap-2.5 font-mono text-[10px] uppercase tracking-eyebrow text-ink-soft transition-colors duration-fast ease-munin hover:text-cobalt dark:text-foreground/80 dark:hover:text-cobalt-soft"
+      className="group inline-flex items-center gap-2.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-soft transition-colors duration-fast ease-munin hover:text-cobalt dark:text-foreground/80 dark:hover:text-cobalt-soft"
     >
       <ArrowLeft
         aria-hidden
@@ -55,7 +55,7 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
     <nav className="flex flex-col gap-6 pl-2 pr-6">
       {visibleGroups.map((group) => (
         <div key={group.groupKey}>
-          <p className="mb-2 px-3.5 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+          <p className="mb-2 px-3.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
             {tGroups(group.groupKey)}
           </p>
           <ul className="space-y-px">
@@ -93,7 +93,7 @@ export function SettingsShell({ groups, children }: SettingsShellProps) {
           onClick={() => setMobileOpen(true)}
           aria-label={tNav('openMenu')}
           aria-expanded={mobileOpen}
-          className="ml-auto flex items-center gap-2.5 font-mono text-[9px] uppercase tracking-eyebrow text-ink-soft dark:text-foreground/80"
+          className="ml-auto flex items-center gap-2.5 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label"
         >
           {tNav('settings')}
           <Menu aria-hidden className="size-4 text-ink dark:text-foreground" />

--- a/packages/dashboard-pages/src/type-floor.test.ts
+++ b/packages/dashboard-pages/src/type-floor.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SRC = fileURLToPath(new URL('.', import.meta.url));
+
+function sources(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sources(path);
+    return entry.isFile() && entry.name.endsWith('.tsx') ? [path] : [];
+  });
+}
+
+describe('console type floor', () => {
+  it('sets no text smaller than 10px', () => {
+    const offenders: string[] = [];
+    for (const path of sources(SRC)) {
+      const lines = readFileSync(path, 'utf8').split('\n');
+      lines.forEach((line, index) => {
+        for (const [, size] of line.matchAll(/text-\[(\d+(?:\.\d+)?)px\]/g)) {
+          if (Number(size) < 10) {
+            offenders.push(`${path.slice(SRC.length)}:${index + 1} text-[${size}px]`);
+          }
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,7 +29,8 @@
   ],
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
@@ -48,10 +49,12 @@
   "devDependencies": {
     "@getmunin/eslint-config": "workspace:*",
     "@getmunin/tsconfig": "workspace:*",
+    "@types/node": "^22.20.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "eslint": "^9.39.5",
     "tailwindcss": "^3.4.19",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.11"
   }
 }

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -46,7 +46,7 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        "flex size-full items-center justify-center rounded-full bg-paper-deep font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute group-data-[size=sm]/avatar:text-[9px] group-data-[size=lg]/avatar:text-xs dark:bg-secondary dark:text-foreground",
+        "flex size-full items-center justify-center rounded-full bg-paper-deep font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-mute group-data-[size=sm]/avatar:text-[10px] group-data-[size=lg]/avatar:text-xs dark:bg-secondary dark:text-foreground",
         className
       )}
       {...props}

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "../cn"
 
 const badgeVariants = cva(
-  "inline-flex items-center gap-1.5 px-2 py-0.5 font-mono text-[9px] uppercase tracking-eyebrow font-medium border-[1px] whitespace-nowrap before:content-[''] before:size-[5px] before:rounded-full before:bg-current",
+  "inline-flex items-center gap-1.5 px-2 py-0.5 font-mono text-[10px] uppercase tracking-eyebrow font-medium border-[1px] whitespace-nowrap before:content-[''] before:size-[5px] before:rounded-full before:bg-current",
   {
     variants: {
       variant: {

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -65,7 +65,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        "px-2 py-1 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute data-inset:pl-7",
+        "px-2 py-1 font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label data-inset:pl-7",
         className
       )}
       {...props}
@@ -241,7 +241,7 @@ function DropdownMenuShortcut({
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
-        "ml-auto font-mono text-[10px] tracking-eyebrow uppercase text-ink-mute",
+        "ml-auto font-mono text-[10px] font-medium tracking-eyebrow uppercase text-ink-label",
         className
       )}
       {...props}

--- a/packages/ui/src/components/eyebrow.tsx
+++ b/packages/ui/src/components/eyebrow.tsx
@@ -9,7 +9,7 @@ const eyebrowVariants = cva(
     variants: {
       tone: {
         accent: 'text-cobalt dark:text-cobalt-soft',
-        muted: 'text-ink-mute',
+        muted: 'text-ink-label',
         ink: 'text-ink dark:text-foreground',
       },
       size: {

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -9,7 +9,7 @@ function Label({ className, ...props }: React.ComponentProps<"label">) {
     <label
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 font-mono text-[10px] uppercase tracking-eyebrow text-ink-label leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}

--- a/packages/ui/src/components/pill.tsx
+++ b/packages/ui/src/components/pill.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../cn';
 
 const pillVariants = cva(
-  'inline-flex items-center gap-1.5 px-[5px] py-[2px] font-mono text-[9px] leading-none uppercase tracking-eyebrow font-medium border-[1px] border-[color-mix(in_srgb,currentColor_55%,transparent)] whitespace-nowrap',
+  'inline-flex items-center gap-1.5 px-[5px] py-[2px] font-mono text-[10px] leading-none uppercase tracking-eyebrow font-medium border-[1px] border-[color-mix(in_srgb,currentColor_55%,transparent)] whitespace-nowrap',
   {
     variants: {
       marker: {

--- a/packages/ui/src/components/section-head.tsx
+++ b/packages/ui/src/components/section-head.tsx
@@ -35,7 +35,7 @@ function SectionHead({
         </h2>
         {subtitle ? <p className="text-[13px] text-ink-mute">{subtitle}</p> : null}
         {meta ? (
-          <p className="font-mono text-[10px] uppercase tracking-eyebrow text-ink-mute">
+          <p className="font-mono text-[10px] font-medium uppercase tracking-eyebrow text-ink-label">
             {meta}
           </p>
         ) : null}

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -62,7 +62,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-3 text-left align-middle font-mono text-[10px] uppercase tracking-eyebrow font-medium text-ink-mute [&:has([role=checkbox])]:pr-0",
+        "h-10 px-3 text-left align-middle font-mono text-[10px] uppercase tracking-eyebrow font-medium text-ink-label [&:has([role=checkbox])]:pr-0",
         className
       )}
       {...props}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -15,7 +15,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "inline-flex items-stretch border-b-[1px] border-rule-soft text-ink-mute dark:border-rule-on-dark",
+        "inline-flex items-stretch border-b-[1px] border-rule-soft text-ink-label dark:border-rule-on-dark",
         className
       )}
       {...props}

--- a/packages/ui/src/styles/tokens.contrast.test.ts
+++ b/packages/ui/src/styles/tokens.contrast.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const CSS = readFileSync(fileURLToPath(new URL('./tokens.css', import.meta.url)), 'utf8');
+
+function block(marker: string): string {
+  const start = CSS.indexOf(marker);
+  if (start === -1) throw new Error(`tokens.css has no ${marker} block`);
+  const open = CSS.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < CSS.length; i += 1) {
+    if (CSS[i] === '{') depth += 1;
+    if (CSS[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return CSS.slice(open + 1, i);
+    }
+  }
+  throw new Error(`unterminated ${marker} block`);
+}
+
+function triples(css: string): Record<string, [number, number, number]> {
+  const out: Record<string, [number, number, number]> = {};
+  for (const match of css.matchAll(/--munin-([a-z0-9-]+):\s*([^;]+);/g)) {
+    const name = match[1];
+    const value = match[2]?.trim();
+    if (name === undefined || value === undefined) continue;
+    const hex = /^#([0-9a-f]{6})$/i.exec(value);
+    if (hex?.[1]) {
+      const n = parseInt(hex[1], 16);
+      out[name] = [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+      continue;
+    }
+    const rgb = /^(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})$/.exec(value);
+    if (rgb) out[name] = [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])];
+  }
+  return out;
+}
+
+const LIGHT = triples(block(':root'));
+const DARK = { ...LIGHT, ...triples(block('@media (prefers-color-scheme: dark)')) };
+const LOCKED = { ...DARK, ...triples(block('.munin-light-locked')) };
+
+function luminance([r, g, b]: [number, number, number]): number {
+  const chan = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * chan(r) + 0.7152 * chan(g) + 0.0722 * chan(b);
+}
+
+function contrast(
+  palette: Record<string, [number, number, number]>,
+  fg: string,
+  bg: string,
+): number {
+  const a = palette[fg];
+  const b = palette[bg];
+  if (!a) throw new Error(`unknown token --munin-${fg}`);
+  if (!b) throw new Error(`unknown token --munin-${bg}`);
+  const la = luminance(a);
+  const lb = luminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+const LIGHT_SURFACES = ['paper', 'paper-deep', 'bone'];
+const DARK_SURFACES = ['ink', 'agent-tint-on-dark'];
+
+const TEXT_PAIRS: ReadonlyArray<
+  [scheme: 'light' | 'dark' | 'locked', fg: string, backgrounds: readonly string[]]
+> = [
+  ['light', 'fg-1', LIGHT_SURFACES],
+  ['light', 'fg-2', [...LIGHT_SURFACES, 'invite-good-bg', 'invite-bad-bg', 'verdigris-tint']],
+  ['light', 'fg-3', LIGHT_SURFACES],
+  ['light', 'fg-label', [...LIGHT_SURFACES, 'invite-good-bg', 'invite-bad-bg', 'alert-bad-bg']],
+  ['light', 'accent', LIGHT_SURFACES],
+  ['light', 'accent-deep', LIGHT_SURFACES],
+  ['light', 'verdigris', ['paper', 'verdigris-tint']],
+  ['light', 'alert-bad-ink', [...LIGHT_SURFACES, 'alert-bad-bg']],
+  ['light', 'invite-good-ink', ['invite-good-bg']],
+  ['light', 'invite-bad-ink', ['invite-bad-bg']],
+  ['light', 'fg-on-dark-1', ['ink', 'auth-navy', 'auth-navy-hover']],
+  ['dark', 'fg-on-dark-1', DARK_SURFACES],
+  ['dark', 'fg-3', DARK_SURFACES],
+  ['dark', 'fg-label', DARK_SURFACES],
+  ['dark', 'accent-soft', DARK_SURFACES],
+  ['dark', 'verdigris-soft', ['ink']],
+  ['dark', 'alert-bad-ink', ['ink', 'alert-bad-bg']],
+  ['locked', 'fg-2', LIGHT_SURFACES],
+  ['locked', 'fg-3', LIGHT_SURFACES],
+  ['locked', 'fg-label', [...LIGHT_SURFACES, 'invite-good-bg', 'invite-bad-bg']],
+  ['locked', 'alert-bad-ink', ['paper', 'alert-bad-bg']],
+];
+
+const PALETTES = { light: LIGHT, dark: DARK, locked: LOCKED };
+
+describe('token contrast', () => {
+  for (const [scheme, fg, backgrounds] of TEXT_PAIRS) {
+    for (const bg of backgrounds) {
+      it(`${scheme}: ${fg} on ${bg} clears AA for normal text`, () => {
+        expect(contrast(PALETTES[scheme], fg, bg)).toBeGreaterThanOrEqual(4.5);
+      });
+    }
+  }
+
+  it('the danger border identifies its callout on both its own tint and the page', () => {
+    expect(contrast(LIGHT, 'alert-bad-border', 'alert-bad-bg')).toBeGreaterThanOrEqual(3);
+    expect(contrast(LIGHT, 'alert-bad-border', 'paper')).toBeGreaterThanOrEqual(3);
+    expect(contrast(DARK, 'alert-bad-border', 'alert-bad-bg')).toBeGreaterThanOrEqual(3);
+    expect(contrast(DARK, 'alert-bad-border', 'ink')).toBeGreaterThanOrEqual(3);
+  });
+
+  it('the label tier reads darker than the mute tier it was split out of', () => {
+    expect(contrast(LIGHT, 'fg-label', 'paper')).toBeGreaterThan(contrast(LIGHT, 'fg-3', 'paper'));
+    expect(contrast(DARK, 'fg-label', 'ink')).toBeGreaterThan(contrast(DARK, 'fg-3', 'ink'));
+  });
+
+  it('a fixed-light surface keeps the light ramp when the OS asks for dark', () => {
+    expect(LOCKED['fg-2']).toEqual(LIGHT['fg-2']);
+    expect(LOCKED['fg-3']).toEqual(LIGHT['fg-3']);
+    expect(LOCKED['fg-label']).toEqual(LIGHT['fg-label']);
+    expect(LOCKED['alert-bad-ink']).toEqual(LIGHT['alert-bad-ink']);
+  });
+
+  it('identity hues carry a per-scheme lightness rather than one value for both', () => {
+    const lightness = (css: string) => /--munin-participant-l:\s*([\d.]+)/.exec(css)?.[1];
+    expect(lightness(block(':root'))).toBe('0.5');
+    expect(lightness(block('@media (prefers-color-scheme: dark)'))).toBe('0.74');
+    expect(lightness(block('.munin-light-locked'))).toBe('0.5');
+  });
+});

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -9,6 +9,12 @@
   --munin-fg-1: 15 20 25;           /* #0F1419 — primary text */
   --munin-fg-2: 61 66 74;           /* #3D424A — secondary text */
   --munin-fg-3: 94 100 108;         /* #5E646C — metadata, mute */
+
+  /* Labels are the smallest type in the console — mono, uppercase, tracked
+     out, 10px. At that size the mute ramp above measures AA but reads as
+     grey noise, so the label tier gets its own colour and its own dark
+     value rather than borrowing fg-2 plus a per-site dark: override. */
+  --munin-fg-label: 61 66 74;       /* #3D424A — mono uppercase labels */
   --munin-fg-on-dark-1: 251 250 247;
   --munin-fg-on-dark-2: 244 239 230; /* used at 0.75 alpha in legacy */
 
@@ -34,6 +40,10 @@
   --munin-auth-navy: 42 63 88;        /* #2A3F58 — primary CTA on auth pages */
   --munin-auth-navy-hover: 31 47 68;  /* #1F2F44 */
 
+  /* The alert family is a set: the ink is legible on the bg *and* on the
+     page, because callers use it both ways (a tinted callout, and a bare
+     eyebrow or inline clause on the surface itself). All three therefore
+     need a dark value — a light-only maroon reaches 1.65:1 on ink. */
   --munin-alert-bad-bg: 236 211 203;     /* #ECD3CB */
   --munin-alert-bad-ink: 110 31 18;      /* #6E1F12 */
   --munin-alert-bad-border: 184 73 58;   /* #B8493A */
@@ -52,6 +62,12 @@
      the soft rule; only form controls take this one. */
   --munin-rule-field: rgb(var(--munin-ink));
 
+  /* Per-participant identity hues carry their lightness in a variable so
+     one hue reads on both schemes: the fixed 0.55 measured 4.36:1 on paper
+     and 3.35:1 on the dark card, and it is text (author names) and a 2px
+     border, not only a fill. */
+  --munin-participant-l: 0.5;
+
   --munin-serif: 'Instrument Serif', 'Times New Roman', serif;
   --munin-sans: 'Inter', 'Helvetica Neue', system-ui, sans-serif;
   --munin-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
@@ -67,22 +83,32 @@
 
   color-scheme: light;
 
+  /* Aliases a utility takes an alpha modifier on (bg-card/85,
+     dark:text-foreground/80) must resolve to a bare RGB triple: Tailwind can
+     only inject <alpha-value> into a channel list, and silently drops the
+     whole declaration when the variable already holds a finished colour.
+     Keep these three-number, and derive the plain alias below from them. */
+  --foreground-rgb: var(--munin-fg-1);
+  --card-rgb: var(--munin-paper);
+  --secondary-rgb: var(--munin-paper-deep);
+  --destructive-rgb: 178 59 59;      /* #b23b3b */
+
   /* shadcn-compatible aliases — wrapped in rgb() so they work as plain colors */
   --background: rgb(var(--munin-paper));
-  --foreground: rgb(var(--munin-fg-1));
-  --card: rgb(var(--munin-paper));
+  --foreground: rgb(var(--foreground-rgb));
+  --card: rgb(var(--card-rgb));
   --card-foreground: rgb(var(--munin-fg-1));
   --popover: rgb(var(--munin-paper));
   --popover-foreground: rgb(var(--munin-fg-1));
   --primary: rgb(var(--munin-ink));
   --primary-foreground: rgb(var(--munin-paper));
-  --secondary: rgb(var(--munin-paper-deep));
+  --secondary: rgb(var(--secondary-rgb));
   --secondary-foreground: rgb(var(--munin-fg-1));
   --muted: rgb(var(--munin-paper-deep));
   --muted-foreground: rgb(var(--munin-fg-3));
   --accent: rgb(var(--munin-paper-deep));
   --accent-foreground: rgb(var(--munin-fg-1));
-  --destructive: #b23b3b;
+  --destructive: rgb(var(--destructive-rgb));
   --destructive-foreground: rgb(var(--munin-paper));
   --border: rgb(var(--munin-ink) / var(--munin-rule-soft-alpha));
   --input: rgb(var(--munin-ink) / var(--munin-rule-soft-alpha));
@@ -98,28 +124,63 @@
        at 3.24:1 on ink, and dark's own lightest surface (--secondary) is
        the binding one at 4.73:1. */
     --munin-fg-3: 134 141 151;        /* #868D97 */
+    --munin-fg-label: 194 200 208;    /* #C2C8D0 */
     --munin-rule-field: rgb(var(--munin-fg-on-dark-2) / 0.36);
 
+    --munin-participant-l: 0.74;
+
+    --munin-alert-bad-bg: 51 24 18;        /* #331812 */
+    --munin-alert-bad-ink: 240 167 155;    /* #F0A79B */
+    --munin-alert-bad-border: 210 104 90;  /* #D2685A */
+
+    --foreground-rgb: var(--munin-fg-on-dark-1);
+    --card-rgb: 21 27 34;              /* #151B22 */
+    --secondary-rgb: 28 35 43;         /* #1C232B */
+    --destructive-rgb: 217 106 106;    /* #D96A6A */
+
     --background: rgb(var(--munin-ink));
-    --foreground: rgb(var(--munin-fg-on-dark-1));
-    --card: #151b22;
+    --foreground: rgb(var(--foreground-rgb));
+    --card: rgb(var(--card-rgb));
     --card-foreground: rgb(var(--munin-fg-on-dark-1));
-    --popover: #151b22;
+    --popover: rgb(var(--card-rgb));
     --popover-foreground: rgb(var(--munin-fg-on-dark-1));
     --primary: rgb(var(--munin-paper));
     --primary-foreground: rgb(var(--munin-ink));
-    --secondary: #1c232b;
+    --secondary: rgb(var(--secondary-rgb));
     --secondary-foreground: rgb(var(--munin-fg-on-dark-1));
-    --muted: #1c232b;
+    --muted: rgb(var(--secondary-rgb));
     --muted-foreground: rgb(var(--munin-fg-on-dark-2) / 0.75);
-    --accent: #1c232b;
+    --accent: rgb(var(--secondary-rgb));
     --accent-foreground: rgb(var(--munin-fg-on-dark-1));
-    --destructive: #d96a6a;
+    --destructive: rgb(var(--destructive-rgb));
     --destructive-foreground: rgb(var(--munin-ink));
     --border: rgb(var(--munin-fg-on-dark-2) / var(--munin-rule-on-dark-alpha));
     --input: rgb(var(--munin-fg-on-dark-2) / var(--munin-rule-on-dark-alpha));
     --ring: rgb(var(--munin-accent-soft));
   }
+}
+
+/* Auth, invitation and consent surfaces paint themselves in fixed light
+   paper whatever the OS scheme is, so they must pin the light ramp too:
+   the dark overrides above would otherwise put a dark-mode grey on light
+   paper (fg-3 lands at 3.21:1 there) and leave inputs with a near-white
+   1px edge on white. Pinning here, rather than per-site dark: overrides,
+   keeps the opt-out in one place as the palette moves.
+
+   This pins variables, not variants: darkMode is 'media', so a dark: class
+   inside a locked subtree still fires. These trees carry none today and
+   must stay that way — a page that wants a real dark mode belongs outside
+   the lock, not inside it with overrides. */
+.munin-light-locked {
+  color-scheme: light;
+  --munin-fg-2: 61 66 74;
+  --munin-fg-3: 94 100 108;
+  --munin-fg-label: 61 66 74;
+  --munin-rule-field: rgb(var(--munin-ink));
+  --munin-participant-l: 0.5;
+  --munin-alert-bad-bg: 236 211 203;
+  --munin-alert-bad-ink: 110 31 18;
+  --munin-alert-bad-border: 184 73 58;
 }
 
 @keyframes munin-pulse-dot {

--- a/packages/ui/src/tailwind-preset.ts
+++ b/packages/ui/src/tailwind-preset.ts
@@ -15,17 +15,17 @@ const muninPreset: Omit<Config, 'content'> = {
         input: 'var(--input)',
         ring: 'var(--ring)',
         background: 'var(--background)',
-        foreground: 'var(--foreground)',
+        foreground: 'rgb(var(--foreground-rgb) / <alpha-value>)',
         primary: {
           DEFAULT: 'var(--primary)',
           foreground: 'var(--primary-foreground)',
         },
         secondary: {
-          DEFAULT: 'var(--secondary)',
+          DEFAULT: 'rgb(var(--secondary-rgb) / <alpha-value>)',
           foreground: 'var(--secondary-foreground)',
         },
         destructive: {
-          DEFAULT: 'var(--destructive)',
+          DEFAULT: 'rgb(var(--destructive-rgb) / <alpha-value>)',
           foreground: 'var(--destructive-foreground)',
         },
         muted: {
@@ -41,7 +41,7 @@ const muninPreset: Omit<Config, 'content'> = {
           foreground: 'var(--popover-foreground)',
         },
         card: {
-          DEFAULT: 'var(--card)',
+          DEFAULT: 'rgb(var(--card-rgb) / <alpha-value>)',
           foreground: 'var(--card-foreground)',
         },
         bone: 'rgb(var(--munin-bone) / <alpha-value>)',
@@ -53,6 +53,7 @@ const muninPreset: Omit<Config, 'content'> = {
           DEFAULT: 'rgb(var(--munin-ink) / <alpha-value>)',
           soft: 'rgb(var(--munin-fg-2) / <alpha-value>)',
           mute: 'rgb(var(--munin-fg-3) / <alpha-value>)',
+          label: 'rgb(var(--munin-fg-label) / <alpha-value>)',
         },
         cobalt: {
           DEFAULT: 'rgb(var(--munin-accent) / <alpha-value>)',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1053,6 +1053,9 @@ importers:
       '@getmunin/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -1068,6 +1071,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@24.1.3)(msw@2.14.2(@types/node@22.20.1)(typescript@5.9.3))(vite@6.4.3(@types/node@22.20.1)(jiti@1.21.7)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
 
   packages/widget-voice:
     dependencies:


### PR DESCRIPTION
Follows #910. That pass audited token *pairs*; this one audits what the browser
actually paints, which is where the rest of the failures were hiding.

Reported as "some texts still seem hard to read", with `BLOCKING` / `IMPROVEMENTS`
on Review and `TOPIC` / `VOLUME / WINDOW` on Automation as the examples.

## Tailwind was discarding every alpha modifier on a shadcn alias

`--foreground`, `--card`, `--secondary` and `--destructive` held finished colours
(`rgb(15 20 25)`), and Tailwind can only inject `<alpha-value>` into a bare channel
list — so it dropped the whole declaration rather than warning. **75 utilities
compiled to nothing:**

- `dark:text-foreground/70` and `/80` (51 sites) left body copy, page ledes, the
  sidebar's inactive nav and the CRM merge pane rendering their *light-mode* ink on
  a dark background at **1.57–1.83:1**.
- `dark:bg-foreground/15`, `dark:bg-card/85`, `dark:bg-secondary/40`,
  `bg-destructive/5` and `border-destructive/40` painted nothing at all.

The four aliases now resolve through `--foreground-rgb` / `--card-rgb` /
`--secondary-rgb` / `--destructive-rgb` triples, with the plain alias derived from
them, so **no call site changed** and all 75 emit.

## Labels get their own tier

The console's mono uppercase labels ran 8–9.5px at `text-ink-mute`: 5.72:1 on paper,
which clears AA and still reads as grey noise at that size — 81 sites in
`dashboard-pages`, 15 more in the widget. They are now **10px `font-medium`**,
matching what `packages/ui`'s own `Label`, `Table` head, `Tabs` and `Button` already
shipped, and structural ones (section labels, column heads, field labels, eyebrows)
take a new `--munin-fg-label` (`text-ink-label`) at **9.69:1** light / **10.99:1**
dark. Incidental metadata — timestamps, row counts — stays on the mute tier.

Labels never shrink below 10px again: `type-floor.test.ts` fails the build on
`text-[<10px]`.

## Four more measured failures

| Site | Measured |
|---|---|
| `text-alert-bad-ink` bare on the page in dark mode (error eyebrows and headings, an inline CRM clause, the outreach and CMS notices) — the token had no dark value | **1.65:1** |
| Activity feed column heads and clocks, `text-paper/45` and `/50` on the ink panel | **4.38:1** at 10px |
| `text-ink-mute/80` on CMS block-prop labels | **3.71:1** |
| `participantColor` = `oklch(0.55 …)` for both schemes, used as 9px semibold author names *and* a 2px bubble border | **4.36:1** light, **3.35:1** dark |

The alert family now flips as a set — bg `#331812`, ink `#F0A79B` (8.36:1 on its own
tint, 8.08–9.44:1 on the three dark surfaces), border `#D2685A`. Identity lightness
moves to `--munin-participant-l`: 0.5 light, 0.74 dark.

## #910's dark mute lift broke the auth pages

`AuthShell` and everything under it carry **no `dark:` class at all** — they are fixed
light paper by design — so the dark `--munin-fg-3` landed at **3.21:1** there (2.45:1
on the invite tint), and the dark `--munin-rule-field` left login inputs with a
near-white 1px edge on white. They now pin the light ramp via `.munin-light-locked`,
one place to hold the opt-out as the palette moves. It pins variables, not variants:
`darkMode` is `media`, so those trees must stay free of `dark:` classes.

## Verification

- `tokens.contrast.test.ts` — 63 assertions over every foreground/background pair the
  design actually meets, in light, dark and light-locked. Confirmed it fails when the
  new values are reverted.
- Compiled-stylesheet check: each of the 75 utilities goes 0 → 1 occurrences.
- Computed-value probe in Chromium: `dark:bg-card/85` → `rgba(21,27,34,0.85)`,
  `dark:text-foreground/80` → `rgba(251,250,247,0.8)`, alert family flips as expected.
- End to end against the running dashboard: sampled `getComputedStyle` on every leaf
  text node across **21 pages in both schemes**, compositing each colour over its real
  backdrop. The only remaining report is the auth wordmark, a false positive — it is
  absolutely positioned over a sibling's `bg-paper`, so a DOM-tree backdrop walk reads
  the page background instead (verified correct in a dark-mode screenshot).

`pnpm typecheck`, `ui` / `dashboard-pages` / `chat-widget` suites, lint and the license
check are all clean. `packages/ui` gains vitest + `@types/node` as devDeps (no
production dependency change, so `THIRD_PARTY_LICENSES.md` is untouched).

## Deliberately not fixed

`/dashboard/oauth/consent` renders `bg-background` with light-only `text-ink`,
`text-ink-soft` and `border-ink` outline buttons — roughly 50 sites, including an
invisible Approve/Deny pair in dark mode. Completing or removing that dark retrofit is
a design decision on a consent screen, not a token change, so it wants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
