### PR TITLE
fix(dashboard): show the org, not the product, in the mobile console head

### DIFF
--- a/.changeset/console-mobile-org-switcher.md
+++ b/.changeset/console-mobile-org-switcher.md
@@ -1,0 +1,18 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+fix(dashboard): the mobile console head identifies the org, not the product
+
+The desktop sidebar has always preferred `headSlot` over the `brand` string — in
+cloud that slot is the org switcher, so the sidebar reads "Acme AS" while the
+mobile header two breakpoints away read "Munin Cloud". Same for the slide-in
+menu, which stacked the brand line *and* the switcher, so the product name got
+the heading treatment and the thing you actually need on a phone sat under it.
+
+Both now follow the sidebar's rule: render `headSlot` where it exists, fall back
+to `brand` where it doesn't. Self-hosted OSS passes no slot and is unchanged.
+
+The sheet keeps a `SheetTitle` either way — visually hidden when the switcher
+takes the row — so the dialog still has an accessible name, and the switcher is
+no longer nested inside a heading element.

--- a/packages/dashboard-pages/src/shells/console-shell.tsx
+++ b/packages/dashboard-pages/src/shells/console-shell.tsx
@@ -320,9 +320,13 @@ function ConsoleShellInner({
               <BrandMark href={brandHref} label={brand}>
                 <Image src={logoSrc} alt="" aria-hidden width={26} height={26} className="block size-[26px] object-contain" />
               </BrandMark>
-              <span className="min-w-0 truncate text-sm font-medium text-ink dark:text-foreground">
-                {brand}
-              </span>
+              {headSlot ? (
+                <div className="min-w-0">{headSlot}</div>
+              ) : (
+                <span className="min-w-0 truncate text-sm font-medium text-ink dark:text-foreground">
+                  {brand}
+                </span>
+              )}
               <button
                 type="button"
                 onClick={() => setMenuOpen(true)}
@@ -344,13 +348,21 @@ function ConsoleShellInner({
       <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
         <SheetContent side="left" className="max-w-[320px] border-0 p-0">
           <div className="flex h-full flex-col bg-bone dark:bg-secondary">
-            <SheetTitle className="flex items-center gap-2.5 px-5 pb-2 pt-5 font-sans text-[15px] font-medium tracking-normal text-ink dark:text-foreground">
+            <div className="flex items-center gap-2.5 px-5 pb-2 pt-5 font-sans text-[15px] font-medium tracking-normal text-ink dark:text-foreground">
               <BrandMark href={brandHref} label={brand}>
                 <Image src={logoSrc} alt="" aria-hidden width={26} height={26} className="block size-[26px] shrink-0 object-contain" />
               </BrandMark>
-              <span className="min-w-0 truncate">{brand}</span>
-            </SheetTitle>
-            {headSlot ? <div className="px-5 pb-1 pt-2">{headSlot}</div> : null}
+              {headSlot ? (
+                <>
+                  <SheetTitle className="sr-only">{brand}</SheetTitle>
+                  <div className="min-w-0">{headSlot}</div>
+                </>
+              ) : (
+                <SheetTitle className="min-w-0 truncate font-sans text-[15px] font-medium tracking-normal">
+                  {brand}
+                </SheetTitle>
+              )}
+            </div>
             <div className="min-h-0 flex-1 overflow-y-auto py-2">
               <NavList groups={groups} badges={badges} onNavigate={() => setMenuOpen(false)} />
             </div>


### PR DESCRIPTION
On a phone the console head read **Munin Cloud** while the desktop sidebar, two breakpoints away, read the org name. The slide-in menu was worse: it gave the product name the heading treatment and stacked the org switcher underneath it.

The rule already existed — `ConsoleShell`'s desktop sidebar prefers `headSlot` over the `brand` string, and in cloud that slot is the org switcher. The `md:hidden` header and the sheet just never applied it. Now both do.

### Changes

`packages/dashboard-pages/src/shells/console-shell.tsx`:

- **Mobile header** — the brandmark stays, `{brand}` becomes `headSlot` when one is passed.
- **Sheet** — the brand line is gone; the switcher sits on the header row beside the logo instead of in a second block below it.

A `SheetTitle` is still rendered in both branches — visually hidden when the switcher takes the row — so the dialog keeps an accessible name, and the switcher is no longer nested inside an `<h2>` (its dropdown is a `<div role="listbox">`, which is not valid heading content).

### Blast radius

Self-hosted OSS passes no `headSlot`, so `apps/web` renders exactly as before. The only consumer that passes one is munin-cloud, which is the case this fixes.

### Verification

Typecheck and eslint clean. Not exercised in a browser: the change only has a visible effect under a `headSlot`, which no app in this repo passes — it will get a real device check in cloud once this releases and the dep is bumped.