### PR TITLE
fix(widget): name the org's assistant on the voice call screen

### DIFF
--- a/.changeset/widget-voice-assistant-name.md
+++ b/.changeset/widget-voice-assistant-name.md
@@ -1,0 +1,23 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/chat-widget': patch
+---
+
+fix(widget): the voice call screen names the org's assistant
+
+The voice overlay and its minimized banner had exactly two cases: a human took
+over (use `assigneeName`) or it's the AI, in which case they fell back to the
+localized `defaultAuthorName` — "Agent" in every locale. An org that named its
+assistant Thea saw "Thea" in the chat transcript and "Agent" the moment the
+caller switched to voice.
+
+The name was already resolved server-side, but only per message: list-messages
+stamped `assistants.name` on each agent message's `authorName` and never put it
+on the conversation envelope, which is all the overlay reads. `agentName` now
+rides along on the envelope (falling back to `Munin`, matching the per-message
+behaviour), and the widget prefers it over the generic string. A human assignee
+still wins once the conversation is handed over.
+
+The lookup also no longer waits for an agent message to exist, so a brand-new
+conversation — the common case for starting a call before the assistant has said
+anything — has the name available on its first load.

--- a/apps/chat-widget/src/api.ts
+++ b/apps/chat-widget/src/api.ts
@@ -36,6 +36,7 @@ export interface ConversationEnvelope {
   status: string;
   handedOver: boolean;
   assigneeName: string | null;
+  agentName: string | null;
   contactEmail: string | null;
 }
 

--- a/apps/chat-widget/src/ui.test.ts
+++ b/apps/chat-widget/src/ui.test.ts
@@ -385,6 +385,7 @@ describe('ui: handover envelope', () => {
       status: 'open',
       handedOver: true,
       assigneeName: 'Maja',
+      agentName: null,
       contactEmail: null,
     });
     expect($('.chat-sub-label').textContent).toMatch(/Maja/);
@@ -397,6 +398,7 @@ describe('ui: handover envelope', () => {
       status: 'open',
       handedOver: false,
       assigneeName: null,
+      agentName: null,
       contactEmail: null,
     });
     expect($('.chat-sub-label').textContent).toMatch(/Online now/);

--- a/apps/chat-widget/src/widget.test.ts
+++ b/apps/chat-widget/src/widget.test.ts
@@ -6,10 +6,24 @@ const h = vi.hoisted(() => {
   return {
     listeners,
     identify: vi.fn(() => Promise.resolve({ endUserId: 'eu_1', contactId: 'ctc_1' })),
-    backfillSince: vi.fn(() =>
-      Promise.resolve({ messages: [], hasMore: false, conversation: null }),
+    backfillSince: vi.fn(
+      (): Promise<{
+        messages: unknown[];
+        hasMore: boolean;
+        cursor?: string | null;
+        conversation: {
+          id: string;
+          subject: string | null;
+          status: string;
+          handedOver: boolean;
+          assigneeName: string | null;
+          agentName: string | null;
+          contactEmail: string | null;
+        } | null;
+      }> => Promise.resolve({ messages: [], hasMore: false, conversation: null }),
     ),
     listConversations: vi.fn(() => Promise.resolve([])),
+    setVoiceCallWho: vi.fn(),
   };
 });
 
@@ -70,6 +84,7 @@ vi.mock('./ui.ts', () => ({
         open = false;
       },
       isOpen: () => open,
+      setVoiceCallWho: h.setVoiceCallWho,
     };
     return new Proxy(stateful, {
       get: (target, prop) => (typeof prop === 'string' && prop in target ? target[prop] : vi.fn()),
@@ -232,5 +247,63 @@ describe('window.mn.widget collisions', () => {
     expect(getMnWidget().isOpen()).toBe(true);
     expect(warn.mock.calls.flat().join(' ')).toContain('already installed');
     warn.mockRestore();
+  });
+});
+
+describe('voice call name', () => {
+  const envelope = {
+    id: 'conv_1',
+    subject: null,
+    status: 'open',
+    handedOver: false,
+    assigneeName: null,
+    agentName: null,
+    contactEmail: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.listeners.state = undefined;
+    document.body.innerHTML = '';
+    delete (window as Window & WindowWithMnWidget).mn;
+  });
+
+  it('uses the org assistant name from the conversation envelope', async () => {
+    h.backfillSince.mockResolvedValueOnce({
+      messages: [],
+      hasMore: false,
+      conversation: { ...envelope, agentName: 'Thea' },
+    });
+    start({ ...baseConfig });
+    h.listeners.state!('connected');
+
+    await vi.waitFor(() => expect(h.setVoiceCallWho).toHaveBeenCalled());
+    expect(h.setVoiceCallWho).toHaveBeenCalledWith('Thea');
+  });
+
+  it('falls back to the generic author name when no assistant name is set', async () => {
+    h.backfillSince.mockResolvedValueOnce({
+      messages: [],
+      hasMore: false,
+      conversation: { ...envelope, agentName: null },
+    });
+    start({ ...baseConfig });
+    h.listeners.state!('connected');
+
+    await vi.waitFor(() => expect(h.setVoiceCallWho).toHaveBeenCalled());
+    expect(h.setVoiceCallWho).toHaveBeenCalledWith('Agent');
+  });
+
+  it('prefers the human assignee over the assistant name once handed over', async () => {
+    h.backfillSince.mockResolvedValueOnce({
+      messages: [],
+      hasMore: false,
+      conversation: { ...envelope, handedOver: true, assigneeName: 'Maja', agentName: 'Thea' },
+    });
+    start({ ...baseConfig });
+    h.listeners.state!('connected');
+
+    await vi.waitFor(() => expect(h.setVoiceCallWho).toHaveBeenCalled());
+    expect(h.setVoiceCallWho).toHaveBeenCalledWith('Maja');
   });
 });

--- a/apps/chat-widget/src/widget.ts
+++ b/apps/chat-widget/src/widget.ts
@@ -271,7 +271,7 @@ export function start(config: WidgetConfig): void {
     if (env?.handedOver) {
       return env.assigneeName ?? strings.defaultTeammateName;
     }
-    return strings.defaultAuthorName;
+    return env?.agentName ?? strings.defaultAuthorName;
   }
 
   async function probeVoiceAvailability(conversationId: string): Promise<void> {

--- a/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget-ingest.service.ts
@@ -155,8 +155,7 @@ export class WidgetIngestService {
       ? firstWord(userNames.get(conv[0].assigneeUserId)) ?? null
       : null;
 
-    const hasAgentMessage = visible.some((r) => r.authorType === 'agent');
-    const assistantName = hasAgentMessage ? await this.loadAssistantName(tx, orgId) : null;
+    const assistantName = await this.loadAssistantName(tx, orgId);
     const agentDisplayName = assistantName ?? 'Munin';
 
     const readableIds = visible
@@ -190,6 +189,7 @@ export class WidgetIngestService {
       status: conv[0].status,
       handedOver: !!conv[0].assigneeUserId,
       assigneeName,
+      agentName: agentDisplayName,
       contactEmail: contactRow?.email ?? null,
     };
 

--- a/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.integration.test.ts
@@ -1910,6 +1910,71 @@ const skipReason = TEST_URL
     }
   });
 
+  it('carries the configured assistants.name as conversation.agentName', async () => {
+    await db
+      .insert(schema.assistants)
+      .values({ orgId, name: 'Thea' })
+      .onConflictDoUpdate({
+        target: schema.assistants.orgId,
+        set: { name: 'Thea', updatedAt: new Date() },
+      });
+    try {
+      const sid = `vis_envelope_name_${Date.now()}`;
+      const first = await call('POST', '/v1/widget/messages', widgetKey, {
+        channelId,
+        sessionId: sid,
+        messages: [{ role: 'end_user', body: 'hi' }],
+      });
+      expect(first.status).toBe(201);
+      await insertAgentMessage(
+        (first.json as { conversationId: string }).conversationId,
+        'hello there',
+        sid,
+      );
+      const res = await call(
+        'GET',
+        `/v1/widget/messages?${qs({ channelId, sessionId: sid })}`,
+        widgetKey,
+      );
+      const body = res.json as { conversation: { agentName: string | null } | null };
+      expect(body.conversation?.agentName).toBe('Thea');
+    } finally {
+      await db.delete(schema.assistants).where(eq(schema.assistants.orgId, orgId));
+    }
+  });
+
+  it('carries conversation.agentName before the agent has replied', async () => {
+    await db
+      .insert(schema.assistants)
+      .values({ orgId, name: 'Thea' })
+      .onConflictDoUpdate({
+        target: schema.assistants.orgId,
+        set: { name: 'Thea', updatedAt: new Date() },
+      });
+    try {
+      const sid = `vis_envelope_early_${Date.now()}`;
+      const first = await call('POST', '/v1/widget/messages', widgetKey, {
+        channelId,
+        sessionId: sid,
+        messages: [{ role: 'end_user', body: 'hi' }],
+      });
+      expect(first.status).toBe(201);
+      const res = await call(
+        'GET',
+        `/v1/widget/messages?${qs({ channelId, sessionId: sid })}`,
+        widgetKey,
+      );
+      const body = res.json as {
+        messages: Array<{ role: string }>;
+        conversation: { agentName: string | null } | null;
+      };
+      expect(body.messages.some((m) => m.role === 'agent')).toBe(false);
+      expect(body.conversation?.agentName).toBe('Thea');
+    } finally {
+      await db.delete(schema.assistants).where(eq(schema.assistants.orgId, orgId));
+    }
+  });
+
   it('returns first-name only for human-author messages', async () => {
     const [op] = await db
       .insert(schema.users)

--- a/packages/backend-core/src/modules/conv/widget/widget.types.ts
+++ b/packages/backend-core/src/modules/conv/widget/widget.types.ts
@@ -170,6 +170,7 @@ export interface WidgetConversationEnvelope {
   status: string;
   handedOver: boolean;
   assigneeName: string | null;
+  agentName: string | null;
   contactEmail: string | null;
 }
 


### PR DESCRIPTION
## What

The chat widget's voice call screen showed **"Agent"** instead of the org's configured assistant name (e.g. "Thea"), while the chat transcript in the same conversation got it right.

## Why it happened

`callWhoFromEnvelope` in `apps/chat-widget/src/widget.ts` had exactly two cases:

```ts
if (env?.handedOver) {
  return env.assigneeName ?? strings.defaultTeammateName;
}
return strings.defaultAuthorName;   // ← "Agent", in every locale file
```

The name was already resolved server-side, but only **per message**: `widget-ingest.service.ts` computed `agentDisplayName` from `assistants.name` and stamped it on each agent message's `authorName` — which is why the transcript is correct. It never reached `WidgetConversationEnvelope`, and the envelope is all the voice overlay reads. `WidgetVoiceStartResult` doesn't carry a name either, so the widget had nothing to use and fell back to the hardcoded string.

Same root cause for the minimized call banner ("I anrop med {who}"), which reads the same value.

## Change

- `agentName` added to `WidgetConversationEnvelope`, set from `assistants.name` with the existing `'Munin'` fallback — the same value already used per message.
- The lookup no longer waits on `hasAgentMessage`. That condition meant a conversation where the assistant hadn't replied yet had no name available anywhere in the response, which is exactly the case when someone opens the widget and immediately starts a call. Cost is one indexed single-row select per list-messages call, and it already ran for any conversation with a reply.
- `callWhoFromEnvelope` prefers `env.agentName`. A human assignee still wins once handed over; the localized `'Agent'` stays as the fallback for orgs with no assistant name and for a call started before the first envelope lands.

## Tests

- `widget.integration.test.ts` — envelope carries the configured name; envelope carries it before the agent has replied.
- `widget.test.ts` — assistant name used; fallback when unset; assignee preferred once handed over. The mocked `ui` was a catch-all Proxy handing out a fresh `vi.fn()` per property access, so `setVoiceCallWho` is now a shared hoisted mock. Verified the first case fails when the `agentName` preference is reverted.

Full `backend-core` suite (2156 tests / 160 files) and `chat-widget` suite (195 tests) pass; workspace typecheck and eslint clean.

## Not included

The chat header subtitle shows `strings.onlineNow` rather than a name while the AI is handling the conversation, so "Thea" doesn't appear there either. That reads as a deliberate status line rather than a naming bug, so it's left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
