### PR TITLE
feat(conv): carry images in and out over the email channel

### DIFF
--- a/.changeset/conv-email-images.md
+++ b/.changeset/conv-email-images.md
@@ -1,0 +1,57 @@
+---
+'@getmunin/backend-core': minor
+'@getmunin/core': minor
+---
+
+Images in and out over the email channel.
+
+Inbound: `parseMessage()` now carries `parsed.attachments` (content, contentType,
+filename, cid, contentDisposition, related) instead of discarding them, and
+`EmailAdapter.ingest()` persists the survivors through
+`ConvAttachmentsService.persistBytes()` inside the existing ingest transaction,
+writing `projectForMessage()` output into `conv_messages.attachments`. Both inbound
+entry points share the change — the IMAP poll path and the relay path go through the
+same `parseMessage` + `adapter.ingest` pair.
+
+The noise filter is the substance and lives on its own in `email/inbound-attachments.ts`
+so it can be unit-tested without a database. Business mail carries a tracking pixel and
+a signature logo on nearly every message, so a part is dropped when its mime is outside
+`CONV_ATTACHMENT_MIME_ALLOWLIST`, when it is under `CONV_ATTACHMENT_INBOUND_BYTES_MIN`
+or has an edge under `CONV_ATTACHMENT_INBOUND_EDGE_MIN_PX`, when sharp cannot decode it,
+when it is an `inline` part whose Content-ID no longer appears in the HTML body, or once
+`CONV_ATTACHMENT_PER_MESSAGE_MAX` parts have been kept. The cid-reference test runs
+against the *stripped* HTML — after `stripQuotedReplyHtml` and `stripSignatureHtml` —
+which is what actually keeps signature logos out; a filter placed before stripping would
+keep every one of them. Filenames take their extension from the part's mime, so a
+PNG-mimed part named `payload.svg` cannot reach the store's SVG rejection by extension.
+
+`simpleParser` is now called with `keepCidLinks: true`. By default mailparser rewrites
+every `cid:` reference in `parsed.html` into a base64 `data:` URI, which meant inbound
+inline images were being inlined whole into `conv_messages.body_html` — a multi-hundred-
+kilobyte text column per message and no attachment row to show for it. The stored HTML
+keeps its `cid:` references, normalized (unbracketed, lowercased) to match the
+`content_id` column exactly so read-time hydration can mint a fresh URL per request;
+nothing time-limited is written to the database. An `<img>` whose part the filter dropped
+is removed rather than left pointing at a cid that will never resolve.
+
+Outbound: `buildOutbound()` takes an `attachments` input and nests the message properly —
+`multipart/related; type="text/html"` around the alternative when a part is inline and
+its cid is actually referenced, `multipart/mixed` for files, both nested when a message
+carries each. Parts are base64-encoded at 76 columns with `Content-Disposition` and, for
+inline parts, `Content-ID`; a non-ASCII filename goes out RFC 2231-encoded. `EmailAdapter.send()`
+loads the bytes with `storage.readBytes()` and embeds real MIME parts — a signed
+attachment URL would outlive its TTL in the recipient's mailbox and leak on forward — and
+an attachment whose object has gone (a tombstoned row) is left out rather than failing
+the send.
+
+`MailMessage` gains `attachments` and `ResendMailer` maps it onto the Resend API's
+attachment array (`SmtpMailer` maps it onto nodemailer's, which would otherwise have
+dropped it silently). The transactional `mailer` path hands its attachments to the mailer
+rather than through `built.raw`, deliberately: that path already loses HTML through
+`extractTextBody`, and feeding it a MIME body full of base64 would have put the encoded
+image into the message text.
+
+`widget-email-fallback.worker.ts` deliberately sends no attachments. It composes a
+"you have unread messages" digest that points the recipient back at the widget rather
+than reproducing the thread, so shipping the images a second time by mail is duplication,
+not delivery.

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { schema, type Db } from '@getmunin/db';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 import {
   ActorIdentity,
   WebhookDispatcher,
@@ -9,15 +9,17 @@ import {
   resolvePublicHost,
   signEmailOpenToken,
   withContext,
+  type AssetStorage,
   type Mailer,
   type RequestContext,
 } from '@getmunin/core';
 import { ImapFlow } from 'imapflow';
-import { simpleParser, type ParsedMail, type AddressObject } from 'mailparser';
+import { simpleParser, type Attachment, type ParsedMail, type AddressObject } from 'mailparser';
 import { randomUUID } from 'node:crypto';
 import { createTransport, type Transporter } from 'nodemailer';
 import { DB } from '../../../common/db/db.module.ts';
 import { MAILER } from '../../../common/mail/mail.module.ts';
+import { STORAGE } from '../../../common/storage/storage.token.ts';
 import { CuratorJobsService } from '../../curator/curator-jobs.service.ts';
 import { buildSetTopicAndTitleJob } from '../set-topic-job.ts';
 import {
@@ -27,9 +29,25 @@ import {
   type StoredEmailChannelConfig,
 } from './email.service.ts';
 import { smtpTransportOptions } from './email-probe.service.ts';
-import { buildOutbound, stripMessageIdBrackets, parseMessageIdHeader, type BuiltMessage } from './mime.ts';
+import {
+  buildOutbound,
+  stripMessageIdBrackets,
+  parseMessageIdHeader,
+  type BuiltMessage,
+  type OutboundAttachment,
+} from './mime.ts';
 import { renderEmailHtml } from './markdown.ts';
 import { resolveInbound, type ParsedInboundEmail } from './threading.ts';
+import {
+  filterInboundAttachments,
+  normalizeCidReferences,
+  type InboundEmailAttachment,
+} from './inbound-attachments.ts';
+import { ConvAttachmentsService } from '../attachments/conv-attachments.service.ts';
+import type {
+  AttachmentDto,
+  MessageAttachmentProjection,
+} from '../attachments/conv-attachments.types.ts';
 import type { ForwardOrigin } from './forwarded-sender.ts';
 import { reopenClosedConversation } from '../conversation-reopen.ts';
 import { raiseAttentionWhenAgentIsOff } from '../unanswerable-handover.ts';
@@ -144,6 +162,8 @@ export class EmailAdapter implements ChannelAdapter {
     @Inject(MAILER) private readonly mailer: Mailer,
     @Inject(EmailService) private readonly emailService: EmailService,
     @Inject(CuratorJobsService) private readonly curatorJobs: CuratorJobsService,
+    @Inject(ConvAttachmentsService) private readonly attachments: ConvAttachmentsService,
+    @Inject(STORAGE) private readonly storage: AssetStorage,
   ) {}
 
   setFetcher(f: ImapFetcher): void {
@@ -178,6 +198,8 @@ export class EmailAdapter implements ChannelAdapter {
     const isReply = prior.length > 0 || ctx.delivery.inReplyToHeader != null;
     const subject = isReply ? ensureReSubject(rawSubject) : (rawSubject ?? '(no subject)');
     const trackerUrl = trackerUrlFor(config, ctx, html);
+    const outboundAttachments = await this.loadOutboundAttachments(ctx);
+    const embedInMime = config.outbound.provider === 'smtp';
 
     const built: BuiltMessage = buildOutbound({
       from: composeFrom(config.addressing.fromName, config.addressing.fromAddress),
@@ -190,6 +212,7 @@ export class EmailAdapter implements ChannelAdapter {
       inReplyTo: ctx.delivery.inReplyToHeader ?? undefined,
       references: ctx.delivery.inReplyToHeader ? [ctx.delivery.inReplyToHeader] : undefined,
       trackerUrl,
+      attachments: embedInMime ? outboundAttachments : undefined,
     });
 
     if (config.outbound.provider === 'smtp') {
@@ -224,6 +247,13 @@ export class EmailAdapter implements ChannelAdapter {
         headers: {
           'Message-ID': `<${built.messageId}>`,
         },
+        attachments: outboundAttachments.length
+          ? outboundAttachments.map((a) => ({
+              filename: a.filename,
+              content: a.content,
+              contentType: a.contentType,
+            }))
+          : undefined,
       });
     }
 
@@ -362,6 +392,11 @@ export class EmailAdapter implements ChannelAdapter {
         const detectedSignatureForMeta =
           regexSignature ?? detectSignatureBlock(quoteStrippedText, parsed.bodyHtml);
         const cleanHtml = stripSignatureHtml(stripQuotedReplyHtml(parsed.bodyHtml));
+        const stored = await this.persistInboundAttachments(
+          conversationId,
+          parsed.attachments,
+          cleanHtml,
+        );
         const [msg] = await tx
           .insert(schema.convMessages)
           .values({
@@ -370,7 +405,8 @@ export class EmailAdapter implements ChannelAdapter {
             authorType: 'end_user',
             authorId: contact.id,
             body: cleanText || '(no body)',
-            bodyHtml: cleanHtml,
+            bodyHtml: stored.bodyHtml,
+            attachments: stored.projection,
             internal: false,
             metadata: buildInboundMetadata(parsed, {
               regexSignatureText: detectedSignatureForMeta,
@@ -379,6 +415,13 @@ export class EmailAdapter implements ChannelAdapter {
             }),
           })
           .returning();
+        if (stored.dtos.length > 0) {
+          await this.attachments.attachToMessage({
+            messageId: msg!.id,
+            conversationId,
+            attachmentIds: stored.dtos.map((a) => a.id),
+          });
+        }
         await tx
           .update(schema.convConversations)
           .set({ lastMessageAt: new Date(), updatedAt: new Date() })
@@ -437,6 +480,102 @@ export class EmailAdapter implements ChannelAdapter {
     });
   }
 
+  private async loadOutboundAttachments(ctx: SendContext): Promise<OutboundAttachment[]> {
+    const projectedIds = projectedAttachmentIds(ctx.message.attachments);
+    if (projectedIds.length === 0) return [];
+
+    const rows = await this.db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+      return tx
+        .select({
+          id: schema.convAttachments.id,
+          name: schema.convAttachments.name,
+          mime: schema.convAttachments.mime,
+          storageKey: schema.convAttachments.storageKey,
+          inline: schema.convAttachments.inline,
+          contentId: schema.convAttachments.contentId,
+        })
+        .from(schema.convAttachments)
+        .where(
+          and(
+            eq(schema.convAttachments.orgId, ctx.message.orgId),
+            eq(schema.convAttachments.messageId, ctx.message.id),
+            isNull(schema.convAttachments.deletedAt),
+          ),
+        );
+    });
+
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    const out: OutboundAttachment[] = [];
+    for (const id of projectedIds) {
+      const row = byId.get(id);
+      if (!row?.storageKey) continue;
+      const content = await this.storage.readBytes(row.storageKey);
+      if (!content) {
+        this.logger.warn(
+          `attachment ${id} on message ${ctx.message.id} has no bytes in storage — sending without it`,
+        );
+        continue;
+      }
+      out.push({
+        filename: row.name,
+        contentType: row.mime,
+        content,
+        inline: row.inline,
+        contentId: row.contentId,
+      });
+    }
+    return out;
+  }
+
+  private async persistInboundAttachments(
+    conversationId: string,
+    parts: readonly InboundEmailAttachment[],
+    cleanHtml: string | null,
+  ): Promise<{
+    bodyHtml: string | null;
+    projection: MessageAttachmentProjection[];
+    dtos: AttachmentDto[];
+  }> {
+    if (parts.length === 0) return { bodyHtml: cleanHtml, projection: [], dtos: [] };
+
+    const filtered = await filterInboundAttachments(parts, { html: cleanHtml });
+    if (filtered.dropped.length > 0) {
+      this.logger.log(
+        `dropped ${filtered.dropped.length} inbound image part(s) on conversation ${conversationId}: ` +
+          filtered.dropped.map((d) => `${d.name}=${d.reason}`).join(', '),
+      );
+    }
+    const keptCids = new Set(
+      filtered.kept
+        .filter((part) => part.inline && part.contentId)
+        .map((part) => part.contentId!),
+    );
+    if (filtered.kept.length === 0) {
+      return { bodyHtml: normalizeCidReferences(cleanHtml, keptCids), projection: [], dtos: [] };
+    }
+
+    const dtos: AttachmentDto[] = [];
+    for (const part of filtered.kept) {
+      dtos.push(
+        await this.attachments.persistBytes({
+          conversationId,
+          name: part.name,
+          mime: part.mime,
+          body: part.content,
+          inline: part.inline,
+          contentId: part.contentId,
+        }),
+      );
+    }
+
+    return {
+      bodyHtml: normalizeCidReferences(cleanHtml, keptCids),
+      projection: this.attachments.projectForMessage(dtos),
+      dtos,
+    };
+  }
+
   private async readCursor(channelId: string): Promise<Record<string, unknown>> {
     return this.db.transaction(async (tx) => {
       await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
@@ -477,7 +616,7 @@ export class EmailAdapter implements ChannelAdapter {
 }
 
 export async function parseMessage(source: Buffer | string): Promise<ParsedInboundEmail> {
-  const parsed: ParsedMail = await simpleParser(source);
+  const parsed: ParsedMail = await simpleParser(source, { keepCidLinks: true });
   const recipients = collectAddresses(parsed.to)
     .concat(collectAddresses(parsed.cc))
     .concat(collectAddresses(parsed.bcc))
@@ -516,7 +655,30 @@ export async function parseMessage(source: Buffer | string): Promise<ParsedInbou
     arcAuthenticationResults,
     forwardedFor: extractHeaderValues(parsed.headerLines, 'x-forwarded-for'),
     forwardedTo: extractHeaderValues(parsed.headerLines, 'x-forwarded-to'),
+    attachments: (parsed.attachments ?? []).map(toInboundAttachment),
   };
+}
+
+function toInboundAttachment(part: Attachment): InboundEmailAttachment {
+  return {
+    content: Buffer.isBuffer(part.content) ? part.content : Buffer.from(part.content ?? []),
+    contentType: part.contentType ?? 'application/octet-stream',
+    filename: part.filename ?? null,
+    cid: part.cid ?? part.contentId ?? null,
+    contentDisposition: part.contentDisposition ?? null,
+    related: part.related === true,
+  };
+}
+
+function projectedAttachmentIds(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const id = (entry as { id?: unknown }).id;
+    if (typeof id === 'string' && id) out.push(id);
+  }
+  return out;
 }
 
 function extractHeaderValues(

--- a/packages/backend-core/src/modules/conv/email/email-images.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email-images.integration.test.ts
@@ -1,0 +1,436 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { INestApplication } from '@nestjs/common';
+import { randomBytes, randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import sharp from 'sharp';
+import { and, eq, sql } from 'drizzle-orm';
+import { ActorIdentity, withContext, type RequestContext, type StubMailer } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { createApp } from '../../../bootstrap-app.ts';
+import { AppModule } from '../../../app.module.ts';
+import { MAILER } from '../../../common/mail/mail.module.ts';
+import { ConvAttachmentsService } from '../attachments/conv-attachments.service.ts';
+import { OutboundDeliveryWorker } from '../channels/outbound-delivery.worker.ts';
+import type { ChannelRow } from '../channels/adapter.ts';
+import { EmailAdapter, parseMessage } from './email-adapter.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run email image integration tests.';
+
+const TRACKING_PIXEL_GIF = Buffer.from(
+  'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+  'base64',
+);
+
+async function noisyImage(
+  width: number,
+  height: number,
+  format: 'png' | 'jpeg',
+): Promise<Buffer> {
+  const raw = randomBytes(width * height * 3);
+  const pipeline = sharp(raw, { raw: { width, height, channels: 3 } });
+  return format === 'png' ? pipeline.png().toBuffer() : pipeline.jpeg({ quality: 92 }).toBuffer();
+}
+
+interface EmlPart {
+  contentType: string;
+  disposition: 'inline' | 'attachment';
+  filename: string;
+  cid?: string;
+  content: Buffer;
+}
+
+function wrap(b64: string): string {
+  const out: string[] = [];
+  for (let i = 0; i < b64.length; i += 76) out.push(b64.slice(i, i + 76));
+  return out.join('\r\n');
+}
+
+function buildEml(input: {
+  from: string;
+  to: string;
+  subject: string;
+  messageId: string;
+  text: string;
+  html: string;
+  parts: EmlPart[];
+}): string {
+  const related = `rel-${randomUUID()}`;
+  const alternative = `alt-${randomUUID()}`;
+  const lines: string[] = [
+    `From: ${input.from}`,
+    `To: ${input.to}`,
+    `Subject: ${input.subject}`,
+    `Message-ID: <${input.messageId}>`,
+    'MIME-Version: 1.0',
+    `Content-Type: multipart/related; type="text/html"; boundary="${related}"`,
+    '',
+    `--${related}`,
+    `Content-Type: multipart/alternative; boundary="${alternative}"`,
+    '',
+    `--${alternative}`,
+    'Content-Type: text/plain; charset="utf-8"',
+    '',
+    input.text,
+    `--${alternative}`,
+    'Content-Type: text/html; charset="utf-8"',
+    '',
+    input.html,
+    `--${alternative}--`,
+  ];
+  for (const part of input.parts) {
+    lines.push(
+      `--${related}`,
+      `Content-Type: ${part.contentType}; name="${part.filename}"`,
+      'Content-Transfer-Encoding: base64',
+      `Content-Disposition: ${part.disposition}; filename="${part.filename}"`,
+      ...(part.cid ? [`Content-ID: <${part.cid}>`] : []),
+      '',
+      wrap(part.content.toString('base64')),
+    );
+  }
+  lines.push(`--${related}--`, '');
+  return lines.join('\r\n');
+}
+
+(skipReason ? describe.skip : describe)('email images: inbound MIME parts in, real MIME parts out', () => {
+  let app: INestApplication;
+  let db: ReturnType<typeof createDb>;
+  let adapter: EmailAdapter;
+  let attachments: ConvAttachmentsService;
+  let outboundWorker: OutboundDeliveryWorker;
+  let mailer: StubMailer;
+  let storageDir: string;
+  let orgId: string;
+  let channel: ChannelRow;
+
+  let photo: Buffer;
+  let inlineShot: Buffer;
+  let signatureLogo: Buffer;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_STORAGE_PROVIDER = 'local';
+    storageDir = await mkdtemp(join(tmpdir(), 'munin-email-img-test-'));
+    process.env.MUNIN_STORAGE_LOCAL_PATH = storageDir;
+    process.env.MUNIN_STORAGE_LOCAL_BASE_URL = 'http://127.0.0.1:1/static/assets';
+
+    await runMigrations(TEST_URL!);
+    const appUrl = TEST_URL!.replace(/(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/, '$1munin_app:munin_app@');
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const [org] = await db.insert(schema.orgs).values({ name: 'Email Image Org' }).returning();
+    orgId = org!.id;
+
+    const [row] = await db
+      .insert(schema.convChannels)
+      .values({
+        orgId,
+        type: 'email',
+        vendor: 'mailer',
+        name: 'Acme Support',
+        config: {
+          addressing: { fromAddress: 'support@acme.test', fromName: 'Acme Support' },
+          outbound: { provider: 'mailer' },
+          inbound: {
+            provider: 'imap',
+            host: 'imap.acme.test',
+            port: 993,
+            secure: true,
+            username: 'support@acme.test',
+            encryptedPassword: 'x',
+            mailbox: 'INBOX',
+          },
+        },
+        active: true,
+      })
+      .returning();
+    channel = {
+      id: row!.id,
+      orgId,
+      type: 'email',
+      vendor: 'mailer',
+      name: row!.name,
+      config: row!.config,
+      active: true,
+      defaultAgentMode: row!.defaultAgentMode,
+    };
+
+    photo = await noisyImage(640, 480, 'jpeg');
+    inlineShot = await noisyImage(320, 200, 'png');
+    signatureLogo = await noisyImage(64, 64, 'png');
+
+    app = await createApp(AppModule, { logger: false });
+    await app.init();
+    adapter = app.get(EmailAdapter);
+    attachments = app.get(ConvAttachmentsService);
+    outboundWorker = app.get(OutboundDeliveryWorker);
+    mailer = app.get<StubMailer>(MAILER);
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      if (orgId) await db.delete(schema.orgs).where(sql`id = ${orgId}`);
+    }
+    if (storageDir) await rm(storageDir, { recursive: true, force: true });
+  });
+
+  it('keeps the photo and the referenced inline shot, drops the signature logo and the tracking pixel, and rewrites cid: to signed urls', async () => {
+    const eml = buildEml({
+      from: 'Customer One <c1@customer.test>',
+      to: 'support@acme.test',
+      subject: 'Broken widget — photo attached',
+      messageId: 'img-inbound-1@customer.test',
+      text: 'The widget arrived cracked. Photo attached, and a screenshot inline.',
+      html:
+        '<div dir="ltr"><p>The widget arrived cracked.</p>' +
+        '<p><img src="cid:shot@customer.test" width="320" height="200"></p>' +
+        '<img src="cid:pixel@track.test" width="1" height="1">' +
+        '<div class="gmail_signature" data-smartmail="gmail_signature">' +
+        '<p>Kind regards,<br>Customer One</p>' +
+        '<img src="cid:siglogo@customer.test" width="64" height="64">' +
+        '</div></div>',
+      parts: [
+        {
+          contentType: 'image/jpeg',
+          disposition: 'attachment',
+          filename: 'cracked-widget.jpg',
+          content: photo,
+        },
+        {
+          contentType: 'image/png',
+          disposition: 'inline',
+          filename: 'screenshot.png',
+          cid: 'shot@customer.test',
+          content: inlineShot,
+        },
+        {
+          contentType: 'image/png',
+          disposition: 'inline',
+          filename: 'company-logo.png',
+          cid: 'siglogo@customer.test',
+          content: signatureLogo,
+        },
+        {
+          contentType: 'image/gif',
+          disposition: 'inline',
+          filename: 'open.gif',
+          cid: 'pixel@track.test',
+          content: TRACKING_PIXEL_GIF,
+        },
+      ],
+    });
+
+    const parsed = await parseMessage(eml);
+    expect(parsed.attachments).toHaveLength(4);
+    await adapter.ingest(channel, parsed);
+
+    const messages = await db
+      .select()
+      .from(schema.convMessages)
+      .where(eq(schema.convMessages.orgId, orgId));
+    expect(messages).toHaveLength(1);
+    const message = messages[0]!;
+
+    const rows = await db
+      .select()
+      .from(schema.convAttachments)
+      .where(eq(schema.convAttachments.orgId, orgId));
+    expect(rows.map((r) => r.name).sort()).toEqual(['cracked-widget.jpg', 'screenshot.png']);
+    expect(rows.every((r) => r.messageId === message.id)).toBe(true);
+    expect(rows.every((r) => r.uploaded)).toBe(true);
+    expect(rows.every((r) => r.storageKey?.startsWith(`conv/${orgId}/`))).toBe(true);
+
+    const shotRow = rows.find((r) => r.name === 'screenshot.png')!;
+    expect(shotRow.inline).toBe(true);
+    expect(shotRow.contentId).toBe('shot@customer.test');
+    expect(shotRow.width).toBe(320);
+    expect(shotRow.height).toBe(200);
+
+    const photoRow = rows.find((r) => r.name === 'cracked-widget.jpg')!;
+    expect(photoRow.inline).toBe(false);
+    expect(photoRow.contentId).toBeNull();
+    expect(photoRow.sizeBytes).toBe(photo.length);
+
+    const projection = message.attachments as Array<Record<string, unknown>>;
+    expect(projection).toHaveLength(2);
+    expect(projection.map((p) => p.id).sort()).toEqual(rows.map((r) => r.id).sort());
+    expect(projection.every((p) => p.deleted === false)).toBe(true);
+
+    const html = message.bodyHtml!;
+    expect(html).toContain(`cid:${shotRow.contentId}`);
+    expect(html).not.toContain('siglogo@customer.test');
+    expect(html).not.toContain('pixel@track.test');
+    expect(html).not.toContain('gmail_signature');
+    expect(html).not.toContain('data:image/');
+    expect(html).not.toContain('/v1/c/a/');
+  });
+
+  it('is idempotent on a redelivered message: no duplicate attachment rows', async () => {
+    const before = await db
+      .select()
+      .from(schema.convAttachments)
+      .where(eq(schema.convAttachments.orgId, orgId));
+    const eml = buildEml({
+      from: 'Customer One <c1@customer.test>',
+      to: 'support@acme.test',
+      subject: 'Broken widget — photo attached',
+      messageId: 'img-inbound-1@customer.test',
+      text: 'The widget arrived cracked.',
+      html: '<p>The widget arrived cracked.</p>',
+      parts: [
+        {
+          contentType: 'image/jpeg',
+          disposition: 'attachment',
+          filename: 'cracked-widget.jpg',
+          content: photo,
+        },
+      ],
+    });
+    await adapter.ingest(channel, await parseMessage(eml));
+    const after = await db
+      .select()
+      .from(schema.convAttachments)
+      .where(eq(schema.convAttachments.orgId, orgId));
+    expect(after).toHaveLength(before.length);
+  });
+
+  it('sends an outbound reply with the image as real bytes, never a signed url', async () => {
+    mailer.clear();
+    const conversations = await db
+      .select()
+      .from(schema.convConversations)
+      .where(eq(schema.convConversations.orgId, orgId));
+    const conversationId = conversations[0]!.id;
+
+    const [reply] = await db
+      .insert(schema.convMessages)
+      .values({
+        orgId,
+        conversationId,
+        authorType: 'user',
+        authorId: 'usr_agent',
+        body: 'Here is the replacement label.',
+      })
+      .returning();
+
+    const label = await noisyImage(300, 200, 'png');
+    const actor = new ActorIdentity('system', 'email-image-test', orgId, ['*'], ['admin']);
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+      const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+      await withContext(ctx, async () => {
+        const dto = await attachments.persistBytes({
+          conversationId,
+          messageId: reply!.id,
+          name: 'replacement-label.png',
+          mime: 'image/png',
+          body: label,
+        });
+        await tx
+          .update(schema.convMessages)
+          .set({ attachments: attachments.projectForMessage([dto]) })
+          .where(eq(schema.convMessages.id, reply!.id));
+      });
+    });
+
+    await db.insert(schema.convMessageDeliveries).values({
+      orgId,
+      messageId: reply!.id,
+      channelId: channel.id,
+      status: 'queued',
+      attempt: 0,
+      nextAttemptAt: new Date(),
+    });
+
+    const drain = await outboundWorker.tick();
+    expect(drain.sent).toBe(1);
+    expect(mailer.outbox).toHaveLength(1);
+
+    const sent = mailer.outbox[0]!;
+    expect(sent.attachments).toHaveLength(1);
+    expect(sent.attachments![0]!.filename).toBe('replacement-label.png');
+    expect(sent.attachments![0]!.contentType).toBe('image/png');
+    expect(sent.attachments![0]!.content.equals(label)).toBe(true);
+    expect(sent.text ?? '').not.toContain('/v1/c/a/');
+    expect(sent.html ?? '').not.toContain('/v1/c/a/');
+  });
+
+  it('omits a tombstoned attachment from the outbound message rather than failing the send', async () => {
+    mailer.clear();
+    const conversations = await db
+      .select()
+      .from(schema.convConversations)
+      .where(eq(schema.convConversations.orgId, orgId));
+    const conversationId = conversations[0]!.id;
+
+    const [reply] = await db
+      .insert(schema.convMessages)
+      .values({
+        orgId,
+        conversationId,
+        authorType: 'user',
+        authorId: 'usr_agent',
+        body: 'Second try.',
+      })
+      .returning();
+
+    const actor = new ActorIdentity('system', 'email-image-test', orgId, ['*'], ['admin']);
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+      const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+      await withContext(ctx, async () => {
+        const dto = await attachments.persistBytes({
+          conversationId,
+          messageId: reply!.id,
+          name: 'doomed.png',
+          mime: 'image/png',
+          body: await noisyImage(120, 120, 'png'),
+        });
+        await tx
+          .update(schema.convMessages)
+          .set({ attachments: attachments.projectForMessage([dto]) })
+          .where(eq(schema.convMessages.id, reply!.id));
+        await attachments.delete({ id: dto.id });
+      });
+    });
+
+    await db.insert(schema.convMessageDeliveries).values({
+      orgId,
+      messageId: reply!.id,
+      channelId: channel.id,
+      status: 'queued',
+      attempt: 0,
+      nextAttemptAt: new Date(),
+    });
+
+    const drain = await outboundWorker.tick();
+    expect(drain.sent).toBe(1);
+    expect(mailer.outbox).toHaveLength(1);
+    expect(mailer.outbox[0]!.attachments ?? []).toHaveLength(0);
+
+    const tombstoned = await db
+      .select()
+      .from(schema.convAttachments)
+      .where(
+        and(eq(schema.convAttachments.orgId, orgId), eq(schema.convAttachments.name, 'doomed.png')),
+      );
+    expect(tombstoned).toHaveLength(1);
+    expect(tombstoned[0]!.deletedAt).not.toBeNull();
+    expect(tombstoned[0]!.storageKey).toBeNull();
+  });
+});

--- a/packages/backend-core/src/modules/conv/email/forwarded-sender.test.ts
+++ b/packages/backend-core/src/modules/conv/email/forwarded-sender.test.ts
@@ -25,6 +25,7 @@ function parsed(overrides: Partial<ParsedInboundEmail>): ParsedInboundEmail {
     arcAuthenticationResults: [],
     forwardedFor: [],
     forwardedTo: [],
+    attachments: [],
     ...overrides,
   };
 }

--- a/packages/backend-core/src/modules/conv/email/inbound-attachments.test.ts
+++ b/packages/backend-core/src/modules/conv/email/inbound-attachments.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONV_ATTACHMENT_INBOUND_BYTES_MIN,
+  CONV_ATTACHMENT_PER_MESSAGE_MAX,
+} from '../attachments/conv-attachments.constants.ts';
+import {
+  collectCidReferences,
+  filterInboundAttachments,
+  inboundAttachmentName,
+  normalizeCid,
+  normalizeCidReferences,
+  type InboundEmailAttachment,
+} from './inbound-attachments.ts';
+
+const BIG = CONV_ATTACHMENT_INBOUND_BYTES_MIN * 3;
+
+function part(overrides: Partial<InboundEmailAttachment> = {}): InboundEmailAttachment {
+  return {
+    content: Buffer.alloc(BIG, 1),
+    contentType: 'image/png',
+    filename: 'photo.png',
+    cid: null,
+    contentDisposition: 'attachment',
+    related: false,
+    ...overrides,
+  };
+}
+
+const probe640 = () => Promise.resolve({ width: 640, height: 480 });
+
+describe('collectCidReferences / normalizeCid', () => {
+  it('finds cids in src attributes, background urls and percent-encoded refs', () => {
+    const html =
+      '<img src="cid:Logo@Mail"><div style="background:url(cid:hero.jpg)"></div>' +
+      "<img src='cid:pct%40host'>";
+    const refs = collectCidReferences(html);
+    expect([...refs].sort()).toEqual(['hero.jpg', 'logo@mail', 'pct@host']);
+  });
+
+  it('strips angle brackets and lowercases a Content-ID header value', () => {
+    expect(normalizeCid('<Abc@Host>')).toBe('abc@host');
+    expect(normalizeCid('   ')).toBeNull();
+    expect(normalizeCid(null)).toBeNull();
+  });
+});
+
+describe('filterInboundAttachments', () => {
+  it('keeps a real photo and drops a tracking pixel by size', async () => {
+    const result = await filterInboundAttachments(
+      [
+        part({ filename: 'holiday.jpg', contentType: 'image/jpeg' }),
+        part({ filename: 'open.gif', contentType: 'image/gif', content: Buffer.alloc(43, 0) }),
+      ],
+      { html: '<p>hi</p>', probe: probe640 },
+    );
+    expect(result.kept.map((k) => k.name)).toEqual(['holiday.jpg']);
+    expect(result.dropped).toEqual([
+      { name: 'open.gif', mime: 'image/gif', sizeBytes: 43, reason: 'too_small' },
+    ]);
+  });
+
+  it('drops an inline part whose cid the stripped html no longer references', async () => {
+    const result = await filterInboundAttachments(
+      [
+        part({ filename: 'logo.png', cid: 'sig-logo@corp', contentDisposition: 'inline', related: true }),
+        part({ filename: 'screenshot.png', cid: 'shot@corp', contentDisposition: 'inline', related: true }),
+      ],
+      { html: '<p>see</p><img src="cid:shot@corp">', probe: probe640 },
+    );
+    expect(result.kept.map((k) => k.name)).toEqual(['screenshot.png']);
+    expect(result.kept[0]!.inline).toBe(true);
+    expect(result.kept[0]!.contentId).toBe('shot@corp');
+    expect(result.dropped[0]).toMatchObject({ name: 'logo.png', reason: 'unreferenced_cid' });
+  });
+
+  it('keeps an inline part when the message has no html body to reference it from', async () => {
+    const result = await filterInboundAttachments(
+      [part({ filename: 'pasted.png', cid: 'x@y', contentDisposition: 'inline', related: true })],
+      { html: null, probe: probe640 },
+    );
+    expect(result.kept).toHaveLength(1);
+    expect(result.kept[0]!.inline).toBe(false);
+    expect(result.kept[0]!.contentId).toBeNull();
+  });
+
+  it('drops anything outside the mime allowlist, svg included', async () => {
+    const result = await filterInboundAttachments(
+      [
+        part({ filename: 'invoice.pdf', contentType: 'application/pdf' }),
+        part({ filename: 'icon.svg', contentType: 'image/svg+xml' }),
+        part({ filename: 'note.txt', contentType: 'text/plain; charset=utf-8' }),
+      ],
+      { html: '<p>hi</p>', probe: probe640 },
+    );
+    expect(result.kept).toHaveLength(0);
+    expect(result.dropped.map((d) => d.reason)).toEqual([
+      'mime_rejected',
+      'mime_rejected',
+      'mime_rejected',
+    ]);
+  });
+
+  it('drops an image whose short edge is under the floor even when its byte size passes', async () => {
+    const result = await filterInboundAttachments([part({ filename: 'rule.png' })], {
+      html: '<p>hi</p>',
+      probe: () => Promise.resolve({ width: 600, height: 8 }),
+    });
+    expect(result.kept).toHaveLength(0);
+    expect(result.dropped[0]).toMatchObject({ reason: 'edge_too_small' });
+  });
+
+  it('drops a part sharp cannot decode', async () => {
+    const result = await filterInboundAttachments([part({ filename: 'broken.png' })], {
+      html: '<p>hi</p>',
+      probe: () => Promise.resolve(null),
+    });
+    expect(result.dropped[0]).toMatchObject({ reason: 'undecodable' });
+  });
+
+  it('keeps at most CONV_ATTACHMENT_PER_MESSAGE_MAX and reports the overflow', async () => {
+    const parts = Array.from({ length: CONV_ATTACHMENT_PER_MESSAGE_MAX + 3 }, (_, i) =>
+      part({ filename: `p${i}.png` }),
+    );
+    const result = await filterInboundAttachments(parts, { html: '<p>hi</p>', probe: probe640 });
+    expect(result.kept).toHaveLength(CONV_ATTACHMENT_PER_MESSAGE_MAX);
+    expect(result.dropped).toHaveLength(3);
+    expect(result.dropped.every((d) => d.reason === 'per_message_max')).toBe(true);
+  });
+});
+
+describe('inboundAttachmentName', () => {
+  it('forces the extension to match the mime so a png named .svg cannot smuggle past the store', () => {
+    expect(inboundAttachmentName({ filename: 'payload.svg', contentType: 'image/png' }, 0)).toBe(
+      'payload.png',
+    );
+  });
+
+  it('strips path segments, quotes and control characters, and names an unnamed part', () => {
+    expect(
+      inboundAttachmentName({ filename: '../../etc/pa"ss.jpeg', contentType: 'image/jpeg' }, 0),
+    ).toBe('pass.jpg');
+    expect(inboundAttachmentName({ filename: null, contentType: 'image/webp' }, 2)).toBe(
+      'image-3.webp',
+    );
+  });
+});
+
+describe('normalizeCidReferences', () => {
+  it('keeps a surviving cid reference and removes images whose part was dropped', () => {
+    const html =
+      '<p>hi</p><img src="cid:shot@corp" alt="a"><img src="cid:sig-logo@corp" width="88">';
+    const out = normalizeCidReferences(html, new Set(['shot@corp']));
+    expect(out).toBe('<p>hi</p><img src="cid:shot@corp" alt="a">');
+  });
+
+  it('writes nothing time-limited into the stored html', () => {
+    const out = normalizeCidReferences(
+      '<img src="cid:shot@corp">',
+      new Set(['shot@corp']),
+    );
+    expect(out).not.toContain('/v1/c/a/');
+    expect(out).not.toMatch(/https?:/);
+  });
+
+  it('lowercases and unbrackets a reference so it matches the stored contentId exactly', () => {
+    expect(normalizeCidReferences('<img src="cid:Shot%40Corp">', new Set(['shot@corp']))).toBe(
+      '<img src="cid:shot@corp">',
+    );
+  });
+
+  it('is a no-op on a null body and leaves non-cid markup alone', () => {
+    expect(normalizeCidReferences(null, new Set())).toBeNull();
+    expect(normalizeCidReferences('<img src="https://x.test/a.png">', new Set())).toBe(
+      '<img src="https://x.test/a.png">',
+    );
+  });
+});

--- a/packages/backend-core/src/modules/conv/email/inbound-attachments.ts
+++ b/packages/backend-core/src/modules/conv/email/inbound-attachments.ts
@@ -1,0 +1,207 @@
+import { normalizeMime } from '../../../common/storage/asset-validation.ts';
+import { probeMaster } from '../../cms/cms.variants.ts';
+import {
+  CONV_ATTACHMENT_BYTES_MAX,
+  CONV_ATTACHMENT_INBOUND_BYTES_MIN,
+  CONV_ATTACHMENT_INBOUND_EDGE_MIN_PX,
+  CONV_ATTACHMENT_MIME_ALLOWLIST,
+  CONV_ATTACHMENT_PER_MESSAGE_MAX,
+} from '../attachments/conv-attachments.constants.ts';
+
+export interface InboundEmailAttachment {
+  content: Buffer;
+  contentType: string;
+  filename: string | null;
+  cid: string | null;
+  contentDisposition: string | null;
+  related: boolean;
+}
+
+export type InboundAttachmentDropReason =
+  | 'mime_rejected'
+  | 'too_large'
+  | 'too_small'
+  | 'unreferenced_cid'
+  | 'undecodable'
+  | 'edge_too_small'
+  | 'per_message_max';
+
+export interface KeptInboundAttachment {
+  name: string;
+  mime: string;
+  content: Buffer;
+  width: number;
+  height: number;
+  inline: boolean;
+  contentId: string | null;
+}
+
+export interface DroppedInboundAttachment {
+  name: string;
+  mime: string;
+  sizeBytes: number;
+  reason: InboundAttachmentDropReason;
+}
+
+export interface InboundAttachmentFilterResult {
+  kept: KeptInboundAttachment[];
+  dropped: DroppedInboundAttachment[];
+}
+
+export type InboundImageProbe = (
+  body: Buffer,
+) => Promise<{ width: number; height: number } | null>;
+
+export const probeInboundImage: InboundImageProbe = async (body) => {
+  try {
+    return await probeMaster(body);
+  } catch {
+    return null;
+  }
+};
+
+const MIME_EXTENSIONS: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+const NAME_MAX_LENGTH = 120;
+
+export function normalizeCid(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim().replace(/^</, '').replace(/>$/, '').trim();
+  if (!trimmed) return null;
+  return trimmed.toLowerCase();
+}
+
+export function collectCidReferences(html: string | null | undefined): Set<string> {
+  const out = new Set<string>();
+  if (!html) return out;
+  const pattern = /cid:([^"'\s)>\\]+)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(html)) !== null) {
+    const cid = normalizeCid(decodeCidToken(match[1]!));
+    if (cid) out.add(cid);
+  }
+  return out;
+}
+
+export function normalizeCidReferences(
+  html: string | null,
+  keptCids: ReadonlySet<string>,
+): string | null {
+  if (!html) return html;
+  const normalized = html.replace(/cid:([^"'\s)>\\]+)/gi, (whole, token: string) => {
+    const cid = normalizeCid(decodeCidToken(token));
+    return cid && keptCids.has(cid) ? `cid:${cid}` : whole;
+  });
+  return dropDanglingCidImages(normalized, keptCids);
+}
+
+export function inboundAttachmentName(
+  part: Pick<InboundEmailAttachment, 'filename' | 'contentType'>,
+  index: number,
+): string {
+  const ext = MIME_EXTENSIONS[normalizeMime(part.contentType)] ?? 'bin';
+  const raw = (part.filename ?? '').split(/[\\/]/).pop() ?? '';
+  const cleaned = [...raw]
+    .filter((ch) => {
+      const code = ch.codePointAt(0) ?? 0;
+      return code >= 0x20 && code !== 0x7f && ch !== '"';
+    })
+    .join('')
+    .trim();
+  const stem = cleaned.replace(/\.[^.]{1,16}$/, '').trim().slice(0, NAME_MAX_LENGTH);
+  return stem ? `${stem}.${ext}` : `image-${index + 1}.${ext}`;
+}
+
+export async function filterInboundAttachments(
+  parts: readonly InboundEmailAttachment[],
+  opts: { html: string | null; probe?: InboundImageProbe },
+): Promise<InboundAttachmentFilterResult> {
+  const probe = opts.probe ?? probeInboundImage;
+  const referenced = collectCidReferences(opts.html);
+  const hasHtmlBody = !!opts.html && opts.html.trim().length > 0;
+
+  const kept: KeptInboundAttachment[] = [];
+  const dropped: DroppedInboundAttachment[] = [];
+
+  for (const [index, part] of parts.entries()) {
+    const mime = normalizeMime(part.contentType);
+    const name = inboundAttachmentName(part, index);
+    const sizeBytes = part.content.length;
+    const drop = (reason: InboundAttachmentDropReason): void => {
+      dropped.push({ name, mime, sizeBytes, reason });
+    };
+
+    if (!CONV_ATTACHMENT_MIME_ALLOWLIST.includes(mime)) {
+      drop('mime_rejected');
+      continue;
+    }
+    if (sizeBytes > CONV_ATTACHMENT_BYTES_MAX) {
+      drop('too_large');
+      continue;
+    }
+    if (sizeBytes < CONV_ATTACHMENT_INBOUND_BYTES_MIN) {
+      drop('too_small');
+      continue;
+    }
+
+    const cid = normalizeCid(part.cid);
+    const declaredInline =
+      part.related || (part.contentDisposition ?? '').trim().toLowerCase() === 'inline';
+    if (declaredInline && cid && hasHtmlBody && !referenced.has(cid)) {
+      drop('unreferenced_cid');
+      continue;
+    }
+
+    const dimensions = await probe(part.content);
+    if (!dimensions) {
+      drop('undecodable');
+      continue;
+    }
+    if (
+      dimensions.width < CONV_ATTACHMENT_INBOUND_EDGE_MIN_PX ||
+      dimensions.height < CONV_ATTACHMENT_INBOUND_EDGE_MIN_PX
+    ) {
+      drop('edge_too_small');
+      continue;
+    }
+
+    if (kept.length >= CONV_ATTACHMENT_PER_MESSAGE_MAX) {
+      drop('per_message_max');
+      continue;
+    }
+
+    const inline = declaredInline && cid != null && referenced.has(cid);
+    kept.push({
+      name,
+      mime,
+      content: part.content,
+      width: dimensions.width,
+      height: dimensions.height,
+      inline,
+      contentId: inline ? cid : null,
+    });
+  }
+
+  return { kept, dropped };
+}
+
+function decodeCidToken(token: string): string {
+  try {
+    return decodeURIComponent(token);
+  } catch {
+    return token;
+  }
+}
+
+function dropDanglingCidImages(html: string, keptCids: ReadonlySet<string>): string {
+  return html.replace(/<img\b[^>]*>/gi, (tag) => {
+    const refs = collectCidReferences(tag);
+    if (refs.size === 0) return tag;
+    return [...refs].every((cid) => keptCids.has(cid)) ? tag : '';
+  });
+}

--- a/packages/backend-core/src/modules/conv/email/mime.attachments.test.ts
+++ b/packages/backend-core/src/modules/conv/email/mime.attachments.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { buildOutbound } from './mime.ts';
+
+const PNG = Buffer.from(
+  '89504e470d0a1a0a0000000d494844520000000100000001080600000' + '01f15c4890000000a49444154789c6300010000050001',
+  'hex',
+);
+
+function boundaryOf(raw: string, subtype: string): string {
+  const m = new RegExp(`multipart/${subtype}[^\\r\\n]*boundary="([^"]+)"`).exec(raw);
+  if (!m) throw new Error(`no multipart/${subtype} in message`);
+  return m[1]!;
+}
+
+function partsOf(raw: string, boundary: string): string[] {
+  const body = raw.slice(raw.indexOf('\r\n\r\n') + 4);
+  return body
+    .split(`--${boundary}`)
+    .slice(1)
+    .filter((chunk) => chunk.trim() !== '--');
+}
+
+const base = {
+  from: 'Support <support@acme.test>',
+  to: 'c@customer.test',
+  subject: 'Re: your order',
+  text: 'here you go',
+  messageIdDomain: 'acme.test',
+};
+
+describe('buildOutbound attachments', () => {
+  it('keeps multipart/alternative at the top when there are no attachments', () => {
+    const built = buildOutbound({ ...base, html: '<p>here you go</p>' });
+    expect(built.raw).toContain('Content-Type: multipart/alternative;');
+    expect(built.raw).not.toContain('multipart/mixed');
+    expect(built.raw).not.toContain('multipart/related');
+  });
+
+  it('wraps the alternative in multipart/mixed and base64-encodes a plain attachment', () => {
+    const built = buildOutbound({
+      ...base,
+      html: '<p>here you go</p>',
+      attachments: [{ filename: 'receipt.png', contentType: 'image/png', content: PNG }],
+    });
+
+    expect(built.raw).toMatch(/^Content-Type: multipart\/mixed;/m);
+    const mixed = boundaryOf(built.raw, 'mixed');
+    const parts = partsOf(built.raw, mixed);
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toContain('Content-Type: multipart/alternative;');
+    expect(parts[1]).toContain('Content-Type: image/png; name="receipt.png"');
+    expect(parts[1]).toContain('Content-Transfer-Encoding: base64');
+    expect(parts[1]).toContain('Content-Disposition: attachment; filename="receipt.png"');
+    expect(parts[1]).not.toContain('Content-ID');
+
+    const encoded = parts[1]!.slice(parts[1]!.indexOf('\r\n\r\n') + 4).trim();
+    expect(Buffer.from(encoded.replace(/\r\n/g, ''), 'base64').equals(PNG)).toBe(true);
+  });
+
+  it('wraps the alternative in multipart/related for an inline part the html references', () => {
+    const built = buildOutbound({
+      ...base,
+      html: '<p>see <img src="cid:shot@acme"></p>',
+      attachments: [
+        {
+          filename: 'shot.png',
+          contentType: 'image/png',
+          content: PNG,
+          inline: true,
+          contentId: 'shot@acme',
+        },
+      ],
+    });
+
+    expect(built.raw).toMatch(/^Content-Type: multipart\/related; type="text\/html";/m);
+    expect(built.raw).not.toContain('multipart/mixed');
+    const related = boundaryOf(built.raw, 'related');
+    const parts = partsOf(built.raw, related);
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toContain('Content-Type: multipart/alternative;');
+    expect(parts[1]).toContain('Content-Disposition: inline; filename="shot.png"');
+    expect(parts[1]).toContain('Content-ID: <shot@acme>');
+  });
+
+  it('nests mixed over related when a message carries both an inline image and a file', () => {
+    const built = buildOutbound({
+      ...base,
+      html: '<p>see <img src="cid:shot@acme"></p>',
+      attachments: [
+        {
+          filename: 'shot.png',
+          contentType: 'image/png',
+          content: PNG,
+          inline: true,
+          contentId: 'shot@acme',
+        },
+        { filename: 'receipt.png', contentType: 'image/png', content: PNG },
+      ],
+    });
+
+    const mixed = boundaryOf(built.raw, 'mixed');
+    const mixedParts = partsOf(built.raw, mixed);
+    expect(mixedParts).toHaveLength(2);
+    expect(mixedParts[0]).toContain('Content-Type: multipart/related; type="text/html";');
+    expect(mixedParts[1]).toContain('Content-Disposition: attachment; filename="receipt.png"');
+    expect(mixedParts[0]).toContain('Content-ID: <shot@acme>');
+  });
+
+  it('demotes an inline part to an attachment when the html does not reference its cid', () => {
+    const built = buildOutbound({
+      ...base,
+      html: '<p>no image here</p>',
+      attachments: [
+        {
+          filename: 'orphan.png',
+          contentType: 'image/png',
+          content: PNG,
+          inline: true,
+          contentId: 'orphan@acme',
+        },
+      ],
+    });
+    expect(built.raw).toContain('multipart/mixed');
+    expect(built.raw).not.toContain('multipart/related');
+    expect(built.raw).toContain('Content-Disposition: attachment; filename="orphan.png"');
+    expect(built.raw).not.toContain('Content-ID:');
+  });
+
+  it('wraps base64 at 76 characters and rfc2231-encodes a non-ascii filename', () => {
+    const big = Buffer.alloc(400, 7);
+    const built = buildOutbound({
+      ...base,
+      attachments: [{ filename: 'kvittering-æøå.png', contentType: 'image/png', content: big }],
+    });
+    expect(built.raw).toContain(
+      "Content-Disposition: attachment; filename*=utf-8''kvittering-%C3%A6%C3%B8%C3%A5.png",
+    );
+    const mixed = boundaryOf(built.raw, 'mixed');
+    const attachmentPart = partsOf(built.raw, mixed)[1]!;
+    const encoded = attachmentPart.slice(attachmentPart.indexOf('\r\n\r\n') + 4).trim();
+    for (const line of encoded.split('\r\n')) expect(line.length).toBeLessThanOrEqual(76);
+    expect(Buffer.from(encoded.replace(/\r\n/g, ''), 'base64').equals(big)).toBe(true);
+  });
+
+  it('never puts an attachment url in the message body', () => {
+    const built = buildOutbound({
+      ...base,
+      html: '<p>see <img src="cid:shot@acme"></p>',
+      attachments: [
+        {
+          filename: 'shot.png',
+          contentType: 'image/png',
+          content: PNG,
+          inline: true,
+          contentId: 'shot@acme',
+        },
+      ],
+    });
+    expect(built.raw).not.toContain('/v1/c/a/');
+  });
+});

--- a/packages/backend-core/src/modules/conv/email/mime.ts
+++ b/packages/backend-core/src/modules/conv/email/mime.ts
@@ -1,5 +1,13 @@
 import { randomUUID } from 'node:crypto';
 
+export interface OutboundAttachment {
+  filename: string;
+  contentType: string;
+  content: Buffer;
+  inline?: boolean;
+  contentId?: string | null;
+}
+
 export interface BuildOutboundInput {
   from: string;
   to: string;
@@ -11,12 +19,24 @@ export interface BuildOutboundInput {
   inReplyTo?: string;
   references?: string[];
   trackerUrl?: string;
+  attachments?: readonly OutboundAttachment[];
 }
 
 export interface BuiltMessage {
   raw: string;
   messageId: string;
 }
+
+type MimePart =
+  | {
+      kind: 'leaf';
+      contentType: string;
+      encoding: string;
+      disposition?: string;
+      contentId?: string;
+      body: string;
+    }
+  | { kind: 'multipart'; subtype: string; params?: string; parts: MimePart[] };
 
 export function buildOutbound(input: BuildOutboundInput): BuiltMessage {
   const localPart = randomUUID();
@@ -35,38 +55,134 @@ export function buildOutbound(input: BuildOutboundInput): BuiltMessage {
     headers.push(['References', input.references.map((r) => `<${r}>`).join(' ')]);
   }
 
-  const text = input.text;
-  const html = input.html;
-  let body: string;
-  if (html) {
-    const boundary = `munin-boundary-${randomUUID()}`;
-    headers.push(['Content-Type', `multipart/alternative; boundary="${boundary}"`]);
-    const htmlWithTracker = input.trackerUrl
-      ? injectTrackingPixel(html, input.trackerUrl)
-      : html;
-    body = [
-      `--${boundary}`,
-      'Content-Type: text/plain; charset="utf-8"',
-      'Content-Transfer-Encoding: 7bit',
-      '',
-      text,
-      '',
-      `--${boundary}`,
-      'Content-Type: text/html; charset="utf-8"',
-      'Content-Transfer-Encoding: 7bit',
-      '',
-      htmlWithTracker,
-      '',
-      `--${boundary}--`,
-    ].join('\r\n');
-  } else {
-    headers.push(['Content-Type', 'text/plain; charset="utf-8"']);
-    headers.push(['Content-Transfer-Encoding', '7bit']);
-    body = text;
+  const html = input.html
+    ? input.trackerUrl
+      ? injectTrackingPixel(input.html, input.trackerUrl)
+      : input.html
+    : undefined;
+
+  const textPart: MimePart = {
+    kind: 'leaf',
+    contentType: 'text/plain; charset="utf-8"',
+    encoding: '7bit',
+    body: input.text,
+  };
+  let root: MimePart = html
+    ? {
+        kind: 'multipart',
+        subtype: 'alternative',
+        parts: [
+          textPart,
+          {
+            kind: 'leaf',
+            contentType: 'text/html; charset="utf-8"',
+            encoding: '7bit',
+            body: html,
+          },
+        ],
+      }
+    : textPart;
+
+  const attachments = input.attachments ?? [];
+  const inlineParts = attachments.filter((a) => isReferencedInline(a, html));
+  const fileParts = attachments.filter((a) => !isReferencedInline(a, html));
+
+  if (inlineParts.length > 0) {
+    root = {
+      kind: 'multipart',
+      subtype: 'related',
+      params: 'type="text/html"',
+      parts: [root, ...inlineParts.map((a) => attachmentPart(a, true))],
+    };
+  }
+  if (fileParts.length > 0) {
+    root = {
+      kind: 'multipart',
+      subtype: 'mixed',
+      parts: [root, ...fileParts.map((a) => attachmentPart(a, false))],
+    };
   }
 
+  const rendered = renderPart(root);
+  for (const header of rendered.headers) headers.push(header);
   const headerLines = headers.map(([k, v]) => `${k}: ${v}`).join('\r\n');
-  return { raw: `${headerLines}\r\n\r\n${body}`, messageId };
+  return { raw: `${headerLines}\r\n\r\n${rendered.body}`, messageId };
+}
+
+function isReferencedInline(part: OutboundAttachment, html: string | undefined): boolean {
+  const cid = bareContentId(part.contentId);
+  if (!part.inline || !cid || !html) return false;
+  return html.toLowerCase().includes(`cid:${cid.toLowerCase()}`);
+}
+
+function bareContentId(raw: string | null | undefined): string | null {
+  const trimmed = (raw ?? '').trim().replace(/^</, '').replace(/>$/, '').trim();
+  return trimmed || null;
+}
+
+function attachmentPart(part: OutboundAttachment, inline: boolean): MimePart {
+  const cid = bareContentId(part.contentId);
+  const nameParam = asciiFilenameParam(part.filename);
+  return {
+    kind: 'leaf',
+    contentType: [sanitizeHeaderToken(part.contentType) || 'application/octet-stream', nameParam]
+      .filter(Boolean)
+      .join('; '),
+    encoding: 'base64',
+    disposition: `${inline ? 'inline' : 'attachment'}; ${filenameParam(part.filename)}`,
+    ...(inline && cid ? { contentId: `<${sanitizeHeaderToken(cid)}>` } : {}),
+    body: wrapBase64(part.content.toString('base64')),
+  };
+}
+
+function renderPart(part: MimePart): { headers: [string, string][]; body: string } {
+  if (part.kind === 'leaf') {
+    const headers: [string, string][] = [
+      ['Content-Type', part.contentType],
+      ['Content-Transfer-Encoding', part.encoding],
+    ];
+    if (part.disposition) headers.push(['Content-Disposition', part.disposition]);
+    if (part.contentId) headers.push(['Content-ID', part.contentId]);
+    return { headers, body: part.body };
+  }
+
+  const boundary = `munin-boundary-${randomUUID()}`;
+  const contentType = [`multipart/${part.subtype}`, part.params, `boundary="${boundary}"`]
+    .filter(Boolean)
+    .join('; ');
+  const chunks = part.parts.map((child) => {
+    const rendered = renderPart(child);
+    const childHeaders = rendered.headers.map(([k, v]) => `${k}: ${v}`).join('\r\n');
+    return `--${boundary}\r\n${childHeaders}\r\n\r\n${rendered.body}`;
+  });
+  return {
+    headers: [['Content-Type', contentType]],
+    body: `${chunks.join('\r\n')}\r\n--${boundary}--`,
+  };
+}
+
+function wrapBase64(b64: string): string {
+  const lines: string[] = [];
+  for (let i = 0; i < b64.length; i += 76) lines.push(b64.slice(i, i + 76));
+  return lines.join('\r\n');
+}
+
+function sanitizeHeaderToken(value: string): string {
+  return value.replace(/[\r\n";]/g, '').trim();
+}
+
+function isAscii(value: string): boolean {
+  return /^[\x20-\x7e]*$/.test(value);
+}
+
+function filenameParam(name: string): string {
+  const clean = sanitizeHeaderToken(name) || 'attachment';
+  return isAscii(clean) ? `filename="${clean}"` : `filename*=utf-8''${encodeURIComponent(clean)}`;
+}
+
+function asciiFilenameParam(name: string): string {
+  const clean = sanitizeHeaderToken(name);
+  return clean && isAscii(clean) ? `name="${clean}"` : '';
 }
 
 function encodeHeaderValue(value: string): string {

--- a/packages/backend-core/src/modules/conv/email/threading.ts
+++ b/packages/backend-core/src/modules/conv/email/threading.ts
@@ -1,6 +1,7 @@
 import { schema, type Db, type Tx } from '@getmunin/db';
 import { and, eq, inArray } from 'drizzle-orm';
 import type { SenderClassification } from './classify-sender.ts';
+import type { InboundEmailAttachment } from './inbound-attachments.ts';
 import {
   extractPlusAddressedConvId,
   parseMessageIdHeader,
@@ -21,6 +22,7 @@ export interface ParsedInboundEmail {
   arcAuthenticationResults: string[];
   forwardedFor: string[];
   forwardedTo: string[];
+  attachments: InboundEmailAttachment[];
 }
 
 export interface ThreadResolution {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,7 @@ export {
 } from './providers/embedding.ts';
 export {
   type Mailer,
+  type MailAttachment,
   type MailMessage,
   type SentMessage,
   ResendMailer,

--- a/packages/core/src/providers/mailer.ts
+++ b/packages/core/src/providers/mailer.ts
@@ -1,5 +1,11 @@
 import { stripTrailingSlashes } from '@getmunin/types';
 
+export interface MailAttachment {
+  filename: string;
+  content: Buffer;
+  contentType: string;
+}
+
 export interface MailMessage {
   to: string;
   subject: string;
@@ -8,6 +14,7 @@ export interface MailMessage {
   replyTo?: string;
   from?: string;
   headers?: Record<string, string>;
+  attachments?: readonly MailAttachment[];
 }
 
 export interface Mailer {
@@ -54,6 +61,13 @@ export class ResendMailer implements Mailer {
         html: msg.html,
         reply_to: msg.replyTo,
         headers: msg.headers,
+        attachments: msg.attachments?.length
+          ? msg.attachments.map((a) => ({
+              filename: a.filename,
+              content: a.content.toString('base64'),
+              content_type: a.contentType,
+            }))
+          : undefined,
       }),
     });
     if (!res.ok) {
@@ -102,6 +116,13 @@ export class SmtpMailer implements Mailer {
       html: msg.html,
       replyTo: msg.replyTo,
       headers: msg.headers,
+      attachments: msg.attachments?.length
+        ? msg.attachments.map((a) => ({
+            filename: a.filename,
+            content: a.content,
+            contentType: a.contentType,
+          }))
+        : undefined,
     };
     await this.transporter.sendMail(mail);
   }


### PR DESCRIPTION
**Stack** — merge bottom-up, and retarget each child before merging its parent:

| | PR | |
|---|---|---|
| 1 | #924 | conversation attachment store (trunk) |
| 2 | #925 | operator + agent attachments, deletion — **required for #928 to work** |
| 3 | #926 | email images in and out |
| 4 | #927 | chat widget images |
| 5 | #928 | agent vision — **must land with or before #927 ships** |
| 6 | #929 | follow-ups: inbound email loss, backfill, storage leaks |

---

Stacked on #925.

## Inbound

`parseMessage` already ran mailparser, which parses attachments and then dropped them on the floor. Survivors are now persisted via `persistBytes` inside the existing ingest transaction.

The filter is the part worth reviewing, and it lives in its own pure, unit-tested module (`email/inbound-attachments.ts`) rather than buried in the adapter. Business email carries tracking pixels and signature logos as inline images on nearly every message, so it drops: anything outside the MIME allow-list, anything under the byte/edge floor, anything sharp can't decode, any `inline` part whose `cid` isn't actually referenced in the *stripped* HTML, and anything past the per-message cap. It takes an injectable probe so it tests without sharp.

Stored `body_html` keeps its `cid:` references, normalized so they match the `content_id` column byte-for-byte; #925 resolves them to fresh URLs at read time. Nothing time-limited is written to the database — tests assert `not.toContain('/v1/c/a/')` and `not.toMatch(/https?:/)` directly.

## A pre-existing bug found on the way

`simpleParser` was being called without `keepCidLinks`, so **mailparser was rewriting every inbound `cid:` image into a base64 `data:` URI inside `conv_messages.body_html`** — whole images inlined into a text column, hundreds of KB per message, with no attachment row. Confirmed in mailparser's own source (`simple-parser.js` runs `updateImageLinks` unless the option is set). Fixed here.

**Existing rows still hold those `data:` URIs.** A backfill for them is in the last PR of this stack.

## Outbound

`buildOutbound` now builds a real MIME tree: `multipart/related; type="text/html"` when an inline part's cid is referenced, `multipart/mixed` for files, nested when both. Base64 at 76 columns, correct `Content-Disposition`, `Content-ID` on inline parts, RFC 2231 for non-ASCII filenames.

Attachments are embedded as real MIME parts read via `storage.readBytes()` — never a signed URL, which would outlive its TTL in the recipient's mailbox and leak on forward.

`MailMessage.attachments` added and mapped in `ResendMailer` **and** `SmtpMailer`, which would otherwise have dropped them silently.

## Deviations worth flagging

1. **`send()` queries `conv_attachments` directly** rather than through the service. `OutboundDeliveryWorker` doesn't wrap `adapter.send()` in `withContext`, so every `getCurrentContext()`-based method is unavailable there. Reads happen in a `bypass_rls` transaction, the same pattern the adapter already uses for password decryption.
2. **The transactional mailer path passes attachments to `mailer.send()`** rather than into `built.raw`, because that path runs the whole MIME body through `extractTextBody` and would push base64 image data into the message text.
3. **`widget-email-fallback.worker.ts` deliberately sends no attachments** — it's a "you have unread messages" pointer back to the widget, so re-shipping images by mail is duplication.

## Testing

27 new tests: `.eml` fixtures with an inline logo plus a real photo asserting the photo persists and the pixel is dropped, outbound MIME structure assertions, and the noise filter unit-tested directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
