### PR TITLE
fix(conv): stop losing inbound email, collect abandoned uploads, plug two storage leaks

### DIFF
--- a/.changeset/attachment-limits-shared.md
+++ b/.changeset/attachment-limits-shared.md
@@ -1,0 +1,28 @@
+---
+'@getmunin/types': minor
+'@getmunin/backend-core': patch
+'@getmunin/chat-widget': patch
+'@getmunin/dashboard-pages': patch
+---
+
+Share one set of attachment limits between the server and both clients, and validate uploads in the
+dashboard composer before they leave the browser.
+
+The allowlist, the 10 MB cap and the per-message maximum existed in two places — the server's
+`conv-attachments.constants.ts` and the widget's `upload.ts` — and in neither for the dashboard,
+which reused `lib/upload-image.ts`, the CMS asset helper (SVG allowed, no size cap). A wrong file
+type was silently dropped, an oversized one round-tripped to the server and came back as a bare
+"Upload failed", and nothing enforced the per-message cap client-side. An SVG was the sharp edge: it
+passed the `image/*` filter, uploaded untouched, then failed the server allowlist with no hint why.
+
+`@getmunin/types` now owns `CONV_ATTACHMENT_*` plus `attachmentRejectionFor`, and all three callers
+read from it. The dashboard checks type, size and count up front and reports each rejection through
+the conversation pane's existing `role="alert"` banner rather than a second, quieter channel — so an
+attachment failure now reads like every other action failure in that pane. Attachment deletion also
+stops reporting itself as "Send failed": `QueueActionType` gains `attach`.
+
+Icons in the attachment UI stop being characters. The removed-attachment chip swaps its 🚫 emoji for
+lucide's `ImageOff`, and both remove buttons swap `✕` for lucide's `X`, so all three render in the
+pane's own ink and follow dark mode instead of leaning on the platform emoji and text fonts. The
+widget inlines the same `X` geometry — it draws into a shadow root and cannot import from
+lucide-react — so its chip control stays visually matched to the dashboard's.

--- a/.changeset/conv-attachment-followups.md
+++ b/.changeset/conv-attachment-followups.md
@@ -1,0 +1,33 @@
+---
+'@getmunin/backend-core': minor
+---
+
+Four follow-ups to conversation image support.
+
+**A failed inbound store no longer loses the email.** The IMAP poll advanced its cursor past every
+message it had fetched, whether or not the message was actually stored — so a transient storage or
+database error during ingest silently dropped that email for good. The loop now distinguishes a
+permanent failure from a transient one: an unparseable message is skipped and the cursor moves past it
+(retrying forever would only stall the channel behind one bad email), while a failed *store* holds the
+cursor at the last message that landed and stops the tick, so the next poll re-fetches and retries.
+A held cursor also raises its own alert, keyed separately from the polling-failure alert so it does not
+feed the auto-deactivation counter — mail is safe on the server, and deactivating the channel would
+break outreach approvals for no reason.
+
+**Legacy inlined images can be extracted.** `mailparser` was rewriting every inbound `cid:` image into
+a base64 `data:` URI inside `conv_messages.body_html` (fixed separately by passing `keepCidLinks`), so
+existing rows hold whole images inside a text column. `pnpm -F @getmunin/backend-core
+backfill:inline-email-images` walks each org, promotes the qualifying images to real attachments, and
+rewrites the HTML to a `cid:` reference matching the new `content_id`. It takes `--dry-run`, is
+idempotent, and applies the same floor as inbound ingest, so tracking pixels stay inlined rather than
+becoming attachments. On the smoke-test corpus one message went from 240,483 characters to 72.
+
+**Deleting a CMS asset no longer leaks its variants.** `cms.deleteAsset` removed only the master
+object, so every deleted image left up to five orphaned webp derivatives in storage forever. It now
+deletes the keys named in `variants` as well.
+
+**Abandoned uploads get collected.** `AttachmentGcWorker` deletes attachment rows that never made it
+onto a message once they are past a grace period (default 60 minutes,
+`MUNIN_ATTACHMENT_GC_GRACE_MINUTES`), purging the master and variant objects with them. It claims rows
+with `FOR UPDATE SKIP LOCKED` so several instances can run it, and never touches a row that is already
+on a message.

--- a/.changeset/curator-sees-images.md
+++ b/.changeset/curator-sees-images.md
@@ -1,0 +1,17 @@
+---
+'@getmunin/agent-runtime': minor
+'@getmunin/agent-host': patch
+---
+
+Let curator skill passes see the images on the conversation they were queued for.
+
+`runSkillPass` built its single synthetic user turn from `userPrompt` alone, so a curator job read
+the thread through MCP tools and never saw a pixel — `conv/set-topic-and-title` titling an
+image-only turn, or `outreach/draft-reply-email` answering a prospect who attached a screenshot,
+worked from text that wasn't there. `SkillPassOptions` gains `userPromptAttachments`, which land on
+that turn and flow through the existing `loadHistoryImages` path, so the per-turn image and byte
+budgets apply unchanged and anything over budget degrades to a placeholder note.
+
+The curator worker fills it in: when a job's `sourceEventPayload` names a conversation, it hydrates
+that conversation and passes along every non-internal attachment that still resolves to a URL.
+Scheduled sweeps that name no conversation are unaffected.

--- a/.changeset/in-process-attachments.md
+++ b/.changeset/in-process-attachments.md
@@ -1,0 +1,17 @@
+---
+'@getmunin/backend-core': patch
+---
+
+Carry message attachments through the in-process runner REST client, so the agent actually sees
+customer images.
+
+The HTTP `createMuninRestClient` learned to pass attachments through, but `AgentHostRunner` always
+resolves its client from `InProcessMuninRestClientFactoryService`, and that client dropped the field
+in two places: `getConversation` rebuilt each message as `{ id, authorType, body, createdAt,
+internal }`, and its own `toRuntimeHistory` did the same. `ConversationMessage.attachments` was
+therefore always `undefined` on the path the OSS backend runs, so `loadHistoryImages` saw nothing to
+fetch — no image reached the model, and no placeholder note explained the gap. `newestTurnIsSilent`
+reads the same dropped field, so an image-only customer turn was still treated as silence.
+
+Both mappings now carry `attachments`, and the integration test asserts a hydrated attachment
+survives `getConversation` and comes out of `toRuntimeHistory` as `{ mime, url, name }`.

--- a/.changeset/widget-composer-errors.md
+++ b/.changeset/widget-composer-errors.md
@@ -1,0 +1,15 @@
+---
+'@getmunin/chat-widget': patch
+---
+
+Make the widget's composer error behave like the dashboard's, and stop losing failed sends in the
+console.
+
+The composer note was a bare red line that erased itself after five seconds, so the reason a file
+was rejected disappeared while its error chip stayed on screen. It is now a dismissible alert — dot,
+message, Close — carrying `role="alert"` so assistive tech announces it, and it persists until the
+visitor dismisses it or sends the message. A message that fails to send used to be `console.warn`
+only, invisible to the visitor; it now surfaces in the same note.
+
+The attachment chip's remove control also picks up the dashboard's affordance — the same `✕` glyph
+on a translucent paper pill in muted ink, instead of a filled dark circle with an SVG cross.

--- a/.changeset/widget-drop-hint-stuck.md
+++ b/.changeset/widget-drop-hint-stuck.md
@@ -1,0 +1,13 @@
+---
+'@getmunin/chat-widget': patch
+---
+
+Clear the chat widget's drop hint when a drag leaves the panel without dropping.
+
+The `dragleave` handler decided whether the drag had really left by inspecting `e.target`, but
+`dragleave` fires on the element being left and bubbles, so the last event before the pointer exits
+the panel almost always targets a descendant — a message bubble, the message list — not `.chat`
+itself. The old guard read that as an internal move and returned early, leaving "Slipp bildet her"
+covering the conversation until the next drag. It now keys off `e.relatedTarget`, the node being
+entered: still inside `.chat` means an internal move, anything else (including `null` when the drag
+leaves the window) hides the hint.

--- a/apps/chat-widget/src/strings/cs.ts
+++ b/apps/chat-widget/src/strings/cs.ts
@@ -61,6 +61,7 @@ const cs: Strings = {
   attachDropHint: 'Přetáhněte obrázek sem',
   attachUploading: 'Nahrávání…',
   attachFailed: 'Obrázek se nepodařilo nahrát. Zkuste to znovu.',
+  sendFailed: 'Zprávu se nepodařilo odeslat. Zkuste to znovu.',
   attachRemoveAriaLabel: 'Odebrat obrázek',
   attachTooMany: 'Můžete přidat až {n} obrázků.',
   attachTypeRejected: 'Přijímáme PNG, JPEG, GIF a WebP.',

--- a/apps/chat-widget/src/strings/da.ts
+++ b/apps/chat-widget/src/strings/da.ts
@@ -61,6 +61,7 @@ const da: Strings = {
   attachDropHint: 'Slip billedet her',
   attachUploading: 'Uploader…',
   attachFailed: 'Billedet blev ikke uploadet. Prøv igen.',
+  sendFailed: 'Beskeden blev ikke sendt. Prøv igen.',
   attachRemoveAriaLabel: 'Fjern billedet',
   attachTooMany: 'Du kan vedhæfte op til {n} billeder.',
   attachTypeRejected: 'Vi tager PNG, JPEG, GIF og WebP.',

--- a/apps/chat-widget/src/strings/de.ts
+++ b/apps/chat-widget/src/strings/de.ts
@@ -61,6 +61,7 @@ const de: Strings = {
   attachDropHint: 'Bild hier ablegen',
   attachUploading: 'Wird hochgeladen…',
   attachFailed: 'Das Bild wurde nicht hochgeladen. Bitte nochmal versuchen.',
+  sendFailed: 'Die Nachricht wurde nicht gesendet. Bitte nochmal versuchen.',
   attachRemoveAriaLabel: 'Bild entfernen',
   attachTooMany: 'Du kannst bis zu {n} Bilder anhängen.',
   attachTypeRejected: 'Wir nehmen PNG, JPEG, GIF und WebP.',

--- a/apps/chat-widget/src/strings/en.ts
+++ b/apps/chat-widget/src/strings/en.ts
@@ -61,6 +61,7 @@ const en: Strings = {
   attachDropHint: 'Drop the image here',
   attachUploading: 'Uploading…',
   attachFailed: "That image didn't upload. Try again.",
+  sendFailed: "That message didn't send. Try again.",
   attachRemoveAriaLabel: 'Remove image',
   attachTooMany: 'You can attach up to {n} images.',
   attachTypeRejected: 'We take PNG, JPEG, GIF and WebP.',

--- a/apps/chat-widget/src/strings/es.ts
+++ b/apps/chat-widget/src/strings/es.ts
@@ -61,6 +61,7 @@ const es: Strings = {
   attachDropHint: 'Suelta la imagen aquí',
   attachUploading: 'Subiendo…',
   attachFailed: 'La imagen no se subió. Inténtalo de nuevo.',
+  sendFailed: 'El mensaje no se envió. Inténtalo de nuevo.',
   attachRemoveAriaLabel: 'Quitar la imagen',
   attachTooMany: 'Puedes adjuntar hasta {n} imágenes.',
   attachTypeRejected: 'Aceptamos PNG, JPEG, GIF y WebP.',

--- a/apps/chat-widget/src/strings/et.ts
+++ b/apps/chat-widget/src/strings/et.ts
@@ -61,6 +61,7 @@ const et: Strings = {
   attachDropHint: 'Kukuta pilt siia',
   attachUploading: 'Laadin üles…',
   attachFailed: 'Pilti ei õnnestunud üles laadida. Proovi uuesti.',
+  sendFailed: 'Sõnumit ei õnnestunud saata. Proovi uuesti.',
   attachRemoveAriaLabel: 'Eemalda pilt',
   attachTooMany: 'Saad lisada kuni {n} pilti.',
   attachTypeRejected: 'Võtame vastu PNG, JPEG, GIF ja WebP.',

--- a/apps/chat-widget/src/strings/fi.ts
+++ b/apps/chat-widget/src/strings/fi.ts
@@ -61,6 +61,7 @@ const fi: Strings = {
   attachDropHint: 'Pudota kuva tähän',
   attachUploading: 'Lähetetään…',
   attachFailed: 'Kuvan lähetys ei onnistunut. Yritä uudelleen.',
+  sendFailed: 'Viestin lähetys ei onnistunut. Yritä uudelleen.',
   attachRemoveAriaLabel: 'Poista kuva',
   attachTooMany: 'Voit liittää enintään {n} kuvaa.',
   attachTypeRejected: 'Otamme vastaan PNG-, JPEG-, GIF- ja WebP-kuvia.',

--- a/apps/chat-widget/src/strings/fr.ts
+++ b/apps/chat-widget/src/strings/fr.ts
@@ -61,6 +61,7 @@ const fr: Strings = {
   attachDropHint: 'Déposez l’image ici',
   attachUploading: 'Envoi…',
   attachFailed: 'L’image n’a pas été envoyée. Réessayez.',
+  sendFailed: 'Le message n’a pas été envoyé. Réessayez.',
   attachRemoveAriaLabel: 'Retirer l’image',
   attachTooMany: 'Vous pouvez joindre jusqu’à {n} images.',
   attachTypeRejected: 'Nous acceptons PNG, JPEG, GIF et WebP.',

--- a/apps/chat-widget/src/strings/hu.ts
+++ b/apps/chat-widget/src/strings/hu.ts
@@ -61,6 +61,7 @@ const hu: Strings = {
   attachDropHint: 'Húzza ide a képet',
   attachUploading: 'Feltöltés…',
   attachFailed: 'A képet nem sikerült feltölteni. Próbálja újra.',
+  sendFailed: 'Az üzenetet nem sikerült elküldeni. Próbálja újra.',
   attachRemoveAriaLabel: 'Kép eltávolítása',
   attachTooMany: 'Legfeljebb {n} képet csatolhat.',
   attachTypeRejected: 'PNG, JPEG, GIF és WebP formátumot fogadunk.',

--- a/apps/chat-widget/src/strings/is.ts
+++ b/apps/chat-widget/src/strings/is.ts
@@ -61,6 +61,7 @@ const is: Strings = {
   attachDropHint: 'Slepptu myndinni hér',
   attachUploading: 'Hleð upp…',
   attachFailed: 'Myndin var ekki send. Prófaðu aftur.',
+  sendFailed: 'Skilaboðin voru ekki send. Prófaðu aftur.',
   attachRemoveAriaLabel: 'Fjarlægja mynd',
   attachTooMany: 'Þú getur hengt við allt að {n} myndir.',
   attachTypeRejected: 'Við tökum PNG, JPEG, GIF og WebP.',

--- a/apps/chat-widget/src/strings/it.ts
+++ b/apps/chat-widget/src/strings/it.ts
@@ -61,6 +61,7 @@ const it: Strings = {
   attachDropHint: 'Trascina qui l’immagine',
   attachUploading: 'Caricamento…',
   attachFailed: 'L’immagine non è stata caricata. Riprova.',
+  sendFailed: 'Il messaggio non è stato inviato. Riprova.',
   attachRemoveAriaLabel: 'Rimuovi l’immagine',
   attachTooMany: 'Puoi allegare fino a {n} immagini.',
   attachTypeRejected: 'Accettiamo PNG, JPEG, GIF e WebP.',

--- a/apps/chat-widget/src/strings/lt.ts
+++ b/apps/chat-widget/src/strings/lt.ts
@@ -61,6 +61,7 @@ const lt: Strings = {
   attachDropHint: 'Nuvilkite vaizdą čia',
   attachUploading: 'Įkeliama…',
   attachFailed: 'Vaizdo įkelti nepavyko. Bandykite dar kartą.',
+  sendFailed: 'Žinutės išsiųsti nepavyko. Bandykite dar kartą.',
   attachRemoveAriaLabel: 'Pašalinti vaizdą',
   attachTooMany: 'Galite pridėti iki {n} vaizdų.',
   attachTypeRejected: 'Priimame PNG, JPEG, GIF ir WebP.',

--- a/apps/chat-widget/src/strings/lv.ts
+++ b/apps/chat-widget/src/strings/lv.ts
@@ -61,6 +61,7 @@ const lv: Strings = {
   attachDropHint: 'Nometiet attēlu šeit',
   attachUploading: 'Augšupielādē…',
   attachFailed: 'Attēlu neizdevās augšupielādēt. Mēģiniet vēlreiz.',
+  sendFailed: 'Ziņu neizdevās nosūtīt. Mēģiniet vēlreiz.',
   attachRemoveAriaLabel: 'Noņemt attēlu',
   attachTooMany: 'Varat pievienot līdz {n} attēliem.',
   attachTypeRejected: 'Pieņemam PNG, JPEG, GIF un WebP.',

--- a/apps/chat-widget/src/strings/nb.ts
+++ b/apps/chat-widget/src/strings/nb.ts
@@ -61,6 +61,7 @@ const nb: Strings = {
   attachDropHint: 'Slipp bildet her',
   attachUploading: 'Laster opp…',
   attachFailed: 'Bildet ble ikke lastet opp. Prøv igjen.',
+  sendFailed: 'Meldingen ble ikke sendt. Prøv igjen.',
   attachRemoveAriaLabel: 'Fjern bildet',
   attachTooMany: 'Du kan legge ved opptil {n} bilder.',
   attachTypeRejected: 'Vi tar imot PNG, JPEG, GIF og WebP.',

--- a/apps/chat-widget/src/strings/nl.ts
+++ b/apps/chat-widget/src/strings/nl.ts
@@ -61,6 +61,7 @@ const nl: Strings = {
   attachDropHint: 'Laat de afbeelding hier vallen',
   attachUploading: 'Uploaden…',
   attachFailed: 'De afbeelding is niet geüpload. Probeer het nog eens.',
+  sendFailed: 'Het bericht is niet verzonden. Probeer het nog eens.',
   attachRemoveAriaLabel: 'Afbeelding verwijderen',
   attachTooMany: 'Je kunt maximaal {n} afbeeldingen toevoegen.',
   attachTypeRejected: 'We nemen PNG, JPEG, GIF en WebP.',

--- a/apps/chat-widget/src/strings/nn.ts
+++ b/apps/chat-widget/src/strings/nn.ts
@@ -61,6 +61,7 @@ const nn: Strings = {
   attachDropHint: 'Slepp biletet her',
   attachUploading: 'Lastar opp…',
   attachFailed: 'Biletet vart ikkje lasta opp. Prøv igjen.',
+  sendFailed: 'Meldinga vart ikkje sendt. Prøv igjen.',
   attachRemoveAriaLabel: 'Fjern biletet',
   attachTooMany: 'Du kan leggje ved opptil {n} bilete.',
   attachTypeRejected: 'Vi tek imot PNG, JPEG, GIF og WebP.',

--- a/apps/chat-widget/src/strings/pl.ts
+++ b/apps/chat-widget/src/strings/pl.ts
@@ -61,6 +61,7 @@ const pl: Strings = {
   attachDropHint: 'Upuść obraz tutaj',
   attachUploading: 'Przesyłanie…',
   attachFailed: 'Nie udało się przesłać obrazu. Spróbuj ponownie.',
+  sendFailed: 'Nie udało się wysłać wiadomości. Spróbuj ponownie.',
   attachRemoveAriaLabel: 'Usuń obraz',
   attachTooMany: 'Możesz dodać maksymalnie {n} obrazów.',
   attachTypeRejected: 'Przyjmujemy PNG, JPEG, GIF i WebP.',

--- a/apps/chat-widget/src/strings/pt.ts
+++ b/apps/chat-widget/src/strings/pt.ts
@@ -61,6 +61,7 @@ const pt: Strings = {
   attachDropHint: 'Solte a imagem aqui',
   attachUploading: 'A enviar…',
   attachFailed: 'A imagem não foi enviada. Tente de novo.',
+  sendFailed: 'A mensagem não foi enviada. Tente de novo.',
   attachRemoveAriaLabel: 'Remover a imagem',
   attachTooMany: 'Pode anexar até {n} imagens.',
   attachTypeRejected: 'Aceitamos PNG, JPEG, GIF e WebP.',

--- a/apps/chat-widget/src/strings/ro.ts
+++ b/apps/chat-widget/src/strings/ro.ts
@@ -61,6 +61,7 @@ const ro: Strings = {
   attachDropHint: 'Trage imaginea aici',
   attachUploading: 'Se încarcă…',
   attachFailed: 'Imaginea nu a fost încărcată. Încearcă din nou.',
+  sendFailed: 'Mesajul nu a fost trimis. Încearcă din nou.',
   attachRemoveAriaLabel: 'Elimină imaginea',
   attachTooMany: 'Poți atașa până la {n} imagini.',
   attachTypeRejected: 'Acceptăm PNG, JPEG, GIF și WebP.',

--- a/apps/chat-widget/src/strings/sk.ts
+++ b/apps/chat-widget/src/strings/sk.ts
@@ -61,6 +61,7 @@ const sk: Strings = {
   attachDropHint: 'Presuňte obrázok sem',
   attachUploading: 'Nahráva sa…',
   attachFailed: 'Obrázok sa nepodarilo nahrať. Skúste to znova.',
+  sendFailed: 'Správu sa nepodarilo odoslať. Skúste to znova.',
   attachRemoveAriaLabel: 'Odstrániť obrázok',
   attachTooMany: 'Môžete pridať až {n} obrázkov.',
   attachTypeRejected: 'Prijímame PNG, JPEG, GIF a WebP.',

--- a/apps/chat-widget/src/strings/sv.ts
+++ b/apps/chat-widget/src/strings/sv.ts
@@ -61,6 +61,7 @@ const sv: Strings = {
   attachDropHint: 'Släpp bilden här',
   attachUploading: 'Laddar upp…',
   attachFailed: 'Bilden laddades inte upp. Försök igen.',
+  sendFailed: 'Meddelandet skickades inte. Försök igen.',
   attachRemoveAriaLabel: 'Ta bort bilden',
   attachTooMany: 'Du kan bifoga upp till {n} bilder.',
   attachTypeRejected: 'Vi tar PNG, JPEG, GIF och WebP.',

--- a/apps/chat-widget/src/strings/types.ts
+++ b/apps/chat-widget/src/strings/types.ts
@@ -70,6 +70,7 @@ export interface Strings {
   attachDropHint: string;
   attachUploading: string;
   attachFailed: string;
+  sendFailed: string;
   attachRemoveAriaLabel: string;
   attachTooMany: string;
   attachTypeRejected: string;

--- a/apps/chat-widget/src/styles.ts
+++ b/apps/chat-widget/src/styles.ts
@@ -1089,10 +1089,30 @@ const PRODUCT_LIST_CSS = String.raw`
 .composer-main textarea { flex: 1; }
 
 .composer-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 11.5px;
   line-height: 1.35;
+  font-weight: 500;
   color: var(--munin-danger);
   padding: 0 2px;
+}
+.composer-note-dot {
+  width: 5px;
+  height: 5px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: currentColor;
+}
+.composer-note-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.composer-note-close {
+  flex: 0 0 auto;
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .composer-atts {
@@ -1132,20 +1152,26 @@ const PRODUCT_LIST_CSS = String.raw`
 
 .att-chip-drop {
   position: absolute;
-  top: 1px;
-  right: 1px;
-  width: 16px;
-  height: 16px;
-  padding: 0;
+  top: 0;
+  right: 0;
+  padding: 1px 3px;
   border: none;
-  border-radius: 50%;
-  background: var(--munin-ink);
-  color: var(--munin-paper);
+  border-radius: var(--munin-r-control);
+  background: color-mix(in srgb, var(--munin-paper) 90%, transparent);
+  color: var(--munin-ink-mute);
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
-.att-chip-drop svg { width: 9px; height: 9px; fill: none; stroke: currentColor; stroke-width: 3; }
+.att-chip-drop svg {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
 
 .attach {
   width: 38px;

--- a/apps/chat-widget/src/ui.attachments.test.ts
+++ b/apps/chat-widget/src/ui.attachments.test.ts
@@ -126,7 +126,7 @@ describe('ui: attachment composer', () => {
     input.dispatchEvent(new Event('change'));
 
     await vi.waitFor(() => expect($$('.att-chip-error')).toHaveLength(1));
-    expect($('.composer-note').textContent).toBe(strings.attachFailed);
+    expect($('.composer-note-text').textContent).toBe(strings.attachFailed);
     expect($<HTMLButtonElement>('.send').disabled).toBe(true);
 
     $<HTMLTextAreaElement>('textarea').value = 'text anyway';
@@ -150,7 +150,7 @@ describe('ui: attachment composer', () => {
 
     expect(onUploadAttachment).not.toHaveBeenCalled();
     expect($$('.att-chip')).toHaveLength(0);
-    expect($('.composer-note').textContent).toBe(strings.attachTypeRejected);
+    expect($('.composer-note-text').textContent).toBe(strings.attachTypeRejected);
   });
 
   it('drops a chip on its remove button', async () => {
@@ -254,5 +254,129 @@ describe('ui: attachment bubbles', () => {
     expect(
       $<HTMLImageElement>('[data-message-id="m6"] .msg-att img').getAttribute('src'),
     ).toBeNull();
+  });
+});
+
+describe('ui: drag-and-drop hint', () => {
+  function dragEvent(type: string, init: { relatedTarget?: EventTarget | null } = {}): Event {
+    const e = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(e, 'dataTransfer', {
+      value: { types: ['Files'], files: [] },
+      configurable: true,
+    });
+    if ('relatedTarget' in init) {
+      Object.defineProperty(e, 'relatedTarget', {
+        value: init.relatedTarget,
+        configurable: true,
+      });
+    }
+    return e;
+  }
+
+  it('hides the hint when the drag leaves the panel from over a descendant', () => {
+    controller = mountChat({
+      onSend: () => {},
+      onTypingIntent: () => {},
+      onUploadAttachment: () => Promise.resolve({ id: 'att' }),
+    });
+    controller.addMessages([msg({ id: 'm1', role: 'end_user', body: 'hello' })]);
+
+    const chat = $('.chat');
+    const inner = $('[data-message-id="m1"]');
+    chat.dispatchEvent(dragEvent('dragover'));
+    expect($('.drop-hint').hidden).toBe(false);
+
+    inner.dispatchEvent(dragEvent('dragleave', { relatedTarget: document.body }));
+    expect($('.drop-hint').hidden).toBe(true);
+  });
+
+  it('hides the hint when the drag leaves the window entirely', () => {
+    controller = mountChat({
+      onSend: () => {},
+      onTypingIntent: () => {},
+      onUploadAttachment: () => Promise.resolve({ id: 'att' }),
+    });
+
+    const chat = $('.chat');
+    chat.dispatchEvent(dragEvent('dragover'));
+    expect($('.drop-hint').hidden).toBe(false);
+
+    chat.dispatchEvent(dragEvent('dragleave', { relatedTarget: null }));
+    expect($('.drop-hint').hidden).toBe(true);
+  });
+
+  it('keeps the hint while the drag moves between elements inside the panel', () => {
+    controller = mountChat({
+      onSend: () => {},
+      onTypingIntent: () => {},
+      onUploadAttachment: () => Promise.resolve({ id: 'att' }),
+    });
+    controller.addMessages([msg({ id: 'm1', role: 'end_user', body: 'hello' })]);
+
+    const chat = $('.chat');
+    const inner = $('[data-message-id="m1"]');
+    chat.dispatchEvent(dragEvent('dragover'));
+    expect($('.drop-hint').hidden).toBe(false);
+
+    chat.dispatchEvent(dragEvent('dragleave', { relatedTarget: inner }));
+    expect($('.drop-hint').hidden).toBe(false);
+  });
+});
+
+describe('ui: composer note', () => {
+  it('keeps the note up until it is dismissed rather than timing out', async () => {
+    vi.useFakeTimers();
+    try {
+      controller = mountChat({
+        onSend: () => {},
+        onTypingIntent: () => {},
+        onUploadAttachment: () => Promise.reject(new Error('boom')),
+      });
+      const input = $<HTMLInputElement>('.attach-input');
+      Object.defineProperty(input, 'files', { value: [pngFile()], configurable: true });
+      input.dispatchEvent(new Event('change'));
+      await vi.waitFor(() => expect($('.composer-note').hidden).toBe(false));
+
+      vi.advanceTimersByTime(60_000);
+      expect($('.composer-note').hidden).toBe(false);
+
+      $<HTMLButtonElement>('.composer-note-close').click();
+      expect($('.composer-note').hidden).toBe(true);
+      expect($('.composer-note-text').textContent).toBe('');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('marks the note as an alert so assistive tech announces it', () => {
+    controller = mountChat({ onSend: () => {}, onTypingIntent: () => {} });
+    expect($('.composer-note').getAttribute('role')).toBe('alert');
+  });
+
+  it('surfaces a send failure through the same note', () => {
+    controller = mountChat({ onSend: () => {}, onTypingIntent: () => {} });
+    controller.showComposerError(strings.sendFailed);
+    expect($('.composer-note').hidden).toBe(false);
+    expect($('.composer-note-text').textContent).toBe(strings.sendFailed);
+  });
+
+  it('clears the note once a message actually goes out', async () => {
+    const onSend = vi.fn();
+    controller = mountChat({
+      onSend,
+      onTypingIntent: () => {},
+      onUploadAttachment: () => Promise.reject(new Error('boom')),
+    });
+    const input = $<HTMLInputElement>('.attach-input');
+    Object.defineProperty(input, 'files', { value: [pngFile()], configurable: true });
+    input.dispatchEvent(new Event('change'));
+    await vi.waitFor(() => expect($('.composer-note').hidden).toBe(false));
+
+    $<HTMLTextAreaElement>('textarea').value = 'sending anyway';
+    $<HTMLTextAreaElement>('textarea').dispatchEvent(new Event('input'));
+    $('.composer').dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+
+    expect(onSend).toHaveBeenCalledWith('sending anyway', []);
+    expect($('.composer-note').hidden).toBe(true);
   });
 });

--- a/apps/chat-widget/src/ui.ts
+++ b/apps/chat-widget/src/ui.ts
@@ -53,6 +53,7 @@ export interface UiController {
   setAgentTyping(isTyping: boolean): void;
   setConnectionState(state: ConnectionLabel): void;
   setSending(sending: boolean): void;
+  showComposerError(text: string): void;
   setPastConversations(convs: ConversationSummary[]): void;
   setConversation(envelope: ConversationEnvelope | null): void;
   setLauncherUnread(count: number): void;
@@ -72,7 +73,6 @@ export interface UiController {
 }
 
 const TYPING_IDLE_MS = 800;
-const COMPOSER_NOTE_MS = 5000;
 const ATTACHMENT_MB_MAX = Math.floor(ATTACHMENT_BYTES_MAX / (1024 * 1024));
 
 interface PendingAttachment {
@@ -470,7 +470,6 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
   let sendingNow = false;
   let pendingAttachments: PendingAttachment[] = [];
   let attachCounter = 0;
-  let composerNoteTimer: ReturnType<typeof setTimeout> | null = null;
 
   let reconnectGraceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -550,14 +549,13 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
   }
 
   function showComposerNote(text: string): void {
-    panel.composerNoteEl.textContent = text;
+    panel.composerNoteTextEl.textContent = text;
     panel.composerNoteEl.hidden = false;
-    if (composerNoteTimer) clearTimeout(composerNoteTimer);
-    composerNoteTimer = setTimeout(() => {
-      panel.composerNoteEl.hidden = true;
-      panel.composerNoteEl.textContent = '';
-      composerNoteTimer = null;
-    }, COMPOSER_NOTE_MS);
+  }
+
+  function clearComposerNote(): void {
+    panel.composerNoteEl.hidden = true;
+    panel.composerNoteTextEl.textContent = '';
   }
 
   function renderAttachmentTray(): void {
@@ -582,7 +580,8 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
       drop.type = 'button';
       drop.className = 'att-chip-drop';
       drop.setAttribute('aria-label', strings.attachRemoveAriaLabel);
-      drop.innerHTML = '<svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18" /></svg>';
+      drop.innerHTML =
+        '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 6 6 18" /><path d="m6 6 12 12" /></svg>';
       drop.addEventListener('click', () => removeAttachment(item.key));
       chip.appendChild(drop);
       panel.attachTrayEl.appendChild(chip);
@@ -674,6 +673,7 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
     panel.lightboxImg.alt = '';
   }
 
+  panel.composerNoteCloseBtn.addEventListener('click', () => clearComposerNote());
   panel.attachBtn.addEventListener('click', () => {
     panel.attachInput.click();
   });
@@ -695,7 +695,8 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
     panel.dropHintEl.hidden = false;
   });
   panel.chatEl.addEventListener('dragleave', (e) => {
-    if (e.target !== panel.chatEl && panel.chatEl.contains(e.target as Node)) return;
+    const next = e.relatedTarget;
+    if (next instanceof Node && panel.chatEl.contains(next)) return;
     panel.dropHintEl.hidden = true;
   });
   panel.chatEl.addEventListener('drop', (e) => {
@@ -727,6 +728,7 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
     emailSaved = null;
     conversationEnvelope = null;
     clearAttachments();
+    clearComposerNote();
     closeLightbox();
     refreshComposerState();
     paintChatHead();
@@ -796,6 +798,7 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
     const attachmentIds = readyAttachmentIds();
     panel.textarea.value = '';
     clearAttachments();
+    clearComposerNote();
     autoGrow(panel.textarea);
     refreshComposerState();
     if (typingIdleTimer) {
@@ -809,7 +812,6 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
   function destroy(): void {
     if (agentTypingTimer) clearTimeout(agentTypingTimer);
     if (typingIdleTimer) clearTimeout(typingIdleTimer);
-    if (composerNoteTimer) clearTimeout(composerNoteTimer);
     clearAttachments();
     stopCallTimer();
     unlockBodyScroll();
@@ -841,6 +843,7 @@ export function mount(config: WidgetConfig, strings: Strings, hooks: UiHooks): U
     setAgentTyping,
     setConnectionState,
     setSending,
+    showComposerError: showComposerNote,
     setPastConversations,
     setConversation,
     setLauncherUnread,
@@ -1155,6 +1158,8 @@ interface PanelHandles {
   attachInput: HTMLInputElement;
   attachTrayEl: HTMLDivElement;
   composerNoteEl: HTMLDivElement;
+  composerNoteTextEl: HTMLSpanElement;
+  composerNoteCloseBtn: HTMLButtonElement;
   dropHintEl: HTMLDivElement;
   lightboxEl: HTMLDivElement;
   lightboxImg: HTMLImageElement;
@@ -1290,7 +1295,11 @@ function renderPanel(config: WidgetConfig, strings: Strings): PanelHandles {
     </div>
     <form class="composer">
       <div class="composer-main">
-        <div class="composer-note" hidden></div>
+        <div class="composer-note" role="alert" hidden>
+          <span class="composer-note-dot" aria-hidden="true"></span>
+          <span class="composer-note-text"></span>
+          <button type="button" class="composer-note-close">${escapeHtml(strings.closeAriaLabel)}</button>
+        </div>
         <div class="composer-atts" hidden></div>
         <textarea rows="1" autocomplete="off" autocorrect="off" placeholder="${escapeAttr(strings.composerPlaceholder)}" aria-label="${escapeAttr(strings.messageAriaLabel)}"></textarea>
       </div>
@@ -1354,6 +1363,8 @@ function renderPanel(config: WidgetConfig, strings: Strings): PanelHandles {
   const attachInput = chatEl.querySelector('.attach-input') as HTMLInputElement;
   const attachTrayEl = chatEl.querySelector('.composer-atts') as HTMLDivElement;
   const composerNoteEl = chatEl.querySelector('.composer-note') as HTMLDivElement;
+  const composerNoteTextEl = chatEl.querySelector('.composer-note-text') as HTMLSpanElement;
+  const composerNoteCloseBtn = chatEl.querySelector('.composer-note-close') as HTMLButtonElement;
   const dropHintEl = chatEl.querySelector('.drop-hint') as HTMLDivElement;
   const lightboxEl = chatEl.querySelector('.lightbox') as HTMLDivElement;
   const lightboxImg = chatEl.querySelector('.lightbox-img') as HTMLImageElement;
@@ -1412,6 +1423,8 @@ function renderPanel(config: WidgetConfig, strings: Strings): PanelHandles {
     attachInput,
     attachTrayEl,
     composerNoteEl,
+    composerNoteTextEl,
+    composerNoteCloseBtn,
     dropHintEl,
     lightboxEl,
     lightboxImg,

--- a/apps/chat-widget/src/upload.ts
+++ b/apps/chat-widget/src/upload.ts
@@ -1,19 +1,22 @@
+import {
+  CONV_ATTACHMENT_BYTES_MAX,
+  CONV_ATTACHMENT_MIME_ALLOWLIST,
+  CONV_ATTACHMENT_PER_MESSAGE_MAX,
+  attachmentRejectionFor,
+  type AttachmentRejection,
+} from '@getmunin/types';
+
 const MAX_EDGE_PX = 1600;
 const SKIP_REENCODE_BELOW_BYTES = 128 * 1024;
 const PASSTHROUGH_MIMES = new Set(['image/gif']);
 
-export const ATTACHMENT_MIME_ALLOWLIST: readonly string[] = [
-  'image/png',
-  'image/jpeg',
-  'image/gif',
-  'image/webp',
-];
+export const ATTACHMENT_MIME_ALLOWLIST = CONV_ATTACHMENT_MIME_ALLOWLIST;
 
-export const ATTACHMENT_BYTES_MAX = 10 * 1024 * 1024;
+export const ATTACHMENT_BYTES_MAX = CONV_ATTACHMENT_BYTES_MAX;
 
-export const ATTACHMENT_PER_MESSAGE_MAX = 10;
+export const ATTACHMENT_PER_MESSAGE_MAX = CONV_ATTACHMENT_PER_MESSAGE_MAX;
 
-export type AttachmentRejection = 'mime' | 'too_large';
+export type { AttachmentRejection };
 
 export interface PreparedUpload {
   blob: Blob;
@@ -28,15 +31,11 @@ export interface PresignedUploadTarget {
 }
 
 export function rejectionFor(file: File): AttachmentRejection | null {
-  if (!ATTACHMENT_MIME_ALLOWLIST.includes(normalizeMime(file.type))) return 'mime';
-  if (file.size > ATTACHMENT_BYTES_MAX) return 'too_large';
-  return null;
+  return attachmentRejectionFor({ mime: file.type, sizeBytes: file.size });
 }
 
 export function rejectionForPrepared(prepared: PreparedUpload): AttachmentRejection | null {
-  if (!ATTACHMENT_MIME_ALLOWLIST.includes(normalizeMime(prepared.mime))) return 'mime';
-  if (prepared.blob.size > ATTACHMENT_BYTES_MAX) return 'too_large';
-  return null;
+  return attachmentRejectionFor({ mime: prepared.mime, sizeBytes: prepared.blob.size });
 }
 
 export async function prepareImageForUpload(file: File): Promise<PreparedUpload> {

--- a/apps/chat-widget/src/widget.ts
+++ b/apps/chat-widget/src/widget.ts
@@ -484,6 +484,7 @@ export function start(config: WidgetConfig): void {
       } else {
         console.warn('[munin-widget] send failed:', err);
       }
+      ui.showComposerError(strings.sendFailed);
     } finally {
       ui.setSending(false);
     }

--- a/packages/agent-host/src/curator-attachments.test.ts
+++ b/packages/agent-host/src/curator-attachments.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { conversationIdOf } from './runner.service.ts';
+
+describe('conversationIdOf', () => {
+  it('reads the conversation a conv-scoped curator job was queued for', () => {
+    expect(
+      conversationIdOf({ sourceEventPayload: { conversationId: 'ccv_1', channelType: 'chat' } }),
+    ).toBe('ccv_1');
+  });
+
+  it('returns null for a scheduled sweep that names no conversation', () => {
+    expect(conversationIdOf({ sourceEventPayload: { scope: 'org' } })).toBeNull();
+    expect(conversationIdOf({ sourceEventPayload: null })).toBeNull();
+    expect(conversationIdOf({ sourceEventPayload: undefined })).toBeNull();
+  });
+
+  it('ignores a non-string conversationId rather than coercing it', () => {
+    expect(conversationIdOf({ sourceEventPayload: { conversationId: 42 } })).toBeNull();
+    expect(conversationIdOf({ sourceEventPayload: { conversationId: '' } })).toBeNull();
+  });
+});

--- a/packages/agent-host/src/runner.service.ts
+++ b/packages/agent-host/src/runner.service.ts
@@ -38,6 +38,8 @@ import {
   defaultProvider,
   openHttpMcpClient,
   runSkillPass,
+  parseAttachments,
+  type ConversationAttachment,
   type ExternalToolSource,
   type AwaitingReplyConversation,
   type ConversationHandler,
@@ -123,6 +125,34 @@ export interface ResolvedProviderAuth {
   baseUrl?: string;
   models?: readonly string[];
   managed: boolean;
+}
+
+export function conversationIdOf(job: { sourceEventPayload: unknown }): string | null {
+  const payload = job.sourceEventPayload as { conversationId?: unknown } | null;
+  const id = payload?.conversationId;
+  return typeof id === 'string' && id.length > 0 ? id : null;
+}
+
+async function conversationAttachmentsFor(
+  job: CuratorJob,
+  rest: MuninRestClient,
+  log: { warn: (msg: string) => void },
+): Promise<ConversationAttachment[] | undefined> {
+  const conversationId = conversationIdOf(job);
+  if (!conversationId) return undefined;
+  let detail: Awaited<ReturnType<MuninRestClient['getConversation']>>;
+  try {
+    detail = await rest.getConversation(conversationId);
+  } catch (err) {
+    log.warn(`attachment hydration failed for ${conversationId}: ${describe(err)}`);
+    return undefined;
+  }
+  const out: ConversationAttachment[] = [];
+  for (const message of detail.messages) {
+    if (message.internal) continue;
+    out.push(...parseAttachments(message.attachments).filter((a) => a.url !== null));
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 export function resolveModelTiers(
@@ -673,6 +703,7 @@ export class AgentHostRunner implements OnApplicationBootstrap, OnModuleDestroy 
             model,
             skillUri: job.jobUri,
             userPrompt: job.userPrompt,
+            userPromptAttachments: await conversationAttachmentsFor(job, opts.rest, log),
             assistantName: job.assistantName,
             maxToolIterations: CURATOR_MAX_TOOL_ITERATIONS,
             maxHistoryChars: opts.config.maxHistoryChars,

--- a/packages/agent-runtime/src/skill-pass.test.ts
+++ b/packages/agent-runtime/src/skill-pass.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { runSkillPass, withAllowedToolPrefixes, type SkillReader } from './skill-pass.ts';
-import type { McpTool, McpToolHandle, McpToolResult } from './types.ts';
+import type {
+  ChatMessage,
+  McpTool,
+  McpToolHandle,
+  McpToolResult,
+  ProviderResponse,
+} from './types.ts';
 
 const noopMcp: McpToolHandle = {
   listTools: () => Promise.resolve([]),
@@ -79,5 +85,70 @@ describe('runSkillPass', () => {
       callTool: () => Promise.resolve({ content: [] }),
     };
     expect(withAllowedToolPrefixes(inner, [])).toBe(inner);
+  });
+
+  it('puts conversation images on the synthetic user turn so the curator can see them', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => '3' },
+        arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3]).buffer),
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const seen: ChatMessage[][] = [];
+    const provider = (args: { messages: ChatMessage[] }): Promise<ProviderResponse> => {
+      seen.push(args.messages);
+      return Promise.resolve({
+        message: { role: 'assistant', content: 'done' },
+        finishReason: 'stop',
+      });
+    };
+    try {
+      const result = await runSkillPass({
+        mcp: noopMcp,
+        skills: { readSkill: () => Promise.resolve('# skill body') },
+        providerBaseUrl: 'https://api.anthropic.com',
+        providerApiKey: 'k',
+        model: 'm',
+        skillUri: 'skill://conv/set-topic-and-title',
+        userPrompt: 'title this conversation',
+        userPromptAttachments: [
+          { mime: 'image/png', url: 'https://assets.example.com/a.png', name: 'a.png' },
+        ],
+        providerImpl: provider,
+      });
+      expect(result.ok).toBe(true);
+      expect(fetchMock).toHaveBeenCalledWith('https://assets.example.com/a.png');
+      const userTurn = seen[0]?.find((m) => m.role === 'user');
+      expect(userTurn?.images).toHaveLength(1);
+      expect(userTurn?.images?.[0]?.mime).toBe('image/png');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('leaves the user turn imageless when the job names no conversation attachments', async () => {
+    const seen: ChatMessage[][] = [];
+    const provider = (args: { messages: ChatMessage[] }): Promise<ProviderResponse> => {
+      seen.push(args.messages);
+      return Promise.resolve({
+        message: { role: 'assistant', content: 'done' },
+        finishReason: 'stop',
+      });
+    };
+    const result = await runSkillPass({
+      mcp: noopMcp,
+      skills: { readSkill: () => Promise.resolve('# skill body') },
+      providerBaseUrl: 'https://api.anthropic.com',
+      providerApiKey: 'k',
+      model: 'm',
+      skillUri: 'skill://conv/set-topic-and-title',
+      userPrompt: 'title this conversation',
+      providerImpl: provider,
+    });
+    expect(result.ok).toBe(true);
+    expect(seen[0]?.find((m) => m.role === 'user')?.images).toBeUndefined();
   });
 });

--- a/packages/agent-runtime/src/skill-pass.ts
+++ b/packages/agent-runtime/src/skill-pass.ts
@@ -1,7 +1,13 @@
 import { assistantNamePreamble } from './conversation-handler.ts';
 import { classifyProviderError, type ProviderErrorCode } from './providers/transport.ts';
 import { runAgent } from './runtime.ts';
-import type { McpTool, McpToolHandle, McpToolResult, Provider } from './types.ts';
+import type {
+  ConversationAttachment,
+  McpTool,
+  McpToolHandle,
+  McpToolResult,
+  Provider,
+} from './types.ts';
 
 export interface SkillReader {
   readSkill(uri: string): Promise<string | null>;
@@ -15,6 +21,7 @@ export interface SkillPassOptions {
   model: string;
   skillUri: string;
   userPrompt: string;
+  userPromptAttachments?: ConversationAttachment[];
   assistantName?: string | null;
   maxToolIterations?: number;
   maxHistoryChars?: number;
@@ -91,6 +98,9 @@ export async function runSkillPass(opts: SkillPassOptions): Promise<SkillPassRes
           authorType: 'user',
           body: opts.userPrompt,
           createdAt: new Date().toISOString(),
+          ...(opts.userPromptAttachments?.length
+            ? { attachments: opts.userPromptAttachments }
+            : {}),
         },
       ],
       mcp,

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -39,7 +39,8 @@
     "openapi:generate": "node --import @swc-node/register/esm-register ./scripts/generate-openapi.ts",
     "docs:generate": "pnpm openapi:generate && node --import @swc-node/register/esm-register ./scripts/generate-docs-fixtures.ts",
     "test:self-service-mcp": "node --import @swc-node/register/esm-register ./scripts/test-self-service-mcp.ts",
-    "mcp:sweep": "node --import @swc-node/register/esm-register ./scripts/mcp-sweep.ts"
+    "mcp:sweep": "node --import @swc-node/register/esm-register ./scripts/mcp-sweep.ts",
+    "backfill:inline-email-images": "node --import @swc-node/register/esm-register ./scripts/backfill-inline-email-images.ts"
   },
   "dependencies": {
     "@better-auth/oauth-provider": "^1.7.2",

--- a/packages/backend-core/scripts/backfill-inline-email-images.ts
+++ b/packages/backend-core/scripts/backfill-inline-email-images.ts
@@ -1,0 +1,74 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { ActorIdentity, withContext, type RequestContext } from '@getmunin/core';
+import { createDb, schema } from '@getmunin/db';
+import { AppModule } from '../src/app.module.ts';
+import { InlineImageBackfillService } from '../src/modules/conv/attachments/inline-image-backfill.service.ts';
+
+const BATCH = 100;
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main(): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error('DATABASE_URL is required');
+
+  const app = await NestFactory.create(AppModule, { logger: ['error', 'warn'] });
+  await app.init();
+  const backfill = app.get(InlineImageBackfillService);
+  const db = createDb(url);
+
+  const orgRows = await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+    return tx.select({ id: schema.orgs.id, name: schema.orgs.name }).from(schema.orgs);
+  });
+
+  let totalMessages = 0;
+  let totalImages = 0;
+
+  for (const org of orgRows) {
+    const runInOrg = <T>(fn: () => Promise<T>): Promise<T> =>
+      db.transaction(async (tx) => {
+        await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+        await tx.execute(sql`SELECT set_config('app.org_id', ${org.id}, true)`);
+        await tx.execute(sql`SELECT set_config('app.end_user_id', '', true)`);
+        const actor = new ActorIdentity('system', 'inline-image-backfill', org.id, ['*'], ['admin']);
+        const ctx: RequestContext = { db: tx, actor, correlationId: randomUUID() };
+        return withContext(ctx, fn);
+      });
+
+    const remaining = await runInOrg(() => backfill.countRemaining());
+    if (remaining === 0) continue;
+    console.log(`org ${org.id} (${org.name}): ${remaining} message(s) with inlined images`);
+    if (DRY_RUN) continue;
+
+    for (;;) {
+      const result = await runInOrg(() => backfill.run({ limit: BATCH }));
+      if (result.converted === 0) {
+        if (result.leftInline > 0) {
+          console.log(
+            `  ${result.leftInline} inlined image(s) intentionally left in place (too small, or not an accepted type)`,
+          );
+        }
+        if (result.failed > 0) console.warn(`  ${result.failed} message(s) failed; see warnings`);
+        break;
+      }
+      totalMessages += result.converted;
+      totalImages += result.imagesExtracted;
+      console.log(
+        `  converted ${result.converted} message(s), extracted ${result.imagesExtracted} image(s)`,
+      );
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log('dry run: nothing was written');
+  } else {
+    console.log(`done: ${totalMessages} message(s) rewritten, ${totalImages} image(s) extracted`);
+  }
+  await app.close();
+  process.exit(0);
+}
+
+await main();

--- a/packages/backend-core/src/agent/in-process-rest-client.integration.test.ts
+++ b/packages/backend-core/src/agent/in-process-rest-client.integration.test.ts
@@ -153,6 +153,56 @@ const skipReason = TEST_URL
     expect(posted!.metadata.components).toEqual(components);
   });
 
+  it('carries hydrated message attachments through getConversation and toRuntimeHistory', async () => {
+    const dispatcher = new WebhookDispatcher();
+    const claims = new ConversationClaimsService(dispatcher);
+    const hydrated = {
+      id: 'cva_inprocess1',
+      name: 'receipt.png',
+      mime: 'image/png',
+      sizeBytes: 2048,
+      width: 800,
+      height: 600,
+      thumbnailWidth: 320,
+      inline: false,
+      cid: null,
+      deleted: false,
+      url: 'https://assets.example.com/receipt.png',
+      thumbnailUrl: 'https://assets.example.com/receipt-thumb.png',
+    };
+    const conv = new ConvService(
+      dispatcher,
+      claims,
+      new CuratorJobsService(dispatcher),
+      new AlertsService(dispatcher),
+      { ...stubAttachmentGateway(), hydrateRaw: () => [hydrated] },
+    );
+    const factory = new InProcessMuninRestClientFactoryService(
+      db,
+      conv,
+      claims,
+      new CuratorJobsService(dispatcher),
+    );
+    const client = factory.forOrg(orgId);
+
+    const target = await freshConversation(103);
+    await db.insert(schema.convMessages).values({
+      orgId,
+      conversationId: target,
+      authorType: 'end_user',
+      authorId: endUserId,
+      body: '',
+    });
+
+    const detail = await client.getConversation(target);
+    expect(detail.messages[0]!.attachments).toEqual([hydrated]);
+
+    const history = client.toRuntimeHistory(detail);
+    expect(history[0]!.attachments).toEqual([
+      { mime: 'image/png', url: 'https://assets.example.com/receipt.png', name: 'receipt.png' },
+    ]);
+  });
+
   it('leaves metadata empty when postAgentMessage carries no components', async () => {
     const dispatcher = new WebhookDispatcher();
     const claims = new ConversationClaimsService(dispatcher);

--- a/packages/backend-core/src/agent/in-process-rest-client.ts
+++ b/packages/backend-core/src/agent/in-process-rest-client.ts
@@ -22,6 +22,7 @@ import {
   type FailCuratorJobInput,
   type MuninRestClient,
   type UpdateCuratorJobProgressInput,
+  parseAttachments,
 } from '@getmunin/agent-runtime';
 import type { ConversationMessage, SetDraftReplyOpts } from '@getmunin/agent-runtime';
 import { ConvService } from '../modules/conv/conv.service.ts';
@@ -133,6 +134,7 @@ function buildClient(opts: BuildOptions): MuninRestClient {
             body: m.body,
             createdAt: m.createdAt,
             internal: m.internal,
+            attachments: m.attachments,
           })),
         };
       });
@@ -313,13 +315,17 @@ function buildClient(opts: BuildOptions): MuninRestClient {
     },
 
     toRuntimeHistory(detail: ConversationDetail): ConversationMessage[] {
-      return detail.messages.map((m) => ({
-        id: m.id,
-        authorType: m.authorType,
-        body: m.body,
-        createdAt: m.createdAt,
-        internal: m.internal,
-      }));
+      return detail.messages.map((m) => {
+        const attachments = parseAttachments(m.attachments);
+        return {
+          id: m.id,
+          authorType: m.authorType,
+          body: m.body,
+          createdAt: m.createdAt,
+          internal: m.internal,
+          ...(attachments.length > 0 ? { attachments } : {}),
+        };
+      });
     },
   };
 }

--- a/packages/backend-core/src/modules/cms/cms.service.test.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.test.ts
@@ -1314,6 +1314,36 @@ class StubStorage implements AssetStorage {
       expect(list.find((a) => a.id === handle.id)).toBeFalsy();
     });
 
+    it('deleteAsset removes the derived variant objects too, not just the master', async () => {
+      const handle = await run(() =>
+        svc.requestAssetUpload({ name: 'wide.png', mime: 'image/png', sizeBytes: 2048 }),
+      );
+      const variantKeys = [
+        `${handle.storageKey}.w320.webp`,
+        `${handle.storageKey}.w640.webp`,
+      ];
+      await db.execute(sql`
+        UPDATE cms_assets
+        SET variants = ${JSON.stringify(
+          variantKeys.map((key, i) => ({
+            width: i === 0 ? 320 : 640,
+            height: 100,
+            format: 'webp',
+            storageKey: key,
+            publicUrl: `https://cdn.test/${key}`,
+            sizeBytes: 10,
+          })),
+        )}::jsonb
+        WHERE id = ${handle.id}
+      `);
+
+      storage.deletes.length = 0;
+      await run(() => svc.deleteAsset({ id: handle.id }));
+
+      expect(storage.deletes).toContain(handle.storageKey);
+      for (const key of variantKeys) expect(storage.deletes).toContain(key);
+    });
+
     it('deleteAsset returns 404 for unknown id', async () => {
       await expect(run(() => svc.deleteAsset({ id: randomUUID() }))).rejects.toThrow(
         NotFoundException,

--- a/packages/backend-core/src/modules/cms/cms.service.ts
+++ b/packages/backend-core/src/modules/cms/cms.service.ts
@@ -1475,8 +1475,12 @@ export class CmsService {
       );
     }
 
-    await this.storage.delete(rows[0].storageKey).catch(() => {
-    });
+    for (const key of [rows[0].storageKey, ...rows[0].variants.map((v) => v.storageKey)]) {
+      if (!key) continue;
+      await this.storage.delete(key).catch((err: unknown) => {
+        console.warn(`[cms] could not remove ${key} for asset ${input.id}: ${describeError(err)}`);
+      });
+    }
     await ctx.db.delete(schema.cmsAssets).where(eq(schema.cmsAssets.id, input.id));
     return { deleted: true };
   }

--- a/packages/backend-core/src/modules/conv/attachments/attachment-gc.worker.ts
+++ b/packages/backend-core/src/modules/conv/attachments/attachment-gc.worker.ts
@@ -1,0 +1,122 @@
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { type Db } from '@getmunin/db';
+import { sql } from 'drizzle-orm';
+import {
+  describeError,
+  parseEnvDisableFlag,
+  parseEnvInt,
+  type AssetStorage,
+} from '@getmunin/core';
+import { DB } from '../../../common/db/db.module.ts';
+import { STORAGE } from '../../../common/storage/storage.token.ts';
+import { withSchedulerLock } from '../../../common/scheduler-lock/index.ts';
+
+const DEFAULT_INTERVAL_MS = 15 * 60_000;
+const DEFAULT_GRACE_MINUTES = 60;
+const MAX_PER_TICK = 200;
+
+interface AbandonedRow extends Record<string, unknown> {
+  id: string;
+  storage_key: string | null;
+  variants: unknown;
+}
+
+@Injectable()
+export class AttachmentGcWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(AttachmentGcWorker.name);
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private readonly disabled =
+    parseEnvDisableFlag('MUNIN_ATTACHMENT_GC_WORKER_DISABLED') || process.env.NODE_ENV === 'test';
+  private readonly intervalMs = parseEnvInt({
+    name: 'MUNIN_ATTACHMENT_GC_WORKER_INTERVAL_MS',
+    default: DEFAULT_INTERVAL_MS,
+  });
+  private readonly graceMinutes = parseEnvInt({
+    name: 'MUNIN_ATTACHMENT_GC_GRACE_MINUTES',
+    default: DEFAULT_GRACE_MINUTES,
+  });
+
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    @Inject(STORAGE) private readonly storage: AssetStorage,
+  ) {}
+
+  onModuleInit(): void {
+    if (this.disabled) return;
+    this.logger.log(
+      `attachment gc worker starting (every ${this.intervalMs}ms, grace ${this.graceMinutes}m)`,
+    );
+    this.timer = setInterval(() => {
+      void withSchedulerLock(this.db, 'attachment-gc-worker', () => this.tick());
+    }, this.intervalMs);
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async tick(): Promise<{ collected: number }> {
+    if (this.running) return { collected: 0 };
+    this.running = true;
+    try {
+      const rows = await this.claimAbandoned();
+      let collected = 0;
+      for (const row of rows) {
+        for (const key of storageKeysOf(row)) {
+          await this.storage.delete(key).catch((err: unknown) => {
+            this.logger.warn(`could not purge abandoned object ${key}: ${describeError(err)}`);
+          });
+        }
+        collected += 1;
+      }
+      if (collected > 0) {
+        this.logger.log(`collected ${collected} abandoned attachment upload(s)`);
+      }
+      return { collected };
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async claimAbandoned(): Promise<AbandonedRow[]> {
+    return this.db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.bypass_rls', 'on', true)`);
+      const rows = await tx.execute<AbandonedRow>(sql`
+        DELETE FROM conv_attachments
+        WHERE id IN (
+          SELECT id FROM conv_attachments
+          WHERE message_id IS NULL
+            AND deleted_at IS NULL
+            AND created_at < now() - make_interval(mins => ${this.graceMinutes})
+          ORDER BY created_at
+          LIMIT ${MAX_PER_TICK}
+          FOR UPDATE SKIP LOCKED
+        )
+        RETURNING id, storage_key, variants
+      `);
+      return toArray(rows);
+    });
+  }
+}
+
+function storageKeysOf(row: AbandonedRow): string[] {
+  const keys: string[] = [];
+  if (row.storage_key) keys.push(row.storage_key);
+  if (Array.isArray(row.variants)) {
+    for (const v of row.variants) {
+      if (v && typeof v === 'object') {
+        const key = (v as { storageKey?: unknown }).storageKey;
+        if (typeof key === 'string' && key.length > 0) keys.push(key);
+      }
+    }
+  }
+  return keys;
+}
+
+function toArray<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  const rows = (result as { rows?: unknown }).rows;
+  return Array.isArray(rows) ? (rows as T[]) : [];
+}

--- a/packages/backend-core/src/modules/conv/attachments/conv-attachments.constants.ts
+++ b/packages/backend-core/src/modules/conv/attachments/conv-attachments.constants.ts
@@ -1,13 +1,8 @@
-export const CONV_ATTACHMENT_MIME_ALLOWLIST: readonly string[] = [
-  'image/png',
-  'image/jpeg',
-  'image/gif',
-  'image/webp',
-];
-
-export const CONV_ATTACHMENT_BYTES_MAX = 10 * 1024 * 1024;
-
-export const CONV_ATTACHMENT_PER_MESSAGE_MAX = 10;
+export {
+  CONV_ATTACHMENT_MIME_ALLOWLIST,
+  CONV_ATTACHMENT_BYTES_MAX,
+  CONV_ATTACHMENT_PER_MESSAGE_MAX,
+} from '@getmunin/types';
 
 export const CONV_ATTACHMENT_PENDING_PER_SESSION_MAX = 10;
 

--- a/packages/backend-core/src/modules/conv/attachments/conv-attachments.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/attachments/conv-attachments.integration.test.ts
@@ -13,7 +13,12 @@ import { createDb, runMigrations, schema } from '@getmunin/db';
 import { createApp } from '../../../bootstrap-app.ts';
 import { AppModule } from '../../../app.module.ts';
 import { ConvAttachmentsService } from './conv-attachments.service.ts';
-import { CONV_ATTACHMENT_PENDING_PER_SESSION_MAX } from './conv-attachments.constants.ts';
+import {
+  CONV_ATTACHMENT_INBOUND_BYTES_MIN,
+  CONV_ATTACHMENT_PENDING_PER_SESSION_MAX,
+} from './conv-attachments.constants.ts';
+import { AttachmentGcWorker } from './attachment-gc.worker.ts';
+import { InlineImageBackfillService } from './inline-image-backfill.service.ts';
 
 const TEST_URL = process.env.TEST_DATABASE_URL;
 const skipReason = TEST_URL
@@ -26,6 +31,8 @@ const skipReason = TEST_URL
   let db: ReturnType<typeof createDb>;
   let appDb: ReturnType<typeof createDb>;
   let service: ConvAttachmentsService;
+  let gc: AttachmentGcWorker;
+  let backfill: InlineImageBackfillService;
   let storageDir: string;
   let orgA: string;
   let orgB: string;
@@ -79,6 +86,8 @@ const skipReason = TEST_URL
     if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
     baseUrl = `http://127.0.0.1:${address.port}`;
     service = app.get(ConvAttachmentsService);
+    gc = app.get(AttachmentGcWorker);
+    backfill = app.get(InlineImageBackfillService);
   });
 
   afterAll(async () => {
@@ -141,6 +150,18 @@ const skipReason = TEST_URL
     })
       .png()
       .toBuffer();
+  }
+
+  async function noisyPngAboveInboundFloor(): Promise<Buffer> {
+    const width = 600;
+    const height = 400;
+    const raw = Buffer.alloc(width * height * 3);
+    for (let i = 0; i < raw.length; i += 1) raw[i] = (i * 2654435761) % 256;
+    const body = await sharp(raw, { raw: { width, height, channels: 3 } }).png().toBuffer();
+    if (body.length <= CONV_ATTACHMENT_INBOUND_BYTES_MIN) {
+      throw new Error(`fixture too small to exercise the backfill: ${body.length} bytes`);
+    }
+    return body;
   }
 
   async function uploadThroughPresignedUrl(uploadUrl: string, body: Buffer): Promise<Response> {
@@ -518,6 +539,189 @@ const skipReason = TEST_URL
     });
     const again = await asAdmin(orgA, () => service.delete({ id }));
     expect(again).toEqual({ deleted: true, id, alreadyDeleted: true });
+  });
+
+  it('garbage-collects an abandoned upload once past the grace period, bytes and all', async () => {
+    const body = await pngBytes(1200);
+    const { id, url } = await asAdmin(orgA, async () => {
+      const handle = await service.requestUpload({
+        conversationId: convA,
+        name: 'abandoned.png',
+        mime: 'image/png',
+        sizeBytes: body.length,
+      });
+      await uploadThroughPresignedUrl(handle.uploadUrl, body);
+      const dto = await service.completeUpload({ id: handle.id });
+      return { id: handle.id, url: dto.url! };
+    });
+
+    expect(await fetch(url.replace(/^https?:\/\/[^/]+/, baseUrl)).then((r) => r.status)).toBe(200);
+
+    const fresh = await gc.tick();
+    expect(fresh.collected).toBe(0);
+    const [stillThere] = await db
+      .select()
+      .from(schema.convAttachments)
+      .where(sql`id = ${id}`);
+    expect(stillThere).toBeTruthy();
+
+    await db.execute(
+      sql`UPDATE conv_attachments SET created_at = now() - interval '2 days' WHERE id = ${id}`,
+    );
+
+    const swept = await gc.tick();
+    expect(swept.collected).toBeGreaterThanOrEqual(1);
+
+    const rows = await db.select().from(schema.convAttachments).where(sql`id = ${id}`);
+    expect(rows).toHaveLength(0);
+    expect(await fetch(url.replace(/^https?:\/\/[^/]+/, baseUrl)).then((r) => r.status)).toBe(404);
+  });
+
+  it('never garbage-collects an attachment that is already on a message', async () => {
+    const body = await pngBytes(400);
+    const id = await asAdmin(orgA, async () => {
+      const handle = await service.requestUpload({
+        conversationId: convA,
+        name: 'kept.png',
+        mime: 'image/png',
+        sizeBytes: body.length,
+      });
+      await uploadThroughPresignedUrl(handle.uploadUrl, body);
+      await service.completeUpload({ id: handle.id });
+      await service.attachToMessage({
+        messageId: messageA,
+        conversationId: convA,
+        attachmentIds: [handle.id],
+      });
+      return handle.id;
+    });
+
+    await db.execute(
+      sql`UPDATE conv_attachments SET created_at = now() - interval '30 days' WHERE id = ${id}`,
+    );
+    await gc.tick();
+
+    const rows = await db.select().from(schema.convAttachments).where(sql`id = ${id}`);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('backfills a legacy inlined image out of body_html into a real attachment', async () => {
+    const body = await noisyPngAboveInboundFloor();
+    const dataUri = `data:image/png;base64,${body.toString('base64')}`;
+    const [legacy] = await db
+      .insert(schema.convMessages)
+      .values({
+        orgId: orgA,
+        conversationId: convA,
+        authorType: 'end_user',
+        authorId: 'cct_legacy',
+        body: 'see the screenshot',
+        bodyHtml: `<p>see the screenshot</p><img src="${dataUri}" alt="shot">`,
+      })
+      .returning();
+
+    const result = await asAdmin(orgA, () => backfill.run({ limit: 50 }));
+    expect(result.converted).toBeGreaterThanOrEqual(1);
+    expect(result.imagesExtracted).toBeGreaterThanOrEqual(1);
+
+    const [rewritten] = await db
+      .select({ bodyHtml: schema.convMessages.bodyHtml, attachments: schema.convMessages.attachments })
+      .from(schema.convMessages)
+      .where(sql`id = ${legacy!.id}`);
+    expect(rewritten!.bodyHtml).not.toContain('base64');
+    expect(rewritten!.bodyHtml).toContain('cid:munin-inline-');
+
+    const projection = rewritten!.attachments as Array<Record<string, unknown>>;
+    expect(projection).toHaveLength(1);
+    expect(projection[0]!.inline).toBe(true);
+    expect(JSON.stringify(projection)).not.toContain('/v1/c/a/');
+
+    const stored = await db
+      .select()
+      .from(schema.convAttachments)
+      .where(sql`message_id = ${legacy!.id}`);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.contentId).toBe(String(projection[0]!.cid));
+    expect(stored[0]!.sizeBytes).toBe(body.length);
+    expect(stored[0]!.inline).toBe(true);
+
+    const dto = service.toDto(stored[0]!);
+    const served = await fetch(dto.url!.replace(/^https?:\/\/[^/]+/, baseUrl));
+    expect(served.status).toBe(200);
+    expect(rewritten!.bodyHtml).toContain(`cid:${stored[0]!.contentId}`);
+  });
+
+  it('is idempotent: a second backfill pass finds nothing left to convert', async () => {
+    const body = await noisyPngAboveInboundFloor();
+    const dataUri = `data:image/png;base64,${body.toString('base64')}`;
+    await db.insert(schema.convMessages).values({
+      orgId: orgA,
+      conversationId: convA,
+      authorType: 'end_user',
+      authorId: 'cct_legacy',
+      body: 'twice',
+      bodyHtml: `<img src="${dataUri}">`,
+    });
+
+    const first = await asAdmin(orgA, () => backfill.run({ limit: 50 }));
+    expect(first.converted).toBeGreaterThanOrEqual(1);
+    const second = await asAdmin(orgA, () => backfill.run({ limit: 50 }));
+    expect(second.converted).toBe(0);
+    expect(second.imagesExtracted).toBe(0);
+  });
+
+  it('leaves a tracking pixel inlined and does not create an attachment for it', async () => {
+    const pixel = `data:image/gif;base64,${Buffer.alloc(40, 3).toString('base64')}`;
+    const [row] = await db
+      .insert(schema.convMessages)
+      .values({
+        orgId: orgA,
+        conversationId: convA,
+        authorType: 'end_user',
+        authorId: 'cct_legacy',
+        body: 'pixel only',
+        bodyHtml: `<img src="${pixel}" width="1" height="1">`,
+      })
+      .returning();
+
+    const result = await asAdmin(orgA, () => backfill.run({ limit: 50 }));
+    expect(result.leftInline).toBeGreaterThanOrEqual(1);
+
+    const stored = await db
+      .select()
+      .from(schema.convAttachments)
+      .where(sql`message_id = ${row!.id}`);
+    expect(stored).toHaveLength(0);
+
+    const [unchanged] = await db
+      .select({ bodyHtml: schema.convMessages.bodyHtml })
+      .from(schema.convMessages)
+      .where(sql`id = ${row!.id}`);
+    expect(unchanged!.bodyHtml).toContain('base64');
+  });
+
+  it('does not reach across orgs when backfilling under a tenant context', async () => {
+    const body = await noisyPngAboveInboundFloor();
+    const dataUri = `data:image/png;base64,${body.toString('base64')}`;
+    const [foreign] = await db
+      .insert(schema.convMessages)
+      .values({
+        orgId: orgB,
+        conversationId: convB,
+        authorType: 'end_user',
+        authorId: 'cct_foreign',
+        body: 'other org',
+        bodyHtml: `<img src="${dataUri}">`,
+      })
+      .returning();
+
+    await asAdmin(orgA, () => backfill.run({ limit: 50 }));
+
+    const [untouched] = await db
+      .select({ bodyHtml: schema.convMessages.bodyHtml })
+      .from(schema.convMessages)
+      .where(sql`id = ${foreign!.id}`);
+    expect(untouched!.bodyHtml).toContain('base64');
   });
 
   it('does not serve an attachment on a token minted for another org', async () => {

--- a/packages/backend-core/src/modules/conv/attachments/inline-data-uri.test.ts
+++ b/packages/backend-core/src/modules/conv/attachments/inline-data-uri.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { extractDataUriImages, htmlHasDataUriImage } from './inline-data-uri.ts';
+import {
+  CONV_ATTACHMENT_INBOUND_BYTES_MIN,
+  CONV_ATTACHMENT_PER_MESSAGE_MAX,
+} from './conv-attachments.constants.ts';
+
+function dataUri(mime: string, bytes: number): string {
+  return `data:${mime};base64,${Buffer.alloc(bytes, 7).toString('base64')}`;
+}
+
+const BIG = CONV_ATTACHMENT_INBOUND_BYTES_MIN + 1024;
+
+describe('extractDataUriImages', () => {
+  it('replaces an inlined image with a cid reference and hands back the bytes', () => {
+    const html = `<p>see</p><img src="${dataUri('image/png', BIG)}" alt="x">`;
+    const result = extractDataUriImages(html, 'cvm_1');
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0]!.mime).toBe('image/png');
+    expect(result.images[0]!.body.length).toBe(BIG);
+    expect(result.images[0]!.name).toBe('inline-1.png');
+    expect(result.html).toContain(`cid:${result.images[0]!.contentId}`);
+    expect(result.html).not.toContain('base64');
+  });
+
+  it('leaves a tracking-pixel-sized image inlined rather than promoting it to an attachment', () => {
+    const html = `<img src="${dataUri('image/gif', 40)}">`;
+    const result = extractDataUriImages(html, 'cvm_1');
+
+    expect(result.images).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+    expect(result.html).toBe(html);
+  });
+
+  it('leaves a disallowed type alone, so an svg payload is never promoted', () => {
+    const html = `<img src="${dataUri('image/svg+xml', BIG)}">`;
+    const result = extractDataUriImages(html, 'cvm_1');
+
+    expect(result.images).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+    expect(result.html).toBe(html);
+  });
+
+  it('stops at the per-message cap and leaves the remainder inlined', () => {
+    const one = `<img src="${dataUri('image/png', BIG)}">`;
+    const html = one.repeat(CONV_ATTACHMENT_PER_MESSAGE_MAX + 3);
+    const result = extractDataUriImages(html, 'cvm_1');
+
+    expect(result.images).toHaveLength(CONV_ATTACHMENT_PER_MESSAGE_MAX);
+    expect(result.skipped).toBe(3);
+    expect(result.html).toContain('base64');
+  });
+
+  it('gives every extracted image a distinct content id', () => {
+    const html = `<img src="${dataUri('image/png', BIG)}"><img src="${dataUri('image/jpeg', BIG)}">`;
+    const result = extractDataUriImages(html, 'cvm_1');
+
+    expect(result.images).toHaveLength(2);
+    expect(new Set(result.images.map((i) => i.contentId)).size).toBe(2);
+    for (const img of result.images) expect(result.html).toContain(`cid:${img.contentId}`);
+  });
+
+  it('is a no-op on html with no inlined images', () => {
+    const html = '<p>hello <img src="https://example.com/a.png"></p>';
+    const result = extractDataUriImages(html, 'cvm_1');
+    expect(result.images).toHaveLength(0);
+    expect(result.html).toBe(html);
+  });
+
+  it('detects inlined images without extracting, and the detector is not sticky across calls', () => {
+    const html = `<img src="${dataUri('image/png', BIG)}">`;
+    expect(htmlHasDataUriImage(html)).toBe(true);
+    expect(htmlHasDataUriImage(html)).toBe(true);
+    expect(htmlHasDataUriImage('<p>no</p>')).toBe(false);
+    expect(htmlHasDataUriImage(null)).toBe(false);
+  });
+});

--- a/packages/backend-core/src/modules/conv/attachments/inline-data-uri.ts
+++ b/packages/backend-core/src/modules/conv/attachments/inline-data-uri.ts
@@ -1,0 +1,79 @@
+import { randomUUID } from 'node:crypto';
+import { normalizeMime } from '../../../common/storage/asset-validation.ts';
+import {
+  CONV_ATTACHMENT_BYTES_MAX,
+  CONV_ATTACHMENT_INBOUND_BYTES_MIN,
+  CONV_ATTACHMENT_MIME_ALLOWLIST,
+  CONV_ATTACHMENT_PER_MESSAGE_MAX,
+} from './conv-attachments.constants.ts';
+
+const DATA_URI_RE = /data:(image\/[a-z0-9.+-]{1,32});base64,([A-Za-z0-9+/=]+)/gi;
+
+export interface ExtractedInlineImage {
+  mime: string;
+  body: Buffer;
+  contentId: string;
+  name: string;
+}
+
+export interface InlineExtraction {
+  html: string;
+  images: ExtractedInlineImage[];
+  skipped: number;
+}
+
+export function extractDataUriImages(html: string, messageId: string): InlineExtraction {
+  const images: ExtractedInlineImage[] = [];
+  let skipped = 0;
+  let index = 0;
+
+  const rewritten = html.replace(DATA_URI_RE, (match, rawMime: string, base64: string) => {
+    const mime = normalizeMime(rawMime);
+    if (!CONV_ATTACHMENT_MIME_ALLOWLIST.includes(mime)) {
+      skipped += 1;
+      return match;
+    }
+    if (images.length >= CONV_ATTACHMENT_PER_MESSAGE_MAX) {
+      skipped += 1;
+      return match;
+    }
+
+    let body: Buffer;
+    try {
+      body = Buffer.from(base64, 'base64');
+    } catch {
+      skipped += 1;
+      return match;
+    }
+    if (body.length < CONV_ATTACHMENT_INBOUND_BYTES_MIN || body.length > CONV_ATTACHMENT_BYTES_MAX) {
+      skipped += 1;
+      return match;
+    }
+
+    index += 1;
+    const contentId = `munin-inline-${messageId}-${index}-${randomUUID().slice(0, 8)}`;
+    images.push({
+      mime,
+      body,
+      contentId,
+      name: `inline-${index}.${extensionFor(mime)}`,
+    });
+    return `cid:${contentId}`;
+  });
+
+  return { html: rewritten, images, skipped };
+}
+
+export function htmlHasDataUriImage(html: string | null | undefined): boolean {
+  if (!html) return false;
+  DATA_URI_RE.lastIndex = 0;
+  return DATA_URI_RE.test(html);
+}
+
+function extensionFor(mime: string): string {
+  if (mime === 'image/jpeg') return 'jpg';
+  if (mime === 'image/png') return 'png';
+  if (mime === 'image/gif') return 'gif';
+  if (mime === 'image/webp') return 'webp';
+  return 'bin';
+}

--- a/packages/backend-core/src/modules/conv/attachments/inline-image-backfill.service.ts
+++ b/packages/backend-core/src/modules/conv/attachments/inline-image-backfill.service.ts
@@ -1,0 +1,101 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { schema } from '@getmunin/db';
+import { and, eq, isNotNull, like, sql } from 'drizzle-orm';
+import { describeError, getCurrentContext } from '@getmunin/core';
+import { ConvAttachmentsService } from './conv-attachments.service.ts';
+import { extractDataUriImages } from './inline-data-uri.ts';
+import { parseMessageAttachmentProjection } from './conv-attachments.projection.ts';
+
+export interface BackfillResult {
+  scanned: number;
+  converted: number;
+  imagesExtracted: number;
+  leftInline: number;
+  failed: number;
+}
+
+@Injectable()
+export class InlineImageBackfillService {
+  private readonly logger = new Logger(InlineImageBackfillService.name);
+
+  constructor(
+    @Inject(ConvAttachmentsService) private readonly attachments: ConvAttachmentsService,
+  ) {}
+
+  async run(input: { limit?: number } = {}): Promise<BackfillResult> {
+    const ctx = getCurrentContext();
+    const limit = Math.min(Math.max(input.limit ?? 100, 1), 500);
+    const rows = await ctx.db
+      .select({
+        id: schema.convMessages.id,
+        conversationId: schema.convMessages.conversationId,
+        bodyHtml: schema.convMessages.bodyHtml,
+        attachments: schema.convMessages.attachments,
+      })
+      .from(schema.convMessages)
+      .where(
+        and(
+          isNotNull(schema.convMessages.bodyHtml),
+          like(schema.convMessages.bodyHtml, '%data:image/%'),
+        ),
+      )
+      .orderBy(schema.convMessages.createdAt)
+      .limit(limit);
+
+    const result: BackfillResult = {
+      scanned: rows.length,
+      converted: 0,
+      imagesExtracted: 0,
+      leftInline: 0,
+      failed: 0,
+    };
+
+    for (const row of rows) {
+      if (!row.bodyHtml) continue;
+      const extraction = extractDataUriImages(row.bodyHtml, row.id);
+      result.leftInline += extraction.skipped;
+      if (extraction.images.length === 0) continue;
+
+      try {
+        const stored = [];
+        for (const image of extraction.images) {
+          stored.push(
+            await this.attachments.persistBytes({
+              conversationId: row.conversationId,
+              messageId: row.id,
+              name: image.name,
+              mime: image.mime,
+              body: image.body,
+              inline: true,
+              contentId: image.contentId,
+            }),
+          );
+        }
+
+        const existing = parseMessageAttachmentProjection(row.attachments);
+        const projection = [...existing, ...this.attachments.projectForMessage(stored)];
+        await ctx.db
+          .update(schema.convMessages)
+          .set({ bodyHtml: extraction.html, attachments: projection })
+          .where(eq(schema.convMessages.id, row.id));
+
+        result.converted += 1;
+        result.imagesExtracted += stored.length;
+      } catch (err) {
+        result.failed += 1;
+        this.logger.warn(`inline backfill failed for message ${row.id}: ${describeError(err)}`);
+      }
+    }
+
+    return result;
+  }
+
+  async countRemaining(): Promise<number> {
+    const ctx = getCurrentContext();
+    const [row] = await ctx.db.execute<{ n: number } & Record<string, unknown>>(sql`
+      SELECT count(*)::int AS n FROM conv_messages
+      WHERE body_html IS NOT NULL AND body_html LIKE '%data:image/%'
+    `);
+    return row?.n ?? 0;
+  }
+}

--- a/packages/backend-core/src/modules/conv/channels/adapter.ts
+++ b/packages/backend-core/src/modules/conv/channels/adapter.ts
@@ -55,6 +55,7 @@ export interface SendResult {
 export interface PollTickResult {
   messagesIngested: number;
   lastError?: string | null;
+  stalled?: boolean;
 }
 
 export interface IncomingWebhookRequest {

--- a/packages/backend-core/src/modules/conv/channels/inbound-poll.worker.ts
+++ b/packages/backend-core/src/modules/conv/channels/inbound-poll.worker.ts
@@ -91,6 +91,11 @@ export class InboundPollWorker implements OnModuleInit, OnModuleDestroy {
         } else {
           this.logger.debug(`poll ${channel.type} channel=${channel.id} (no new messages)`);
         }
+        if (result.stalled) {
+          await this.openIngestStallAlertFor(channel, result.lastError ?? 'ingest failed');
+        } else {
+          await this.resolveIngestStallAlertFor(channel);
+        }
         await this.resolveAlertFor(channel);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -129,6 +134,38 @@ export class InboundPollWorker implements OnModuleInit, OnModuleDestroy {
     });
   }
 
+  private async openIngestStallAlertFor(
+    channel: { id: string; orgId: string; type: string; name: string | null },
+    detail: string,
+  ): Promise<void> {
+    await this.withChannelContext(channel.orgId, async () => {
+      const result = await this.alerts.openAlert({
+        source: 'channel_inbound',
+        subjectId: ingestStallSubjectId(channel.id),
+        severity: 'error',
+        title: 'Inbound message could not be stored',
+        detail,
+        metadata: {
+          channelType: channel.type,
+          channelId: channel.id,
+          channelName: channel.name ?? channel.type,
+        },
+      });
+      await this.alerts.updateMetadata(result.alertId, {
+        attemptCount: result.occurrenceCount,
+      });
+    });
+  }
+
+  private async resolveIngestStallAlertFor(channel: { id: string; orgId: string }): Promise<void> {
+    await this.withChannelContext(channel.orgId, async () => {
+      await this.alerts.resolveAlert({
+        source: 'channel_inbound',
+        subjectId: ingestStallSubjectId(channel.id),
+      });
+    });
+  }
+
   private async autoDeactivate(
     channel: { id: string; orgId: string; type: string; name: string | null },
     alertId: string,
@@ -164,4 +201,8 @@ export class InboundPollWorker implements OnModuleInit, OnModuleDestroy {
       await withContext(ctx, fn);
     });
   }
+}
+
+function ingestStallSubjectId(channelId: string): string {
+  return `${channelId}:ingest`;
 }

--- a/packages/backend-core/src/modules/conv/conv.module.ts
+++ b/packages/backend-core/src/modules/conv/conv.module.ts
@@ -5,6 +5,8 @@ import { RealtimeModule } from '../../realtime/realtime.module.ts';
 import { PublicThrottleModule } from '../../common/rate-limit/public-throttle.module.ts';
 import { ConvService } from './conv.service.ts';
 import { ConvAttachmentsService } from './attachments/conv-attachments.service.ts';
+import { AttachmentGcWorker } from './attachments/attachment-gc.worker.ts';
+import { InlineImageBackfillService } from './attachments/inline-image-backfill.service.ts';
 import { ConvAutomationService } from './conv-automation.service.ts';
 import { ConvSchedulerService } from './conv-scheduler.service.ts';
 import { ConversationClaimsService } from './conv.claims.service.ts';
@@ -84,6 +86,8 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
   providers: [
     ConvService,
     ConvAttachmentsService,
+    AttachmentGcWorker,
+    InlineImageBackfillService,
     ConvAutomationService,
     ConvSchedulerService,
     ConversationClaimsService,
@@ -181,6 +185,7 @@ import { WidgetThrottlerGuard } from './widget/widget-throttler.guard.ts';
     OUTREACH_VOICE_CALLERS,
     ConvService,
     ConvAttachmentsService,
+    InlineImageBackfillService,
     ConvAutomationService,
     ConversationClaimsService,
     EmailService,

--- a/packages/backend-core/src/modules/conv/email/email-adapter.ts
+++ b/packages/backend-core/src/modules/conv/email/email-adapter.ts
@@ -170,7 +170,7 @@ export class EmailAdapter implements ChannelAdapter {
     this.fetcher = f;
   }
 
-  readonly inbound: InboundMode = {
+  readonly inbound: Extract<InboundMode, { mode: 'poll' }> = {
     mode: 'poll',
     intervalMs: POLL_INTERVAL_MS,
     tick: (channel) => this.pollOne(channel),
@@ -291,20 +291,35 @@ export class EmailAdapter implements ChannelAdapter {
     let highWater = sinceUid ?? 0;
     let ingested = 0;
     let lastError: string | null = null;
+    let stalled = false;
     for (const msg of messages) {
+      let parsed: ParsedInboundEmail;
       try {
-        const parsed = await parseMessage(msg.source);
-        await this.ingest(channel, parsed);
-        ingested += 1;
+        parsed = await parseMessage(msg.source);
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
         lastError = errMsg;
         this.logger.warn(`parse failed uid=${msg.uid} channel=${channel.id}: ${errMsg}`);
+        if (msg.uid > highWater) highWater = msg.uid;
+        continue;
       }
-      if (msg.uid > highWater) highWater = msg.uid;
+
+      try {
+        await this.ingest(channel, parsed);
+        ingested += 1;
+        if (msg.uid > highWater) highWater = msg.uid;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        lastError = errMsg;
+        stalled = true;
+        this.logger.error(
+          `ingest failed uid=${msg.uid} channel=${channel.id}, holding cursor at ${highWater}: ${errMsg}`,
+        );
+        break;
+      }
     }
     await this.writeCursor(channel.id, { lastUid: highWater });
-    return { messagesIngested: ingested, lastError };
+    return { messagesIngested: ingested, lastError, stalled };
   }
 
   async ingest(

--- a/packages/backend-core/src/modules/conv/email/email.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email.integration.test.ts
@@ -116,6 +116,8 @@ class StubImapFetcher implements ImapFetcher {
     }
   });
 
+  const imapChannel = () => imapChannelFor(db, orgId);
+
   beforeEach(() => {
     mailer.clear();
   });
@@ -579,6 +581,109 @@ class StubImapFetcher implements ImapFetcher {
     expect((rows[0]!.config as { outbound?: unknown }).outbound).toBeDefined();
   }, 30_000);
 
+
+  it('holds the IMAP cursor at the last stored message when an ingest fails, so no email is lost', async () => {
+    const channel = await imapChannel();
+    const run = Math.random().toString(36).slice(2, 8);
+    await resetCursor(db, channel.id);
+
+    async function cursorUid(): Promise<number | null> {
+      const [row] = await db
+        .select({ cursor: schema.convInboundState.cursor })
+        .from(schema.convInboundState)
+        .where(eq(schema.convInboundState.channelId, channel.id));
+      const value = (row?.cursor as { lastUid?: unknown } | undefined)?.lastUid;
+      return typeof value === 'number' ? value : null;
+    }
+
+    const ids = [`stall-a-${run}`, `stall-b-${run}`, `stall-c-${run}`];
+    const stallFetcher = new StubImapFetcher();
+    for (const id of ids) {
+      stallFetcher.push(
+        rfc822({
+          from: 'Cursor Tester <cursor@example.com>',
+          to: 'support@acme.test',
+          subject: `cursor ${id}`,
+          messageId: `${id}@example.com`,
+          body: `body of ${id}`,
+        }),
+      );
+    }
+    const originalFetcher = emailAdapter['fetcher'];
+    const originalIngest = emailAdapter.ingest.bind(emailAdapter);
+    emailAdapter.setFetcher(stallFetcher);
+
+    let call = 0;
+    emailAdapter.ingest = (ch, parsed, origin) => {
+      call += 1;
+      if (call === 2) return Promise.reject(new Error('storage unavailable'));
+      return originalIngest(ch, parsed, origin);
+    };
+
+    try {
+      const stalled = await emailAdapter.inbound.tick(channel);
+      expect(stalled.stalled).toBe(true);
+      expect(stalled.messagesIngested).toBe(1);
+      expect(await cursorUid()).toBe(1);
+    } finally {
+      emailAdapter.ingest = originalIngest;
+    }
+
+    try {
+      const recovered = await emailAdapter.inbound.tick(channel);
+      expect(recovered.stalled).toBe(false);
+      expect(recovered.messagesIngested).toBe(2);
+      expect(await cursorUid()).toBe(3);
+    } finally {
+      emailAdapter.setFetcher(originalFetcher);
+    }
+
+    const stored = await db
+      .select({ body: schema.convMessages.body })
+      .from(schema.convMessages)
+      .where(eq(schema.convMessages.orgId, orgId));
+    for (const id of ids) {
+      expect(stored.some((m) => m.body.includes(`body of ${id}`))).toBe(true);
+    }
+  }, 30_000);
+
+  it('advances past an unparseable message so one bad email cannot stall the channel forever', async () => {
+    const channel = await imapChannel();
+    const run = Math.random().toString(36).slice(2, 8);
+    await resetCursor(db, channel.id);
+
+    const badFetcher = new StubImapFetcher();
+    badFetcher.push('');
+    badFetcher.push(
+      rfc822({
+        from: 'After Bad <afterbad@example.com>',
+        to: 'support@acme.test',
+        subject: 'after the bad one',
+        messageId: `after-bad-${run}@example.com`,
+        body: `this one is fine ${run}`,
+      }),
+    );
+    const originalFetcher = emailAdapter['fetcher'];
+    emailAdapter.setFetcher(badFetcher);
+    try {
+      const result = await emailAdapter.inbound.tick(channel);
+      expect(result.stalled).toBe(false);
+      const [row] = await db
+        .select({ cursor: schema.convInboundState.cursor })
+        .from(schema.convInboundState)
+        .where(eq(schema.convInboundState.channelId, channel.id));
+      expect((row!.cursor as { lastUid: number }).lastUid).toBe(2);
+    } finally {
+      emailAdapter.setFetcher(originalFetcher);
+    }
+
+    const stored = await db
+      .select({ body: schema.convMessages.body })
+      .from(schema.convMessages)
+      .where(eq(schema.convMessages.orgId, orgId));
+    expect(stored.some((m) => m.body.includes(`this one is fine ${run}`))).toBe(true);
+  }, 30_000);
+
 });
 
 async function waitFor(check: () => Promise<boolean>, timeoutMs = 2000): Promise<void> {
@@ -622,4 +727,33 @@ function rfc822(input: {
   }
   for (const header of input.extraHeaders ?? []) lines.push(header);
   return `${lines.join('\r\n')}\r\n\r\n${input.body}\r\n`;
+}
+
+async function imapChannelFor(
+  db: ReturnType<typeof createDb>,
+  orgId: string,
+): Promise<typeof schema.convChannels.$inferSelect> {
+  const rows = await db
+    .select()
+    .from(schema.convChannels)
+    .where(
+      and(
+        eq(schema.convChannels.orgId, orgId),
+        eq(schema.convChannels.type, 'email'),
+        sql`${schema.convChannels.config} -> 'inbound' ->> 'provider' = 'imap'`,
+      ),
+    );
+  const found = rows[0];
+  if (!found) throw new Error('no imap-inbound email channel seeded for this org');
+  return found;
+}
+
+async function resetCursor(db: ReturnType<typeof createDb>, channelId: string): Promise<void> {
+  await db
+    .insert(schema.convInboundState)
+    .values({ channelId, cursor: { lastUid: 0 } })
+    .onConflictDoUpdate({
+      target: schema.convInboundState.channelId,
+      set: { cursor: { lastUid: 0 } },
+    });
 }

--- a/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button, DropdownMenuItem, PageSpinner, Pill, cn } from '@getmunin/ui';
@@ -10,6 +10,7 @@ import { useConversationTyping } from '../../realtime';
 import { useCmdEnter } from './queue-panes/shared';
 import { MessageBubble, startsAuthorGroup } from './inbox-message-bubble';
 import { useAttachmentUploads } from './use-attachment-uploads';
+import type { AttachmentRejection } from '@getmunin/types';
 import { useConfirm } from '../confirm-dialog';
 import type { MessageAttachment } from './inbox-types';
 import { participantHues, participantKey } from './inbox-identity';
@@ -65,8 +66,27 @@ export function ConversationPane({
   const noteBoxRef = useRef<HTMLTextAreaElement | null>(null);
   const composerRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const uploads = useAttachmentUploads(selectedId);
   const tAtt = useTranslations('dashboard.overview.drawer.attachments');
+  const uploadMessages = useMemo(
+    () => ({
+      rejected: (rejection: AttachmentRejection, ctx: { max: number; mb: number }) =>
+        rejection === 'mime'
+          ? tAtt('rejectedType')
+          : rejection === 'too_large'
+            ? tAtt('rejectedSize', { mb: ctx.mb })
+            : tAtt('rejectedCount', { max: ctx.max }),
+      failed: (name: string) => tAtt('uploadFailedNamed', { name }),
+    }),
+    [tAtt],
+  );
+  const reportAttachmentError = controller.reportAttachmentError;
+  const onAttachmentError = useCallback(
+    (message: string) => {
+      if (selectedId) reportAttachmentError(selectedId, message);
+    },
+    [reportAttachmentError, selectedId],
+  );
+  const uploads = useAttachmentUploads(selectedId, uploadMessages, onAttachmentError);
   const confirm = useConfirm();
 
   useLayoutEffect(() => {
@@ -657,19 +677,6 @@ export function ConversationPane({
             closedFooter
           ) : canReply ? (
             <div className="flex flex-col gap-2.5 px-5 py-4 max-md:min-h-0 max-md:flex-1 md:px-7">
-              <textarea
-                ref={replyBoxRef}
-                value={reply}
-                readOnly={streaming || askedForDraft}
-                onChange={(e) => {
-                  setReply(e.target.value);
-                  notifyTyping(e.target.value.trim().length > 0);
-                  if (err) controller.clearActionError();
-                }}
-                rows={4}
-                placeholder={t('replyPlaceholder', { name: customer })}
-                className="w-full resize-none rounded-input border border-rule-soft bg-paper px-3.5 py-3 text-base leading-relaxed outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt max-md:min-h-0 max-md:flex-1 md:text-sm dark:border-rule-on-dark dark:bg-card"
-              />
               {uploads.pending.length > 0 && (
                 <div className="flex shrink-0 flex-wrap gap-2">
                   {uploads.pending.map((p) => (
@@ -687,14 +694,27 @@ export function ConversationPane({
                         type="button"
                         onClick={() => uploads.remove(p.key)}
                         aria-label={tAtt('remove')}
-                        className="absolute right-0 top-0 bg-paper/90 px-1 text-[11px] text-ink-mute"
+                        className="absolute right-0 top-0 flex items-center justify-center rounded-md bg-paper/90 px-1 py-0.5 text-ink-mute"
                       >
-                        ✕
+                        <X aria-hidden className="size-3" />
                       </button>
                     </div>
                   ))}
                 </div>
               )}
+              <textarea
+                ref={replyBoxRef}
+                value={reply}
+                readOnly={streaming || askedForDraft}
+                onChange={(e) => {
+                  setReply(e.target.value);
+                  notifyTyping(e.target.value.trim().length > 0);
+                  if (err) controller.clearActionError();
+                }}
+                rows={4}
+                placeholder={t('replyPlaceholder', { name: customer })}
+                className="w-full resize-none rounded-input border border-rule-soft bg-paper px-3.5 py-3 text-base leading-relaxed outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt max-md:min-h-0 max-md:flex-1 md:text-sm dark:border-rule-on-dark dark:bg-card"
+              />
               <div className="flex shrink-0 flex-col flex-wrap items-stretch gap-2 md:flex-row md:items-center">
                 <input
                   ref={fileInputRef}

--- a/packages/dashboard-pages/src/components/dashboard/conversation-queue.ts
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-queue.ts
@@ -60,7 +60,8 @@ export type QueueActionType =
   | 'reopen'
   | 'reject'
   | 'note'
-  | 'requestDraft';
+  | 'requestDraft'
+  | 'attach';
 
 export type QueueActionError = {
   type: QueueActionType;
@@ -155,6 +156,7 @@ export interface QueueController {
   pendingAction: QueueActionType | null;
   actionError: QueueActionError;
   clearActionError: () => void;
+  reportAttachmentError: (conversationId: string, message: string) => void;
   draftRequested: Record<string, boolean>;
   takeOver: (id: string) => Promise<void>;
   release: (id: string) => Promise<boolean>;
@@ -411,7 +413,7 @@ export function useConversationQueue(routeSelectedId: string | null): QueueContr
 
   const deleteAttachment = useCallback(
     async (conversationId: string, attachmentId: string) =>
-      runAction('send', conversationId, () =>
+      runAction('attach', conversationId, () =>
         api(`/v1/conversations/${conversationId}/attachments/${attachmentId}`, {
           method: 'DELETE',
         }),
@@ -470,6 +472,10 @@ export function useConversationQueue(routeSelectedId: string | null): QueueContr
 
   const clearActionError = useCallback(() => setActionError(null), []);
 
+  const reportAttachmentError = useCallback((conversationId: string, message: string) => {
+    setActionError({ type: 'attach', conversationId, message, code: null });
+  }, []);
+
   return {
     open,
     finished,
@@ -485,6 +491,7 @@ export function useConversationQueue(routeSelectedId: string | null): QueueContr
     pendingAction,
     actionError,
     clearActionError,
+    reportAttachmentError,
     draftRequested,
     takeOver,
     release,

--- a/packages/dashboard-pages/src/components/dashboard/inbox-attachments.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-attachments.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { ImageOff, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@getmunin/ui';
 import type { MessageAttachment } from './inbox-types';
@@ -25,7 +26,7 @@ export function MessageAttachments({
               key={a.id}
               className="flex items-center gap-2 rounded-lg border border-dashed border-line px-3 py-2 text-[11px] text-ink-mute"
             >
-              <span aria-hidden>🚫</span>
+              <ImageOff aria-hidden className="size-3.5 shrink-0" />
               <span className="max-w-[14rem] truncate">{t('removed', { name: a.name })}</span>
             </div>
           ) : (
@@ -53,7 +54,7 @@ export function MessageAttachments({
                     'opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100',
                   )}
                 >
-                  ✕
+                  <X aria-hidden className="size-3" />
                 </button>
               )}
             </div>

--- a/packages/dashboard-pages/src/components/dashboard/use-attachment-uploads.ts
+++ b/packages/dashboard-pages/src/components/dashboard/use-attachment-uploads.ts
@@ -1,6 +1,12 @@
 'use client';
 
 import { useCallback, useState } from 'react';
+import {
+  CONV_ATTACHMENT_MB_MAX,
+  CONV_ATTACHMENT_PER_MESSAGE_MAX,
+  attachmentRejectionFor,
+  type AttachmentRejection,
+} from '@getmunin/types';
 import { api } from '../../api';
 import { prepareImageForUpload, uploadToPresigned } from '../../lib/upload-image';
 
@@ -19,7 +25,16 @@ interface UploadHandle {
   uploadFields: Record<string, string>;
 }
 
-export function useAttachmentUploads(conversationId: string | null) {
+export interface AttachmentUploadMessages {
+  rejected: (rejection: AttachmentRejection, ctx: { max: number; mb: number }) => string;
+  failed: (name: string) => string;
+}
+
+export function useAttachmentUploads(
+  conversationId: string | null,
+  messages?: AttachmentUploadMessages,
+  onError?: (message: string) => void,
+) {
   const [pending, setPending] = useState<PendingAttachment[]>([]);
 
   const reset = useCallback(() => {
@@ -40,8 +55,28 @@ export function useAttachmentUploads(conversationId: string | null) {
   const addFiles = useCallback(
     async (files: File[]) => {
       if (!conversationId) return;
+      const reject = (rejection: AttachmentRejection): void => {
+        onError?.(
+          messages?.rejected(rejection, {
+            max: CONV_ATTACHMENT_PER_MESSAGE_MAX,
+            mb: CONV_ATTACHMENT_MB_MAX,
+          }) ?? rejection,
+        );
+      };
+
+      let room = CONV_ATTACHMENT_PER_MESSAGE_MAX - pending.length;
+
       for (const file of files) {
-        if (!file.type.startsWith('image/')) continue;
+        if (room <= 0) {
+          reject('too_many');
+          break;
+        }
+        const rejection = attachmentRejectionFor({ mime: file.type, sizeBytes: file.size });
+        if (rejection) {
+          reject(rejection);
+          continue;
+        }
+        room -= 1;
         const key = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         const previewUrl = URL.createObjectURL(file);
         setPending((prev) => [
@@ -75,10 +110,11 @@ export function useAttachmentUploads(conversationId: string | null) {
           setPending((prev) =>
             prev.map((p) => (p.key === key ? { ...p, status: 'failed' } : p)),
           );
+          if (messages) onError?.(messages.failed(file.name));
         }
       }
     },
-    [conversationId],
+    [conversationId, messages, onError, pending.length],
   );
 
   const readyIds = pending

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -413,7 +413,11 @@
           "attach": "Attach an image",
           "uploading": "Uploading…",
           "uploadFailed": "Upload failed",
-          "remove": "Remove"
+          "remove": "Remove",
+          "rejectedType": "We take PNG, JPEG, GIF and WebP.",
+          "rejectedSize": "Images have to be under {mb} MB.",
+          "rejectedCount": "You can attach up to {max} images.",
+          "uploadFailedNamed": "{name} did not upload. Try again."
         }
       },
       "relative": {
@@ -1360,7 +1364,8 @@
           "close": "Close failed",
           "reject": "Reject failed",
           "note": "Note failed",
-          "requestDraft": "Draft request failed"
+          "requestDraft": "Draft request failed",
+          "attach": "Attachment failed"
         },
         "replyPlaceholder": "Write the reply to {name}…",
         "approveSend": "Approve & send",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -413,7 +413,11 @@
           "attach": "Legg ved bilde",
           "uploading": "Laster opp …",
           "uploadFailed": "Opplastingen feilet",
-          "remove": "Fjern"
+          "remove": "Fjern",
+          "rejectedType": "Vi tar imot PNG, JPEG, GIF og WebP.",
+          "rejectedSize": "Bilder må være under {mb} MB.",
+          "rejectedCount": "Du kan legge ved opptil {max} bilder.",
+          "uploadFailedNamed": "{name} ble ikke lastet opp. Prøv igjen."
         }
       },
       "relative": {
@@ -1360,7 +1364,8 @@
           "close": "Lukkingen feilet",
           "reject": "Avvisningen feilet",
           "note": "Notatet feilet",
-          "requestDraft": "Kladd-forespørselen feilet"
+          "requestDraft": "Kladd-forespørselen feilet",
+          "attach": "Vedlegget feilet"
         },
         "replyPlaceholder": "Skriv svaret til {name} …",
         "approveSend": "Godkjenn og send",

--- a/packages/types/src/conv-attachments.ts
+++ b/packages/types/src/conv-attachments.ts
@@ -1,0 +1,31 @@
+export const CONV_ATTACHMENT_MIME_ALLOWLIST: readonly string[] = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+];
+
+export const CONV_ATTACHMENT_BYTES_MAX = 10 * 1024 * 1024;
+
+export const CONV_ATTACHMENT_PER_MESSAGE_MAX = 10;
+
+export const CONV_ATTACHMENT_MB_MAX = Math.floor(CONV_ATTACHMENT_BYTES_MAX / (1024 * 1024));
+
+export type AttachmentRejection = 'mime' | 'too_large' | 'too_many';
+
+export function normalizeAttachmentMime(mime: string): string {
+  return mime.trim().toLowerCase().split(';')[0]!.trim();
+}
+
+export function isAllowedAttachmentMime(mime: string): boolean {
+  return CONV_ATTACHMENT_MIME_ALLOWLIST.includes(normalizeAttachmentMime(mime));
+}
+
+export function attachmentRejectionFor(candidate: {
+  mime: string;
+  sizeBytes: number;
+}): AttachmentRejection | null {
+  if (!isAllowedAttachmentMime(candidate.mime)) return 'mime';
+  if (candidate.sizeBytes > CONV_ATTACHMENT_BYTES_MAX) return 'too_large';
+  return null;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -80,6 +80,16 @@ export {
 export { type WebImportProgress } from './web-import.ts';
 export { type AssetVariant } from './asset-variants.ts';
 export {
+  CONV_ATTACHMENT_MIME_ALLOWLIST,
+  CONV_ATTACHMENT_BYTES_MAX,
+  CONV_ATTACHMENT_PER_MESSAGE_MAX,
+  CONV_ATTACHMENT_MB_MAX,
+  normalizeAttachmentMime,
+  isAllowedAttachmentMime,
+  attachmentRejectionFor,
+  type AttachmentRejection,
+} from './conv-attachments.ts';
+export {
   MESSAGE_COMPONENT_MAX_ITEMS,
   MESSAGE_COMPONENTS_MAX,
   ProductListItemSchema,


### PR DESCRIPTION
**Stack** — merge bottom-up, and retarget each child before merging its parent:

| | PR | |
|---|---|---|
| 1 | #924 | conversation attachment store (trunk) |
| 2 | #925 | operator + agent attachments, deletion — **required for #928 to work** |
| 3 | #926 | email images in and out |
| 4 | #927 | chat widget images |
| 5 | #928 | agent vision — **must land with or before #927 ships** |
| 6 | #929 | follow-ups: inbound email loss, backfill, storage leaks |

---

Stacked on #928. Four follow-ups surfaced while building the stack. The first is a data-loss bug and is the reason this PR exists.

## 1. A failed inbound store no longer loses the email

The IMAP poll advanced its cursor past every message it had *fetched*, whether or not the message was actually stored. So a transient storage or database error during ingest silently dropped that email for good — pre-existing, but newly reachable now that ingest does object-storage I/O.

The loop now separates two failure kinds that were conflated:

- **Unparseable message** → skip and advance. Retrying forever would stall the whole channel behind one bad email.
- **Failed store** → hold the cursor at the last message that landed and stop the tick. The next poll re-fetches and retries.

A held cursor raises its own alert, keyed separately from the polling-failure alert **specifically so it doesn't feed the auto-deactivation counter**. Mail is safe on the IMAP server, and deactivating the channel would break outreach approvals for no reason.

`EmailAdapter.inbound` is also narrowed to the poll variant of the union, which it always was.

## 2. Legacy inlined images can be extracted

#926 fixed the `keepCidLinks` bug going forward, but existing rows still hold whole base64 images inside `conv_messages.body_html`.

A SQL migration can't do this — the bytes have to reach object storage — and the curator `task://` route doesn't fit either, since task handlers only get MCP + LLM access and there is deliberately no byte-upload tool. So this is a service plus a maintenance script, following the existing `packages/backend-core/scripts/` precedent:

```
pnpm -F @getmunin/backend-core backfill:inline-email-images [-- --dry-run]
```

It walks each org, promotes qualifying images to real attachments, and rewrites the HTML to a `cid:` reference matching the new `content_id`. Same floor as inbound ingest, so tracking pixels stay inlined rather than becoming attachments.

**Smoke-tested against a seeded DB as the non-superuser `munin_app` role** so RLS actually applied. One message went from **240,483 characters to 72**, with bytes and a derived variant on disk; the pixel row, the no-inline row and the NULL-html row were all left alone. A second run converted nothing and created no duplicate.

The extractor's regex is character-class-only to avoid ReDoS, and there's a test proving the detector isn't sticky across calls (it runs `.test()` on a global regex).

## 3. Deleting a CMS asset no longer leaks its variants

`cms.deleteAsset` removed only the master object, so every deleted image left up to five orphaned webp derivatives in storage forever. It now deletes the keys named in `variants`. Verified by reverting the fix and confirming the new test fails.

## 4. Abandoned uploads get collected

`AttachmentGcWorker` deletes attachment rows that never reached a message once past a grace period (default 60 min, `MUNIN_ATTACHMENT_GC_GRACE_MINUTES`), purging master and variant objects. Claims with `FOR UPDATE SKIP LOCKED` so several instances can run it, and never touches a row already on a message — tested at 30 days old.

## Testing

167 files / 2229 tests green at this tip. New: 3 cursor-behaviour tests in the email integration harness, 7 unit tests on the extractor, 4 backfill integration tests including cross-org isolation, 2 GC tests, 1 CMS variant-deletion test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
