### PR TITLE
feat(dashboard): show the agent draft read-only before claiming a conversation

### DIFF
--- a/.changeset/read-only-draft-preview.md
+++ b/.changeset/read-only-draft-preview.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Let an operator read the agent's draft before claiming the conversation
+
+Deciding whether to take a conversation over meant claiming it first, which is the one move you
+cannot make speculatively — it moves the claim off a teammate. When a pending draft exists the
+composer now renders the reply box read-only with the draft body, above the same claim/take-over
+button as before, so the draft is readable without owning the thread. Editing and sending still
+require the claim, and a conversation with no draft keeps today's behaviour: no composer until you
+claim it.

--- a/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
@@ -25,6 +25,9 @@ import type { ConversationDetail } from './inbox-types';
 
 const COMPOSER_MAX_HEIGHT_PX = 320;
 
+const REPLY_BOX_CLASS =
+  'w-full resize-none rounded-input border border-rule-soft bg-paper px-3.5 py-3 text-base leading-relaxed outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt max-md:min-h-0 max-md:flex-1 md:text-sm dark:border-rule-on-dark dark:bg-card';
+
 export function ConversationPane({
   selectedId,
   item,
@@ -62,15 +65,15 @@ export function ConversationPane({
   const noteBoxRef = useRef<HTMLTextAreaElement | null>(null);
   const composerRef = useRef<HTMLDivElement | null>(null);
 
+  const draft = pendingDraftOf(detail);
+
   useLayoutEffect(() => {
     for (const el of [replyBoxRef.current, noteBoxRef.current]) {
       if (!el) continue;
       el.style.height = 'auto';
       el.style.height = `${Math.min(el.scrollHeight, COMPOSER_MAX_HEIGHT_PX)}px`;
     }
-  }, [reply, noteDraft, tab, expanded]);
-
-  const draft = pendingDraftOf(detail);
+  }, [reply, noteDraft, tab, expanded, draft?.body]);
 
   const stopStream = () => {
     if (streamTimer.current) {
@@ -298,11 +301,15 @@ export function ConversationPane({
     </div>
   );
 
-  const claimGateCaption = claim ? (
-    <span className="font-mono text-[10px] font-medium uppercase tracking-meta leading-relaxed text-ink-mute">
-      {t('claimGateOther', { name: claimHolderName ?? t('teammate') })}
+  const gateCaption = (text: string) => (
+    <span className="min-w-0 font-mono text-[10px] font-medium uppercase tracking-meta leading-relaxed text-ink-mute">
+      {text}
     </span>
-  ) : null;
+  );
+
+  const claimGateCaption = claim
+    ? gateCaption(t('claimGateOther', { name: claimHolderName ?? t('teammate') }))
+    : null;
 
   const askDraftButton = (className?: string) =>
     canAskDraft ? (
@@ -643,7 +650,7 @@ export function ConversationPane({
                 }}
                 rows={4}
                 placeholder={t('replyPlaceholder', { name: customer })}
-                className="w-full resize-none rounded-input border border-rule-soft bg-paper px-3.5 py-3 text-base leading-relaxed outline-none focus-visible:border-cobalt focus-visible:ring-1 focus-visible:ring-cobalt max-md:min-h-0 max-md:flex-1 md:text-sm dark:border-rule-on-dark dark:bg-card"
+                className={REPLY_BOX_CLASS}
               />
               <div className="flex shrink-0 flex-col flex-wrap items-stretch gap-2 md:flex-row md:items-center">
                 <Button
@@ -678,6 +685,24 @@ export function ConversationPane({
                 >
                   {t('closeNoReply')}
                 </Button>
+              </div>
+            </div>
+          ) : draft ? (
+            <div className="flex flex-col gap-2.5 px-5 py-4 max-md:min-h-0 max-md:flex-1 md:px-7">
+              <textarea
+                ref={replyBoxRef}
+                value={draft.body}
+                readOnly
+                rows={4}
+                aria-label={t('draftPreviewLabel')}
+                className={cn(
+                  REPLY_BOX_CLASS,
+                  'bg-bone text-ink-soft dark:bg-secondary dark:text-foreground/80',
+                )}
+              />
+              <div className="flex shrink-0 flex-col flex-wrap items-stretch gap-2.5 md:flex-row md:items-center">
+                {takeOverButton('max-md:h-11')}
+                {claimGateCaption ?? gateCaption(t('draftPreviewHint'))}
               </div>
             </div>
           ) : (

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -1355,6 +1355,8 @@
         "sendReply": "Send reply",
         "rejectDraft": "Reject draft",
         "reviewDraft": "Review draft",
+        "draftPreviewLabel": "Agent draft",
+        "draftPreviewHint": "Read-only until you claim it",
         "writeReply": "Write reply",
         "continueReply": "Continue reply",
         "restoreDraft": "Restore draft",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -1355,6 +1355,8 @@
         "sendReply": "Send svar",
         "rejectDraft": "Avvis kladden",
         "reviewDraft": "Se over kladden",
+        "draftPreviewLabel": "Kladd fra agenten",
+        "draftPreviewHint": "Skrivebeskyttet til du tar saken",
         "writeReply": "Skriv svar",
         "continueReply": "Fortsett svaret",
         "restoreDraft": "Hent tilbake kladden",


### PR DESCRIPTION
## What

In the conversation pane's reply tab, a conversation you don't hold now shows the pending agent draft in a **read-only** composer, above the same `Claim to review draft` / `Take over to review draft` button as before.

- **Draft present, not yours** (unclaimed or teammate-owned) → read-only reply box with the draft body + the claim button. Caption is the existing claim-gate line when a teammate owns it, otherwise "Read-only until you claim it".
- **No draft** → unchanged: no composer until you claim.
- **Closed** → unchanged: reopen footer only.
- **Mobile** → unchanged; the collapsed footer still shows only the claim button.

Editing, sending and rejecting still require the claim. After take-over the editable box carries the draft exactly as it did before.

## Why

Deciding whether to take a conversation over meant claiming it first — the one move you can't make speculatively, since it moves the claim off a teammate. Reading the draft is now free.

## Notes

- The reply textarea's class string moved to a shared `REPLY_BOX_CLASS`; the read-only variant adds `bg-bone` / `dark:bg-secondary` so it reads as inert in both themes.
- The auto-grow layout effect also keys off `draft?.body` so the preview sizes to the draft.
- New `draftPreviewLabel` / `draftPreviewHint` keys in `en.json` + `nb.json`.

## Testing

`pnpm -F @getmunin/dashboard-pages typecheck / lint / test` (186 tests) all pass. Not exercised against a running dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)