### PR TITLE
feat(agent-host): show a model's name in the picker, and fill it on first paint

### DIFF
--- a/.changeset/managed-model-labels.md
+++ b/.changeset/managed-model-labels.md
@@ -1,0 +1,28 @@
+---
+'@getmunin/agent-host': minor
+'@getmunin/dashboard-pages': minor
+---
+
+Show a model's name in the picker, not just its id.
+
+The picker rendered the raw model id, so a deployment offering built-in models could only
+present them as `gpt-oss-120b` and `qwen3.5-397b-a17b` — accurate, and unreadable to the
+person choosing. `ModelEntry` gains a `label`, and `formatModel` uses it as the head of the
+option while pushing the id into the detail line beside context length and pricing, so the
+list reads `GPT-OSS 120B (chat) · gpt-oss-120b · 128k ctx`. The id stays visible on purpose:
+it is what actually goes to the provider, and it is what an operator matches against the
+provider's own catalogue.
+
+Two sources fill it, mirroring how `supportsVision` is resolved:
+
+- **The host**, through `AgentHostModule`'s `defaultProviderModels`: `ProviderModelOffer`
+  gains an optional `label`, so `{ id: 'gpt-oss-120b', label: 'GPT-OSS 120B' }` names a
+  managed model. Bare strings keep working and report `null`.
+- **The provider's own `/models` payload**, which already carried the name the host was
+  hardcoding. OpenRouter returns `name` ("Anthropic: Claude Haiku 4.5") and Anthropic
+  returns `display_name`; `readModelLabel` reads either. Plain OpenAI returns neither, so
+  those entries keep showing the id — which is what its own docs call them anyway.
+
+The picker's sort moves from the id to the displayed name (`modelSortKey`), because a list
+labelled with names but ordered by hidden ids looks arbitrary. `value` on each option is
+still the id, so nothing about what gets saved or sent changes.

--- a/.changeset/managed-models-load-on-first-paint.md
+++ b/.changeset/managed-models-load-on-first-paint.md
@@ -1,0 +1,23 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Fill the model picker on first paint for an org with no provider key of its own.
+
+`useAgentConfig` skipped `GET /v1/agent-config/models` unless `providerApiKeySet` was true.
+That guard was correct when it was written — the endpoint could only answer by asking the
+org's own provider — but it outlived its reason: the endpoint now serves the deployment's
+managed list to an org with no key. The client kept not asking, so `models` stayed `null`,
+and `ModelsCard` — which treats a managed provider as credentialed — fell through every
+branch to its loading state and stayed there.
+
+A host whose managed preset still carried a hardcoded `models` array masked it, because the
+page fed that array to the card instead. The moment a host deletes the array and relies on
+the endpoint, as the endpoint now invites, the picker reads `Loading…` on the settings page
+and on the equivalent step of the first-run wizard until the operator presses Save on the
+provider card, which is the one action that already refetched.
+
+The guard now waits only for the config to arrive. An org that is neither keyed nor covered
+by a managed list gets `supported: false` and renders the "needs a key" branch it already
+had, so the extra request costs one small GET and removes the client's stale assumption
+about when the server has something to say.

--- a/packages/agent-host/src/config.service.test.ts
+++ b/packages/agent-host/src/config.service.test.ts
@@ -49,6 +49,7 @@ function makeModels(modelIds: string[] = []): ProviderModelLister & {
       supported: modelIds.length > 0,
       models: modelIds.map((id) => ({
         id,
+        label: null,
         contextLength: null,
         promptCostPerMillion: null,
         completionCostPerMillion: null,

--- a/packages/agent-host/src/models.service.test.ts
+++ b/packages/agent-host/src/models.service.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as core from '@getmunin/core';
-import { AgentModelsService, normalizeProviderModels, readSupportsVision, normalizeProviderOfferings } from './models.service.ts';
+import { AgentModelsService, normalizeProviderModels, readModelLabel, readSupportsVision, normalizeProviderOfferings } from './models.service.ts';
 import type { AgentConfigRepository, AgentConfigRow } from './config.repository.ts';
 
 const baseRow: AgentConfigRow = {
@@ -64,6 +64,19 @@ describe('AgentModelsService', () => {
     expect(result.models.map((m) => m.id)).toEqual(['gpt-oss-120b', 'gemma-4-26b-a4b-it']);
   });
 
+  it('publishes a host-declared label for a built-in model', async () => {
+    const repo = makeRepo({ apiKey: null });
+    const svc = new AgentModelsService(repo, [
+      { id: 'gpt-oss-120b', label: 'GPT-OSS 120B' },
+      'gemma-4-26b-a4b-it',
+    ]);
+    const result = await svc.listForCurrentActor();
+    expect(result.models.map((m) => [m.id, m.label])).toEqual([
+      ['gpt-oss-120b', 'GPT-OSS 120B'],
+      ['gemma-4-26b-a4b-it', null],
+    ]);
+  });
+
   it('prefers the org provider over the built-in list once a key is stored', async () => {
     mockSafeFetch({ status: 200, body: { data: [{ id: 'anthropic/claude-opus-5' }] } });
     const repo = makeRepo({ apiKey: 'sk-test' });
@@ -96,6 +109,7 @@ describe('AgentModelsService', () => {
     expect(result.models).toHaveLength(2);
     expect(result.models[0]).toEqual({
       id: 'anthropic/claude-haiku-4.5',
+      label: null,
       contextLength: 200_000,
       promptCostPerMillion: 1,
       completionCostPerMillion: 5,
@@ -118,6 +132,7 @@ describe('AgentModelsService', () => {
     expect(result.supported).toBe(true);
     expect(result.models[0]).toEqual({
       id: 'gpt-4o-mini',
+      label: null,
       contextLength: null,
       promptCostPerMillion: null,
       completionCostPerMillion: null,
@@ -236,6 +251,27 @@ describe('readSupportsVision', () => {
   });
 });
 
+describe('readModelLabel', () => {
+  it("reads OpenRouter's name", () => {
+    expect(readModelLabel({ id: 'anthropic/claude-haiku-4.5', name: 'Anthropic: Claude Haiku 4.5' })).toBe(
+      'Anthropic: Claude Haiku 4.5',
+    );
+  });
+
+  it("reads Anthropic's display_name", () => {
+    expect(readModelLabel({ id: 'claude-haiku-4-5', display_name: 'Claude Haiku 4.5' })).toBe(
+      'Claude Haiku 4.5',
+    );
+  });
+
+  it('returns null when the provider names nothing usable', () => {
+    expect(readModelLabel({ id: 'gpt-4o-mini' })).toBeNull();
+    expect(readModelLabel({ id: 'x', name: '   ' })).toBeNull();
+    expect(readModelLabel({ id: 'x', name: 42 })).toBeNull();
+    expect(readModelLabel(null)).toBeNull();
+  });
+});
+
 describe('normalizeProviderOfferings', () => {
   it('accepts bare model ids so a host that supplies strings keeps working', () => {
     expect(normalizeProviderOfferings(['a', 'b'])).toEqual([{ id: 'a' }, { id: 'b' }]);
@@ -244,6 +280,13 @@ describe('normalizeProviderOfferings', () => {
   it('carries a host-declared capability through', () => {
     expect(normalizeProviderOfferings([{ id: 'a', supportsVision: true }, 'b'])).toEqual([
       { id: 'a', supportsVision: true },
+      { id: 'b' },
+    ]);
+  });
+
+  it('carries a host-declared label through', () => {
+    expect(normalizeProviderOfferings([{ id: 'a', label: 'Model A' }, 'b'])).toEqual([
+      { id: 'a', label: 'Model A' },
       { id: 'b' },
     ]);
   });

--- a/packages/agent-host/src/models.service.ts
+++ b/packages/agent-host/src/models.service.ts
@@ -9,6 +9,7 @@ const CACHE_TTL_MS = 10 * 60 * 1000;
 
 export interface ModelEntry {
   id: string;
+  label: string | null;
   contextLength: number | null;
   promptCostPerMillion: number | null;
   completionCostPerMillion: number | null;
@@ -17,6 +18,7 @@ export interface ModelEntry {
 
 export interface ProviderModelOffer {
   id: string;
+  label?: string;
   supportsVision?: boolean;
 }
 
@@ -160,6 +162,7 @@ function offeringId(model: ProviderModelOffering): string {
 function toModelEntry(model: ProviderModelOffering): ModelEntry {
   return {
     id: offeringId(model),
+    label: typeof model === 'string' ? null : model.label?.trim() || null,
     contextLength: null,
     promptCostPerMillion: null,
     completionCostPerMillion: null,
@@ -178,6 +181,7 @@ function parseOpenAiCompatModels(body: unknown): ModelEntry[] | null {
     if (typeof id !== 'string') continue;
     out.push({
       id,
+      label: readModelLabel(item),
       contextLength: readContextLength(item),
       promptCostPerMillion: readPromptCost(item),
       completionCostPerMillion: readCompletionCost(item),
@@ -185,6 +189,16 @@ function parseOpenAiCompatModels(body: unknown): ModelEntry[] | null {
     });
   }
   return out;
+}
+
+export function readModelLabel(item: unknown): string | null {
+  if (!item || typeof item !== 'object') return null;
+  const record = item as Record<string, unknown>;
+  for (const key of ['name', 'display_name']) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim();
+  }
+  return null;
 }
 
 export function readSupportsVision(item: unknown): boolean | null {

--- a/packages/backend-core/src/modules/slack/slack-bridge.integration.test.ts
+++ b/packages/backend-core/src/modules/slack/slack-bridge.integration.test.ts
@@ -20,6 +20,12 @@ const skipReason = TEST_URL
   ? null
   : 'Set TEST_DATABASE_URL to a Postgres URL to run slack bridge tests.';
 
+const ORDERED_AT = [
+  '2026-08-21T09:00:00.000Z',
+  '2026-08-21T09:00:01.000Z',
+  '2026-08-21T09:00:02.000Z',
+] as const;
+
 interface PostedMessage {
   channel: string;
   text: string;
@@ -224,7 +230,12 @@ function actionIds(blocks: unknown[] | undefined): string[] {
     return conversation!.id;
   }
 
-  async function seedMessage(conversationId: string, body: string, internal = false) {
+  async function seedMessage(
+    conversationId: string,
+    body: string,
+    internal = false,
+    createdAt?: Date,
+  ) {
     const [message] = await db
       .insert(schema.convMessages)
       .values({
@@ -234,6 +245,7 @@ function actionIds(blocks: unknown[] | undefined): string[] {
         authorId: contactId,
         body,
         internal,
+        ...(createdAt ? { createdAt } : {}),
       })
       .returning();
     return message!.id;
@@ -409,8 +421,8 @@ function actionIds(blocks: unknown[] | undefined): string[] {
     api.failNextPosts = 1;
     const worker = new SlackBridgeWorker(db, api);
     const conversationId = await seedConversation();
-    const firstId = await seedMessage(conversationId, 'first');
-    const secondId = await seedMessage(conversationId, 'second');
+    const firstId = await seedMessage(conversationId, 'first', false, new Date(ORDERED_AT[0]));
+    const secondId = await seedMessage(conversationId, 'second', false, new Date(ORDERED_AT[1]));
     await enqueue('conversation.message.received', conversationId, {
       conversationId,
       messageId: firstId,
@@ -944,9 +956,14 @@ function actionIds(blocks: unknown[] | undefined): string[] {
 
   it('keeps non-voice conversations in message createdAt order', async () => {
     const conversationId = await seedConversation();
-    const first = await seedMessage(conversationId, 'First email');
-    const second = await seedMessage(conversationId, 'Second email');
-    const third = await seedMessage(conversationId, 'Third email');
+    const first = await seedMessage(conversationId, 'First email', false, new Date(ORDERED_AT[0]));
+    const second = await seedMessage(
+      conversationId,
+      'Second email',
+      false,
+      new Date(ORDERED_AT[1]),
+    );
+    const third = await seedMessage(conversationId, 'Third email', false, new Date(ORDERED_AT[2]));
 
     await emitReceived([third, first, second], conversationId);
 

--- a/packages/dashboard-pages/src/components/agent-config/models-card.tsx
+++ b/packages/dashboard-pages/src/components/agent-config/models-card.tsx
@@ -17,6 +17,7 @@ import { NativeSelect } from '../native-select';
 import { useTranslateError } from '../../i18n/translate-error';
 import {
   formatModel,
+  modelSortKey,
   BARE_CARD,
   type AgentConfigDto,
   type ListModelsResult,
@@ -57,7 +58,7 @@ export function ModelsCard({
 
   const sortedModels = useMemo(() => {
     if (!models?.supported) return [];
-    return [...models.models].sort((a, b) => a.id.localeCompare(b.id));
+    return [...models.models].sort((a, b) => modelSortKey(a).localeCompare(modelSortKey(b)));
   }, [models]);
 
   const knownIds = useMemo(() => new Set(sortedModels.map((m) => m.id)), [sortedModels]);

--- a/packages/dashboard-pages/src/components/agent-config/types.ts
+++ b/packages/dashboard-pages/src/components/agent-config/types.ts
@@ -14,6 +14,7 @@ export interface AgentConfigDto {
 
 export interface ModelEntry {
   id: string;
+  label?: string | null;
   contextLength: number | null;
   promptCostPerMillion: number | null;
   completionCostPerMillion: number | null;
@@ -71,6 +72,7 @@ export function presetForUrl(url: string): PresetId {
 
 export function formatModel(m: ModelEntry, labels?: ModalityLabels): string {
   const parts: string[] = [modelHead(m, labels)];
+  if (m.label) parts.push(m.id);
   if (m.contextLength) parts.push(`${(m.contextLength / 1000).toFixed(0)}k ctx`);
   if (m.promptCostPerMillion !== null) {
     parts.push(`$${m.promptCostPerMillion.toFixed(2)}/M in`);
@@ -82,7 +84,12 @@ export function formatModel(m: ModelEntry, labels?: ModalityLabels): string {
 }
 
 function modelHead(m: ModelEntry, labels?: ModalityLabels): string {
-  if (!labels || m.supportsVision == null) return m.id;
+  const head = m.label || m.id;
+  if (!labels || m.supportsVision == null) return head;
   const modalities = m.supportsVision ? [labels.chat, labels.vision] : [labels.chat];
-  return `${m.id} (${modalities.join(', ')})`;
+  return `${head} (${modalities.join(', ')})`;
+}
+
+export function modelSortKey(m: ModelEntry): string {
+  return m.label || m.id;
 }

--- a/packages/dashboard-pages/src/components/agent-config/use-agent-config.ts
+++ b/packages/dashboard-pages/src/components/agent-config/use-agent-config.ts
@@ -39,7 +39,7 @@ export function useAgentConfig(): UseAgentConfigResult {
   }, [tryLoad]);
 
   useEffect(() => {
-    if (!config?.providerApiKeySet) return;
+    if (!config) return;
     void api<ListModelsResult>('/v1/agent-config/models')
       .then(setModels)
       .catch(() => undefined);


### PR DESCRIPTION
Follow-up to #923. The model picker rendered the raw model id, so a deployment offering
built-in models could only present them as `gpt-oss-120b` and `qwen3.5-397b-a17b` —
accurate, and unreadable to the person choosing.

`ModelEntry` gains a `label`. `formatModel` uses it as the head of the option and pushes
the id into the detail line beside context length and pricing:

```
GPT-OSS 120B (chat) · gpt-oss-120b · 128k ctx
Gemma 4 26B (chat, vision) · gemma-4-26b-a4b-it
```

The id stays visible on purpose — it is what goes to the provider, and it is what an
operator matches against the provider's own catalogue.

## Where the label comes from

Two sources, mirroring how `supportsVision` is resolved in the same file:

- **The host**, through `AgentHostModule`'s `defaultProviderModels`: `ProviderModelOffer`
  gains an optional `label`, so `{ id: 'gpt-oss-120b', label: 'GPT-OSS 120B' }` names a
  managed model. Bare strings keep working and report `null`.
- **The provider's own `/models` payload**, which already carried the name a host would
  otherwise hardcode. OpenRouter returns `name` ("Anthropic: Claude Haiku 4.5"), Anthropic
  returns `display_name`, and `readModelLabel` reads either. Plain OpenAI returns neither,
  so those entries keep showing the id — which is what its own docs call them anyway.

So BYOK orgs get readable names out of this too, not just deployments with a managed list.

## Sort

The picker's sort moves from the id to the displayed name (`modelSortKey`), because a list
labelled with names but ordered by hidden ids looks arbitrary. Each option's `value` is
still the id, so nothing about what is saved or sent to the provider changes.

## Second commit: a flaky test, not a behaviour change

`slack-bridge.integration.test.ts`'s `seedMessage` never set `createdAt`, so its two
ordering tests relied on three rapid inserts landing on distinct column defaults. When two
share a timestamp the bridge's `(order_at, order_seq, created_at, id)` sort falls through
to `id` — a random UUID — and the assertion fails on whichever order that produced. This
fired on the 5.21.0 publish run as `['First email', 'Third email', 'Second email']`, which
skipped the `release` job and left main version-bumped with nothing published until the job
was rerun.

The worker's ordering is already fully deterministic for rows whose timestamps differ,
which is every real conversation; only the fixture was ambiguous. Both tests now seed
explicit spaced timestamps. No changeset — nothing shipped changes.

## Verification

`agent-host` 192 tests, `dashboard-pages` 186 tests, and the slack bridge file 32 tests all
pass locally (the last run 4x against a throwaway pgvector database to check stability).

## Third commit: the picker never filled on first paint

Found while smoke-testing the cloud side of #923 on dev, and it is a direct consequence of
a host doing what #923 invites — deleting the hardcoded `models` array from its managed
preset.

`useAgentConfig` skipped `GET /v1/agent-config/models` unless `providerApiKeySet` was true.
That guard was correct when written, since the endpoint could only answer by asking the
org's own provider. #923 made the endpoint serve the deployment's managed list to a keyless
org, but the client kept not asking — so `models` stayed `null`, and `ModelsCard`, which
counts a managed provider as credentialed, fell through every branch to its loading state
and stayed there.

A preset still carrying a `models` array masks it, because the page feeds that array to the
card instead. Delete the array and the picker reads `Loading…` — on the settings page **and
on the same step of the first-run wizard** — until the operator presses Save on the provider
card, which is the one action that already refetched. `provider-card.tsx`'s fallback only
fires on a provider change, not on page load, so it did not cover this.

The guard now waits only for the config to arrive. An org that is neither keyed nor covered
by a managed list gets `supported: false` and renders the "needs a key" branch it already
had, so the cost is one small GET on a page that then explains itself correctly.

No test: this package has no React-hook test infrastructure (no jsdom or testing-library,
its suites are pure-logic `.test.ts`), and standing that up for a one-line guard would be
disproportionate. Verified by hand on dev.
