### PR TITLE
fix(dashboard): drop the raw model id from a named picker option

### DIFF
--- a/.changeset/model-picker-drop-raw-id.md
+++ b/.changeset/model-picker-drop-raw-id.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Drop the raw model id from a picker option that already has a name.
+
+The option text carried both, reading `Gemma 4 26B (chat, vision) · gemma-4-26b-a4b-it`.
+The reasoning was that the id is what actually goes to the provider and what an operator
+matches against the provider's catalogue — but it defeats the point of naming the model at
+all, and the two longest strings in the row are then the same fact twice. A model with no
+name still shows its id through `modelHead`, so nothing becomes anonymous.
+
+`value` on each option was always the id and is untouched, so what gets saved and sent is
+unchanged.

--- a/packages/dashboard-pages/src/components/agent-config/types.ts
+++ b/packages/dashboard-pages/src/components/agent-config/types.ts
@@ -72,7 +72,6 @@ export function presetForUrl(url: string): PresetId {
 
 export function formatModel(m: ModelEntry, labels?: ModalityLabels): string {
   const parts: string[] = [modelHead(m, labels)];
-  if (m.label) parts.push(m.id);
   if (m.contextLength) parts.push(`${(m.contextLength / 1000).toFixed(0)}k ctx`);
   if (m.promptCostPerMillion !== null) {
     parts.push(`$${m.promptCostPerMillion.toFixed(2)}/M in`);


### PR DESCRIPTION
Drops the raw model id from a picker option that already has a name.

Before / after, for a deployment whose managed models carry labels:

```
- Gemma 4 26B (chat, vision) · gemma-4-26b-a4b-it
- GPT-OSS 120B (chat) · gpt-oss-120b
- Qwen3.5 397B (chat, vision) · qwen3.5-397b-a17b
+ Gemma 4 26B (chat, vision)
+ GPT-OSS 120B (chat)
+ Qwen3.5 397B (chat, vision)
```

#934 added the id beside the label deliberately, on the grounds that it is what actually
goes to the provider and what an operator matches against the provider's own catalogue.
That was the wrong call: it defeats the point of naming the model, and the two longest
strings in the row end up stating the same fact twice.

A model the provider does not name still shows its id, because `modelHead` falls back to it
— so no option becomes anonymous, and OpenAI-style providers that return neither `name` nor
`display_name` are unaffected. Context length and pricing still append where the provider
reports them.

Each option's `value` was always the id and is untouched, so what gets saved and sent to the
provider does not change. One line, no behaviour change beyond the label text.
