### PR TITLE
fix(conv): file away mail from an address that takes no replies

### DIFF
--- a/.changeset/suppress-no-reply-senders.md
+++ b/.changeset/suppress-no-reply-senders.md
@@ -1,0 +1,14 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+File away mail from an address that takes no replies
+
+A mailbox deleted at the far end answers with an ordinary email, not a bounce: `noreply.autoresponder.no@kaefer.no` writing "the email address you have tried to reach does not exist within our company anymore". It carries no `Auto-Submitted`, no auto-reply subject and no delivery-status report, so nothing suppressed it — it opened a conversation, raised the attention flag, and the agent drafted a courteous reply to an address that by construction discards it.
+
+`classifySender` already saw this: `isRoleAccount` was true. But role accounts are deliberately answerable, because a human reads `support@` and `sales@`. A `noreply@` / `do-not-reply@` address is the narrower case where a reply is guaranteed to go nowhere, so it is now its own classification, `isNoReplyAddress`, and its own suppression reason, `no_reply_address` — filed away closed at ingest with no draft and no attention, exactly like an out-of-office.
+
+A bounce or an auto-reply still reports its own reason over this one, which says least about the mail. A mailing-list post from a no-reply address stays answerable, the same carve-out `Precedence: bulk` already has.
+
+Detection is on the address alone. Body phrases like "no longer available" are multilingual and a quoted original can carry them, so the "mailbox does not exist" wording is not matched — a no-reply sender that no human reads is a fact about the header.

--- a/packages/backend-core/src/modules/conv/email/classify-sender.test.ts
+++ b/packages/backend-core/src/modules/conv/email/classify-sender.test.ts
@@ -13,6 +13,7 @@ describe('classifySender', () => {
       isMailingList: false,
       isAutoReply: false,
       isRoleAccount: false,
+      isNoReplyAddress: false,
       isBounce: false,
       autoReplySignal: null,
     });
@@ -300,6 +301,51 @@ describe('classifySender', () => {
     expect(suppressionReason(c)).toBeNull();
   });
 
+  it('suppresses a sender whose address says it takes no replies', () => {
+    for (const from of [
+      'noreply.autoresponder.no@kaefer.no',
+      'noreply@vendor.example',
+      'no-reply+thread-42@acme.com',
+      'donotreply@acme.com',
+      'do-not-reply@acme.com',
+    ]) {
+      const c = classifySender(h({ From: from }), from);
+      expect(c.isNoReplyAddress, from).toBe(true);
+      expect(suppressionReason(c), from).toBe('no_reply_address');
+    }
+  });
+
+  it('reports bounce and auto-reply over a no-reply address, which says least about the mail', () => {
+    const bounce = classifySender(
+      h({ From: 'noreply@acme.com', 'X-Failed-Recipients': 'kari@acme.com' }),
+      'noreply@acme.com',
+    );
+    expect(suppressionReason(bounce)).toBe('bounce');
+    const ooo = classifySender(
+      h({ From: 'noreply@acme.com', Subject: 'Automatic reply: hei' }),
+      'noreply@acme.com',
+    );
+    expect(suppressionReason(ooo)).toBe('auto_reply');
+  });
+
+  it('leaves a mailing-list post from a no-reply address answerable, as Precedence: bulk already does', () => {
+    const c = classifySender(
+      h({ From: 'noreply@acme.com', 'List-Id': 'announce.acme.com' }),
+      'noreply@acme.com',
+    );
+    expect(c.isNoReplyAddress).toBe(true);
+    expect(suppressionReason(c)).toBeNull();
+  });
+
+  it('does not treat an ordinary role account as a no-reply address', () => {
+    for (const from of ['support@acme.com', 'sales@acme.com', 'info@acme.com']) {
+      const c = classifySender(h({ From: from }), from);
+      expect(c.isRoleAccount, from).toBe(true);
+      expect(c.isNoReplyAddress, from).toBe(false);
+      expect(suppressionReason(c), from).toBeNull();
+    }
+  });
+
   it('does not suppress a mailing-list post or a role account', () => {
     const list = classifySender(h({ 'List-Id': 'announce.acme.com' }), 'jane@acme.com');
     expect(suppressionReason(list)).toBeNull();
@@ -318,6 +364,7 @@ describe('classifySender', () => {
         isMailingList: false,
         isAutoReply: true,
         isRoleAccount: false,
+        isNoReplyAddress: false,
         isBounce: false,
         autoReplySignal: 'subject',
       }),

--- a/packages/backend-core/src/modules/conv/email/classify-sender.ts
+++ b/packages/backend-core/src/modules/conv/email/classify-sender.ts
@@ -10,6 +10,7 @@ export interface SenderClassification {
   isMailingList: boolean;
   isAutoReply: boolean;
   isRoleAccount: boolean;
+  isNoReplyAddress: boolean;
   isBounce: boolean;
   autoReplySignal: AutoReplySignal | null;
 }
@@ -131,9 +132,10 @@ export function classifySender(
 
   const isBounce = reportsDeliveryFailure || (bounceShapedEnvelopeSender && !isAutoReply);
 
-  const isRoleAccount = ROLE_LOCAL_PARTS.has(localBase) || /^no-?reply|^do-?not-?reply/.test(localBase);
+  const isNoReplyAddress = /^no-?reply|^do-?not-?reply/.test(localBase);
+  const isRoleAccount = ROLE_LOCAL_PARTS.has(localBase) || isNoReplyAddress;
 
-  return { isMailingList, isAutoReply, isRoleAccount, isBounce, autoReplySignal };
+  return { isMailingList, isAutoReply, isRoleAccount, isNoReplyAddress, isBounce, autoReplySignal };
 }
 
 function detectAutoReplySignal(
@@ -170,14 +172,17 @@ function foldDiacritics(value: string): string {
 }
 
 export function hasAnyClassification(c: SenderClassification): boolean {
-  return c.isMailingList || c.isAutoReply || c.isRoleAccount || c.isBounce;
+  return (
+    c.isMailingList || c.isAutoReply || c.isRoleAccount || c.isNoReplyAddress || c.isBounce
+  );
 }
 
-export type SuppressionReason = 'auto_reply' | 'bounce';
+export type SuppressionReason = 'auto_reply' | 'bounce' | 'no_reply_address';
 
 export function suppressionReason(c: SenderClassification): SuppressionReason | null {
   if (c.isBounce) return 'bounce';
   if (c.isAutoReply) return 'auto_reply';
+  if (c.isNoReplyAddress && !c.isMailingList) return 'no_reply_address';
   return null;
 }
 

--- a/packages/backend-core/src/modules/conv/email/email-relay.integration.test.ts
+++ b/packages/backend-core/src/modules/conv/email/email-relay.integration.test.ts
@@ -421,6 +421,41 @@ const RELAY_DOMAIN = 'in.getmunin.test';
       expect(conv!.needsHumanAttention).toBe(false);
     });
 
+    it('files away closed a deleted-mailbox notice from an address that takes no replies', async () => {
+      const raw = [
+        'From: noreply.autoresponder_NO_01 <noreply.autoresponder.no@kaefer.no>',
+        `To: <${relayAddress}>`,
+        'Subject: This mailbox is no longer available',
+        'Message-ID: <deleted-mailbox@kaefer.no>',
+        'Content-Type: text/plain; charset="utf-8"',
+        '',
+        'We are sorry, but the email address you have tried to reach does not exist',
+        'within our company anymore.',
+        '',
+      ].join('\r\n');
+      const res = await postRelay({
+        recipient: relayAddress,
+        raw: Buffer.from(raw).toString('base64'),
+      });
+      expect(res.status).toBe(201);
+
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      const msg = (
+        await db.select().from(schema.convMessages).where(eq(schema.convMessages.orgId, orgId))
+      ).find((m) => m.body.includes('does not exist'));
+      expect(msg).toBeDefined();
+      expect(msg!.metadata).toMatchObject({ suppressed: 'no_reply_address' });
+
+      const conv = (
+        await db
+          .select()
+          .from(schema.convConversations)
+          .where(eq(schema.convConversations.id, msg!.conversationId))
+      )[0];
+      expect(conv!.status).toBe('closed');
+      expect(conv!.needsHumanAttention).toBe(false);
+    });
+
     it('leaves a live customer thread open when a later auto-reply lands on it', async () => {
       await postRelay({
         recipient: relayAddress,

--- a/packages/backend-core/src/modules/conv/email/forwarded-sender.test.ts
+++ b/packages/backend-core/src/modules/conv/email/forwarded-sender.test.ts
@@ -19,6 +19,7 @@ function parsed(overrides: Partial<ParsedInboundEmail>): ParsedInboundEmail {
       isMailingList: false,
       isAutoReply: false,
       isRoleAccount: false,
+      isNoReplyAddress: false,
       isBounce: false,
       autoReplySignal: null,
     },

--- a/packages/dashboard-pages/src/components/dashboard/inbox-message-bubble.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-message-bubble.tsx
@@ -131,7 +131,12 @@ export function MessageBubble({
           <span>· {formatSeenAt(message.createdAt)}</span>
           {suppressed ? (
             <span className="text-ink-label">
-              · {suppressed === 'bounce' ? t('bounceNotice') : t('autoReply')}
+              ·{' '}
+              {suppressed === 'bounce'
+                ? t('bounceNotice')
+                : suppressed === 'no_reply_address'
+                  ? t('noReplyAddress')
+                  : t('autoReply')}
             </span>
           ) : null}
         </div>

--- a/packages/dashboard-pages/src/messages/en.json
+++ b/packages/dashboard-pages/src/messages/en.json
@@ -378,6 +378,7 @@
         "noSpeech": "No speech transcribed",
         "autoReply": "Auto-reply",
         "bounceNotice": "Bounced",
+        "noReplyAddress": "No-reply address",
         "outreachRevised": "Revised {count}× since it was drafted",
         "outreachRevisedAfterReview": "Revised {count}× after it was opened for review — read it again before approving",
         "outreachRevisionReason": "Reason — {reason}",

--- a/packages/dashboard-pages/src/messages/nb.json
+++ b/packages/dashboard-pages/src/messages/nb.json
@@ -378,6 +378,7 @@
         "noSpeech": "Ingen tale oppfattet",
         "autoReply": "Autosvar",
         "bounceNotice": "Returmelding",
+        "noReplyAddress": "Ingen svaradresse",
         "outreachRevised": "Endret {count}× siden utkastet ble skrevet",
         "outreachRevisedAfterReview": "Endret {count}× etter at det ble åpnet til gjennomgang — les det på nytt før du godkjenner",
         "outreachRevisionReason": "Begrunnelse — {reason}",


### PR DESCRIPTION
## The case

Globex conv #186. A recipient's mailbox was deleted, and their employer's system answered — as an ordinary email, not a bounce:

> **From:** `noreply.autoresponder_NO_01 <noreply.autoresponder.no@contoso.test>`
> **Subject:** This mailbox is no longer available
> Dear Sir or Madam, We are sorry, but the email address you have tried to reach does not exist within our company anymore.

No `Auto-Submitted`, no auto-reply subject prefix, no `multipart/report`, an ordinary envelope sender. Nothing in the classifier fired:

```json
{ "isBounce": false, "isAutoReply": false, "isMailingList": false, "isRoleAccount": true }
```

So it opened a conversation, raised the attention flag, and the agent drafted a polite reply explaining what Globex is — addressed to a mailbox that discards it.

## The handle

`isRoleAccount` was true, and that is the one thing the classifier already knew. But role accounts are answerable on purpose: a human reads `support@`, `sales@`, `info@`. A `noreply@` / `do-not-reply@` address is the strictly narrower case where a reply is guaranteed to reach nobody — which makes it a fact worth acting on rather than merely recording.

So it becomes its own classification (`isNoReplyAddress`) and its own suppression reason (`no_reply_address`): filed away closed at ingest, no draft, no attention flag, no Slack mirror — the same treatment an out-of-office gets.

Precedence among the reasons: `bounce` > `auto_reply` > `no_reply_address`. The address says least about what the mail *is*, so a real bounce or a real auto-reply from a `noreply@` sender still reports what it actually is. And a mailing-list post from a no-reply address stays answerable — the same carve-out `Precedence: bulk` already has, so this doesn't quietly reverse that decision.

## Why not match the wording

"no longer available" / "does not exist" is tempting and wrong: it is multilingual, and a quoted original inside a reply can carry the phrase. That a sender accepts no replies is a fact about the header, so the detection stays on the header.

## Testing

Unit: five real no-reply shapes (including the Contoso one) suppress; a bounce and an auto-reply from a `noreply@` sender still report their own reason; a `List-Id` post from a no-reply address stays answerable; `support@` / `sales@` / `info@` stay role accounts that are *not* suppressed.

Integration: the exact Contoso message through `/relay` lands `suppressed: 'no_reply_address'` on a conversation that opens closed with no attention flag.

Full conv suite (637) and workspace typecheck green.

## Not included

No migration. This is a new policy rather than a bug backfill, and the one conversation it applies to in the wild is a click on **Close, no reply** — say the word if you'd rather I close it in SQL across all orgs.

Worth naming separately: nothing in Munin tracks that an address is **undeliverable**. `crm_contacts` has `do_not_contact` and `unsubscribed_at`, but both are consent, not deliverability — a colleague who left the company hasn't opted out, and conflating the two would be wrong. So outreach will keep mailing a dead address until someone notices. That's a real gap and its own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFeprNBvT38AoBUPPQzCND

