### PR TITLE
fix(dashboard): seed the agent draft when reopening a visited conversation

### DIFF
--- a/.changeset/inbox-reopen-draft-dirty.md
+++ b/.changeset/inbox-reopen-draft-dirty.md
@@ -1,0 +1,7 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Stop the inbox composer from reporting a pending draft as "edited by you" when you reopen a conversation you have already visited.
+
+`conversation-pane` mirrors the composer text in `replyRef` so the draft-seeding effect can read it without depending on it. The per-conversation reset effect cleared the `reply` state but not that mirror, and the mirror is only re-synced on the next render. Reopening a conversation whose detail is already cached puts the selection change and the draft in the same commit, so the seeding effect ran with the *previous* conversation's text still in the ref, judged the composer "touched", and skipped seeding — leaving an empty box with a non-null `suggestionId`, which renders as "edited by you" plus a Restore draft button. The reset now clears the mirror alongside the state, so the cached draft seeds exactly as it does on a fresh page load.

--- a/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-pane.tsx
@@ -127,6 +127,7 @@ export function ConversationPane({
     seededDraftId.current = null;
     seededBody.current = null;
     setSuggestionId(null);
+    replyRef.current = '';
     setReply('');
     setNoteDraft('');
     setTab('reply');


### PR DESCRIPTION
## What

Reopening an already-visited conversation in the inbox showed an **empty composer** plus "edited by you" and a **Restore draft** button, with no edit having happened. Refreshing the page and reopening the same conversation showed the draft correctly.

## Why it happened

`conversation-pane` mirrors the composer text into `replyRef` on every render so the draft-seeding effect can read it without taking it as a dependency:

```tsx
replyRef.current = reply;                                    // :76, render-time
// …
useEffect(() => { /* … */ setReply(''); }, [selectedId]);    // reset: cleared the state, not the mirror
// …
const untouched =
  replyRef.current.trim() === '' || replyRef.current === seededBody.current;
```

The mirror is only re-synced on the next render. Conversation details are cached in `conversation-queue.ts` (`details` record), so reopening a visited conversation delivers the selection change **and** the draft in the same commit:

1. the reset effect clears `reply`, `seededDraftId` and `seededBody` — but `replyRef.current` still holds the *previous* conversation's draft body;
2. the seeding effect runs in that same commit, computes `untouched === false` (stale non-empty text that no longer matches the nulled `seededBody`), sets `suggestionId = draft.id` and **skips** `setReply(draft.body)`.

Empty box + live `suggestionId` + `reply !== draft.body` ⇒ `dirty`, which renders as "edited by you" with Restore draft. On a fresh load the detail isn't cached, so the draft arrives a commit later when the mirror has already re-synced to `''` — hence the refresh appearing to fix it.

## The fix

Clear the mirror alongside the state it mirrors, in the `selectedId` reset effect. `replyRef` is read by that one effect only, so this is the whole change.

## Testing

Typecheck, lint and the 190 `dashboard-pages` tests pass.

No regression test: the package has no DOM test infrastructure (no `vitest.config.ts`, no `@testing-library`, 117 `.tsx` files and zero component tests), and this is a commit-ordering bug — it needs two conversations, a real selection change and React's actual effect ordering. Extracting the decision into a pure helper would not catch it, because the defect is the stale *input* to the decision rather than the decision itself. Filed #946 for the infrastructure, with this case as the worked example.

Not exercised in a running app — worth a manual pass before merge: claim two conversations with pending
drafts, open the first, open the second, then return to the first. Expected: the draft is seeded and the
composer is clean, with no "edited by you".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
