### PR TITLE
fix(dashboard): serve the first-run MCP endpoint from the running server

### DIFF
--- a/.changeset/first-run-mcp-endpoint-from-server.md
+++ b/.changeset/first-run-mcp-endpoint-from-server.md
@@ -1,0 +1,11 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+'@getmunin/core': patch
+---
+
+First-run onboarding now shows the MCP endpoint the running server reports, instead of the one baked into the client bundle at build time.
+
+`NEXT_PUBLIC_MCP_URL` is read inside `'use client'` components, so its value is inlined when the Next app is compiled — not when the container starts. A deployment that sets the variable only as a runtime container env var (which is how the cloud stack passes it) therefore shipped the local fallback, and every operator opening a fresh dashboard in production was told to point their agent at `http://localhost:3001/mcp`.
+
+`/v1/overview/setup` now carries `mcpUrl` (the backend's own `mcpResourceBase()`, resolved per request), the setup snapshot threads it through to `SetupSnapshot.mcpUrl`, and the first-run overview and review scenes prefer it, falling back to the build-time constant only when the endpoint could not be read.

--- a/packages/backend-core/src/control/overview.controller.integration.test.ts
+++ b/packages/backend-core/src/control/overview.controller.integration.test.ts
@@ -101,6 +101,7 @@ const skipReason = TEST_URL
   }
 
   interface SetupBody {
+    mcpUrl: string;
     channels: Array<{ id: string; type: string; active: boolean }>;
     conversationCount: number;
     topicCount: number;
@@ -154,6 +155,11 @@ const skipReason = TEST_URL
     expect(body.selfServiceAgentSubscriberCount).toBe(0);
     expect(body.lastInboundEndUserMessageAt).toBeNull();
     expect(body.lastAgentMessageAt).toBeNull();
+  });
+
+  it('setup hands the dashboard the running server\'s MCP endpoint', async () => {
+    const setup = await getSetup(adminKeyA);
+    expect(setup.mcpUrl).toMatch(/^https?:\/\/\S+[^/]$/);
   });
 
   it('setup reports a brand-new org as having nothing to listen with', async () => {

--- a/packages/backend-core/src/control/setup-state.service.ts
+++ b/packages/backend-core/src/control/setup-state.service.ts
@@ -11,6 +11,7 @@ import {
   AGENT_RUNTIME_PROMPT_SPACE_SLUG,
   COMPANY_PROFILE_SPACE_SLUG,
   getCurrentContext,
+  mcpResourceBase,
 } from '@getmunin/core';
 import { ConvService, type ChannelDto } from '../modules/conv/conv.service.ts';
 import { CURATION_INBOX_SLUG, KbService } from '../modules/kb/kb.service.ts';
@@ -32,6 +33,7 @@ export interface SetupReviewQueueDto {
 }
 
 export interface SetupStateDto {
+  mcpUrl: string;
   channels: ChannelDto[];
   conversationCount: number;
   topicCount: number;
@@ -65,6 +67,7 @@ export class SetupStateService {
       ]);
 
     return {
+      mcpUrl: mcpResourceBase(),
       channels,
       conversationCount,
       topicCount,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
 } from './request/credentials.ts';
 export {
   canonicalMcpResource,
+  mcpResourceBase,
   mcpResourcePaths,
   mcpResourceUrls,
   registerMcpResourcePaths,

--- a/packages/dashboard-pages/src/components/first-run/first-run-links.tsx
+++ b/packages/dashboard-pages/src/components/first-run/first-run-links.tsx
@@ -5,6 +5,10 @@ import { DEFAULT_DOCS_HOST, DEFAULT_MCP_HOST } from '../../data/mcp-setups';
 
 export const MCP_ENDPOINT = DEFAULT_MCP_HOST;
 
+export function mcpEndpoint(setup: { mcpUrl: string | null }): string {
+  return setup.mcpUrl ?? MCP_ENDPOINT;
+}
+
 export const FIRST_RUN_ROUTES = {
   channels: '/dashboard/settings/channels',
 } as const;

--- a/packages/dashboard-pages/src/components/first-run/first-run-view.test.ts
+++ b/packages/dashboard-pages/src/components/first-run/first-run-view.test.ts
@@ -6,6 +6,7 @@ function setupState(overrides: Partial<SetupState> = {}): SetupState {
   return {
     known: true,
     stage: 'active',
+    mcpUrl: null,
     liveChannels: [],
     pendingChannels: [],
     agentConnected: false,

--- a/packages/dashboard-pages/src/components/first-run/index.ts
+++ b/packages/dashboard-pages/src/components/first-run/index.ts
@@ -23,6 +23,7 @@ export {
   FIRST_RUN_ROUTES,
   FirstRunLink,
   MCP_ENDPOINT,
+  mcpEndpoint,
 } from './first-run-links';
 export {
   FirstRunActions,

--- a/packages/dashboard-pages/src/components/first-run/overview-first-run.tsx
+++ b/packages/dashboard-pages/src/components/first-run/overview-first-run.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import { CopyField } from '../copy-field';
-import { FIRST_RUN_DOCS, FIRST_RUN_ROUTES, FirstRunLink, MCP_ENDPOINT } from './first-run-links';
+import { FIRST_RUN_DOCS, FIRST_RUN_ROUTES, FirstRunLink, mcpEndpoint } from './first-run-links';
 import { FirstRunAside, FirstRunNote, FirstRunScene } from './first-run-scene';
 import { FirstRunSteps } from './first-run-steps';
 import { FirstRunStatusList, type FirstRunStatusRow } from './first-run-status';
@@ -23,6 +23,7 @@ function stepsDone(setup: SetupState): number {
 
 function UnconfiguredOverview({ setup }: { setup: SetupState }) {
   const t = useTranslations('dashboard.firstRun');
+  const endpoint = mcpEndpoint(setup);
   return (
     <FirstRunScene
       eyebrow={t('overview.eyebrowSetup', { done: stepsDone(setup) })}
@@ -41,7 +42,7 @@ function UnconfiguredOverview({ setup }: { setup: SetupState }) {
             }),
             actions: (
               <>
-                <CopyField value={MCP_ENDPOINT} className="mb-1 max-w-[460px] basis-full" />
+                <CopyField value={endpoint} className="mb-1 max-w-[460px] basis-full" />
                 <FirstRunLink href={FIRST_RUN_DOCS.connectClient} accent>
                   {t('actions.clientSetup')}
                 </FirstRunLink>
@@ -71,6 +72,7 @@ function UnconfiguredOverview({ setup }: { setup: SetupState }) {
 function ListeningOverview({ setup }: { setup: SetupState }) {
   const t = useTranslations('dashboard.firstRun');
   const channelKind = useChannelKindLabel();
+  const endpoint = mcpEndpoint(setup);
 
   const rows: FirstRunStatusRow[] = setup.liveChannels.map((channel) => ({
     key: channel.id,
@@ -88,7 +90,7 @@ function ListeningOverview({ setup }: { setup: SetupState }) {
     live: setup.agentConnected,
     detail: (
       <>
-        <code>{MCP_ENDPOINT}</code>{' '}
+        <code>{endpoint}</code>{' '}
         <span>
           —{' '}
           {setup.agentConnected

--- a/packages/dashboard-pages/src/components/first-run/review-first-run.tsx
+++ b/packages/dashboard-pages/src/components/first-run/review-first-run.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import { CopyField } from '../copy-field';
-import { MCP_ENDPOINT } from './first-run-links';
+import { mcpEndpoint } from './first-run-links';
 import { FirstRunFootnote, FirstRunNote, FirstRunScene } from './first-run-scene';
 import { FirstRunFigures } from './first-run-status';
 import type { SetupState } from './use-setup-state';
@@ -24,7 +24,7 @@ export function ReviewFirstRun({
         title={t.rich('review.titleEmptyBase', { em: (chunks) => <em>{chunks}</em> })}
         lede={t.rich('review.ledeEmptyBase', { code: (chunks) => <code>{chunks}</code> })}
       >
-        <CopyField value={MCP_ENDPOINT} className="max-w-[460px]" />
+        <CopyField value={mcpEndpoint(setup)} className="max-w-[460px]" />
         <FirstRunNote>{t('review.noteEmptyBase')}</FirstRunNote>
       </FirstRunScene>
     );

--- a/packages/dashboard-pages/src/components/first-run/setup-snapshot.test.ts
+++ b/packages/dashboard-pages/src/components/first-run/setup-snapshot.test.ts
@@ -36,6 +36,14 @@ describe('toSetupSnapshot', () => {
     expect(snapshot.stage).toBe('active');
   });
 
+  it('carries the endpoint the server reports, not the one baked in at build time', () => {
+    expect(toSetupSnapshot(dto({ mcpUrl: 'https://mcp.example.com' })).mcpUrl).toBe(
+      'https://mcp.example.com',
+    );
+    expect(toSetupSnapshot(dto()).mcpUrl).toBeNull();
+    expect(toSetupSnapshot(null).mcpUrl).toBeNull();
+  });
+
   it('is unconfigured when no channel can accept a message', () => {
     expect(toSetupSnapshot(dto()).stage).toBe('unconfigured');
   });

--- a/packages/dashboard-pages/src/components/first-run/setup-snapshot.ts
+++ b/packages/dashboard-pages/src/components/first-run/setup-snapshot.ts
@@ -18,6 +18,7 @@ export interface SetupReviewQueue {
 }
 
 export interface SetupStateDto {
+  mcpUrl?: string | null;
   channels: SetupChannelDto[];
   conversationCount: number;
   topicCount: number;
@@ -36,6 +37,7 @@ export interface SetupChannel {
 export interface SetupSnapshot {
   known: boolean;
   stage: SetupStage;
+  mcpUrl: string | null;
   liveChannels: SetupChannel[];
   pendingChannels: SetupChannel[];
   agentConnected: boolean;
@@ -52,6 +54,7 @@ const CHANNEL_ORDER: SetupChannelType[] = ['email', 'chat', 'sms', 'voice'];
 const UNKNOWN: SetupSnapshot = {
   known: false,
   stage: 'active',
+  mcpUrl: null,
   liveChannels: [],
   pendingChannels: [],
   agentConnected: false,
@@ -71,6 +74,7 @@ export function toSetupSnapshot(dto: SetupStateDto | null): SetupSnapshot {
 
   return {
     known: true,
+    mcpUrl: dto.mcpUrl ?? null,
     stage:
       dto.conversationCount > 0 ? 'active' : live.length > 0 ? 'listening' : 'unconfigured',
     liveChannels: toSetupChannels(live),


### PR DESCRIPTION
First-run onboarding on app.getmunin.com tells operators to point their agent at `http://localhost:3001/mcp`.

## Why

`MCP_ENDPOINT` comes from `DEFAULT_MCP_HOST` in `packages/dashboard-pages/src/data/mcp-setups.ts`, which reads `process.env.NEXT_PUBLIC_MCP_URL ?? 'http://localhost:3001/mcp'`. The first-run scenes are `'use client'`, so that read is inlined **when the Next app is compiled**, not when the container starts. A deployment that passes the variable only as a runtime container env var — which is how the cloud stack passes it; its web Dockerfile takes build args for `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_DOCS_URL` and the tracker key, but not the MCP URL — therefore ships the local fallback to every browser.

That also makes the value fragile in general: it is correct only when the build environment happens to match the deploy environment.

## What changed

The endpoint is now reported by the running server, which always has the variable at hand:

- `/v1/overview/setup` carries `mcpUrl`, resolved per request from `mcpResourceBase()` (now exported from `@getmunin/core`).
- `SetupSnapshot` gains `mcpUrl`, `null` when the endpoint could not be read.
- The first-run overview and review scenes render `mcpEndpoint(setup)`, falling back to the build-time constant only for an unknown snapshot.

No new env var, no migration, no cloud-side change required — the backend container already receives `NEXT_PUBLIC_MCP_URL` at runtime. Self-hosters that set it only at runtime are fixed by the same change.

## Testing

- `setup-snapshot.test.ts` — the snapshot carries the server's endpoint, and stays `null` for a DTO without one and for an unreadable snapshot.
- `overview.controller.integration.test.ts` — `/v1/overview/setup` serves an absolute, non-trailing-slash endpoint (11 passed against a scratch DB).
- `pnpm typecheck`, dashboard-pages (191) and core (516) unit suites, lint across the three packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)