### PR TITLE
fix(dashboard): report the real needs-attention count instead of saturating at 50

### DIFF
--- a/.changeset/lucky-hounds-smile.md
+++ b/.changeset/lucky-hounds-smile.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+Report the real "needs your attention" count on the overview and sidebar badge instead of saturating at 50.
+
+`GET /v1/inbox` returns `live` as a preview list capped at 50 conversations, and the dashboard counted that array: the overview stat row and the console sidebar badge both froze at 50 once an org had more flagged conversations than that. An org with 65 waiting saw 50, with no hint anything was missing.
+
+The response now carries `liveTotal` — a `COUNT(*)` over the same filters the list uses (flagged and not closed/spam, plus actively claimed conversations whose flag was already cleared) — and both counters read that instead of `live.length`. The list itself stays capped; only the number is exact.
+
+Two smaller consequences: `ConvService.countConversations` is new and shares `buildConversationListFilters` with the list queries, so filters can never drift between count and page; and `listConversationsByIds` takes an optional `needsHumanAttention` filter, which lets the claimed-only branch ask for exactly the unflagged claims rather than subtracting a truncated id set — previously a flagged-and-claimed conversation ranked past the 50th leaked into the list through that subtraction.

--- a/packages/backend-core/src/control/inbox.controller.integration.test.ts
+++ b/packages/backend-core/src/control/inbox.controller.integration.test.ts
@@ -1,0 +1,169 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { randomToken } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { eq, sql } from 'drizzle-orm';
+import { createApp } from '../bootstrap-app.ts';
+import { AppModule } from '../app.module.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run inbox controller tests.';
+
+const FLAGGED_COUNT = 57;
+const LIVE_LIST_LIMIT = 50;
+
+interface InboxResponse {
+  live: Array<{ id: string }>;
+  liveTotal: number;
+}
+
+(skipReason ? describe.skip : describe)('GET /v1/inbox live count', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let userId: string;
+  let sessionToken: string;
+  let channelId: string;
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED = '1';
+    process.env.MUNIN_STORAGE_PROVIDER = 'local';
+
+    await runMigrations(TEST_URL!);
+
+    const appUrl = TEST_URL!.replace(
+      /(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/,
+      '$1munin_app:munin_app@',
+    );
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const label = `inbox-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const [org] = await db.insert(schema.orgs).values({ name: `Org ${label}` }).returning();
+    orgId = org!.id;
+
+    const [user] = await db
+      .insert(schema.users)
+      .values({ email: `${label}@example.com`, name: 'Owner User' })
+      .returning();
+    userId = user!.id;
+    await db
+      .insert(schema.orgMembers)
+      .values({ orgId, userId, role: 'owner', isDefault: true });
+
+    sessionToken = randomToken(32);
+    await db.insert(schema.sessions).values({
+      userId,
+      token: sessionToken,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    const [channel] = await db
+      .insert(schema.convChannels)
+      .values({ orgId, type: 'chat', vendor: 'munin', name: `${label}-channel` })
+      .returning();
+    channelId = channel!.id;
+
+    await db.insert(schema.convConversations).values(
+      Array.from({ length: FLAGGED_COUNT }, (_, i) => ({
+        orgId,
+        displayId: i + 1,
+        channelId,
+        status: 'open',
+        needsHumanAttention: true,
+        needsHumanAttentionAt: new Date(Date.now() - i * 60_000),
+        lastMessageAt: new Date(Date.now() - i * 60_000),
+      })),
+    );
+
+    app = await createApp(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      if (orgId) await db.delete(schema.orgs).where(eq(schema.orgs.id, orgId));
+    }
+  });
+
+  async function fetchInbox(): Promise<InboxResponse> {
+    const res = await fetch(`${baseUrl}/v1/inbox`, {
+      headers: { Cookie: `better-auth.session_token=${sessionToken}.placeholder-sig` },
+    });
+    expect(res.status).toBe(200);
+    return (await res.json()) as InboxResponse;
+  }
+
+  it('truncates the live list but reports every flagged conversation in liveTotal', async () => {
+    const body = await fetchInbox();
+    expect(body.live).toHaveLength(LIVE_LIST_LIMIT);
+    expect(body.liveTotal).toBe(FLAGGED_COUNT);
+  });
+
+  it('counts a claimed conversation whose attention flag was cleared', async () => {
+    const [taken] = await db
+      .insert(schema.convConversations)
+      .values({
+        orgId,
+        displayId: FLAGGED_COUNT + 1,
+        channelId,
+        status: 'open',
+        needsHumanAttention: false,
+        lastMessageAt: new Date(),
+      })
+      .returning();
+    await db.insert(schema.claims).values({
+      orgId,
+      entityType: 'conversation',
+      entityId: taken!.id,
+      userId,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    const body = await fetchInbox();
+    expect(body.liveTotal).toBe(FLAGGED_COUNT + 1);
+    expect(body.live.some((c) => c.id === taken!.id)).toBe(true);
+  });
+
+  it('leaves closed and spam conversations out of the count', async () => {
+    await db.insert(schema.convConversations).values([
+      {
+        orgId,
+        displayId: FLAGGED_COUNT + 2,
+        channelId,
+        status: 'closed',
+        needsHumanAttention: true,
+        lastMessageAt: new Date(),
+      },
+      {
+        orgId,
+        displayId: FLAGGED_COUNT + 3,
+        channelId,
+        status: 'spam',
+        needsHumanAttention: true,
+        lastMessageAt: new Date(),
+      },
+    ]);
+
+    const body = await fetchInbox();
+    expect(body.liveTotal).toBe(FLAGGED_COUNT + 1);
+  });
+});

--- a/packages/backend-core/src/control/inbox.controller.ts
+++ b/packages/backend-core/src/control/inbox.controller.ts
@@ -44,9 +44,11 @@ interface LiveConversation extends ConversationSummary {
 }
 
 const EXCLUDED_LIVE_STATUSES = ['closed', 'spam'] as const;
+const LIVE_LIST_LIMIT = 50;
 
 interface InboxQueueResponse {
   live: LiveConversation[];
+  liveTotal: number;
   queue: {
     kb: CurationCandidateSummary[];
     crm: MergeProposalDto[];
@@ -75,7 +77,7 @@ export class InboxController {
   @Get()
   async queue(): Promise<InboxQueueResponse> {
     const [
-      live,
+      liveResult,
       kbItems,
       crmItems,
       outreachItems,
@@ -95,7 +97,8 @@ export class InboxController {
     ]);
 
     return {
-      live,
+      live: liveResult.live,
+      liveTotal: liveResult.total,
       queue: {
         kb: kbItems,
         crm: crmItems,
@@ -108,7 +111,7 @@ export class InboxController {
     };
   }
 
-  private async loadLive(): Promise<LiveConversation[]> {
+  private async loadLive(): Promise<{ live: LiveConversation[]; total: number }> {
     const ctx = getCurrentContext();
     const claimedIdRows = await ctx.db
       .select({ id: schema.claims.entityId })
@@ -120,23 +123,27 @@ export class InboxController {
           gt(schema.claims.expiresAt, sql`now()`),
         ),
       );
-    const claimedIds = new Set(claimedIdRows.map((r) => r.id));
+    const claimedIds = [...new Set(claimedIdRows.map((r) => r.id))];
 
-    const flaggedSummaries = await this.conv.listConversations({
-      needsHumanAttention: true,
-      excludeStatuses: EXCLUDED_LIVE_STATUSES,
-      limit: 50,
-    });
-    const flaggedIds = new Set(flaggedSummaries.map((c) => c.id));
-    const missingClaimedIds = [...claimedIds].filter((id) => !flaggedIds.has(id));
-    const claimedOnly =
-      missingClaimedIds.length > 0
-        ? await this.conv.listConversationsByIds(missingClaimedIds, {
-            excludeStatuses: EXCLUDED_LIVE_STATUSES,
-          })
-        : [];
+    const [flaggedSummaries, flaggedTotal, claimedOnly] = await Promise.all([
+      this.conv.listConversations({
+        needsHumanAttention: true,
+        excludeStatuses: EXCLUDED_LIVE_STATUSES,
+        limit: LIVE_LIST_LIMIT,
+      }),
+      this.conv.countConversations({
+        needsHumanAttention: true,
+        excludeStatuses: EXCLUDED_LIVE_STATUSES,
+      }),
+      this.conv.listConversationsByIds(claimedIds, {
+        excludeStatuses: EXCLUDED_LIVE_STATUSES,
+        needsHumanAttention: false,
+      }),
+    ]);
+
     const summaries = [...flaggedSummaries, ...claimedOnly];
-    if (summaries.length === 0) return [];
+    const total = flaggedTotal + claimedOnly.length;
+    if (summaries.length === 0) return { live: [], total };
 
     const ids = summaries.map((c) => c.id);
 
@@ -151,11 +158,14 @@ export class InboxController {
       }),
     ]);
 
-    return summaries.map((s) => ({
-      ...s,
-      latestEndUserMessage: latestByConv.get(s.id) ?? null,
-      claim: claimsByConv.get(s.id) ?? null,
-    }));
+    return {
+      live: summaries.map((s) => ({
+        ...s,
+        latestEndUserMessage: latestByConv.get(s.id) ?? null,
+        claim: claimsByConv.get(s.id) ?? null,
+      })),
+      total,
+    };
   }
 
   private async loadLatestEndUserMessages(

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -480,13 +480,21 @@ export class ConvService {
 
   async listConversationsByIds(
     ids: string[],
-    options: { excludeStatuses?: readonly ConversationStatus[] } = {},
+    options: {
+      excludeStatuses?: readonly ConversationStatus[];
+      needsHumanAttention?: boolean;
+    } = {},
   ): Promise<ConversationSummary[]> {
     if (ids.length === 0) return [];
     const ctx = getCurrentContext();
     const filters: SQL[] = [inArray(schema.convConversations.id, ids)];
     if (options.excludeStatuses && options.excludeStatuses.length > 0) {
       filters.push(notInArray(schema.convConversations.status, [...options.excludeStatuses]));
+    }
+    if (options.needsHumanAttention !== undefined) {
+      filters.push(
+        eq(schema.convConversations.needsHumanAttention, options.needsHumanAttention),
+      );
     }
     const rows = await ctx.db
       .select()
@@ -508,6 +516,25 @@ export class ConvService {
   }): Promise<ConversationSummary[]> {
     const page = await this.listConversationsPage({ ...input });
     return page.items;
+  }
+
+  async countConversations(input: {
+    status?: ConversationStatus;
+    excludeStatuses?: readonly ConversationStatus[];
+    assigneeUserId?: string;
+    topicId?: string;
+    endUserId?: string;
+    needsHumanAttention?: boolean;
+    handover?: HandoverFilter;
+    since?: string;
+  }): Promise<number> {
+    const ctx = getCurrentContext();
+    const filters = this.buildConversationListFilters({ ...input });
+    const [row] = await ctx.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(schema.convConversations)
+      .where(filters.length === 0 ? undefined : and(...filters));
+    return row?.count ?? 0;
   }
 
   private buildConversationListFilters(input: {

--- a/packages/dashboard-pages/src/components/dashboard/inbox-data.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-data.ts
@@ -136,6 +136,7 @@ export function useInboxData(): InboxController {
   const buildScheduled = useScheduledBuilder();
   const translateErr = useTranslateError();
   const [items, setItems] = useState<LiveSummary[]>([]);
+  const [itemsTotal, setItemsTotal] = useState(0);
   const [queue, setQueue] = useState<QueueItem[]>([]);
   const [scheduled, setScheduled] = useState<ScheduledItem[]>([]);
   const [cmsDetails, setCmsDetails] = useState<Record<string, CmsDraftDetailDto>>({});
@@ -158,6 +159,7 @@ export function useInboxData(): InboxController {
     try {
       const res = await api<InboxQueueResponse>('/v1/inbox');
       setItems(res.live);
+      setItemsTotal(res.liveTotal);
       setQueue(buildQueue(res.queue));
       setScheduled(buildScheduled(res.queue));
       setLoadError(null);
@@ -540,6 +542,7 @@ export function useInboxData(): InboxController {
 
   return {
     items,
+    itemsTotal,
     queue,
     pending,
     loadError,

--- a/packages/dashboard-pages/src/components/dashboard/inbox-types.ts
+++ b/packages/dashboard-pages/src/components/dashboard/inbox-types.ts
@@ -91,6 +91,7 @@ export type LiveSummary = ConversationSummary & {
 
 export interface InboxQueueResponse {
   live: LiveSummary[];
+  liveTotal: number;
   queue: {
     kb: KbCandidateDto[];
     crm: CrmMergeProposalDto[];
@@ -113,6 +114,7 @@ export type QueueActionError =
 
 export interface InboxController {
   items: LiveSummary[];
+  itemsTotal: number;
   queue: QueueItem[];
   pending: boolean;
   loadError: ApiError | null;

--- a/packages/dashboard-pages/src/pages/overview.tsx
+++ b/packages/dashboard-pages/src/pages/overview.tsx
@@ -60,7 +60,7 @@ export function DashboardPage() {
     <div className={OVERVIEW_SHELL}>
       <DashboardHero date={new Date()} />
 
-      <OverviewConversations liveCount={inbox.items.length} />
+      <OverviewConversations liveCount={inbox.itemsTotal} />
 
       <OverviewReview queue={inbox.queue} scheduled={inbox.scheduled} />
 

--- a/packages/dashboard-pages/src/shells/console-shell.tsx
+++ b/packages/dashboard-pages/src/shells/console-shell.tsx
@@ -61,7 +61,7 @@ function useConsoleData(isAdmin: boolean, roleLoading: boolean): { badges: Conso
     void api<InboxQueueResponse>('/v1/inbox')
       .then((res) =>
         setBadges({
-          queue: res.live.length,
+          queue: res.liveTotal,
           review:
             res.queue.kb.length +
             res.queue.crm.length +


### PR DESCRIPTION
## The bug

Globex prod had 65 conversations flagged as needing a human. The overview stat row and the console sidebar badge both said **50**.

`GET /v1/inbox` builds its `live` array from a list truncated at 50:

```ts
const flaggedSummaries = await this.conv.listConversations({
  needsHumanAttention: true,
  excludeStatuses: EXCLUDED_LIVE_STATUSES,
  limit: 50,
});
```

…and the dashboard counted the array — `overview.tsx` via `inbox.items.length`, `console-shell.tsx` via `res.live.length`. Both saturate at 50 regardless of how many are actually flagged, and nothing on the page hints that the number is a ceiling rather than a count.

## The fix

The response now carries `liveTotal` alongside `live`: a `COUNT(*)` over the same filters the list uses — flagged and not closed/spam, plus the actively claimed conversations whose attention flag was already cleared (those are part of `live` today, so they belong in its total). Both counters read `liveTotal`. The list stays capped at 50; only the number is exact.

`ConvService.countConversations` shares `buildConversationListFilters` with the list queries, so the count and the page can't drift apart as filters evolve.

### Incidental fix

`listConversationsByIds` gained an optional `needsHumanAttention` filter. `loadLive` used to derive its claimed-only branch by subtracting the **truncated** flagged id set:

```ts
const flaggedIds = new Set(flaggedSummaries.map((c) => c.id));   // only the first 50
const missingClaimedIds = [...claimedIds].filter((id) => !flaggedIds.has(id));
```

so a conversation that was both flagged *and* claimed, ranked past the 50th, was absent from `flaggedIds` and leaked back into the list through the claimed-only query. The branch now asks for exactly the unflagged claims, which is both correct and what makes the total add up without double-counting.

## Tests

New `inbox.controller.integration.test.ts`:

- 57 flagged conversations → `live.length === 50`, `liveTotal === 57`
- a claimed conversation whose flag was cleared is counted and listed
- closed and spam conversations stay out of the count

Full `modules/conv/` + control-plane suites pass (764 tests), dashboard-pages 190 pass, typecheck and lint clean. `docs:generate` produced no fixture diff.

## Known gap — not fixed here

The Conversations page header (`Needs your attention · {count}`) counts a *different* truncated fetch: `conversation-queue.ts` loads `/v1/conversations/queue?status=open&limit=100` and never follows `nextCursor`, then partitions client-side. Ordering is `lastMessageAt DESC`, so past 100 open conversations the rows that fall off are the least recently active — exactly the neglected flagged ones — and they are neither counted nor reachable from that page.

So after this lands the sidebar may legitimately read *higher* than the Conversations page header. Tracked in #950 with the options (paginate the open queue vs. viewer-aware server-side counts); `countConversations` added here is the natural building block for the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

