### PR TITLE
fix(dashboard): give the consent screen a head-only shell

### DIFF
--- a/.changeset/consent-page-own-chrome.md
+++ b/.changeset/consent-page-own-chrome.md
@@ -1,0 +1,17 @@
+---
+'@getmunin/dashboard-pages': patch
+---
+
+Give the OAuth consent screen a head-only shell instead of the full console
+
+An authorization request arrived framed by the whole dashboard — sidebar, nav counts,
+alerts banner, user footer — none of which belongs on a page whose only question is
+whether to hand a client a token.
+
+`DashboardShell` now renders `/dashboard/oauth/consent` with a head-only shell: the brand
+head, then the page. The head is the same `BrandHead` the console sidebar uses, fed by the
+same `brand` / `brandHref` / `logoSrc` / `leftSlot` props, so a host that puts an
+organization switcher in the sidebar gets that switcher here and one that passes no slot
+gets its organization name — one contract, not two. `BrandMark` and the brand/slot
+resolution move to `shells/brand-head.tsx`, shared by the sidebar, the mobile header and
+the consent head so they cannot drift.

--- a/packages/dashboard-pages/src/pages/oauth-consent.tsx
+++ b/packages/dashboard-pages/src/pages/oauth-consent.tsx
@@ -152,7 +152,7 @@ export function OAuthConsentPage({
 
   if (!clientId || !oauthQuery) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-bone px-6 dark:bg-background">
+      <div className="flex min-h-[60vh] items-center justify-center bg-bone px-6 dark:bg-background">
         <div className="max-w-md border-[1px] border-ink bg-paper p-6 text-sm text-destructive dark:border-rule-on-dark dark:bg-card">
           {t('missingParams')}
         </div>
@@ -189,7 +189,7 @@ export function OAuthConsentPage({
   const resourceName = denial?.resourceName ?? resourceInfo?.name ?? '';
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="bg-background">
       <main className="mx-auto flex w-full max-w-[720px] flex-col px-6 py-12 sm:py-16">
         <EditorialHeader
           flow={stale ? 'expired' : blocked ? 'blocked' : flow}

--- a/packages/dashboard-pages/src/shells/brand-head.tsx
+++ b/packages/dashboard-pages/src/shells/brand-head.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import Image from 'next/image';
+import type { ReactNode } from 'react';
+import { cn } from '@getmunin/ui';
+import { Link } from '../i18n-navigation';
+
+export function BrandMark({
+  href,
+  label,
+  children,
+}: {
+  href: string;
+  label: string;
+  children: ReactNode;
+}) {
+  if (/^https?:\/\//i.test(href)) {
+    return (
+      <a href={href} aria-label={label} className="block shrink-0">
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link href={href} aria-label={label} className="block shrink-0">
+      {children}
+    </Link>
+  );
+}
+
+export interface BrandHeadProps {
+  brand: string;
+  brandHref: string;
+  logoSrc: string;
+  logoSize: number;
+  logoClassName: string;
+  headSlot?: ReactNode;
+  brandClassName: string;
+}
+
+export function BrandHead({
+  brand,
+  brandHref,
+  logoSrc,
+  logoSize,
+  logoClassName,
+  headSlot,
+  brandClassName,
+}: BrandHeadProps) {
+  return (
+    <>
+      <BrandMark href={brandHref} label={brand}>
+        <Image
+          src={logoSrc}
+          alt=""
+          aria-hidden
+          width={logoSize}
+          height={logoSize}
+          className={cn('block object-contain', logoClassName)}
+        />
+      </BrandMark>
+      {headSlot ? (
+        <div className="min-w-0">{headSlot}</div>
+      ) : (
+        <span className={cn('min-w-0 truncate', brandClassName)}>{brand}</span>
+      )}
+    </>
+  );
+}

--- a/packages/dashboard-pages/src/shells/console-shell.tsx
+++ b/packages/dashboard-pages/src/shells/console-shell.tsx
@@ -30,6 +30,7 @@ import {
   type ConsoleNavGroup,
 } from '../nav/console-groups';
 import type { InboxQueueResponse } from '../components/dashboard/inbox-types';
+import { BrandHead, BrandMark } from './brand-head';
 import { MobileBackProvider, useMobileBackAction } from './mobile-back';
 
 interface ConsoleBadges {
@@ -193,29 +194,6 @@ export interface ConsoleShellProps {
   children: ReactNode;
 }
 
-function BrandMark({
-  href,
-  label,
-  children,
-}: {
-  href: string;
-  label: string;
-  children: ReactNode;
-}) {
-  if (/^https?:\/\//i.test(href)) {
-    return (
-      <a href={href} aria-label={label} className="block shrink-0">
-        {children}
-      </a>
-    );
-  }
-  return (
-    <Link href={href} aria-label={label} className="block shrink-0">
-      {children}
-    </Link>
-  );
-}
-
 export function ConsoleShell(props: ConsoleShellProps) {
   return (
     <MobileBackProvider>
@@ -267,16 +245,15 @@ function ConsoleShellInner({
     <div className="grid h-full min-h-0 grid-cols-1 md:grid-cols-[280px_minmax(0,1fr)]">
       <aside className="hidden min-h-0 flex-col border-r border-ink bg-bone md:flex dark:border-rule-on-dark dark:bg-secondary">
         <div className="flex items-center gap-3 px-5 pb-4 pt-5">
-          <BrandMark href={brandHref} label={brand}>
-            <Image src={logoSrc} alt="" aria-hidden width={44} height={44} className="block size-11 object-contain" />
-          </BrandMark>
-          {headSlot ? (
-            <div className="min-w-0">{headSlot}</div>
-          ) : (
-            <span className="min-w-0 truncate text-[15px] font-medium text-ink dark:text-foreground">
-              {brand}
-            </span>
-          )}
+          <BrandHead
+            brand={brand}
+            brandHref={brandHref}
+            logoSrc={logoSrc}
+            logoSize={44}
+            logoClassName="size-11"
+            headSlot={headSlot}
+            brandClassName="text-[15px] font-medium text-ink dark:text-foreground"
+          />
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto py-3">
           <NavList groups={groups} badges={badges} />
@@ -317,16 +294,15 @@ function ConsoleShellInner({
             </button>
           ) : (
             <>
-              <BrandMark href={brandHref} label={brand}>
-                <Image src={logoSrc} alt="" aria-hidden width={26} height={26} className="block size-[26px] object-contain" />
-              </BrandMark>
-              {headSlot ? (
-                <div className="min-w-0">{headSlot}</div>
-              ) : (
-                <span className="min-w-0 truncate text-sm font-medium text-ink dark:text-foreground">
-                  {brand}
-                </span>
-              )}
+              <BrandHead
+                brand={brand}
+                brandHref={brandHref}
+                logoSrc={logoSrc}
+                logoSize={26}
+                logoClassName="size-[26px]"
+                headSlot={headSlot}
+                brandClassName="text-sm font-medium text-ink dark:text-foreground"
+              />
               <button
                 type="button"
                 onClick={() => setMenuOpen(true)}

--- a/packages/dashboard-pages/src/shells/dashboard-shell.tsx
+++ b/packages/dashboard-pages/src/shells/dashboard-shell.tsx
@@ -7,6 +7,7 @@ import { SystemAlertsBanner } from '../components/system-alerts-banner';
 import { SetupStateProvider } from '../components/first-run';
 import { ConfirmDialogProvider } from '../components/confirm-dialog';
 import { usePathname } from '../i18n-navigation';
+import { BrandHead } from './brand-head';
 import { ConsoleShell } from './console-shell';
 
 export interface DashboardShellProps {
@@ -18,7 +19,42 @@ export interface DashboardShellProps {
   children: ReactNode;
 }
 
-export function DashboardShell({
+const HEAD_ONLY_PREFIXES = ['/dashboard/oauth/consent'];
+
+export function DashboardShell(props: DashboardShellProps) {
+  const pathname = usePathname();
+  if (HEAD_ONLY_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return <HeadOnlyShell {...props} />;
+  }
+  return <ConsoleDashboardShell {...props} />;
+}
+
+function HeadOnlyShell({
+  brand,
+  brandHref = '/dashboard',
+  logoSrc = '/munin-logo.png',
+  leftSlot,
+  children,
+}: DashboardShellProps) {
+  return (
+    <div className="flex min-h-dvh flex-col bg-background">
+      <header className="flex shrink-0 items-center gap-3 border-b border-ink bg-bone px-5 py-3 dark:border-rule-on-dark dark:bg-secondary">
+        <BrandHead
+          brand={brand}
+          brandHref={brandHref}
+          logoSrc={logoSrc}
+          logoSize={32}
+          logoClassName="size-8"
+          headSlot={leftSlot}
+          brandClassName="text-[15px] font-medium text-ink dark:text-foreground"
+        />
+      </header>
+      <div className="min-h-0 flex-1">{children}</div>
+    </div>
+  );
+}
+
+function ConsoleDashboardShell({
   brand,
   brandHref,
   logoSrc = '/munin-logo.png',


### PR DESCRIPTION
An OAuth authorization request arrived wearing the whole dashboard — sidebar, nav counts, alerts banner, user footer. None of it belongs on a page whose only question is whether to hand a client a token, and the org name in that chrome was actively misleading: it tracks the dashboard's active-org preference, while the grant binds to the org the request pinned (or the `isDefault` membership) via `resolveConsentOrgId`.

`DashboardShell` now renders `/dashboard/oauth/consent` through a head-only shell: brand head, then the page. The head takes the same `brand` / `brandHref` / `logoSrc` / `leftSlot` the console sidebar gets, so a host that puts an organization switcher in the sidebar gets that switcher here, and one that passes no slot gets its organization name. One contract — not a second org UI that would have to re-derive which org a grant binds to.

`BrandMark` and the brand/slot resolution move to `shells/brand-head.tsx`, shared by the sidebar, the mobile header and the consent head so they cannot drift. The consent page stops forcing `min-h-screen` on its root, which under the new shell would have stacked a second viewport below the bar.

## Verified

Locally against `munin_dev` with a signed session cookie:

- consent page renders mark + org name, no console chrome
- sidebar and mobile header pixel-unchanged after the extraction
- the full pinned flow still resolves: authorize with `resource=…/mcp/o/<org>` writes both `mcp-org-scope:` association rows, the consent redirect carries `code_challenge`, and `/v1/oauth/pending-org` answers `{"pinned":true,"orgId":"org_kdci…"}`

`pnpm typecheck` (workspace), package lint and tests green.

## Follow-ups for munin-cloud

Not in this repo, but this shell is what cloud renders:

- `OrgSwitcher` fails open. When the pinned org isn't in `/v1/me/memberships` — e.g. you haven't joined it yet — `boundOrg` is `undefined` and it silently shows your *active* org instead. `resolveConsentOrgId` then throws `FORBIDDEN` on submit with no explanation. It should name the pinned org and say you can't authorize for it.
- `AnalyticsIdentify` / `FunnelStep` / `ChatWidget` are passed as *children* of `DashboardShell`, so they still render on the consent page under the new shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFeprNBvT38AoBUPPQzCND