### PR TITLE
fix(dashboard): count the conversations queue server-side and page past the first 100

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,12 @@
+---
+'@getmunin/backend-core': patch
+'@getmunin/dashboard-pages': patch
+---
+
+Count the whole Conversations queue server-side, and let the list reach past the first 100 rows.
+
+The Conversations page loaded one 100-row page of open conversations and partitioned it client-side, so `Needs your attention · {count}` counted only what the client happened to fetch. The queue is ordered by `lastMessageAt DESC`, so the rows that fell off the bottom were the least recently active ones — exactly the flagged, un-replied conversations the header is meant to point at. They were neither counted nor reachable from the page.
+
+`GET /v1/conversations/queue/counts` is new: `ConvService.countConversationQueueSections` runs one aggregate over the open conversations, splitting them into `needsYou` / `inProgress` with the same rule the client used (claimed by the caller, or flagged and unclaimed) by resolving each conversation's newest live claim in SQL. It reuses `buildConversationListFilters`, so the counts cannot drift from the list. The page headers read those totals, and the member sidebar badge reads `total` instead of the length of a `limit=100` fetch that saturated at 100.
+
+The list itself now follows `nextCursor` behind a "Load more" button rather than fetching every page on load, and a refresh re-fetches as many pages as are on screen so a realtime event does not collapse the list back to the first page. The Done section keeps its client-side 7-day window.

--- a/packages/backend-core/openapi.json
+++ b/packages/backend-core/openapi.json
@@ -3705,6 +3705,45 @@
         ]
       }
     },
+    "/v1/conversations/queue/counts": {
+      "get": {
+        "operationId": "ConversationsController_queueCounts",
+        "parameters": [
+          {
+            "name": "assigneeUserId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "topicId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Conversations"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "session": []
+          }
+        ]
+      }
+    },
     "/v1/conversations/topics": {
       "get": {
         "operationId": "ConversationsController_listTopics",

--- a/packages/backend-core/src/common/auth/member-surface.test.ts
+++ b/packages/backend-core/src/common/auth/member-surface.test.ts
@@ -7,6 +7,7 @@ const SRC_ROOT = fileURLToPath(new URL('../..', import.meta.url));
 
 const EXPECTED_MEMBER_SURFACE = [
   'v1/conversations GET queue',
+  'v1/conversations GET queue/counts',
   'v1/conversations GET :id',
   'v1/conversations POST :id/messages',
   'v1/conversations POST :id/messages/:messageId/retry-delivery',

--- a/packages/backend-core/src/control/conversations-queue-counts.integration.test.ts
+++ b/packages/backend-core/src/control/conversations-queue-counts.integration.test.ts
@@ -1,0 +1,217 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { INestApplication } from '@nestjs/common';
+import type { AddressInfo } from 'node:net';
+import { randomToken } from '@getmunin/core';
+import { createDb, runMigrations, schema } from '@getmunin/db';
+import { eq, sql } from 'drizzle-orm';
+import { createApp } from '../bootstrap-app.ts';
+import { AppModule } from '../app.module.ts';
+
+const TEST_URL = process.env.TEST_DATABASE_URL;
+const skipReason = TEST_URL
+  ? null
+  : 'Set TEST_DATABASE_URL to a Postgres URL to run conversation queue count tests.';
+
+const OPEN_COUNT = 105;
+const PAGE_LIMIT = 100;
+const FLAGGED_INDEXES = [0, 100, 101, 102, 103, 104];
+
+interface QueuePage {
+  items: Array<{ id: string; needsHumanAttention: boolean }>;
+  nextCursor: string | null;
+}
+
+interface QueueCounts {
+  needsYou: number;
+  inProgress: number;
+  total: number;
+}
+
+(skipReason ? describe.skip : describe)('GET /v1/conversations/queue/counts', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let db: ReturnType<typeof createDb>;
+  let orgId: string;
+  let userId: string;
+  let otherUserId: string;
+  let sessionToken: string;
+  let conversationIds: string[] = [];
+
+  beforeAll(async () => {
+    process.env.MUNIN_AUTH_SECRET ??= 'test-secret-do-not-use-in-prod';
+    process.env.MUNIN_KEY_PEPPER ??= 'test-pepper';
+    process.env.MUNIN_EMBEDDING_PROVIDER = 'stub';
+    process.env.MUNIN_MAIL_PROVIDER = 'stub';
+    process.env.MUNIN_WEBHOOK_WORKER_DISABLED = '1';
+    process.env.MUNIN_CMS_SCHEDULE_WORKER_DISABLED = '1';
+    process.env.MUNIN_STORAGE_PROVIDER = 'local';
+
+    await runMigrations(TEST_URL!);
+
+    const appUrl = TEST_URL!.replace(
+      /(postgres(?:ql)?:\/\/)[^:@]+:[^@]+@/,
+      '$1munin_app:munin_app@',
+    );
+    process.env.DATABASE_URL = appUrl;
+
+    db = createDb(TEST_URL!, { serviceRole: true });
+    await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+
+    const label = `queue-counts-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const [org] = await db.insert(schema.orgs).values({ name: `Org ${label}` }).returning();
+    orgId = org!.id;
+
+    const [user] = await db
+      .insert(schema.users)
+      .values({ email: `${label}@example.com`, name: 'Owner User' })
+      .returning();
+    userId = user!.id;
+    await db
+      .insert(schema.orgMembers)
+      .values({ orgId, userId, role: 'owner', isDefault: true });
+
+    const [other] = await db
+      .insert(schema.users)
+      .values({ email: `${label}-mate@example.com`, name: 'Teammate' })
+      .returning();
+    otherUserId = other!.id;
+    await db.insert(schema.orgMembers).values({ orgId, userId: otherUserId, role: 'admin' });
+
+    sessionToken = randomToken(32);
+    await db.insert(schema.sessions).values({
+      userId,
+      token: sessionToken,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    const [channel] = await db
+      .insert(schema.convChannels)
+      .values({ orgId, type: 'chat', vendor: 'munin', name: `${label}-channel` })
+      .returning();
+
+    const rows = await db
+      .insert(schema.convConversations)
+      .values(
+        Array.from({ length: OPEN_COUNT }, (_, i) => ({
+          orgId,
+          displayId: i + 1,
+          channelId: channel!.id,
+          status: 'open',
+          needsHumanAttention: FLAGGED_INDEXES.includes(i),
+          ...(FLAGGED_INDEXES.includes(i)
+            ? { needsHumanAttentionAt: new Date(Date.now() - i * 60_000) }
+            : {}),
+          lastMessageAt: new Date(Date.now() - i * 60_000),
+        })),
+      )
+      .returning();
+    conversationIds = rows.map((r) => r.id);
+
+    app = await createApp(AppModule, { logger: false });
+    await app.listen(0, '127.0.0.1');
+    const server = app.getHttpServer() as { address(): AddressInfo | string | null };
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected AddressInfo');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (db) {
+      await db.execute(sql`SELECT set_config('app.bypass_rls', 'on', false)`);
+      if (orgId) await db.delete(schema.orgs).where(eq(schema.orgs.id, orgId));
+    }
+  });
+
+  async function get<T>(path: string): Promise<T> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      headers: { Cookie: `better-auth.session_token=${sessionToken}.placeholder-sig` },
+    });
+    expect(res.status).toBe(200);
+    return (await res.json()) as T;
+  }
+
+  const counts = () => get<QueueCounts>('/v1/conversations/queue/counts');
+
+  it('counts flagged conversations the first page never reaches', async () => {
+    const page = await get<QueuePage>(
+      `/v1/conversations/queue?status=open&limit=${PAGE_LIMIT}`,
+    );
+    expect(page.items).toHaveLength(PAGE_LIMIT);
+    expect(page.items.filter((i) => i.needsHumanAttention)).toHaveLength(1);
+
+    const body = await counts();
+    expect(body.total).toBe(OPEN_COUNT);
+    expect(body.needsYou).toBe(FLAGGED_INDEXES.length);
+    expect(body.inProgress).toBe(OPEN_COUNT - FLAGGED_INDEXES.length);
+  });
+
+  it('reaches the conversations past the first page through the cursor', async () => {
+    const first = await get<QueuePage>(
+      `/v1/conversations/queue?status=open&limit=${PAGE_LIMIT}`,
+    );
+    expect(first.nextCursor).not.toBeNull();
+    const second = await get<QueuePage>(
+      `/v1/conversations/queue?status=open&limit=${PAGE_LIMIT}&cursor=${encodeURIComponent(
+        first.nextCursor!,
+      )}`,
+    );
+    expect(second.items).toHaveLength(OPEN_COUNT - PAGE_LIMIT);
+    expect(second.items.filter((i) => i.needsHumanAttention)).toHaveLength(
+      FLAGGED_INDEXES.length - 1,
+    );
+    expect(second.nextCursor).toBeNull();
+  });
+
+  it('moves a conversation the viewer claimed into needsYou and one a teammate claimed out of it', async () => {
+    const before = await counts();
+
+    await db.insert(schema.claims).values({
+      orgId,
+      entityType: 'conversation',
+      entityId: conversationIds[5]!,
+      userId,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    const mine = await counts();
+    expect(mine.needsYou).toBe(before.needsYou + 1);
+    expect(mine.inProgress).toBe(before.inProgress - 1);
+
+    await db.insert(schema.claims).values({
+      orgId,
+      entityType: 'conversation',
+      entityId: conversationIds[104]!,
+      userId: otherUserId,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    const theirs = await counts();
+    expect(theirs.needsYou).toBe(before.needsYou);
+    expect(theirs.inProgress).toBe(before.inProgress);
+    expect(theirs.total).toBe(before.total);
+  });
+
+  it('ignores an expired claim', async () => {
+    await db.insert(schema.claims).values({
+      orgId,
+      entityType: 'conversation',
+      entityId: conversationIds[100]!,
+      userId: otherUserId,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+
+    const body = await counts();
+    expect(body.needsYou).toBe(FLAGGED_INDEXES.length);
+  });
+
+  it('leaves closed conversations out of the open queue counts', async () => {
+    await db
+      .update(schema.convConversations)
+      .set({ status: 'closed' })
+      .where(eq(schema.convConversations.id, conversationIds[1]!));
+
+    const body = await counts();
+    expect(body.total).toBe(OPEN_COUNT - 1);
+    expect(body.inProgress).toBe(OPEN_COUNT - 1 - body.needsYou);
+  });
+});

--- a/packages/backend-core/src/control/conversations.controller.ts
+++ b/packages/backend-core/src/control/conversations.controller.ts
@@ -48,6 +48,7 @@ import {
   STATUSES,
   type ConversationStatus,
   type ConversationDetail,
+  type ConversationQueueCounts,
   type ConversationQueueItem,
   type ConversationSummary,
   type MessageDto,
@@ -220,6 +221,20 @@ export class ConversationsController {
       items: page.items,
       nextCursor: page.nextCursor ? encodeListCursor(page.nextCursor) : null,
     };
+  }
+
+  @Get('queue/counts')
+  @AllowMember()
+  async queueCounts(
+    @Query('assigneeUserId') assigneeUserId?: string,
+    @Query('topicId') topicId?: string,
+  ): Promise<ConversationQueueCounts> {
+    return translate(() =>
+      this.conv.countConversationQueueSections({
+        ...(assigneeUserId ? { assigneeUserId } : {}),
+        ...(topicId ? { topicId } : {}),
+      }),
+    );
   }
 
   @Get('topics')

--- a/packages/backend-core/src/modules/conv/conv.service.ts
+++ b/packages/backend-core/src/modules/conv/conv.service.ts
@@ -174,6 +174,12 @@ export interface ConversationSummary {
   createdAt: string;
 }
 
+export interface ConversationQueueCounts {
+  needsYou: number;
+  inProgress: number;
+  total: number;
+}
+
 export interface ConversationQueueItem extends ConversationSummary {
   channelType: string;
   customerName: string | null;
@@ -804,6 +810,43 @@ export class ConvService {
     const nextCursor =
       rows.length > limit && last ? { lastMessageAt: last.lastMessageAt, id: last.id } : null;
     return { items, nextCursor };
+  }
+
+  async countConversationQueueSections(input?: {
+    assigneeUserId?: string;
+    topicId?: string;
+  }): Promise<ConversationQueueCounts> {
+    const ctx = getCurrentContext();
+    const actor = ctx.actor;
+    const viewerUserId = actor
+      ? actor.type === 'user'
+        ? actor.id
+        : (actor.userId ?? null)
+      : null;
+    const filters = this.buildConversationListFilters({ status: 'open', ...input });
+    const claimHolder = sql`(
+          SELECT ${schema.claims.userId} FROM ${schema.claims}
+          WHERE ${schema.claims.entityType} = 'conversation'
+            AND ${schema.claims.entityId} = ${schema.convConversations.id}
+            AND ${schema.claims.userId} IS NOT NULL
+            AND ${schema.claims.expiresAt} > now()
+          ORDER BY ${schema.claims.createdAt} DESC
+          LIMIT 1
+        )`;
+    const claimedByViewer = viewerUserId ? sql`${claimHolder} = ${viewerUserId}` : sql`false`;
+    const [row] = await ctx.db
+      .select({
+        total: sql<number>`count(*)::int`,
+        needsYou: sql<number>`count(*) FILTER (
+          WHERE ${claimedByViewer}
+             OR (${schema.convConversations.needsHumanAttention} AND ${claimHolder} IS NULL)
+        )::int`,
+      })
+      .from(schema.convConversations)
+      .where(filters.length === 0 ? undefined : and(...filters));
+    const total = row?.total ?? 0;
+    const needsYou = row?.needsYou ?? 0;
+    return { needsYou, inProgress: total - needsYou, total };
   }
 
   async listConversationsAwaitingAgentReply(input?: {

--- a/packages/dashboard-pages/src/components/dashboard/conversation-queue.test.ts
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-queue.test.ts
@@ -1,14 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   FINISHED_MIN_ITEMS,
   FINISHED_WINDOW_DAYS,
+  loadOpenPages,
   matchesQueueSearch,
   messageDraftKind,
   partitionQueue,
   visibleFinished,
   type QueueItemDto,
 } from './conversation-queue';
+import { api } from '../../api';
 import type { MessageDto } from './inbox-types';
+
+vi.mock('../../api', () => ({ api: vi.fn(), ApiError: class ApiError extends Error {} }));
+
+const apiMock = vi.mocked(api);
 
 function item(overrides: Partial<QueueItemDto>): QueueItemDto {
   return {
@@ -189,5 +195,61 @@ describe('visibleFinished', () => {
   it('is applied by partitionQueue, so the Done section is already trimmed', () => {
     const finished = closedRun(FINISHED_MIN_ITEMS + 10, FINISHED_WINDOW_DAYS + 5);
     expect(partitionQueue([], finished, 'me').finished).toHaveLength(FINISHED_MIN_ITEMS);
+  });
+});
+
+describe('loadOpenPages', () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+  });
+
+  function respondWithPages(pages: Array<{ ids: string[]; nextCursor: string | null }>): void {
+    let call = 0;
+    apiMock.mockImplementation(() => {
+      const page = pages[call];
+      call += 1;
+      if (!page) throw new Error(`unexpected page request ${call}`);
+      return Promise.resolve({
+        items: page.ids.map((id) => item({ id })),
+        nextCursor: page.nextCursor,
+      });
+    });
+  }
+
+  it('fetches a single page by default and reports the cursor the caller can follow', async () => {
+    respondWithPages([{ ids: ['a', 'b'], nextCursor: 'cur_1' }]);
+    const page = await loadOpenPages(1);
+    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(apiMock.mock.calls[0]![0]).toBe('/v1/conversations/queue?status=open&limit=100');
+    expect(page.items.map((i) => i.id)).toEqual(['a', 'b']);
+    expect(page.nextCursor).toBe('cur_1');
+  });
+
+  it('follows the cursor for as many pages as were loaded before', async () => {
+    respondWithPages([
+      { ids: ['a'], nextCursor: 'cur_1' },
+      { ids: ['b'], nextCursor: 'cur_2' },
+      { ids: ['c'], nextCursor: null },
+    ]);
+    const page = await loadOpenPages(3);
+    expect(apiMock.mock.calls[1]![0]).toContain('cursor=cur_1');
+    expect(page.items.map((i) => i.id)).toEqual(['a', 'b', 'c']);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('stops early when the queue runs out before the requested page count', async () => {
+    respondWithPages([{ ids: ['a'], nextCursor: null }]);
+    const page = await loadOpenPages(5);
+    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('keeps one row when a conversation shifts across a page boundary', async () => {
+    respondWithPages([
+      { ids: ['a', 'b'], nextCursor: 'cur_1' },
+      { ids: ['b', 'c'], nextCursor: null },
+    ]);
+    const page = await loadOpenPages(2);
+    expect(page.items.map((i) => i.id)).toEqual(['a', 'b', 'c']);
   });
 });

--- a/packages/dashboard-pages/src/components/dashboard/conversation-queue.ts
+++ b/packages/dashboard-pages/src/components/dashboard/conversation-queue.ts
@@ -52,6 +52,12 @@ interface QueuePageResponse {
   nextCursor: string | null;
 }
 
+export interface QueueCounts {
+  needsYou: number;
+  inProgress: number;
+  total: number;
+}
+
 export type QueueActionType =
   | 'send'
   | 'takeOver'
@@ -75,6 +81,38 @@ export const FINISHED_MIN_ITEMS = 25;
 export const FINISHED_WINDOW_DAYS = 7;
 
 const FINISHED_FETCH_LIMIT = 100;
+const OPEN_PAGE_LIMIT = 100;
+
+function queueUrl(status: 'open' | 'closed', limit: number, cursor?: string | null): string {
+  const params = new URLSearchParams({ status, limit: String(limit) });
+  if (cursor) params.set('cursor', cursor);
+  return `/v1/conversations/queue?${params.toString()}`;
+}
+
+function dedupeById(items: QueueItemDto[]): QueueItemDto[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+}
+
+export async function loadOpenPages(
+  pages: number,
+): Promise<{ items: QueueItemDto[]; nextCursor: string | null }> {
+  const items: QueueItemDto[] = [];
+  let cursor: string | null = null;
+  for (let i = 0; i < pages; i += 1) {
+    const page: QueuePageResponse = await api<QueuePageResponse>(
+      queueUrl('open', OPEN_PAGE_LIMIT, cursor),
+    );
+    items.push(...page.items);
+    cursor = page.nextCursor;
+    if (!cursor) break;
+  }
+  return { items: dedupeById(items), nextCursor: cursor };
+}
 
 export function visibleFinished(
   finished: QueueItemDto[],
@@ -145,6 +183,10 @@ export function pendingDraftOf(detail: ConversationDetail | undefined): MessageD
 export interface QueueController {
   open: QueueItemDto[];
   finished: QueueItemDto[];
+  counts: QueueCounts | null;
+  hasMoreOpen: boolean;
+  loadingMore: boolean;
+  loadMoreOpen: () => Promise<void>;
   selectedId: string | null;
   details: Record<string, ConversationDetail>;
   detailErrors: Record<string, ApiError>;
@@ -181,6 +223,14 @@ export function useConversationQueue(routeSelectedId: string | null): QueueContr
   const t = useTranslations('dashboard.console.queue');
   const [open, setOpen] = useState<QueueItemDto[]>([]);
   const [finished, setFinished] = useState<QueueItemDto[]>([]);
+  const [counts, setCounts] = useState<QueueCounts | null>(null);
+  const [openCursor, setOpenCursor] = useState<string | null>(null);
+  const openCursorRef = useRef(openCursor);
+  openCursorRef.current = openCursor;
+  const openPagesRef = useRef(1);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loadingMoreRef = useRef(loadingMore);
+  loadingMoreRef.current = loadingMore;
   const selectedId = routeSelectedId ?? open[0]?.id ?? finished[0]?.id ?? null;
   const [details, setDetails] = useState<Record<string, ConversationDetail>>({});
   const [detailErrors, setDetailErrors] = useState<Record<string, ApiError>>({});
@@ -222,17 +272,18 @@ export function useConversationQueue(routeSelectedId: string | null): QueueContr
 
   const loadQueue = useCallback(async () => {
     try {
-      const [openPage, finishedPage] = await Promise.all([
-        api<QueuePageResponse>('/v1/conversations/queue?status=open&limit=100'),
-        api<QueuePageResponse>(
-          `/v1/conversations/queue?status=closed&limit=${FINISHED_FETCH_LIMIT}`,
-        ),
+      const [openPages, openCounts, finishedPage] = await Promise.all([
+        loadOpenPages(openPagesRef.current),
+        api<QueueCounts>('/v1/conversations/queue/counts'),
+        api<QueuePageResponse>(queueUrl('closed', FINISHED_FETCH_LIMIT)),
       ]);
-      setOpen(openPage.items);
+      setOpen(openPages.items);
+      setOpenCursor(openPages.nextCursor);
+      setCounts(openCounts);
       setFinished(finishedPage.items);
       setLoadError(null);
       setHasLoadedOnce(true);
-      for (const item of openPage.items) {
+      for (const item of openPages.items) {
         if (item.hasPendingDraft && draftRequestedRef.current[item.id]) {
           clearDraftRequested(item.id);
         }
@@ -241,6 +292,23 @@ export function useConversationQueue(routeSelectedId: string | null): QueueContr
       if (err instanceof ApiError) setLoadError(err);
     }
   }, [clearDraftRequested]);
+
+  const loadMoreOpen = useCallback(async () => {
+    const cursor = openCursorRef.current;
+    if (!cursor || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    try {
+      const page = await api<QueuePageResponse>(queueUrl('open', OPEN_PAGE_LIMIT, cursor));
+      openPagesRef.current += 1;
+      setOpen((prev) => dedupeById([...prev, ...page.items]));
+      setOpenCursor(page.nextCursor);
+    } catch (err) {
+      if (err instanceof ApiError) setLoadError(err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, []);
 
   const retryLoad = useCallback(async () => {
     setRetrying(true);
@@ -492,6 +560,10 @@ export function useConversationQueue(routeSelectedId: string | null): QueueContr
   return {
     open,
     finished,
+    counts,
+    hasMoreOpen: openCursor !== null,
+    loadingMore,
+    loadMoreOpen,
     selectedId,
     details,
     detailErrors,

--- a/packages/dashboard-pages/src/pages/conversations.tsx
+++ b/packages/dashboard-pages/src/pages/conversations.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { cn } from '@getmunin/ui';
+import { Button, cn } from '@getmunin/ui';
 import { authClient } from '../auth-client';
 import { LoadFailed } from '../components/load-failed';
 import { useInboxLoadFailedProps } from '../lib/use-load-failed-props';
@@ -26,6 +26,7 @@ const SPLIT_GRID = 'md:grid-cols-[minmax(0,1.05fr)_minmax(0,1.4fr)]';
 
 export function ConversationsPage({ selectedId = null }: { selectedId?: string | null }) {
   const t = useTranslations('dashboard.console.queue');
+  const tCommon = useTranslations('common');
   const router = useRouter();
   const pathname = usePathname();
   const onQueueRoute = /^\/dashboard\/conversations\/?$/.test(pathname);
@@ -109,8 +110,6 @@ export function ConversationsPage({ selectedId = null }: { selectedId?: string |
 
   const select = (id: string) => shallowGo(`/dashboard/conversations/${id}`);
 
-  const dimInProgress = sections.needsYou.length > 0;
-
   const renderRows = (items: QueueItemDto[], faded?: boolean) =>
     items.map((item) => (
       <ConversationRow
@@ -125,11 +124,13 @@ export function ConversationsPage({ selectedId = null }: { selectedId?: string |
     ));
 
   const loaded = queue.hasLoadedOnce;
+  const searching = search.trim().length > 0;
+  const counts = searching ? null : queue.counts;
+  const needsYouCount = counts ? counts.needsYou : sections.needsYou.length;
+  const inProgressCount = counts ? counts.inProgress : sections.inProgress.length;
+  const dimInProgress = needsYouCount > 0;
   const nothingToShow =
-    loaded &&
-    sections.needsYou.length === 0 &&
-    sections.inProgress.length === 0 &&
-    sections.finished.length === 0;
+    loaded && needsYouCount === 0 && inProgressCount === 0 && sections.finished.length === 0;
 
   return (
     <div className={cn('grid h-full min-h-0 grid-cols-1', SPLIT_GRID)}>
@@ -166,17 +167,29 @@ export function ConversationsPage({ selectedId = null }: { selectedId?: string |
               body={search ? t('emptySearchBody') : t('emptyBody')}
             />
           ) : null}
-          {sections.needsYou.length > 0 ? (
+          {needsYouCount > 0 ? (
             <>
-              <ConsoleSectionLabel>{t('sectionNeedsYou', { count: sections.needsYou.length })}</ConsoleSectionLabel>
+              <ConsoleSectionLabel>{t('sectionNeedsYou', { count: needsYouCount })}</ConsoleSectionLabel>
               {renderRows(sections.needsYou)}
             </>
           ) : null}
-          {sections.inProgress.length > 0 ? (
+          {inProgressCount > 0 ? (
             <>
-              <ConsoleSectionLabel>{t('sectionInProgress', { count: sections.inProgress.length })}</ConsoleSectionLabel>
+              <ConsoleSectionLabel>{t('sectionInProgress', { count: inProgressCount })}</ConsoleSectionLabel>
               {renderRows(sections.inProgress, dimInProgress)}
             </>
+          ) : null}
+          {queue.hasMoreOpen ? (
+            <li className="flex justify-center border-b border-rule-soft px-5 py-3 dark:border-rule-on-dark">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={queue.loadingMore}
+                onClick={() => void queue.loadMoreOpen()}
+              >
+                {tCommon('loadMore')}
+              </Button>
+            </li>
           ) : null}
           {sections.finished.length > 0 ? (
             <>

--- a/packages/dashboard-pages/src/shells/console-shell.tsx
+++ b/packages/dashboard-pages/src/shells/console-shell.tsx
@@ -29,6 +29,7 @@ import {
   type ConsoleBadge,
   type ConsoleNavGroup,
 } from '../nav/console-groups';
+import type { QueueCounts } from '../components/dashboard/conversation-queue';
 import type { InboxQueueResponse } from '../components/dashboard/inbox-types';
 import { BrandHead, BrandMark } from './brand-head';
 import { MobileBackProvider, useMobileBackAction } from './mobile-back';
@@ -54,8 +55,8 @@ function useConsoleData(isAdmin: boolean, roleLoading: boolean): { badges: Conso
   const load = useCallback(() => {
     if (roleLoading) return;
     if (!isAdmin) {
-      void api<{ items: unknown[] }>('/v1/conversations/queue?status=open&limit=100')
-        .then((res) => setBadges({ queue: res.items.length, review: 0 }))
+      void api<QueueCounts>('/v1/conversations/queue/counts')
+        .then((res) => setBadges({ queue: res.total, review: 0 }))
         .catch(() => undefined);
       return;
     }


### PR DESCRIPTION
Closes #950.

## The bug

`ConversationsPage` loaded one 100-row page of open conversations and partitioned it client-side, so `Needs your attention · {count}` counted only what the client happened to fetch. The queue is ordered by `lastMessageAt DESC`, so the rows that fell off the bottom were the *least* recently active ones — exactly the flagged, un-replied conversations the header is meant to point at. They were neither counted nor reachable from the page.

#951 made the sidebar badge and overview stat report a real `COUNT(*)`, which left the two surfaces disagreeing in the other direction. They agree again now.

## The fix

**Exact counts from the server.** `GET /v1/conversations/queue/counts` is new (`@AllowMember`, added to the closed member-surface list in `member-surface.test.ts`). `ConvService.countConversationQueueSections` runs one aggregate over the open conversations and splits them into `needsYou` / `inProgress` using the rule the client used — claimed by the caller, or flagged and unclaimed — resolving each conversation's newest live claim in SQL. It reuses `buildConversationListFilters`, so the counts cannot drift from the list query.

The page headers read those totals; while a search is active the headers fall back to the filtered row count, since search is client-side. The member sidebar badge reads `total` instead of the length of a `limit=100` fetch that saturated at 100 — and no longer pulls 100 rows to count them.

**Reachability.** The list follows `nextCursor` behind a "Load more" button rather than fetching every page on load (issue option 3: exact counts, explicit paging). A refresh re-fetches as many pages as are currently on screen, so a realtime event does not collapse the list back to page one, and rows that shift across a page boundary are deduped by id. The Done section keeps its client-side 7-day window — unchanged, per the issue's note.

## Tests

- `conversations-queue-counts.integration.test.ts` — 105 open conversations with 5 of the 6 flagged ones ranked past the first page: the page returns 100 rows carrying a single flagged one, while `counts.needsYou` reports all 6; the rest are reachable through the cursor. Also covers a viewer claim moving a row into `needsYou`, a teammate claim moving one out, an expired claim being ignored, and closed conversations staying out of the totals.
- `conversation-queue.test.ts` — `loadOpenPages` follows the cursor for the requested page count, stops early when the queue runs out, and keeps one row when a conversation shifts across a page boundary.
- Full `@getmunin/backend-core` suite and `@getmunin/dashboard-pages` suite green; workspace typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)